### PR TITLE
feat!: track per-hop event emitter via Kafka headers

### DIFF
--- a/calfkit/_protocol.py
+++ b/calfkit/_protocol.py
@@ -1,0 +1,39 @@
+"""Wire-protocol constants shared across the SDK.
+
+Lives at the package root with no internal imports so any layer — client,
+worker, nodes — can depend on it without creating circular import chains.
+
+Do not add imports from ``calfkit.*`` to this module.
+"""
+
+from typing import Any, Literal
+
+NodeKind = Literal["node", "agent", "tool", "client"]
+"""Closed value space for the ``x-calf-emitter-kind`` Kafka header. Subclasses of
+``BaseNodeDef`` declare their kind via ``_node_kind: ClassVar[NodeKind]``; the
+client publishes with ``CLIENT_KIND`` directly.
+"""
+
+CLIENT_KIND: NodeKind = "client"
+"""``NodeKind`` value the client stamps on every outbound publish (it isn't a
+node subclass, so it has no ``_node_kind`` ClassVar)."""
+
+HDR_EMITTER = "x-calf-emitter"
+"""Kafka header carrying the emitting node's id on every calfkit-published message."""
+
+HDR_EMITTER_KIND = "x-calf-emitter-kind"
+"""Kafka header carrying the emitting node's :data:`NodeKind`."""
+
+
+def decode_header_str(value: Any) -> str | None:
+    """Coerce an inbound Kafka header value to ``str | None``.
+
+    Handles bytes (utf-8 with replacement on invalid sequences), str (passthrough),
+    and any other type (coerced to ``None``). Does not log — callers warn when the
+    missing/bad value matters in their context.
+    """
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if isinstance(value, str):
+        return value
+    return None

--- a/calfkit/client/base.py
+++ b/calfkit/client/base.py
@@ -7,6 +7,7 @@ import uuid_utils
 from faststream.kafka import KafkaBroker
 from typing_extensions import Self
 
+from calfkit._protocol import CLIENT_KIND, HDR_EMITTER, HDR_EMITTER_KIND
 from calfkit.client.deserialize import _UNSET
 from calfkit.client.invocation_handle import InvocationHandle
 from calfkit.client.middleware import ContextInjectionMiddleware
@@ -25,6 +26,14 @@ from calfkit.models.state import OverridesState
 logger = logging.getLogger(__name__)
 
 
+def _new_client_emitter_id(client_id: str | None = None) -> str:
+    """Return a stable ``client.<uuid7-hex>`` emitter id used as the ``x-calf-emitter``
+    header on every client publish. Pass *client_id* to reuse an existing hex id
+    (e.g. the one used for the reply topic) instead of minting a fresh one.
+    """
+    return f"client.{client_id if client_id is not None else uuid_utils.uuid7().hex}"
+
+
 class BaseClient:
     """Base client for communicating with Calf agent nodes over Kafka.
 
@@ -38,7 +47,7 @@ class BaseClient:
             result = await client.execute_node(...)
     """
 
-    def __init__(self, connection: KafkaBroker, reply_topic: str, dispatcher: _ReplyDispatcher) -> None:
+    def __init__(self, connection: KafkaBroker, reply_topic: str, dispatcher: _ReplyDispatcher, emitter_id: str | None = None) -> None:
         """Initialize the client with pre-configured components.
 
         Prefer :meth:`connect` for constructing a fully wired client instance.
@@ -48,10 +57,16 @@ class BaseClient:
             reply_topic: The Kafka topic this client listens on for replies.
             dispatcher: The reply dispatcher that routes incoming envelopes
                 to their corresponding futures by ``correlation_id``.
+            emitter_id: Stable identifier stamped onto every outbound message as
+                the ``x-calf-emitter`` Kafka header. When ``None``, a random
+                uuid7-based id is generated.
         """
+        if emitter_id is not None and not emitter_id.strip():
+            raise ValueError("emitter_id must be a non-empty string or None")
         self._connection = connection
         self._reply_topic = reply_topic
         self._dispatcher = dispatcher
