### PR TITLE
feat: add gates to BaseNodeDef for pre-run event filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,48 @@ result = await client.execute_node(
 
 <br>
 
+### Gating Node Invocations (Optional)
+
+When multiple agents share an input topic (each with its own consumer group), every agent receives every message published to that topic. A **gate stack** lets a node decide whether to handle an inbound event *before* `run()` runs — avoiding wasted LLM tokens on messages addressed elsewhere.
+
+Gates are predicates: `Callable[[SessionRunContext], bool | Awaitable[bool]]`. They stack with **AND semantics** in registration order and short-circuit on the first `False`, exception, or non-bool return. When any gate rejects, `run()` is skipped and the envelope is returned unchanged — the Kafka offset still commits.
+
+**Constructor form** — good for shared, cross-cutting predicates passed in as values:
+
+```python
+def is_scheduler_target(ctx) -> bool:
+    discord = ctx.deps.provided_deps.get("discord", {})
+    return discord.get("slash_target") == "scheduler"
+
+scheduler = Agent(
+    "scheduler",
+    subscribe_topics="discord.thread.123",
+    model_client=OpenAIResponsesModelClient(model_name="gpt-5.4-nano"),
+    gates=[is_scheduler_target],
+)
+```
+
+**Decorator form** — good for node-specific gates defined inline:
+
+```python
+scheduler = Agent("scheduler", subscribe_topics="discord.thread.123", model_client=...)
+
+@scheduler.gate
+def is_scheduler_target(ctx) -> bool:
+    discord = ctx.deps.provided_deps.get("discord", {})
+    return discord.get("slash_target") == "scheduler"
+```
+
+Constructor and decorator forms can be combined; constructor gates run first.
+
+**Idempotency requirement**: Kafka may redeliver an event before its offset commits, so gates may run more than once for the same logical message. Keep gate functions deterministic and side-effect-free.
+
+**Failure behavior**: If a gate raises or returns a non-bool, the framework logs the failure and rejects the message (fail-safe). Place cheap fast-reject gates first to maximize short-circuit efficiency.
+
+For tool-node gating, pass `gates=[...]` to `ToolNodeDef.create_tool_node(...)` directly; the `@agent_tool` decorator doesn't expose `gates=` because tool topics are typically 1:1.
+
+<br>
+
 ## Documentation
 
 Full documentation is coming soon. In the meantime, this README serves as the primary reference for getting started with Calfkit.

--- a/calfkit/__init__.py
+++ b/calfkit/__init__.py
@@ -2,7 +2,7 @@ from importlib.metadata import version
 
 from calfkit.client import Client, InvocationHandle, NodeResult
 from calfkit.models import ToolContext
-from calfkit.nodes import Agent, BaseNodeDef, NodeDef, ToolNodeDef, agent_tool
+from calfkit.nodes import Agent, BaseNodeDef, GateFunction, NodeDef, ToolNodeDef, agent_tool
 from calfkit.providers import AnthropicModelClient, OpenAIModelClient, OpenAIResponsesModelClient
 from calfkit.worker import Worker
 
@@ -18,6 +18,7 @@ __all__ = [
     # nodes
     "Agent",
     "BaseNodeDef",
+    "GateFunction",
     "NodeDef",
     "ToolNodeDef",
     "agent_tool",

--- a/calfkit/nodes/__init__.py
+++ b/calfkit/nodes/__init__.py
@@ -1,5 +1,5 @@
 from calfkit.nodes.agent import Agent, BaseAgentNodeDef
-from calfkit.nodes.base import BaseNodeDef
+from calfkit.nodes.base import BaseNodeDef, GateFunction
 from calfkit.nodes.node import NodeDef
 from calfkit.nodes.tool import BaseToolNodeDef, ToolNodeDef, agent_tool
 
@@ -8,6 +8,7 @@ __all__ = [
     "BaseAgentNodeDef",
     "BaseNodeDef",
     "BaseToolNodeDef",
+    "GateFunction",
     "NodeDef",
     "ToolNodeDef",
     "agent_tool",

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -14,7 +14,7 @@ from calfkit.models.actions import Silent
 from calfkit.models.node_schema import BaseToolNodeSchema
 from calfkit.models.session_context import SessionRunContext
 from calfkit.models.state import PendingToolBatch
-from calfkit.nodes.base import BaseNodeDef
+from calfkit.nodes.base import BaseNodeDef, GateFunction
 from calfkit.nodes.tool import ToolNodeDef
 from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
 
@@ -34,6 +34,7 @@ class BaseAgentNodeDef(
         system_prompt: str = "You are a helpful AI assistant.",
         subscribe_topics: str | list[str],
         publish_topic: str | None = None,
+        gates: list[GateFunction] | None = None,
         tools: list[ToolNodeDef] | None = None,
         model_client: PydanticModelClient,
         final_output_type: OutputSpec[AgentOutputT] = str,  # type: ignore[assignment]
@@ -48,7 +49,7 @@ class BaseAgentNodeDef(
         if not isinstance(subscribe_topics, (list, tuple)):
             subscribe_topics = [subscribe_topics]
 
-        super().__init__(node_id=node_id, subscribe_topics=subscribe_topics, publish_topic=publish_topic)
+        super().__init__(node_id=node_id, subscribe_topics=subscribe_topics, publish_topic=publish_topic, gates=gates)
 
         self._agent_loop: InternalAgentLoop[dict[str, Any], AgentOutputT | DeferredToolRequests] = InternalAgentLoop(
             model_client, name=self.name, output_type=[final_output_type, DeferredToolRequests], deps_type=dict, instructions=system_prompt

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -24,7 +24,7 @@ from calfkit.models.session_context import SessionRunContext
 logger = logging.getLogger(__name__)
 
 
-GateFunction = Callable[[SessionRunContext], "bool | Awaitable[bool]"]
+GateFunction = Callable[[SessionRunContext], bool | Awaitable[bool]]
 """A predicate evaluated in ``handler()`` before ``run()``. Sync or async; must return ``bool``.
 
 Returning ``False`` (or raising, or returning a non-bool) skips ``run()`` and returns the

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -1,6 +1,7 @@
 import inspect
 import logging
 from abc import abstractmethod
+from collections.abc import Awaitable, Callable
 from typing import Annotated, Any
 
 from faststream import Context
@@ -23,6 +24,15 @@ from calfkit.models.session_context import SessionRunContext
 logger = logging.getLogger(__name__)
 
 
+GateFunction = Callable[[SessionRunContext], "bool | Awaitable[bool]"]
+"""A predicate evaluated in ``handler()`` before ``run()``. Sync or async; must return ``bool``.
+
+Returning ``False`` (or raising, or returning a non-bool) skips ``run()`` and returns the
+envelope unchanged. Gates stack with AND semantics in registration order and short-circuit
+on the first rejection.
+"""
+
+
 # ---------------------------------------------------------------------------
 # Base node definition
 # ---------------------------------------------------------------------------
@@ -37,6 +47,73 @@ class BaseNodeDef(BaseNodeSchema):
         # Unbound method signature includes self, so self + ctx = 2 params.
         # If > 2, the subclass declared an input parameter (any name).
         cls._run_accepts_input = len(sig.parameters) > 2
+
+    def __init__(
+        self,
+        *,
+        node_id: str,
+        subscribe_topics: list[str],
+        publish_topic: str | None = None,
+        gates: list[GateFunction] | None = None,
+    ) -> None:
+        """Initialize a node definition.
+
+        Args:
+            node_id: Unique identifier for the node.
+            subscribe_topics: One or more topics the node consumes from.
+            publish_topic: Optional default topic to publish results to.
+            gates: Optional list of predicates evaluated in ``handler()`` before
+                ``run()``. Stack with AND semantics in registration order;
+                short-circuits on the first ``False``, exception, or non-bool.
+                Returning anything other than ``True`` rejects the message:
+                ``run()`` is skipped and the envelope is returned unchanged.
+        """
+        super().__init__(
+            node_id=node_id,
+            subscribe_topics=subscribe_topics,
+            publish_topic=publish_topic,
+        )
+        self.gates: list[GateFunction] = list(gates) if gates else []
+
+    def gate(self, fn: GateFunction) -> GateFunction:
+        """Register a gate predicate. Usable as a decorator. Repeatable.
+
+        Multiple gates evaluate in registration order with AND semantics
+        (short-circuit on the first ``False``, exception, or non-bool return).
+        Returns ``fn`` unchanged so it remains callable.
+        """
+        self.gates.append(fn)
+        return fn
+
+    async def _evaluate_gates(self, ctx: SessionRunContext, correlation_id: str) -> bool:
+        for i, gate in enumerate(self.gates):
+            try:
+                result = gate(ctx)
+                if inspect.isawaitable(result):
+                    result = await result
+                if not isinstance(result, bool):
+                    raise TypeError(
+                        f"gate[{i}] {getattr(gate, '__name__', repr(gate))} for node={self.node_id} returned {type(result).__name__}; expected bool"
+                    )
+                if not result:
+                    logger.debug(
+                        "[%s] gate[%d]=%s rejected node=%s",
+                        correlation_id[:8],
+                        i,
+                        getattr(gate, "__name__", "?"),
+                        self.node_id,
+                    )
+                    return False
+            except Exception:
+                logger.exception(
+                    "[%s] gate[%d]=%s raised for node=%s; treating as reject",
+                    correlation_id[:8],
+                    i,
+                    getattr(gate, "__name__", "?"),
+                    self.node_id,
+                )
+                return False
+        return True
 
     # TODO: consider multiple abstract methods per node based on the incoming communication pattern,
     # like a delgation or emit. So the communication-specific handler can properly handle it
@@ -154,6 +231,10 @@ class BaseNodeDef(BaseNodeSchema):
     ) -> Envelope:
         logger.debug("[%s] handler entered node=%s", correlation_id[:8], self.node_id)
         ctx = await self.prepare_context(envelope)
+
+        if not await self._evaluate_gates(ctx, correlation_id):
+            return envelope
+
         if self._run_accepts_input and envelope.internal_workflow_state.current_frame.input_args is not None:
             output = await self.run(ctx, *envelope.internal_workflow_state.current_frame.input_args)
         else:

--- a/calfkit/nodes/tool.py
+++ b/calfkit/nodes/tool.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from typing_extensions import Self
@@ -10,7 +10,7 @@ from calfkit._vendor.pydantic_ai.messages import ToolReturn
 from calfkit.models import SessionRunContext, Silent, State, ToolContext
 from calfkit.models.actions import NodeResult, ReturnCall
 from calfkit.models.node_schema import BaseToolNodeSchema
-from calfkit.nodes.base import BaseNodeDef
+from calfkit.nodes.base import BaseNodeDef, GateFunction
 
 logger = logging.getLogger(__name__)
 
@@ -18,11 +18,18 @@ logger = logging.getLogger(__name__)
 @dataclass
 class BaseToolNodeDef(BaseToolNodeSchema, BaseNodeDef):
     _tool: Tool
+    gates: list[GateFunction] = field(default_factory=list)
 
 
 class ToolNodeDef(BaseToolNodeDef):
     @classmethod
-    def create_tool_node(cls, func: Callable[..., Any], subscribe_topics: str | list[str], publish_topic: str) -> Self:
+    def create_tool_node(
+        cls,
+        func: Callable[..., Any],
+        subscribe_topics: str | list[str],
+        publish_topic: str,
+        gates: list[GateFunction] | None = None,
+    ) -> Self:
         if not isinstance(subscribe_topics, (list, tuple)):
             subscribe_topics = [subscribe_topics]
         tool = Tool(func)
@@ -32,6 +39,7 @@ class ToolNodeDef(BaseToolNodeDef):
             subscribe_topics=subscribe_topics,
             publish_topic=publish_topic,
             _tool=tool,
+            gates=list(gates) if gates else [],
         )
 
     async def run(self, ctx: SessionRunContext, tool_call_id: str, source_node_name: str) -> NodeResult[State]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,26 @@ def deploy_function_agent(agent_constructor_args_sequential_modes, container) ->
 
 
 @pytest.fixture
+def deploy_gated_function_agent(container) -> Callable[..., Agent]:
+    worker = container.get(Worker)
+    model = container.get(FunctionModel)
+
+    def _factory(*, gates: list | None = None) -> Agent:
+        agent = Agent(
+            "test_gated_agent",
+            system_prompt="You are a helpful AI assistant.",
+            subscribe_topics="test_gated_agent.input",
+            publish_topic="test_gated_agent.output",
+            model_client=model,
+            gates=gates,
+        )
+        worker.add_nodes(agent)
+        return agent
+
+    return _factory
+
+
+@pytest.fixture
 def deploy_structured_agent(agent_constructor_args_model_client, container) -> StructuredAgent:
     worker = container.get(Worker)
     agent = StructuredAgent(

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -1,0 +1,391 @@
+"""End-to-end tests for gate stack on BaseNodeDef.
+
+Tests follow the project pattern: TestKafkaBroker for in-memory broker,
+FunctionModel for offline agent runs, client.execute_node / invoke_node for
+real message dispatch. No broker mocking.
+"""
+
+import asyncio
+import logging
+
+import pytest
+from faststream.kafka import KafkaBroker, TestKafkaBroker
+
+from calfkit.client import Client
+from calfkit.models import SessionRunContext
+from calfkit.nodes import ToolNodeDef
+from calfkit.worker import Worker
+from tests.providers import NO_TOOLS_RESPONSE_TEXT, prepare_worker
+
+GATED_AGENT_TOPIC = "test_gated_agent.input"
+
+
+# ---------------------------------------------------------------------------
+# Acceptance cases (run() executes, agent replies)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("gates_arg", [None, []], ids=["no-gates", "empty-list"])
+async def test_no_gates_passes_through(container, deploy_gated_function_agent, gates_arg):
+    deploy_gated_function_agent(gates=gates_arg)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        result = await client.execute_node("hi", GATED_AGENT_TOPIC, timeout=5)
+
+        assert result.output == NO_TOOLS_RESPONSE_TEXT
+
+
+async def test_single_sync_gate_true_allows_run(container, deploy_gated_function_agent):
+    calls: list[str] = []
+
+    def g1(ctx: SessionRunContext) -> bool:
+        calls.append("g1")
+        return True
+
+    deploy_gated_function_agent(gates=[g1])
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        result = await client.execute_node("hi", GATED_AGENT_TOPIC, timeout=5)
+
+        assert result.output == NO_TOOLS_RESPONSE_TEXT
+        assert calls == ["g1"]
+
+
+async def test_single_async_gate_true_allows_run(container, deploy_gated_function_agent):
+    calls: list[str] = []
+
+    async def g1(ctx: SessionRunContext) -> bool:
+        calls.append("g1")
+        return True
+
+    deploy_gated_function_agent(gates=[g1])
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        result = await client.execute_node("hi", GATED_AGENT_TOPIC, timeout=5)
+
+        assert result.output == NO_TOOLS_RESPONSE_TEXT
+        assert calls == ["g1"]
+
+
+async def test_multiple_gates_all_true_run_in_order(container, deploy_gated_function_agent):
+    calls: list[str] = []
+
+    def g1(ctx: SessionRunContext) -> bool:
+        calls.append("g1")
+        return True
+
+    def g2(ctx: SessionRunContext) -> bool:
+        calls.append("g2")
+        return True
+
+    def g3(ctx: SessionRunContext) -> bool:
+        calls.append("g3")
+        return True
+
+    deploy_gated_function_agent(gates=[g1, g2, g3])
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        result = await client.execute_node("hi", GATED_AGENT_TOPIC, timeout=5)
+
+        assert result.output == NO_TOOLS_RESPONSE_TEXT
+        assert calls == ["g1", "g2", "g3"]
+
+
+async def test_mixed_sync_and_async_gates(container, deploy_gated_function_agent):
+    calls: list[str] = []
+
+    def sync_gate(ctx: SessionRunContext) -> bool:
+        calls.append("sync")
+        return True
+
+    async def async_gate(ctx: SessionRunContext) -> bool:
+        calls.append("async")
+        return True
+
+    deploy_gated_function_agent(gates=[sync_gate, async_gate])
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        result = await client.execute_node("hi", GATED_AGENT_TOPIC, timeout=5)
+
+        assert result.output == NO_TOOLS_RESPONSE_TEXT
+        assert calls == ["sync", "async"]
+
+
+async def test_decorator_form_registers_gate(container, deploy_gated_function_agent):
+    calls: list[str] = []
+
+    agent = deploy_gated_function_agent(gates=None)
+
+    @agent.gate
+    def added_via_decorator(ctx: SessionRunContext) -> bool:
+        calls.append("decorated")
+        return True
+
+    assert agent.gates == [added_via_decorator]
+
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        result = await client.execute_node("hi", GATED_AGENT_TOPIC, timeout=5)
+
+        assert result.output == NO_TOOLS_RESPONSE_TEXT
+        assert calls == ["decorated"]
+
+
+async def test_constructor_then_decorator_order(container, deploy_gated_function_agent):
+    calls: list[str] = []
+
+    def from_ctor(ctx: SessionRunContext) -> bool:
+        calls.append("ctor")
+        return True
+
+    agent = deploy_gated_function_agent(gates=[from_ctor])
+
+    @agent.gate
+    def from_decorator(ctx: SessionRunContext) -> bool:
+        calls.append("decorator")
+        return True
+
+    assert agent.gates == [from_ctor, from_decorator]
+
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        result = await client.execute_node("hi", GATED_AGENT_TOPIC, timeout=5)
+
+        assert result.output == NO_TOOLS_RESPONSE_TEXT
+        assert calls == ["ctor", "decorator"]
+
+
+async def test_gate_sees_overrides_applied_by_prepare_context(
+    container,
+    deploy_gated_function_agent,
+    deploy_multiple_contextual_tools,
+):
+    """Gates must see post-prepare_context state — including overrides from current_frame."""
+
+    seen_overrides: list[object] = []
+
+    def capturing_gate(ctx: SessionRunContext) -> bool:
+        seen_overrides.append(ctx.state.overrides)
+        return True
+
+    deploy_gated_function_agent(gates=[capturing_gate])
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        await client.execute_node(
+            "hi",
+            GATED_AGENT_TOPIC,
+            tool_overrides=[],
+            timeout=5,
+        )
+
+    assert seen_overrides
+    assert seen_overrides[0] is not None
+    assert seen_overrides[0].override_agent_tools == []
+
+
+# ---------------------------------------------------------------------------
+# Rejection cases (run() skipped, no reply, client times out)
+# ---------------------------------------------------------------------------
+
+
+async def test_single_sync_gate_false_blocks_run(container, deploy_gated_function_agent):
+    calls: list[str] = []
+
+    def g1(ctx: SessionRunContext) -> bool:
+        calls.append("g1")
+        return False
+
+    deploy_gated_function_agent(gates=[g1])
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        handle = await client.invoke_node("hi", GATED_AGENT_TOPIC)
+        with pytest.raises(asyncio.TimeoutError):
+            await handle.result(timeout=2)
+
+    assert calls == ["g1"]
+
+
+async def test_single_async_gate_false_blocks_run(container, deploy_gated_function_agent):
+    calls: list[str] = []
+
+    async def g1(ctx: SessionRunContext) -> bool:
+        calls.append("g1")
+        return False
+
+    deploy_gated_function_agent(gates=[g1])
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        handle = await client.invoke_node("hi", GATED_AGENT_TOPIC)
+        with pytest.raises(asyncio.TimeoutError):
+            await handle.result(timeout=2)
+
+    assert calls == ["g1"]
+
+
+async def test_short_circuit_stops_after_first_false(container, deploy_gated_function_agent):
+    calls: list[str] = []
+
+    def g1(ctx: SessionRunContext) -> bool:
+        calls.append("g1")
+        return True
+
+    def g2(ctx: SessionRunContext) -> bool:
+        calls.append("g2")
+        return False
+
+    def g3(ctx: SessionRunContext) -> bool:
+        calls.append("g3")
+        return True
+
+    deploy_gated_function_agent(gates=[g1, g2, g3])
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        handle = await client.invoke_node("hi", GATED_AGENT_TOPIC)
+        with pytest.raises(asyncio.TimeoutError):
+            await handle.result(timeout=2)
+
+    assert calls == ["g1", "g2"]
+
+
+async def test_gate_raises_treated_as_reject_and_logged(
+    container,
+    deploy_gated_function_agent,
+    caplog,
+):
+    calls: list[str] = []
+
+    def boom(ctx: SessionRunContext) -> bool:
+        calls.append("boom")
+        raise RuntimeError("intentional")
+
+    def never_called(ctx: SessionRunContext) -> bool:
+        calls.append("never")
+        return True
+
+    deploy_gated_function_agent(gates=[boom, never_called])
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    with caplog.at_level(logging.ERROR, logger="calfkit.nodes.base"):
+        async with TestKafkaBroker(broker):
+            handle = await client.invoke_node("hi", GATED_AGENT_TOPIC)
+            with pytest.raises(asyncio.TimeoutError):
+                await handle.result(timeout=2)
+
+    assert calls == ["boom"]
+    assert any("gate[0]=boom raised" in rec.getMessage() for rec in caplog.records)
+
+
+@pytest.mark.parametrize("non_bool_value", [1, "yes", None], ids=["int", "str", "none"])
+async def test_non_bool_return_rejects_and_logs(
+    container,
+    deploy_gated_function_agent,
+    caplog,
+    non_bool_value,
+):
+    def bad_return(ctx: SessionRunContext):
+        return non_bool_value
+
+    deploy_gated_function_agent(gates=[bad_return])
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    with caplog.at_level(logging.ERROR, logger="calfkit.nodes.base"):
+        async with TestKafkaBroker(broker):
+            handle = await client.invoke_node("hi", GATED_AGENT_TOPIC)
+            with pytest.raises(asyncio.TimeoutError):
+                await handle.result(timeout=2)
+
+    assert any(
+        rec.exc_info is not None and isinstance(rec.exc_info[1], TypeError) and "expected bool" in str(rec.exc_info[1]) for rec in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool-node gating
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_node_gating_blocks_tool_function(container, deploy_function_agent):
+    """A gate on a ToolNodeDef rejects before the tool function is invoked."""
+
+    tool_invocations: list[str] = []
+    gate_invocations: list[str] = []
+
+    def my_tool() -> str:
+        """Use this tool."""
+        tool_invocations.append("ran")
+        return "tool ran"
+
+    def reject_tool(ctx: SessionRunContext) -> bool:
+        gate_invocations.append("gate")
+        return False
+
+    gated_tool = ToolNodeDef.create_tool_node(
+        func=my_tool,
+        subscribe_topics="tool.my_tool.input",
+        publish_topic="tool.my_tool.output",
+        gates=[reject_tool],
+    )
+    deploy_function_agent.add_tools(gated_tool)
+    container.get(Worker).add_nodes(gated_tool)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        handle = await client.invoke_node("hi", deploy_function_agent.subscribe_topics[0])
+        with pytest.raises(asyncio.TimeoutError):
+            await handle.result(timeout=2)
+
+    assert gate_invocations == ["gate"]
+    assert tool_invocations == []


### PR DESCRIPTION
Gates are predicates evaluated in handler() between prepare_context and run(). When any gate rejects, run() is skipped and the envelope is returned unchanged — avoiding wasted LLM tokens on messages addressed elsewhere on a shared topic. Stack semantics are additive (constructor list + @node.gate decorator), AND with short-circuit on the first False, exception, or non-bool return.

Gates live on BaseNodeDef / BaseToolNodeDef (the runtime Def classes), not on the Schema classes serialized over Kafka, so wire-format roundtrip is preserved.