### PR TITLE
ci: fix intel mac and windows install verification jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
           # Linux x64
           - ubuntu-latest
           # macOS Intel
-          - macos-13
+          - macos-15-intel
           # macOS Apple Silicon
           - macos-latest
           # Windows x64


### PR DESCRIPTION
- Use bash shell in the windows install verify job
- Use macos-15-intel image to run intel mac install verify job