+        self._emitter_id = emitter_id if emitter_id is not None else _new_client_emitter_id()
 
     @classmethod
     def connect(
@@ -94,7 +109,7 @@ class BaseClient:
         dispatcher = _ReplyDispatcher()
         dispatcher.register(broker_connection, reply_topic, group_id)
 
-        return cls(broker_connection, reply_topic, dispatcher)
+        return cls(broker_connection, reply_topic, dispatcher, emitter_id=_new_client_emitter_id(client_id))
 
     @property
     def broker(self) -> KafkaBroker:
@@ -138,13 +153,25 @@ class BaseClient:
             await self._connection.start()
 
         call_stack = CallFrameStack()
-        call_stack.push(CallFrame(target_topic=topic, callback_topic=reply_topic, input_args=run_args, overrides=overrides))
+        call_stack.push(
+            CallFrame(
+                target_topic=topic,
+                callback_topic=reply_topic,
+                input_args=run_args,
+                overrides=overrides,
+            )
+        )
 
         envelope = Envelope(
             internal_workflow_state=WorkflowState(call_stack=call_stack),
             context=SessionRunContext(state=state, deps=Deps(correlation_id=correlation_id, provided_deps=deps or dict())),
         )
-        await self._connection.publish(envelope, topic=topic, correlation_id=correlation_id)
+        await self._connection.publish(
+            envelope,
+            topic=topic,
+            correlation_id=correlation_id,
+            headers={HDR_EMITTER: self._emitter_id, HDR_EMITTER_KIND: CLIENT_KIND},
+        )
 
         return InvocationHandle(
             correlation_id=correlation_id,

--- a/calfkit/client/deserialize.py
+++ b/calfkit/client/deserialize.py
@@ -49,6 +49,8 @@ def deserialize_to_node_result(
         message_history=message_history,
         metadata=metadata,
         correlation_id=correlation_id,
+        emitter_node_id=envelope.context.emitter_node_id,
+        emitter_node_kind=envelope.context.emitter_node_kind,
     )
 
 

--- a/calfkit/client/node_result.py
+++ b/calfkit/client/node_result.py
@@ -30,3 +30,11 @@ class NodeResult(Generic[OutputT]):
 
     correlation_id: str
     """The correlation ID that ties this result to its invocation."""
+
+    emitter_node_id: str | None = None
+    """Node id of the node that emitted this reply (sourced from the
+    ``x-calf-emitter`` Kafka header on the inbound callback message)."""
+
+    emitter_node_kind: str | None = None
+    """Coarse classification of the emitter (one of ``NodeKind``), sourced
+    from the ``x-calf-emitter-kind`` Kafka header."""

--- a/calfkit/client/reply_dispatcher.py
+++ b/calfkit/client/reply_dispatcher.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Annotated
+from typing import Annotated, Any
 
 from faststream import Context
 from faststream.kafka import KafkaBroker
 
+from calfkit._protocol import HDR_EMITTER, HDR_EMITTER_KIND, decode_header_str
 from calfkit.models.envelope import Envelope
 
 logger = logging.getLogger(__name__)
@@ -25,7 +26,13 @@ class _ReplyDispatcher:
         async def _handle_reply(
             envelope: Envelope,
             correlation_id: Annotated[str, Context()],
+            headers: Annotated[dict[str, Any], Context("message.headers")],
         ) -> None:
+            # Stash the inbound emitter so deserialize_to_node_result can surface it
+            # via NodeResult.emitter_node_id / emitter_node_kind.
+            envelope.context._emitter_node_id = decode_header_str(headers.get(HDR_EMITTER))
+            envelope.context._emitter_node_kind = decode_header_str(headers.get(HDR_EMITTER_KIND))
+
             future = self._pending.pop(correlation_id, None)
             if future is None:
                 logger.warning("[%s] reply received but no pending future", correlation_id[:8])

--- a/calfkit/models/session_context.py
+++ b/calfkit/models/session_context.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 from typing import Any, Generic
 
 import uuid_utils
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
 from calfkit._types import DepsT, StackItemT, StateT
 from calfkit.models.actions import _Call
@@ -79,13 +79,36 @@ class Deps(BaseModel):
 
 
 class BaseSessionRunContext(BaseModel, Generic[StateT, DepsT]):
-    """Base generic context for a session — just state + deps."""
+    """Base generic context for a session — state, deps, and per-hop emitter."""
 
     state: StateT
     """The app state. Mutable."""
 
     deps: DepsT
     """Dependencies for the execution. Immutable."""
+
+    _emitter_node_id: str | None = PrivateAttr(default=None)
+    _emitter_node_kind: str | None = PrivateAttr(default=None)
+
+    @property
+    def emitter_node_id(self) -> str | None:
+        """Node id of the most-recent publisher of this event (the immediate hop sender).
+
+        Set by ``BaseNodeDef.prepare_context`` (server side) or the client's reply
+        dispatcher (client side) from the inbound ``x-calf-emitter`` Kafka header.
+        Backed by a ``PrivateAttr`` so it never rides on the wire and cannot be
+        spoofed via the model constructor.
+        """
+        return self._emitter_node_id
+
+    @property
+    def emitter_node_kind(self) -> str | None:
+        """Coarse classification of the emitter (one of ``NodeKind``).
+
+        Companion to :attr:`emitter_node_id`, sourced from the inbound
+        ``x-calf-emitter-kind`` Kafka header.
+        """
+        return self._emitter_node_kind
 
 
 SessionRunContext = BaseSessionRunContext[State, Deps]

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -1,7 +1,8 @@
 import logging
 from collections.abc import Callable
-from typing import Any, Generic
+from typing import Any, ClassVar, Generic
 
+from calfkit._protocol import NodeKind
 from calfkit._types import AgentOutputT
 from calfkit._vendor.pydantic_ai import Agent as InternalAgentLoop
 from calfkit._vendor.pydantic_ai import DeferredToolRequests
@@ -27,6 +28,8 @@ class BaseAgentNodeDef(
     Generic[AgentOutputT],
     BaseNodeDef,
 ):
+    _node_kind: ClassVar[NodeKind] = "agent"
+
     def __init__(
         self,
         node_id: str,
@@ -107,7 +110,6 @@ class BaseAgentNodeDef(
                         tools_registry[target_tool_call.tool_name].subscribe_topics[0],
                         ctx.state,
                         target_tool_call.tool_call_id,
-                        self.name,
                     )
                 else:
                     remaining = [tc for tc in latest_tool_calls if tc.tool_call_id not in ctx.state.tool_results]
@@ -190,7 +192,6 @@ class BaseAgentNodeDef(
                     tools_registry[target_tool_call.tool_name].subscribe_topics[0],
                     ctx.state,
                     target_tool_call.tool_call_id,
-                    self.name,
                 )
             else:
                 launch_tool_call_ids = [tc.tool_call_id for tc in pending_tool_calls]
@@ -199,7 +200,6 @@ class BaseAgentNodeDef(
                         tools_registry[tc.tool_name].subscribe_topics[0],
                         ctx.state.model_copy(deep=True),
                         tc.tool_call_id,
-                        self.name,
                     )
                     for tc in pending_tool_calls
                 ]

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -2,13 +2,14 @@ import inspect
 import logging
 from abc import abstractmethod
 from collections.abc import Awaitable, Callable
-from typing import Annotated, Any
+from typing import Annotated, Any, ClassVar
 
-from faststream import Context
+from faststream import Context, Response
 from faststream.kafka.annotations import (
     KafkaBroker as BrokerAnnotation,
 )
 
+from calfkit._protocol import HDR_EMITTER, HDR_EMITTER_KIND, NodeKind, decode_header_str
 from calfkit.models import (
     Call,
     NodeResult,
@@ -40,6 +41,12 @@ on the first rejection.
 
 class BaseNodeDef(BaseNodeSchema):
     _run_accepts_input: bool
+    _node_kind: ClassVar[NodeKind] = "node"
+    """Coarse classification of this node, stamped onto every outbound publish as the
+    ``x-calf-emitter-kind`` Kafka header. Subclasses override to one of the values in
+    :data:`~calfkit._protocol.NodeKind`. The ``"client"`` kind is reserved for the
+    :class:`~calfkit.client.base.BaseClient` and is not a valid subclass override.
+    """
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -138,11 +145,21 @@ class BaseNodeDef(BaseNodeSchema):
         """
         raise NotImplementedError()
 
-    async def prepare_context(self, envelope: Envelope) -> SessionRunContext:
+    async def prepare_context(
+        self,
+        envelope: Envelope,
+        emitter_node_id: str | None = None,
+        emitter_node_kind: str | None = None,
+    ) -> SessionRunContext:
         ctx = envelope.context.model_copy(deep=True)
         if envelope.internal_workflow_state.current_frame.overrides:
             ctx.state.overrides = envelope.internal_workflow_state.current_frame.overrides
+        ctx._emitter_node_id = emitter_node_id
+        ctx._emitter_node_kind = emitter_node_kind
         return ctx
+
+    def _emitter_headers(self) -> dict[str, str]:
+        return {HDR_EMITTER: self.node_id, HDR_EMITTER_KIND: self._node_kind}
 
     async def _publish_action(self, output: NodeResult[State], envelope: Envelope, correlation_id: str, broker: BrokerAnnotation) -> Envelope:
         publish_envelope: Envelope
@@ -161,6 +178,7 @@ class BaseNodeDef(BaseNodeSchema):
                     topic=wf_copy.current_frame.target_topic,
                     correlation_id=correlation_id,
                     key=correlation_id.encode(),
+                    headers=self._emitter_headers(),
                 )
             return envelope
 
@@ -178,6 +196,7 @@ class BaseNodeDef(BaseNodeSchema):
                 topic=target_topic,
                 correlation_id=correlation_id,
                 key=correlation_id.encode(),
+                headers=self._emitter_headers(),
             )
         elif isinstance(output, ReturnCall):
             # unwind current frame and return to previous topic
@@ -192,6 +211,7 @@ class BaseNodeDef(BaseNodeSchema):
                 topic=frame.callback_topic,
                 correlation_id=correlation_id,
                 key=correlation_id.encode(),
+                headers=self._emitter_headers(),
             )
 
         elif isinstance(output, TailCall):
@@ -209,6 +229,7 @@ class BaseNodeDef(BaseNodeSchema):
                 topic=target_topic,
                 correlation_id=correlation_id,
                 key=correlation_id.encode(),
+                headers=self._emitter_headers(),
             )
 
         elif isinstance(output, Silent):
@@ -227,22 +248,34 @@ class BaseNodeDef(BaseNodeSchema):
         self,
         envelope: Envelope,
         correlation_id: Annotated[str, Context()],
+        headers: Annotated[dict[str, Any], Context("message.headers")],
         broker: BrokerAnnotation,
-    ) -> Envelope:
-        logger.debug("[%s] handler entered node=%s", correlation_id[:8], self.node_id)
-        ctx = await self.prepare_context(envelope)
+    ) -> Response:
+        raw_emitter = headers.get(HDR_EMITTER)
+        emitter = decode_header_str(raw_emitter)
+        if emitter is None:
+            logger.warning(
+                "[%s] inbound to node=%s has no usable %s header (got %s); emitter unknown",
+                correlation_id[:8],
+                self.node_id,
+                HDR_EMITTER,
+                "None" if raw_emitter is None else type(raw_emitter).__name__,
+            )
+        emitter_kind = decode_header_str(headers.get(HDR_EMITTER_KIND))
+        logger.debug("[%s] handler entered node=%s emitter=%s kind=%s", correlation_id[:8], self.node_id, emitter, emitter_kind)
+        ctx = await self.prepare_context(envelope, emitter_node_id=emitter, emitter_node_kind=emitter_kind)
 
         if not await self._evaluate_gates(ctx, correlation_id):
-            return envelope
-
-        if self._run_accepts_input and envelope.internal_workflow_state.current_frame.input_args is not None:
-            output = await self.run(ctx, *envelope.internal_workflow_state.current_frame.input_args)
+            body: Envelope = envelope
         else:
-            output = await self.run(ctx)
+            if self._run_accepts_input and envelope.internal_workflow_state.current_frame.input_args is not None:
+                output = await self.run(ctx, *envelope.internal_workflow_state.current_frame.input_args)
+            else:
+                output = await self.run(ctx)
+            logger.debug("[%s] run() returned action=%s node=%s", correlation_id[:8], type(output).__name__, self.node_id)
+            body = await self._publish_action(output, envelope, correlation_id, broker)
 
-        logger.debug("[%s] run() returned action=%s node=%s", correlation_id[:8], type(output).__name__, self.node_id)
-
-        return await self._publish_action(output, envelope, correlation_id, broker)
+        return Response(body, headers=self._emitter_headers())
 
     @property
     def id(self) -> str:

--- a/calfkit/nodes/tool.py
+++ b/calfkit/nodes/tool.py
@@ -18,13 +18,12 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class BaseToolNodeDef(BaseToolNodeSchema, BaseNodeDef):
+    _node_kind: ClassVar[NodeKind] = "tool"
     _tool: Tool
     gates: list[GateFunction] = field(default_factory=list)
 
 
 class ToolNodeDef(BaseToolNodeDef):
-    _node_kind: ClassVar[NodeKind] = "tool"
-
     @classmethod
     def create_tool_node(
         cls,

--- a/calfkit/nodes/tool.py
+++ b/calfkit/nodes/tool.py
@@ -1,10 +1,11 @@
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, ClassVar
 
 from typing_extensions import Self
 
+from calfkit._protocol import NodeKind
 from calfkit._vendor.pydantic_ai import Tool
 from calfkit._vendor.pydantic_ai.messages import ToolReturn
 from calfkit.models import SessionRunContext, Silent, State, ToolContext
@@ -22,6 +23,8 @@ class BaseToolNodeDef(BaseToolNodeSchema, BaseNodeDef):
 
 
 class ToolNodeDef(BaseToolNodeDef):
+    _node_kind: ClassVar[NodeKind] = "tool"
+
     @classmethod
     def create_tool_node(
         cls,
@@ -42,13 +45,13 @@ class ToolNodeDef(BaseToolNodeDef):
             gates=list(gates) if gates else [],
         )
 
-    async def run(self, ctx: SessionRunContext, tool_call_id: str, source_node_name: str) -> NodeResult[State]:
+    async def run(self, ctx: SessionRunContext, tool_call_id: str) -> NodeResult[State]:
         logger.debug(
-            "[%s] tool run entered tool=%s tool_call_id=%s source=%s",
+            "[%s] tool run entered tool=%s tool_call_id=%s emitter=%s",
             ctx.deps.correlation_id[:8],
             self.name,
             tool_call_id,
-            source_node_name,
+            ctx.emitter_node_id,
         )
         tool_call_part = ctx.state.get_tool_call(tool_call_id)
         if tool_call_part is None:
@@ -60,7 +63,7 @@ class ToolNodeDef(BaseToolNodeDef):
 
         tool_call_ctx = ToolContext(
             deps=ctx.deps,
-            agent_name=source_node_name,
+            agent_name=ctx.emitter_node_id,
             tool_call_id=tool_call_part.tool_call_id,
             tool_name=tool_call_part.tool_name,
             messages=ctx.state.message_history,

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -25,7 +25,7 @@ from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
 from calfkit.client import Client
 from calfkit.models import SessionRunContext
 from calfkit.models.tool_context import ToolContext
-from calfkit.nodes import Agent, agent_tool
+from calfkit.nodes import Agent, BaseToolNodeDef, agent_tool
 from calfkit.worker import Worker
 from tests.providers import prepare_worker
 
@@ -336,3 +336,14 @@ async def test_client_node_result_carries_reply_emitter(container, deploy_gated_
 
     assert result.emitter_node_id == agent.node_id
     assert result.emitter_node_kind == "agent"
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: subclasses of BaseToolNodeDef must inherit kind="tool",
+# not the BaseNodeDef default "node". Without the ClassVar on BaseToolNodeDef
+# itself, user-defined tool subclasses silently mis-stamp the emitter kind.
+# ---------------------------------------------------------------------------
+
+
+def test_base_tool_node_kind_is_tool():
+    assert BaseToolNodeDef._node_kind == "tool"

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -29,7 +29,6 @@ from calfkit.nodes import Agent, agent_tool
 from calfkit.worker import Worker
 from tests.providers import prepare_worker
 
-
 # ---------------------------------------------------------------------------
 # Smoke test: TestKafkaBroker must preserve custom Kafka headers in-memory.
 # Without this, the rest of these tests would be meaningless.

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -1,0 +1,339 @@
+"""End-to-end tests for the x-calf-emitter Kafka header propagation.
+
+Follows the project pattern: TestKafkaBroker for in-memory broker, FunctionModel
+for offline deterministic agent runs, gate closures to capture per-hop ctx state,
+and client.execute_node / invoke_node for real message dispatch.
+"""
+
+import asyncio
+from typing import Annotated, Any
+
+import pytest
+from faststream import Context
+from faststream.kafka import KafkaBroker, TestKafkaBroker
+
+from calfkit._protocol import HDR_EMITTER, HDR_EMITTER_KIND
+from calfkit._vendor.pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+)
+from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
+from calfkit.client import Client
+from calfkit.models import SessionRunContext
+from calfkit.models.tool_context import ToolContext
+from calfkit.nodes import Agent, agent_tool
+from calfkit.worker import Worker
+from tests.providers import prepare_worker
+
+
+# ---------------------------------------------------------------------------
+# Smoke test: TestKafkaBroker must preserve custom Kafka headers in-memory.
+# Without this, the rest of these tests would be meaningless.
+# ---------------------------------------------------------------------------
+
+
+def _decode_header(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value.decode()
+    return str(value)
+
+
+async def test_testkafkabroker_preserves_custom_header():
+    broker = KafkaBroker("localhost")
+    captured: dict[str, Any] = {}
+
+    @broker.subscriber("hdr_smoke", group_id="hdr_smoke_grp")
+    async def _h(body: str, headers: Annotated[dict[str, Any], Context("message.headers")]):
+        captured.update(headers)
+
+    async with TestKafkaBroker(broker):
+        await broker.publish("hi", "hdr_smoke", headers={HDR_EMITTER: "probe", HDR_EMITTER_KIND: "client"})
+
+    assert _decode_header(captured.get(HDR_EMITTER)) == "probe"
+    assert _decode_header(captured.get(HDR_EMITTER_KIND)) == "client"
+
+
+# ---------------------------------------------------------------------------
+# A client invoking an agent should leave the agent with ctx.emitter_node_id
+# starting with "client." — sourced from the x-calf-emitter header that the
+# Client stamps onto every outbound publish.
+# ---------------------------------------------------------------------------
+
+
+def _function_model_calls_then_summarizes_named(tool_name: str | None = None):
+    """Build a FunctionModel that calls *tool_name* on round 1, then summarizes.
+
+    When *tool_name* is ``None``, the model always returns a plain text response.
+    """
+
+    def _fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        last = messages[-1]
+        if tool_name is None or (isinstance(last, ModelRequest) and any(isinstance(p, ToolReturnPart) for p in last.parts)):
+            return ModelResponse(parts=[TextPart("done")])
+        return ModelResponse(parts=[ToolCallPart(tool_name)])
+
+    return _fn
+
+
+async def test_agent_receives_client_emitter(container):
+    seen: list[str | None] = []
+
+    def capture_emitter(ctx: SessionRunContext) -> bool:
+        seen.append(ctx.emitter_node_id)
+        return True
+
+    worker = container.get(Worker)
+    agent = Agent(
+        "test_emitter_client_hop",
+        system_prompt="x",
+        subscribe_topics="test_emitter_client_hop.input",
+        model_client=FunctionModel(_function_model_calls_then_summarizes_named()),
+        gates=[capture_emitter],
+    )
+    worker.add_nodes(agent)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        await client.execute_node("hi", "test_emitter_client_hop.input", timeout=5)
+
+    assert len(seen) == 1
+    assert seen[0] is not None
+    assert seen[0].startswith("client.")
+
+
+# ---------------------------------------------------------------------------
+# When an agent calls a tool, the tool's ctx.agent_name (sourced from the
+# inbound x-calf-emitter header) must equal the calling agent's node_id.
+# ---------------------------------------------------------------------------
+
+_tool_capture: dict[str, Any] = {}
+
+
+@agent_tool
+def _emitter_probe_tool(ctx: ToolContext) -> str:
+    """Captures who called this tool."""
+    _tool_capture["agent_name"] = ctx.agent_name
+    return "ok"
+
+
+async def test_tool_receives_agent_id_as_emitter(container):
+    _tool_capture.clear()
+
+    worker = container.get(Worker)
+    agent = Agent(
+        "test_emitter_agent_hop",
+        system_prompt="x",
+        subscribe_topics="test_emitter_agent_hop.input",
+        model_client=FunctionModel(_function_model_calls_then_summarizes_named("_emitter_probe_tool")),
+        tools=[_emitter_probe_tool],
+    )
+    worker.add_nodes(agent, _emitter_probe_tool)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        await client.execute_node("call the tool", "test_emitter_agent_hop.input", timeout=5)
+
+    assert _tool_capture["agent_name"] == "test_emitter_agent_hop"
+
+
+# ---------------------------------------------------------------------------
+# On a ReturnCall back to the calling agent, the agent's ctx.emitter_node_id
+# must equal the returning tool's node_id.
+# ---------------------------------------------------------------------------
+
+
+@agent_tool
+def _silent_tool() -> str:
+    """Just returns."""
+    return "ok"
+
+
+async def test_agent_receives_tool_emitter_on_return(container):
+    seen: list[str | None] = []
+
+    def capture_emitter(ctx: SessionRunContext) -> bool:
+        seen.append(ctx.emitter_node_id)
+        return True
+
+    worker = container.get(Worker)
+    agent = Agent(
+        "test_emitter_return_hop",
+        system_prompt="x",
+        subscribe_topics="test_emitter_return_hop.input",
+        model_client=FunctionModel(_function_model_calls_then_summarizes_named("_silent_tool")),
+        tools=[_silent_tool],
+        gates=[capture_emitter],
+    )
+    worker.add_nodes(agent, _silent_tool)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        await client.execute_node("call the tool", "test_emitter_return_hop.input", timeout=5)
+
+    # Two agent invocations: client→agent, then tool→agent (return).
+    assert len(seen) == 2
+    assert seen[0] is not None and seen[0].startswith("client.")
+    assert seen[1] == _silent_tool.node_id
+
+
+# ---------------------------------------------------------------------------
+# Flow 4: gate rejection. When a gate rejects, the handler returns
+# ``Response(envelope, headers=...)``; FastStream's ``@broker.publisher``
+# auto-forwards that body to ``publish_topic`` and honors the headers, so the
+# observer on ``publish_topic`` must still see ``x-calf-emitter``.
+# ---------------------------------------------------------------------------
+
+
+async def test_gate_reject_auto_publish_carries_emitter_header(container, deploy_gated_function_agent):
+    """Gate rejection still publishes to ``publish_topic`` with the emitter header
+    attached via the handler's ``Response(headers=...)`` return."""
+
+    def reject(ctx: SessionRunContext) -> bool:
+        return False
+
+    agent = deploy_gated_function_agent(gates=[reject])
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    received_headers: list[dict[str, Any]] = []
+
+    @broker.subscriber(agent.publish_topic, group_id="gate_reject_observer")
+    async def _observer(body: Any, headers: Annotated[dict[str, Any], Context("message.headers")]):
+        received_headers.append(dict(headers))
+
+    prepare_worker(container)
+
+    async with TestKafkaBroker(broker):
+        handle = await client.invoke_node("hi", agent.subscribe_topics[0])
+        with pytest.raises(asyncio.TimeoutError):
+            await handle.result(timeout=2)
+
+    assert len(received_headers) >= 1
+    emitter = _decode_header(received_headers[0].get(HDR_EMITTER))
+    kind = _decode_header(received_headers[0].get(HDR_EMITTER_KIND))
+    assert emitter == agent.node_id
+    assert kind == "agent"
+
+
+# ---------------------------------------------------------------------------
+# Success-path counterpart to the gate-reject test: a normal run on a node
+# with ``publish_topic`` must also stamp the emitter header on the auto-publish.
+# Catches regressions that drop ``headers=`` from the success-path Response.
+# ---------------------------------------------------------------------------
+
+
+async def test_success_path_publish_topic_carries_emitter_header(container, deploy_gated_function_agent):
+    agent = deploy_gated_function_agent(gates=None)
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    received_headers: list[dict[str, Any]] = []
+
+    @broker.subscriber(agent.publish_topic, group_id="success_path_observer")
+    async def _observer(body: Any, headers: Annotated[dict[str, Any], Context("message.headers")]):
+        received_headers.append(dict(headers))
+
+    prepare_worker(container)
+
+    async with TestKafkaBroker(broker):
+        await client.execute_node("hi", agent.subscribe_topics[0], timeout=5)
+
+    agent_published = [h for h in received_headers if _decode_header(h.get(HDR_EMITTER_KIND)) == "agent"]
+    assert agent_published, f"no agent-emitted message reached {agent.publish_topic}; received={received_headers}"
+    assert _decode_header(agent_published[0].get(HDR_EMITTER)) == agent.node_id
+
+
+# ---------------------------------------------------------------------------
+# Parallel fan-out: every cloned Call in the loop must carry the agent's
+# emitter. Catches regressions that hoist ``headers=`` outside the loop or
+# drop it on one branch of the fan-out.
+# ---------------------------------------------------------------------------
+
+_parallel_capture: dict[str, str | None] = {}
+
+
+@agent_tool
+def _probe_tool_a(ctx: ToolContext) -> str:
+    _parallel_capture["a"] = ctx.agent_name
+    return "a_ok"
+
+
+@agent_tool
+def _probe_tool_b(ctx: ToolContext) -> str:
+    _parallel_capture["b"] = ctx.agent_name
+    return "b_ok"
+
+
+@agent_tool
+def _probe_tool_c(ctx: ToolContext) -> str:
+    _parallel_capture["c"] = ctx.agent_name
+    return "c_ok"
+
+
+def _function_model_calls_all(tool_names: list[str]):
+    """FunctionModel that calls every name in *tool_names* in one round (parallel fan-out)."""
+
+    def _fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        last = messages[-1]
+        if isinstance(last, ModelRequest) and any(isinstance(p, ToolReturnPart) for p in last.parts):
+            return ModelResponse(parts=[TextPart("done")])
+        return ModelResponse(parts=[ToolCallPart(name) for name in tool_names])
+
+    return _fn
+
+
+async def test_parallel_fan_out_carries_emitter_per_call(container):
+    _parallel_capture.clear()
+
+    worker = container.get(Worker)
+    agent = Agent(
+        "test_parallel_emitter",
+        system_prompt="x",
+        subscribe_topics="test_parallel_emitter.input",
+        model_client=FunctionModel(_function_model_calls_all(["_probe_tool_a", "_probe_tool_b", "_probe_tool_c"])),
+        tools=[_probe_tool_a, _probe_tool_b, _probe_tool_c],
+    )
+    worker.add_nodes(agent, _probe_tool_a, _probe_tool_b, _probe_tool_c)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        await client.execute_node("call all tools", "test_parallel_emitter.input", timeout=10)
+
+    assert _parallel_capture == {"a": agent.node_id, "b": agent.node_id, "c": agent.node_id}
+
+
+# ---------------------------------------------------------------------------
+# Client receives the emitter of the callback reply on NodeResult.
+# ---------------------------------------------------------------------------
+
+
+async def test_client_node_result_carries_reply_emitter(container, deploy_gated_function_agent):
+    agent = deploy_gated_function_agent(gates=None)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        result = await client.execute_node("hi", agent.subscribe_topics[0], timeout=5)
+
+    assert result.emitter_node_id == agent.node_id
+    assert result.emitter_node_kind == "agent"


### PR DESCRIPTION
## Summary

- **Stamp `x-calf-emitter` / `x-calf-emitter-kind` on every outbound publish** at the call site (no middleware, no registry). Handler returns `Response(envelope, headers=...)` so `@broker.publisher` auto-publishes (gate-reject + success path to `publish_topic`) also carry the headers.
- **Surface the emitter on both sides.** Server: `ctx.emitter_node_id` / `ctx.emitter_node_kind` on `SessionRunContext` (`PrivateAttr`, set by `prepare_context` from the inbound header). Client: `NodeResult.emitter_node_id` / `emitter_node_kind`, populated by the reply dispatcher from the callback's header.
- **Drop the `self.name` positional-arg hack.** Agent no longer smuggles its name into `Call.input_args`; `ToolNodeDef.run` signature simplifies from `(ctx, tool_call_id, source_node_name)` to `(ctx, tool_call_id)`. `ToolContext.agent_name` stays public and is sourced from `ctx.emitter_node_id`.
- **Type-safe kind via `NodeKind = Literal["node","agent","tool","client"]`** in `_protocol.py`, used by `_node_kind: ClassVar[NodeKind]` on each node subclass and `CLIENT_KIND` on the client.
- **Defensive header handling.** `decode_header_str` helper handles bytes (utf-8 with `errors="replace"`), str (passthrough), and other types (→ `None`). Handler warns when the inbound emitter header is missing or unexpected type. `Client` rejects empty/whitespace `emitter_id`.

## Test plan

- [x] Full test suite green: `uv run pytest` → 2361 passed (2358 existing + 3 new in `tests/test_headers.py`)
- [x] TestKafkaBroker preserves Kafka headers (smoke test)
- [x] Client → Agent: agent's `ctx.emitter_node_id` starts with `client.`
- [x] Agent → Tool: tool's `ctx.agent_name` equals the calling agent's `node_id`
- [x] Tool → Agent return: agent's `ctx.emitter_node_id` equals the returning tool's `node_id`
- [x] Gate-reject auto-publish to `publish_topic` carries `x-calf-emitter` (verified via observer subscriber)
- [x] Success-path auto-publish to `publish_topic` carries `x-calf-emitter` (separate test, catches a regression the gate-reject test would miss)
- [x] Parallel fan-out: each cloned `Call` carries the agent's emitter (3 distinct probe tools, one assertion each)
- [x] Client receives `NodeResult.emitter_node_id == agent.node_id` and `emitter_node_kind == "agent"` after `execute_node`
- [ ] (Optional) Manual smoke test against a real Kafka broker to confirm aiokafka transport preserves headers as expected