### PR TITLE
feat: add serializable node schemas and runtime tool overrides

### DIFF
--- a/calfkit/client/base.py
+++ b/calfkit/client/base.py
@@ -20,6 +20,7 @@ from calfkit.models.session_context import (
     SessionRunContext,
     WorkflowState,
 )
+from calfkit.models.state import OverridesState
 
 logger = logging.getLogger(__name__)
 
@@ -111,6 +112,7 @@ class BaseClient:
         reply_topic: str,
         correlation_id: str,
         state: State,
+        overrides: OverridesState | None = None,
         run_args: Sequence[Any] | None = None,
         deps: dict[str, Any] | None = None,
         output_type: type[Any] = _UNSET,
@@ -136,7 +138,7 @@ class BaseClient:
             await self._connection.start()
 
         call_stack = CallFrameStack()
-        call_stack.push(CallFrame(target_topic=topic, callback_topic=reply_topic, input_args=run_args))
+        call_stack.push(CallFrame(target_topic=topic, callback_topic=reply_topic, input_args=run_args, overrides=overrides))
 
         envelope = Envelope(
             internal_workflow_state=WorkflowState(call_stack=call_stack),

--- a/calfkit/client/client.py
+++ b/calfkit/client/client.py
@@ -12,6 +12,8 @@ from calfkit.client.deserialize import _UNSET
 from calfkit.client.invocation_handle import InvocationHandle
 from calfkit.client.node_result import NodeResult
 from calfkit.models import State
+from calfkit.models.node_schema import BaseToolNodeSchema
+from calfkit.models.state import OverridesState
 
 
 class Client(BaseClient):
@@ -30,6 +32,7 @@ class Client(BaseClient):
         topic: str,
         *,
         output_type: type[OutputT],
+        tool_overrides: list[BaseToolNodeSchema] | None = ...,
         reply_topic: str | None = ...,
         correlation_id: str | None = ...,
         temp_instructions: str | None = ...,
@@ -44,6 +47,7 @@ class Client(BaseClient):
         user_prompt: str,
         topic: str,
         *,
+        tool_overrides: list[BaseToolNodeSchema] | None = ...,
         reply_topic: str | None = ...,
         correlation_id: str | None = ...,
         temp_instructions: str | None = ...,
@@ -57,6 +61,7 @@ class Client(BaseClient):
         user_prompt: str,
         topic: str,
         *,
+        tool_overrides: list[BaseToolNodeSchema] | None = None,
         output_type: type[Any] = _UNSET,
         reply_topic: str | None = None,
         correlation_id: str | None = None,
@@ -74,6 +79,7 @@ class Client(BaseClient):
         Args:
             user_prompt: The user message to send to the agent node.
             topic: The Kafka topic the target node subscribes to.
+            tool_overrides: Runtime agent tool overrides.
             output_type: The expected Python type for deserializing the agent's
                 output. When omitted, auto-detection is used (``DataPart`` →
                 ``TextPart`` fallback).
@@ -82,7 +88,7 @@ class Client(BaseClient):
             correlation_id: Unique identifier to correlate this request with its
                 reply. Auto-generated (uuid7) when ``None``.
             temp_instructions: Optional system-level instructions injected into
-                the user prompt as a one-shot override.
+                the user prompt as a temporary prompt addition.
             message_history: Prior conversation messages to include for
                 multi-turn context. Defaults to an empty history.
             run_args: Positional arguments forwarded to the node's ``run()``
@@ -107,6 +113,7 @@ class Client(BaseClient):
             correlation_id=correlation_id,
             run_args=run_args,
             state=state,
+            overrides=OverridesState(override_agent_tools=tool_overrides) if tool_overrides is not None else None,
             deps=deps,
             output_type=output_type,
         )
@@ -118,6 +125,7 @@ class Client(BaseClient):
         topic: str,
         *,
         output_type: type[OutputT],
+        tool_overrides: list[BaseToolNodeSchema] | None = ...,
         reply_topic: str | None = ...,
         correlation_id: str | None = ...,
         temp_instructions: str | None = ...,
@@ -133,6 +141,7 @@ class Client(BaseClient):
         user_prompt: str,
         topic: str,
         *,
+        tool_overrides: list[BaseToolNodeSchema] | None = ...,
         reply_topic: str | None = ...,
         correlation_id: str | None = ...,
         temp_instructions: str | None = ...,
@@ -147,6 +156,7 @@ class Client(BaseClient):
         user_prompt: str,
         topic: str,
         *,
+        tool_overrides: list[BaseToolNodeSchema] | None = None,
         output_type: type[Any] = _UNSET,
         reply_topic: str | None = None,
         correlation_id: str | None = None,
@@ -168,6 +178,7 @@ class Client(BaseClient):
         Args:
             user_prompt: The user message to send to the agent node.
             topic: The Kafka topic the target node subscribes to.
+            tool_overrides: Runtime agent tool overrides.
             output_type: The expected Python type for deserializing the agent's
                 output. When omitted, auto-detection is used.
             reply_topic: Topic the node should publish its reply to.
@@ -175,7 +186,7 @@ class Client(BaseClient):
             correlation_id: Unique identifier to correlate this request with its
                 reply. Auto-generated (uuid7) when ``None``.
             temp_instructions: Optional system-level instructions injected into
-                the user prompt as a one-shot override.
+                the user prompt as a temporary prompt addition.
             message_history: Prior conversation messages to include for
                 multi-turn context. Defaults to an empty history.
             run_args: Positional arguments forwarded to the node's ``run()``
@@ -195,6 +206,7 @@ class Client(BaseClient):
         handle = await self.invoke_node(
             user_prompt,
             topic,
+            tool_overrides=tool_overrides,
             output_type=output_type,
             reply_topic=reply_topic,
             correlation_id=correlation_id,

--- a/calfkit/models/node_schema.py
+++ b/calfkit/models/node_schema.py
@@ -10,7 +10,7 @@ class BaseNodeSchema:
     subscribe_topics: list[str]
     publish_topic: str | None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if not isinstance(self.subscribe_topics, (list, tuple)):
             self.subscribe_topics = [self.subscribe_topics]
 

--- a/calfkit/models/node_schema.py
+++ b/calfkit/models/node_schema.py
@@ -1,0 +1,21 @@
+from dataclasses import KW_ONLY, dataclass
+
+from calfkit._vendor.pydantic_ai.tools import ToolDefinition
+
+
+@dataclass
+class BaseNodeSchema:
+    _: KW_ONLY
+    node_id: str
+    subscribe_topics: list[str]
+    publish_topic: str | None
+
+    def __post_init__(self):
+        if not isinstance(self.subscribe_topics, (list, tuple)):
+            self.subscribe_topics = [self.subscribe_topics]
+
+
+@dataclass
+class BaseToolNodeSchema(BaseNodeSchema):
+    _: KW_ONLY
+    tool_schema: ToolDefinition

--- a/calfkit/models/session_context.py
+++ b/calfkit/models/session_context.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from calfkit._types import DepsT, StackItemT, StateT
 from calfkit.models.actions import _Call
-from calfkit.models.state import State
+from calfkit.models.state import OverridesState, State
 
 
 @dataclass
@@ -36,6 +36,7 @@ class CallFrame:
     callback_topic: str  # return address
     input_args: Sequence[Any] | None = field(default=None)
     frame_id: str = field(default_factory=lambda: uuid_utils.uuid7().hex)
+    overrides: OverridesState | None = field(default=None)
 
 
 CallFrameStack = Stack[CallFrame]

--- a/calfkit/models/state.py
+++ b/calfkit/models/state.py
@@ -23,7 +23,7 @@ class OverridesState(BaseAgentActivityState):
     """State for storing any override objects"""
 
     model_config = ConfigDict(extra="ignore")
-    override_agent_tools: list[BaseToolNodeSchema] | None = None
+    override_agent_tools: list[BaseToolNodeSchema] | None
 
 
 class CoreMessageState(BaseAgentActivityState):

--- a/calfkit/models/state.py
+++ b/calfkit/models/state.py
@@ -11,11 +11,19 @@ from calfkit._vendor.pydantic_ai.messages import (
     ToolCallPart,
 )
 from calfkit._vendor.pydantic_ai.tools import DeferredToolCallResult as ToolCallResult
+from calfkit.models.node_schema import BaseToolNodeSchema
 from calfkit.models.payload import ContentPart
 
 
 class BaseAgentActivityState(BaseModel):
     model_config = ConfigDict(extra="ignore")
+
+
+class OverridesState(BaseAgentActivityState):
+    """State for storing any override objects"""
+
+    model_config = ConfigDict(extra="ignore")
+    override_agent_tools: list[BaseToolNodeSchema] | None = None
 
 
 class CoreMessageState(BaseAgentActivityState):
@@ -90,6 +98,7 @@ class State(CoreMessageState, InFlightToolsState):
         default=None,
         description="Additional data that can be accessed programmatically by the application but is not sent to the LLM.",  # noqa: E501
     )
+    overrides: OverridesState | None = None
 
 
 # class State(BaseModel):

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -15,7 +15,7 @@ from calfkit.models.node_schema import BaseToolNodeSchema
 from calfkit.models.session_context import SessionRunContext
 from calfkit.models.state import PendingToolBatch
 from calfkit.nodes.base import BaseNodeDef
-from calfkit.nodes.tool import BaseToolNodeDef, ToolNodeDef
+from calfkit.nodes.tool import ToolNodeDef
 from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
 
 logger = logging.getLogger(__name__)
@@ -44,6 +44,9 @@ class BaseAgentNodeDef(
         self.tools = tools or list()
         self.sequential_only_mode = sequential_only_mode
         self._pending_batches: dict[str, PendingToolBatch] = dict()
+
+        if not isinstance(subscribe_topics, (list, tuple)):
+            subscribe_topics = [subscribe_topics]
 
         super().__init__(node_id=node_id, subscribe_topics=subscribe_topics, publish_topic=publish_topic)
 

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -11,10 +11,11 @@ from calfkit._vendor.pydantic_ai.tools import DeferredToolResults
 from calfkit._vendor.pydantic_ai.toolsets.external import ExternalToolset
 from calfkit.models import Call, DataPart, NodeResult, ReturnCall, State, TailCall, TextPart
 from calfkit.models.actions import Silent
+from calfkit.models.node_schema import BaseToolNodeSchema
 from calfkit.models.session_context import SessionRunContext
 from calfkit.models.state import PendingToolBatch
 from calfkit.nodes.base import BaseNodeDef
-from calfkit.nodes.tool import ToolNodeDef
+from calfkit.nodes.tool import BaseToolNodeDef, ToolNodeDef
 from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
 
 logger = logging.getLogger(__name__)
@@ -64,7 +65,11 @@ class BaseAgentNodeDef(
                 del self._pending_batches[ctx.deps.correlation_id]
 
     async def run(self, ctx: SessionRunContext) -> NodeResult[State]:
-        tools_registry = {tool.tool_schema.name: tool for tool in self.tools} if self.tools else dict[str, ToolNodeDef]()
+        tools_registry = dict[str, BaseToolNodeSchema]()
+        if ctx.state.overrides is not None and ctx.state.overrides.override_agent_tools is not None:
+            tools_registry = {tool.tool_schema.name: tool for tool in ctx.state.overrides.override_agent_tools}
+        elif self.tools:
+            tools_registry = {tool.tool_schema.name: tool for tool in self.tools}
 
         logger.debug(
             "[%s] agent run entered node=%s pending_tool_calls=%d history_len=%d",

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -17,6 +17,7 @@ from calfkit.models import (
     TailCall,
 )
 from calfkit.models.envelope import Envelope
+from calfkit.models.node_schema import BaseNodeSchema
 from calfkit.models.session_context import SessionRunContext
 
 logger = logging.getLogger(__name__)
@@ -27,7 +28,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-class BaseNodeDef:
+class BaseNodeDef(BaseNodeSchema):
     _run_accepts_input: bool
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
@@ -36,21 +37,6 @@ class BaseNodeDef:
         # Unbound method signature includes self, so self + ctx = 2 params.
         # If > 2, the subclass declared an input parameter (any name).
         cls._run_accepts_input = len(sig.parameters) > 2
-
-    def __init__(
-        self,
-        node_id: str,
-        *,
-        subscribe_topics: str | list[str],
-        publish_topic: str | None,
-    ):
-        self._node_id = node_id
-        if isinstance(subscribe_topics, str):
-            self.subscribe_topics = [subscribe_topics]
-        elif subscribe_topics is not None:
-            self.subscribe_topics = list(subscribe_topics)
-        self.publish_topic = publish_topic
-        self._return_topic = f"{node_id}.private.return"
 
     # TODO: consider multiple abstract methods per node based on the incoming communication pattern,
     # like a delgation or emit. So the communication-specific handler can properly handle it
@@ -77,6 +63,8 @@ class BaseNodeDef:
 
     async def prepare_context(self, envelope: Envelope) -> SessionRunContext:
         ctx = envelope.context.model_copy(deep=True)
+        if envelope.internal_workflow_state.current_frame.overrides:
+            ctx.state.overrides = envelope.internal_workflow_state.current_frame.overrides
         return ctx
 
     async def _publish_action(self, output: NodeResult[State], envelope: Envelope, correlation_id: str, broker: BrokerAnnotation) -> Envelope:
@@ -107,7 +95,7 @@ class BaseNodeDef:
                 internal_workflow_state=envelope.internal_workflow_state,
             )
             target_topic = envelope.internal_workflow_state.current_frame.target_topic
-            logger.debug("[%s] Call target=%s frame_pushed node=%s", correlation_id[:8], target_topic, self._node_id)
+            logger.debug("[%s] Call target=%s frame_pushed node=%s", correlation_id[:8], target_topic, self.node_id)
             await broker.publish(
                 publish_envelope,
                 topic=target_topic,
@@ -121,7 +109,7 @@ class BaseNodeDef:
                 context=SessionRunContext(state=output.state, deps=envelope.context.deps),
                 internal_workflow_state=envelope.internal_workflow_state,
             )
-            logger.debug("[%s] ReturnCall callback=%s node=%s", correlation_id[:8], frame.callback_topic, self._node_id)
+            logger.debug("[%s] ReturnCall callback=%s node=%s", correlation_id[:8], frame.callback_topic, self.node_id)
             await broker.publish(
                 publish_envelope,
                 topic=frame.callback_topic,
@@ -138,7 +126,7 @@ class BaseNodeDef:
                 internal_workflow_state=envelope.internal_workflow_state,
             )
             target_topic = envelope.internal_workflow_state.current_frame.target_topic
-            logger.debug("[%s] TailCall target=%s node=%s", correlation_id[:8], target_topic, self._node_id)
+            logger.debug("[%s] TailCall target=%s node=%s", correlation_id[:8], target_topic, self.node_id)
             await broker.publish(
                 publish_envelope,
                 topic=target_topic,
@@ -164,21 +152,25 @@ class BaseNodeDef:
         correlation_id: Annotated[str, Context()],
         broker: BrokerAnnotation,
     ) -> Envelope:
-        logger.debug("[%s] handler entered node=%s", correlation_id[:8], self._node_id)
+        logger.debug("[%s] handler entered node=%s", correlation_id[:8], self.node_id)
         ctx = await self.prepare_context(envelope)
         if self._run_accepts_input and envelope.internal_workflow_state.current_frame.input_args is not None:
             output = await self.run(ctx, *envelope.internal_workflow_state.current_frame.input_args)
         else:
             output = await self.run(ctx)
 
-        logger.debug("[%s] run() returned action=%s node=%s", correlation_id[:8], type(output).__name__, self._node_id)
+        logger.debug("[%s] run() returned action=%s node=%s", correlation_id[:8], type(output).__name__, self.node_id)
 
         return await self._publish_action(output, envelope, correlation_id, broker)
 
     @property
     def id(self) -> str:
-        return self._node_id
+        return self.node_id
 
     @property
     def name(self) -> str:
-        return self._node_id
+        return self.node_id
+
+    @property
+    def _return_topic(self) -> str:
+        return f"{self.node_id}.private.return"

--- a/calfkit/nodes/tool.py
+++ b/calfkit/nodes/tool.py
@@ -3,6 +3,8 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
+from typing_extensions import Self
+
 from calfkit._vendor.pydantic_ai import Tool
 from calfkit._vendor.pydantic_ai.messages import ToolReturn
 from calfkit.models import SessionRunContext, Silent, State, ToolContext
@@ -20,7 +22,7 @@ class BaseToolNodeDef(BaseToolNodeSchema, BaseNodeDef):
 
 class ToolNodeDef(BaseToolNodeDef):
     @classmethod
-    def create_tool_node(cls, func: Callable[..., Any], subscribe_topics: str | list[str], publish_topic: str):
+    def create_tool_node(cls, func: Callable[..., Any], subscribe_topics: str | list[str], publish_topic: str) -> Self:
         if not isinstance(subscribe_topics, (list, tuple)):
             subscribe_topics = [subscribe_topics]
         tool = Tool(func)

--- a/calfkit/nodes/tool.py
+++ b/calfkit/nodes/tool.py
@@ -1,30 +1,35 @@
 import logging
-from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
-from typing import Any, cast
+from dataclasses import dataclass
+from typing import Any
 
-from calfkit._vendor.pydantic_ai import Tool, ToolDefinition
+from calfkit._vendor.pydantic_ai import Tool
 from calfkit._vendor.pydantic_ai.messages import ToolReturn
 from calfkit.models import SessionRunContext, Silent, State, ToolContext
 from calfkit.models.actions import NodeResult, ReturnCall
+from calfkit.models.node_schema import BaseToolNodeSchema
 from calfkit.nodes.base import BaseNodeDef
 
 logger = logging.getLogger(__name__)
 
 
-class BaseToolNodeDef(BaseNodeDef, ABC):
-    @property
-    @abstractmethod
-    def tool_schema(self) -> ToolDefinition: ...
+@dataclass
+class BaseToolNodeDef(BaseToolNodeSchema, BaseNodeDef):
+    _tool: Tool
 
 
 class ToolNodeDef(BaseToolNodeDef):
-    def __init__(self, func: Callable[..., Any], subscribe_topics: str | list[str], publish_topic: str):
-        self._tool = Tool(func)
-        super().__init__(
+    @classmethod
+    def create_tool_node(cls, func: Callable[..., Any], subscribe_topics: str | list[str], publish_topic: str):
+        if not isinstance(subscribe_topics, (list, tuple)):
+            subscribe_topics = [subscribe_topics]
+        tool = Tool(func)
+        return cls(
             node_id=f"tool_{func.__name__}",
+            tool_schema=tool.tool_def,
             subscribe_topics=subscribe_topics,
             publish_topic=publish_topic,
+            _tool=tool,
         )
 
     async def run(self, ctx: SessionRunContext, tool_call_id: str, source_node_name: str) -> NodeResult[State]:
@@ -78,15 +83,11 @@ class ToolNodeDef(BaseToolNodeDef):
         logger.debug("[%s] tool completed tool=%s", ctx.deps.correlation_id[:8], self.name)
         return ReturnCall[State](state=ctx.state)
 
-    @property
-    def tool_schema(self) -> ToolDefinition:
-        return cast(ToolDefinition, self._tool.tool_def)
-
 
 def agent_tool(func: Callable[..., Any] | Callable[..., Awaitable[Any]]) -> ToolNodeDef:
     """Decorator to turn a function into a deployable tool node that agents can call"""
     subscribe_topic = f"tool.{func.__name__}.input"
     publish_topic = f"tool.{func.__name__}.output"
-    tool_node = ToolNodeDef(func=func, subscribe_topics=subscribe_topic, publish_topic=publish_topic)
+    tool_node = ToolNodeDef.create_tool_node(func=func, subscribe_topics=subscribe_topic, publish_topic=publish_topic)
 
     return tool_node

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,23 @@
 import os
-from collections.abc import Callable
+import random
+from collections.abc import Callable, Sequence
 from typing import Any
 
 import pytest
+import uuid_utils
 from dishka import make_container
 from dotenv import load_dotenv
+from faker import Faker
 
 from calfkit._types import OutputT
+from calfkit._vendor.pydantic_ai.exceptions import ModelRetry
+from calfkit._vendor.pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, RetryPromptPart, TextPart, ToolCallPart, ToolReturn
 from calfkit._vendor.pydantic_ai.models.function import FunctionModel
+from calfkit._vendor.pydantic_ai.tools import DeferredToolCallResult as ToolCallResult
+from calfkit.models.envelope import Envelope
+from calfkit.models.node_schema import BaseToolNodeSchema
+from calfkit.models.session_context import CallFrame, CallFrameStack, Deps, SessionRunContext, WorkflowState
+from calfkit.models.state import OverridesState, State
 from calfkit.nodes import Agent, ToolNodeDef
 from calfkit.providers.pydantic_ai.openai import OpenAIModelClient, OpenAIResponsesModelClient
 from calfkit.worker import Worker
@@ -25,6 +35,8 @@ from tests.providers import (
 )
 
 load_dotenv()
+
+fake = Faker()
 
 
 @pytest.fixture
@@ -155,3 +167,199 @@ def deploy_instructions_agent(container) -> Agent:
     )
     worker.add_nodes(agent)
     return agent
+
+
+@pytest.fixture(params=["tool-override", "tool-override-none", "tool-override-empty", None])
+def make_overrides_state_factory(request, container) -> Callable[..., OverridesState | None]:
+    mode = request.param
+
+    if mode is None:
+        return lambda: None
+
+    elif mode == "tool-override":
+        tools = container.get(list[ToolNodeDef])
+        return lambda: OverridesState(
+            override_agent_tools=[
+                BaseToolNodeSchema(
+                    node_id=t.node_id,
+                    subscribe_topics=t.subscribe_topics,
+                    publish_topic=t.publish_topic,
+                    tool_schema=t.tool_schema,
+                )
+                for t in tools
+            ]
+        )
+
+    elif mode == "tool-override-none":
+        return lambda: OverridesState(override_agent_tools=None)
+
+    elif mode == "tool-override-empty":
+        return lambda: OverridesState(override_agent_tools=list())
+
+    raise ValueError(f"Unknown mode={mode}")
+
+
+@pytest.fixture(params=["input-args", None])
+def make_input_args_factory(request) -> Callable[..., Sequence[Any] | None]:
+    mode = request.param
+
+    if mode is None:
+        return lambda: None
+
+    elif mode == "input-args":
+        return lambda: fake.pylist(allowed_types=[str, int, float, bool])
+
+    raise ValueError(f"Unknown mode={mode}")
+
+
+@pytest.fixture(params=["empty-stack", "stack"])
+def make_internal_workflow_state(request, make_overrides_state_factory, make_input_args_factory) -> WorkflowState:
+    mode = request.param
+    stack = CallFrameStack()
+    if mode == "empty-stack":
+        pass
+    elif mode == "stack":
+        stack_size = fake.pyint(min_value=1, max_value=20)
+        for _ in range(stack_size):
+            stack.push(
+                CallFrame(
+                    target_topic=fake.pystr(min_chars=2),
+                    callback_topic=fake.pystr(min_chars=2),
+                    overrides=make_overrides_state_factory(),
+                    input_args=make_input_args_factory(),
+                )
+            )
+    return WorkflowState(call_stack=stack)
+
+
+@pytest.fixture(params=[dict, str, None])
+def make_tool_call_factory(request) -> Callable[..., ToolCallPart]:
+    mode = request.param
+
+    def make_tool_call() -> ToolCallPart:
+        args = None
+        if mode is dict:
+            args = fake.pydict(allowed_types=[str, int, float, bool])
+        elif mode is str:
+            args = fake.pystr(min_chars=1)
+
+        tool_call = ToolCallPart(tool_name=fake.pystr(min_chars=1), args=args)
+        return tool_call
+
+    return make_tool_call
+
+
+@pytest.fixture(params=[ToolReturn, ModelRetry, RetryPromptPart])
+def make_tool_result_factory(request) -> Callable[..., ToolCallResult]:
+    mode = request.param
+
+    def make_tool_result() -> ToolCallResult:
+        tool_result: ToolCallResult
+        if mode is ToolReturn:
+            tool_result = ToolReturn(return_value=fake.pyobject(random.choice([bool, str, float, int])))
+        elif mode is ModelRetry:
+            tool_result = ModelRetry(message=fake.sentence())
+        elif mode is RetryPromptPart:
+            tool_result = RetryPromptPart(tool_name=fake.pystr(min_chars=1), content=fake.sentence())
+        else:
+            raise ValueError(f"Unknown mode={mode}")
+        return tool_result
+
+    return make_tool_result
+
+
+@pytest.fixture(params=["tool-calls", "no-tool-calls"])
+def make_tool_calls(request, make_tool_call_factory) -> dict[str, ToolCallPart]:
+    mode = request.param
+
+    if mode == "tool-calls":
+        tool_calls_dict = dict()
+        tool_calls_size = fake.pyint(min_value=1, max_value=10)
+        for _ in range(tool_calls_size):
+            tool_call = make_tool_call_factory()
+            tool_calls_dict[tool_call.tool_call_id] = tool_call
+        return tool_calls_dict
+    elif mode == "no-tool-calls":
+        return dict()
+
+    raise ValueError(f"Unknown mode={mode}")
+
+
+@pytest.fixture(params=["tool-results", "no-tool-results"])
+def make_tool_results(request, make_tool_result_factory) -> dict[str, ToolCallResult]:
+    mode = request.param
+
+    if mode == "tool-results":
+        tool_results_dict = dict()
+        tool_results_size = fake.pyint(min_value=1, max_value=10)
+        for _ in range(tool_results_size):
+            tool_result = make_tool_result_factory()
+            tool_results_dict[uuid_utils.uuid4().hex] = tool_result
+        return tool_results_dict
+    elif mode == "no-tool-results":
+        return dict()
+
+    raise ValueError(f"Unknown mode={mode}")
+
+
+@pytest.fixture(params=[fake.text, None])
+def make_uncommitted_message(request) -> ModelMessage | None:
+    mode = request.param
+
+    if mode is None:
+        return None
+    elif mode is fake.text:
+        return ModelRequest.user_text_prompt(fake.text())
+
+
+@pytest.fixture
+def make_message_history(make_tool_calls) -> list[ModelMessage]:
+    message_history = list()
+    history_size = fake.pyint(min_value=1, max_value=20, step=2)
+    for i in range(history_size):
+        if i % 2 == 0:
+            message_history.append(ModelRequest.user_text_prompt(fake.text()))
+        else:
+            message_history.append(ModelResponse(parts=[TextPart(content=fake.text())]))
+
+    message_history.append(ModelResponse(parts=[part for part in make_tool_calls.values()]))
+    return message_history
+
+
+@pytest.fixture(params=[fake.text, None])
+def make_temp_instructions(request) -> str | None:
+    mode = request.param
+
+    if mode is None:
+        return None
+    elif mode is fake.text:
+        return fake.text()
+
+
+@pytest.fixture
+def make_envelope_state(
+    make_overrides_state_factory, make_tool_calls, make_tool_results, make_uncommitted_message, make_message_history, make_temp_instructions
+) -> State:
+    return State(
+        overrides=make_overrides_state_factory(),
+        tool_calls=make_tool_calls,
+        tool_results=make_tool_results,
+        uncommitted_message=make_uncommitted_message,
+        message_history=make_message_history,
+        temp_instructions=make_temp_instructions,
+    )
+
+
+@pytest.fixture
+def make_envelope_deps() -> Deps:
+    return Deps(correlation_id=uuid_utils.uuid4().hex, provided_deps=fake.pydict(allowed_types=[str, int, float, bool]))
+
+
+@pytest.fixture
+def make_run_context(make_envelope_state, make_envelope_deps) -> SessionRunContext:
+    return SessionRunContext(state=make_envelope_state, deps=make_envelope_deps)
+
+
+@pytest.fixture
+def make_envelope(make_run_context, make_internal_workflow_state) -> Envelope:
+    return Envelope(context=make_run_context, internal_workflow_state=make_internal_workflow_state)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ from tests.providers import (
     AgentProvider,
     ClientProvider,
     ContextualTool,
+    NoArgTool,
     Response,
     SimpleAgent,
     StructuredAgent,
@@ -133,6 +134,14 @@ def deploy_structured_agent_factory(agent_constructor_args_model_client, contain
 @pytest.fixture
 def deploy_multiple_agent_tools(container) -> list[ToolNodeDef]:
     tools = container.get(list[ToolNodeDef])
+    worker = container.get(Worker)
+    worker.add_nodes(*tools)
+    return tools
+
+
+@pytest.fixture
+def deploy_no_arg_tools(container) -> list[NoArgTool]:
+    tools = container.get(list[NoArgTool])
     worker = container.get(Worker)
     worker.add_nodes(*tools)
     return tools

--- a/tests/providers.py
+++ b/tests/providers.py
@@ -90,6 +90,8 @@ def get_random_city(ctx: ToolContext) -> str:
 
 INSTRUCTIONS_TEST_SYSTEM_PROMPT = "You are a test assistant."
 
+NO_TOOLS_RESPONSE_TEXT = "There are no tools."
+
 
 def echo_instructions(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
     """FunctionModel that returns the resolved instructions string as its text output."""
@@ -101,7 +103,10 @@ def call_all_tools_concurrently(messages: list[ModelMessage], info: AgentInfo) -
     assert isinstance(last_msg, ModelRequest)
 
     if all(isinstance(part, ToolReturnPart) for part in last_msg.parts):
-        return ModelResponse(parts=[TextPart(f"{part.content}\n\n") for part in last_msg.parts])
+        return ModelResponse(parts=[TextPart(f"{part.tool_name}: {part.content}\n\n") for part in last_msg.parts])  # pyright: ignore[reportAttributeAccessIssue]
+
+    if not info.function_tools:
+        return ModelResponse(parts=[TextPart(NO_TOOLS_RESPONSE_TEXT)])
 
     tool_calls = list[ToolCallPart]()
     for tool in info.function_tools:
@@ -110,6 +115,8 @@ def call_all_tools_concurrently(messages: list[ModelMessage], info: AgentInfo) -
 
 
 ContextualTool = NewType("ContextualTool", ToolNodeDef)
+
+NoArgTool = NewType("NoArgTool", ToolNodeDef)
 
 
 class AgentProvider(Provider):
@@ -122,6 +129,10 @@ class AgentProvider(Provider):
     @provide
     def get_multiple_tools(self) -> AnyOf[list[BaseToolNodeDef], list[ToolNodeDef]]:
         return [agent_tool(get_users_name), agent_tool(weather), agent_tool(get_users_birthday)]
+
+    @provide
+    def get_no_arg_tools(self) -> list[NoArgTool]:
+        return [NoArgTool(agent_tool(get_users_name)), NoArgTool(agent_tool(get_users_birthday))]
 
     @provide
     def get_multiple_contextual_tools(self) -> list[ContextualTool]:

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -1,0 +1,55 @@
+from faststream.kafka import KafkaBroker, TestKafkaBroker
+
+from calfkit.client import Client
+from tests.providers import NO_TOOLS_RESPONSE_TEXT, prepare_worker
+from tests.utils import find_last_tool_call_message
+
+
+async def test_agent_tools_overrides_none(container, deploy_function_agent, deploy_multiple_contextual_tools):
+    deploy_function_agent.add_tools(*deploy_multiple_contextual_tools)
+    prepare_worker(container)
+
+    client = container.get(Client)
+
+    async with TestKafkaBroker(container.get(KafkaBroker)) as _:
+        result = await client.execute_node(
+            "Hey! Call all your tools concurrently right now", deploy_function_agent.subscribe_topics[0], tool_overrides=None
+        )
+
+        assert result.output is not None
+        last_tool_msg = find_last_tool_call_message(result.message_history)
+        assert last_tool_msg
+        assert len(last_tool_msg.tool_calls) == len(deploy_multiple_contextual_tools)
+        assert set(call.tool_name for call in last_tool_msg.tool_calls) == set(tool.tool_schema.name for tool in deploy_multiple_contextual_tools)
+
+
+async def test_agent_tools_overrides_empty(container, deploy_function_agent, deploy_multiple_contextual_tools):
+    deploy_function_agent.add_tools(*deploy_multiple_contextual_tools)
+    prepare_worker(container)
+
+    client = container.get(Client)
+
+    async with TestKafkaBroker(container.get(KafkaBroker)) as _:
+        result = await client.execute_node(
+            "Hey! Call all your tools concurrently right now again.", deploy_function_agent.subscribe_topics[0], tool_overrides=[]
+        )
+
+        assert result.output is not None and result.output == NO_TOOLS_RESPONSE_TEXT
+
+
+async def test_agent_tools_overrides_new_tools(container, deploy_function_agent, deploy_multiple_contextual_tools, deploy_no_arg_tools):
+    deploy_function_agent.add_tools(*deploy_multiple_contextual_tools)
+    prepare_worker(container)
+
+    client = container.get(Client)
+
+    async with TestKafkaBroker(container.get(KafkaBroker)) as _:
+        result = await client.execute_node(
+            "Hey! Call all your tools concurrently right now", deploy_function_agent.subscribe_topics[0], tool_overrides=deploy_no_arg_tools
+        )
+
+        assert result.output is not None
+        last_tool_msg = find_last_tool_call_message(result.message_history)
+        assert last_tool_msg
+        assert len(last_tool_msg.tool_calls) == len(deploy_no_arg_tools)
+        assert set(call.tool_name for call in last_tool_msg.tool_calls) == set(tool.tool_schema.name for tool in deploy_no_arg_tools)

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -1,0 +1,31 @@
+"""Roundtrip serialization tests for all network-serialized models.
+
+These tests verify that every model used in the Kafka wire format survives
+``model_dump_json()`` → ``model_validate_json()`` (or the TypeAdapter equivalent
+for standalone dataclasses).  The existing test suite uses ``TestKafkaBroker``
+which passes objects in-memory, bypassing actual JSON serde — so these tests
+catch missing fields, broken discriminated unions, dataclass quirks, etc.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Roundtrip helpers
+# ---------------------------------------------------------------------------
+
+
+def assert_json_roundtrip(instance):
+    """Assert a Pydantic BaseModel survives JSON roundtrip."""
+    json_bytes = instance.model_dump_json()
+    cls = type(instance)
+    reconstructed = cls.model_validate_json(json_bytes)
+    assert reconstructed == instance, f"Roundtrip mismatch for {cls.__name__}"
+
+
+# ---------------------------------------------------------------------------
+# Factory functions
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_serialization_roundtrip(make_envelope):
+    assert_json_roundtrip(make_envelope)


### PR DESCRIPTION
Extract BaseNodeSchema and BaseToolNodeSchema as serializable dataclass DTOs in models/node_schema.py, enabling node metadata to be passed over the wire. BaseNodeDef now inherits from BaseNodeSchema, and BaseToolNodeDef becomes a combined dataclass inheriting both schemas.

Add runtime tool override support: clients can pass tool_overrides via invoke_node/execute_node, which are carried through CallFrame.overrides and applied in the agent's run() method.