### PR TITLE
feat: add runtime model_settings to Agent and Client

### DIFF
--- a/calfkit/client/client.py
+++ b/calfkit/client/client.py
@@ -18,30 +18,6 @@ from calfkit.models.node_schema import BaseToolNodeSchema
 from calfkit.models.state import OverridesState
 
 
-def _validate_model_settings_jsonable(model_settings: ModelSettings | dict[str, Any] | None) -> None:
-    if model_settings is None:
-        return
-    try:
-        json.dumps(model_settings, allow_nan=False)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(
-            f"model_settings is not JSON-serializable and cannot be sent over the wire. "
-            f"Offending payload: {model_settings!r}. Underlying error: {exc}"
-        ) from exc
-
-
-def _build_overrides(
-    tool_overrides: list[BaseToolNodeSchema] | None,
-    model_settings: ModelSettings | dict[str, Any] | None,
-) -> OverridesState | None:
-    if tool_overrides is None and model_settings is None:
-        return None
-    return OverridesState(
-        override_agent_tools=tool_overrides,
-        model_settings=dict(model_settings) if model_settings is not None else None,
-    )
-
-
 class Client(BaseClient):
     """High-level client for invoking Calf agent nodes.
 
@@ -133,7 +109,12 @@ class Client(BaseClient):
             An :class:`InvocationHandle` whose ``result()`` resolves to a
             :class:`NodeResult`.
         """
-        _validate_model_settings_jsonable(model_settings)
+        if model_settings is not None:
+            try:
+                json.dumps(model_settings, allow_nan=False)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"model_settings is not JSON-serializable: {exc}. Payload: {model_settings!r}") from exc
+
         if correlation_id is None:
             correlation_id = uuid_utils.uuid7().hex
         if reply_topic is None:
@@ -141,13 +122,21 @@ class Client(BaseClient):
 
         state = State(message_history=message_history or list(), temp_instructions=temp_instructions)
         state.stage_message(ModelRequest.user_text_prompt(user_prompt))
+        overrides = (
+            OverridesState(
+                override_agent_tools=tool_overrides,
+                model_settings=dict(model_settings) if model_settings is not None else None,
+            )
+            if tool_overrides is not None or model_settings is not None
+            else None
+        )
         return await self._invoke(
             topic=topic,
             reply_topic=reply_topic,
             correlation_id=correlation_id,
             run_args=run_args,
             state=state,
-            overrides=_build_overrides(tool_overrides, model_settings),
+            overrides=overrides,
             deps=deps,
             output_type=output_type,
         )

--- a/calfkit/client/client.py
+++ b/calfkit/client/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Sequence
 from typing import Any, overload
 
@@ -7,6 +8,7 @@ import uuid_utils
 
 from calfkit._types import OutputT
 from calfkit._vendor.pydantic_ai.messages import ModelMessage, ModelRequest
+from calfkit._vendor.pydantic_ai.settings import ModelSettings
 from calfkit.client.base import BaseClient
 from calfkit.client.deserialize import _UNSET
 from calfkit.client.invocation_handle import InvocationHandle
@@ -14,6 +16,30 @@ from calfkit.client.node_result import NodeResult
 from calfkit.models import State
 from calfkit.models.node_schema import BaseToolNodeSchema
 from calfkit.models.state import OverridesState
+
+
+def _validate_model_settings_jsonable(model_settings: ModelSettings | dict[str, Any] | None) -> None:
+    if model_settings is None:
+        return
+    try:
+        json.dumps(model_settings, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"model_settings is not JSON-serializable and cannot be sent over the wire. "
+            f"Offending payload: {model_settings!r}. Underlying error: {exc}"
+        ) from exc
+
+
+def _build_overrides(
+    tool_overrides: list[BaseToolNodeSchema] | None,
+    model_settings: ModelSettings | dict[str, Any] | None,
+) -> OverridesState | None:
+    if tool_overrides is None and model_settings is None:
+        return None
+    return OverridesState(
+        override_agent_tools=tool_overrides,
+        model_settings=dict(model_settings) if model_settings is not None else None,
+    )
 
 
 class Client(BaseClient):
@@ -39,6 +65,7 @@ class Client(BaseClient):
         message_history: list[ModelMessage] | None = ...,
         run_args: Sequence[Any] | None = ...,
         deps: dict[str, Any] | None = ...,
+        model_settings: ModelSettings | dict[str, Any] | None = ...,
     ) -> InvocationHandle[OutputT]: ...
 
     @overload
@@ -54,6 +81,7 @@ class Client(BaseClient):
         message_history: list[ModelMessage] | None = ...,
         run_args: Sequence[Any] | None = ...,
         deps: dict[str, Any] | None = ...,
+        model_settings: ModelSettings | dict[str, Any] | None = ...,
     ) -> InvocationHandle[Any]: ...
 
     async def invoke_node(
@@ -69,6 +97,7 @@ class Client(BaseClient):
         message_history: list[ModelMessage] | None = None,
         run_args: Sequence[Any] | None = None,
         deps: dict[str, Any] | None = None,
+        model_settings: ModelSettings | dict[str, Any] | None = None,
     ) -> InvocationHandle[Any]:
         """Invoke an agent node asynchronously and return a handle for the reply.
 
@@ -95,11 +124,16 @@ class Client(BaseClient):
                 method.
             deps: A mapping of dependency keys to values, made available to
                 the node's tools at runtime via the session context.
+            model_settings: Per-call model settings (e.g. ``{"temperature": 0.0}``)
+                that merge over the agent's constructor defaults, which in turn
+                merge over the model client's defaults. Must be JSON-serializable
+                since it travels over Kafka.
 
         Returns:
             An :class:`InvocationHandle` whose ``result()`` resolves to a
             :class:`NodeResult`.
         """
+        _validate_model_settings_jsonable(model_settings)
         if correlation_id is None:
             correlation_id = uuid_utils.uuid7().hex
         if reply_topic is None:
@@ -113,7 +147,7 @@ class Client(BaseClient):
             correlation_id=correlation_id,
             run_args=run_args,
             state=state,
-            overrides=OverridesState(override_agent_tools=tool_overrides) if tool_overrides is not None else None,
+            overrides=_build_overrides(tool_overrides, model_settings),
             deps=deps,
             output_type=output_type,
         )
@@ -132,6 +166,7 @@ class Client(BaseClient):
         message_history: list[ModelMessage] | None = ...,
         run_args: Sequence[Any] | None = ...,
         deps: dict[str, Any] | None = ...,
+        model_settings: ModelSettings | dict[str, Any] | None = ...,
         timeout: float | None = ...,
     ) -> NodeResult[OutputT]: ...
 
@@ -148,6 +183,7 @@ class Client(BaseClient):
         message_history: list[ModelMessage] | None = ...,
         run_args: Sequence[Any] | None = ...,
         deps: dict[str, Any] | None = ...,
+        model_settings: ModelSettings | dict[str, Any] | None = ...,
         timeout: float | None = ...,
     ) -> NodeResult[Any]: ...
 
@@ -164,6 +200,7 @@ class Client(BaseClient):
         message_history: list[ModelMessage] | None = None,
         run_args: Sequence[Any] | None = None,
         deps: dict[str, Any] | None = None,
+        model_settings: ModelSettings | dict[str, Any] | None = None,
         timeout: float | None = None,
     ) -> NodeResult[Any]:
         """Invoke an agent node and await the reply in a single call.
@@ -193,6 +230,10 @@ class Client(BaseClient):
                 method.
             deps: A mapping of dependency keys to values, made available to
                 the node's tools at runtime via the session context.
+            model_settings: Per-call model settings (e.g. ``{"temperature": 0.0}``)
+                that merge over the agent's constructor defaults, which in turn
+                merge over the model client's defaults. Must be JSON-serializable
+                since it travels over Kafka.
             timeout: Maximum seconds to wait for the reply. ``None`` means
                 wait indefinitely.
 
@@ -214,5 +255,6 @@ class Client(BaseClient):
             message_history=message_history,
             run_args=run_args,
             deps=deps,
+            model_settings=model_settings,
         )
         return await handle.result(timeout=timeout)

--- a/calfkit/models/state.py
+++ b/calfkit/models/state.py
@@ -23,7 +23,8 @@ class OverridesState(BaseAgentActivityState):
     """State for storing any override objects"""
 
     model_config = ConfigDict(extra="ignore")
-    override_agent_tools: list[BaseToolNodeSchema] | None
+    override_agent_tools: list[BaseToolNodeSchema] | None = None
+    model_settings: dict[str, Any] | None = None
 
 
 class CoreMessageState(BaseAgentActivityState):

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Callable
-from typing import Any, ClassVar, Generic
+from typing import Any, ClassVar, Generic, cast
 
 from calfkit._protocol import NodeKind
 from calfkit._types import AgentOutputT
@@ -8,6 +8,7 @@ from calfkit._vendor.pydantic_ai import Agent as InternalAgentLoop
 from calfkit._vendor.pydantic_ai import DeferredToolRequests
 from calfkit._vendor.pydantic_ai.messages import RetryPromptPart
 from calfkit._vendor.pydantic_ai.output import OutputSpec
+from calfkit._vendor.pydantic_ai.settings import ModelSettings
 from calfkit._vendor.pydantic_ai.tools import DeferredToolResults
 from calfkit._vendor.pydantic_ai.toolsets.external import ExternalToolset
 from calfkit.models import Call, DataPart, NodeResult, ReturnCall, State, TailCall, TextPart
@@ -42,6 +43,7 @@ class BaseAgentNodeDef(
         model_client: PydanticModelClient,
         final_output_type: OutputSpec[AgentOutputT] = str,  # type: ignore[assignment]
         sequential_only_mode: bool = False,
+        model_settings: ModelSettings | dict[str, Any] | None = None,
     ):
         self.final_output_type = final_output_type
         self.system_prompt = system_prompt
@@ -55,7 +57,12 @@ class BaseAgentNodeDef(
         super().__init__(node_id=node_id, subscribe_topics=subscribe_topics, publish_topic=publish_topic, gates=gates)
 
         self._agent_loop: InternalAgentLoop[dict[str, Any], AgentOutputT | DeferredToolRequests] = InternalAgentLoop(
-            model_client, name=self.name, output_type=[final_output_type, DeferredToolRequests], deps_type=dict, instructions=system_prompt
+            model_client,
+            name=self.name,
+            output_type=[final_output_type, DeferredToolRequests],
+            deps_type=dict,
+            instructions=system_prompt,
+            model_settings=cast(ModelSettings | None, model_settings),
         )
 
     def _parallel_state_aggregation(self, ctx: SessionRunContext) -> None:
@@ -130,6 +137,7 @@ class BaseAgentNodeDef(
             toolsets=[ExternalToolset([tool.tool_schema for tool in tools_registry.values()])],
             deps=ctx.deps.provided_deps,  # None valid when AgentDepsT=NoneType
             deferred_tool_results=tool_results,
+            model_settings=cast(ModelSettings | None, ctx.state.overrides.model_settings) if ctx.state.overrides is not None else None,
         )
         if isinstance(result.output, DeferredToolRequests):
             # The LLM called one or more tools

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -131,13 +131,14 @@ class BaseAgentNodeDef(
         if ctx.state.uncommitted_message is not None:
             ctx.state.commit_message_to_history()
 
+        run_model_settings = cast(ModelSettings | None, ctx.state.overrides.model_settings) if ctx.state.overrides is not None else None
         result = await self._agent_loop.run(
             message_history=ctx.state.message_history,
             instructions=ctx.state.temp_instructions,
             toolsets=[ExternalToolset([tool.tool_schema for tool in tools_registry.values()])],
             deps=ctx.deps.provided_deps,  # None valid when AgentDepsT=NoneType
             deferred_tool_results=tool_results,
-            model_settings=cast(ModelSettings | None, ctx.state.overrides.model_settings) if ctx.state.overrides is not None else None,
+            model_settings=run_model_settings,
         )
         if isinstance(result.output, DeferredToolRequests):
             # The LLM called one or more tools

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,7 +198,17 @@ def deploy_instructions_agent(container) -> Agent:
     return agent
 
 
-@pytest.fixture(params=["tool-override", "tool-override-none", "tool-override-empty", None])
+@pytest.fixture(
+    params=[
+        "tool-override",
+        "tool-override-none",
+        "tool-override-empty",
+        "model-settings-only",
+        "model-settings-nested",
+        "both-overrides",
+        None,
+    ]
+)
 def make_overrides_state_factory(request, container) -> Callable[..., OverridesState | None]:
     mode = request.param
 
@@ -224,6 +234,33 @@ def make_overrides_state_factory(request, container) -> Callable[..., OverridesS
 
     elif mode == "tool-override-empty":
         return lambda: OverridesState(override_agent_tools=list())
+
+    elif mode == "model-settings-only":
+        return lambda: OverridesState(model_settings={"temperature": 0.5})
+
+    elif mode == "model-settings-nested":
+        return lambda: OverridesState(
+            model_settings={
+                "extra_body": {"reasoning_effort": "high", "verbosity": "verbose"},
+                "stop_sequences": ["<END>", "<<STOP>>"],
+                "logit_bias": {"50256": -100},
+            }
+        )
+
+    elif mode == "both-overrides":
+        tools = container.get(list[ToolNodeDef])
+        return lambda: OverridesState(
+            override_agent_tools=[
+                BaseToolNodeSchema(
+                    node_id=t.node_id,
+                    subscribe_topics=t.subscribe_topics,
+                    publish_topic=t.publish_topic,
+                    tool_schema=t.tool_schema,
+                )
+                for t in tools
+            ],
+            model_settings={"max_tokens": 1024, "temperature": 0.2},
+        )
 
     raise ValueError(f"Unknown mode={mode}")
 

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -1,0 +1,220 @@
+"""Tests for runtime model_settings: three-tier merge (model client < Agent constructor < per-call wire)."""
+
+from typing import Any
+
+import pytest
+from faststream.kafka import KafkaBroker, TestKafkaBroker
+
+from calfkit._vendor.pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
+from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
+from calfkit._vendor.pydantic_ai.settings import ModelSettings
+from calfkit.client import Client
+from calfkit.nodes import Agent, ToolNodeDef
+from calfkit.worker import Worker
+from tests.providers import prepare_worker
+
+
+class _Capture:
+    """Records FunctionModel observations across multiple invocations within one test."""
+
+    settings: list[dict[str, Any] | None]
+    tool_names: list[list[str]]
+
+    def __init__(self) -> None:
+        self.settings = []
+        self.tool_names = []
+
+
+def _make_capture_model(
+    settings: ModelSettings | dict[str, Any] | None = None,
+) -> tuple[FunctionModel, _Capture]:
+    captured = _Capture()
+
+    def fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        captured.settings.append(dict(info.model_settings) if info.model_settings is not None else None)
+        captured.tool_names.append([t.name for t in info.function_tools])
+        return ModelResponse(parts=[TextPart(content="ok")])
+
+    model = FunctionModel(fn, settings=settings)
+    return model, captured
+
+
+def _deploy_agent(
+    container,
+    *,
+    tier1: ModelSettings | dict[str, Any] | None = None,
+    tier2: ModelSettings | dict[str, Any] | None = None,
+    tools: list[ToolNodeDef] | None = None,
+    topic: str = "test_model_settings_agent.input",
+) -> tuple[Agent, _Capture]:
+    worker = container.get(Worker)
+    model, captured = _make_capture_model(tier1)
+    agent = Agent(
+        "test_model_settings_agent",
+        system_prompt="You are a helpful AI assistant.",
+        subscribe_topics=topic,
+        publish_topic="test_model_settings_agent.output",
+        model_client=model,
+        model_settings=tier2,
+        tools=tools,
+    )
+    worker.add_nodes(agent)
+    return agent, captured
+
+
+async def test_no_settings_anywhere(container):
+    """Baseline: when all three tiers are unset, the model observes None for model_settings."""
+    agent, captured = _deploy_agent(container)
+    prepare_worker(container)
+    client = container.get(Client)
+    async with TestKafkaBroker(container.get(KafkaBroker)):
+        await client.execute_node("hello", agent.subscribe_topics[0])
+    assert captured.settings[0] is None
+
+
+async def test_tier3_only_overrides_baseline(container):
+    """Per-call wire settings reach the model when Tier 1/2 are unset."""
+    agent, captured = _deploy_agent(container)
+    prepare_worker(container)
+    client = container.get(Client)
+    async with TestKafkaBroker(container.get(KafkaBroker)):
+        await client.execute_node("hello", agent.subscribe_topics[0], model_settings={"temperature": 0.7})
+    assert captured.settings[0] == {"temperature": 0.7}
+
+
+async def test_tier2_only_overrides_baseline(container):
+    """Agent-constructor settings reach the model when Tier 1/3 are unset."""
+    agent, captured = _deploy_agent(container, tier2={"temperature": 0.3})
+    prepare_worker(container)
+    client = container.get(Client)
+    async with TestKafkaBroker(container.get(KafkaBroker)):
+        await client.execute_node("hello", agent.subscribe_topics[0])
+    assert captured.settings[0] == {"temperature": 0.3}
+
+
+async def test_tier1_only_overrides_baseline(container):
+    """Model-client settings reach the model when Tier 2/3 are unset."""
+    agent, captured = _deploy_agent(container, tier1={"temperature": 0.1})
+    prepare_worker(container)
+    client = container.get(Client)
+    async with TestKafkaBroker(container.get(KafkaBroker)):
+        await client.execute_node("hello", agent.subscribe_topics[0])
+    assert captured.settings[0] == {"temperature": 0.1}
+
+
+async def test_tier2_beats_tier1_when_tier3_unset(container):
+    """When Tier 3 is unset, Tier 2 (Agent constructor) wins over Tier 1 (model client)."""
+    agent, captured = _deploy_agent(container, tier1={"temperature": 0.1}, tier2={"temperature": 0.5})
+    prepare_worker(container)
+    client = container.get(Client)
+    async with TestKafkaBroker(container.get(KafkaBroker)):
+        await client.execute_node("hello", agent.subscribe_topics[0])
+    assert captured.settings[0] is not None
+    assert captured.settings[0]["temperature"] == 0.5
+
+
+async def test_three_tier_precedence(container):
+    """When all three tiers set the same key, Tier 3 wins."""
+    agent, captured = _deploy_agent(container, tier1={"temperature": 0.1}, tier2={"temperature": 0.5})
+    prepare_worker(container)
+    client = container.get(Client)
+    async with TestKafkaBroker(container.get(KafkaBroker)):
+        await client.execute_node("hello", agent.subscribe_topics[0], model_settings={"temperature": 0.9})
+    assert captured.settings[0] is not None
+    assert captured.settings[0]["temperature"] == 0.9
+
+
+async def test_disjoint_keys_merge(container):
+    """When each tier sets a disjoint key, all keys appear in the final merged settings."""
+    agent, captured = _deploy_agent(container, tier1={"max_tokens": 100}, tier2={"top_p": 0.95})
+    prepare_worker(container)
+    client = container.get(Client)
+    async with TestKafkaBroker(container.get(KafkaBroker)):
+        await client.execute_node("hello", agent.subscribe_topics[0], model_settings={"temperature": 0.7})
+    assert captured.settings[0] is not None
+    assert captured.settings[0]["max_tokens"] == 100
+    assert captured.settings[0]["top_p"] == 0.95
+    assert captured.settings[0]["temperature"] == 0.7
+
+
+async def test_fail_fast_non_serializable_model_settings(container):
+    """Client raises ValueError before publishing when model_settings cannot be JSON-serialized."""
+    agent, _ = _deploy_agent(container)
+    prepare_worker(container)
+    client = container.get(Client)
+    with pytest.raises(ValueError, match="not JSON-serializable"):
+        await client.invoke_node("hello", agent.subscribe_topics[0], model_settings={"bad": object()})
+
+
+async def test_fail_fast_rejects_nested_non_serializable(container):
+    """Fail-fast detects non-serializable values nested under extra_body (the most likely real-world failure site)."""
+    agent, _ = _deploy_agent(container)
+    prepare_worker(container)
+    client = container.get(Client)
+    with pytest.raises(ValueError, match="not JSON-serializable"):
+        await client.invoke_node("hello", agent.subscribe_topics[0], model_settings={"extra_body": {"nested": object()}})
+
+
+async def test_fail_fast_rejects_nan_and_inf(container):
+    """NaN/Infinity are silently corrupted on the wire by pydantic; reject at the client boundary."""
+    agent, _ = _deploy_agent(container)
+    prepare_worker(container)
+    client = container.get(Client)
+    with pytest.raises(ValueError, match="not JSON-serializable"):
+        await client.invoke_node("hello", agent.subscribe_topics[0], model_settings={"temperature": float("nan")})
+    with pytest.raises(ValueError, match="not JSON-serializable"):
+        await client.invoke_node("hello", agent.subscribe_topics[0], model_settings={"temperature": float("inf")})
+
+
+async def test_unchanged_baseline_when_no_settings_passed(container):
+    """An invocation with no model_settings kwarg behaves identically to passing None."""
+    agent, captured = _deploy_agent(container)
+    prepare_worker(container)
+    client = container.get(Client)
+    async with TestKafkaBroker(container.get(KafkaBroker)):
+        await client.execute_node("hello", agent.subscribe_topics[0])
+    async with TestKafkaBroker(container.get(KafkaBroker)):
+        await client.execute_node("hello", agent.subscribe_topics[0], model_settings=None)
+    assert captured.settings[0] == captured.settings[1]
+    assert captured.settings[0] is None
+
+
+async def test_empty_dict_behaves_like_none(container):
+    """An empty model_settings dict behaves like None (pydantic_ai's merge short-circuits on falsy overrides)."""
+    agent, captured = _deploy_agent(container, tier1={"temperature": 0.1})
+    prepare_worker(container)
+    client = container.get(Client)
+    async with TestKafkaBroker(container.get(KafkaBroker)):
+        await client.execute_node("hello", agent.subscribe_topics[0], model_settings={})
+    async with TestKafkaBroker(container.get(KafkaBroker)):
+        await client.execute_node("hello", agent.subscribe_topics[0], model_settings=None)
+    assert captured.settings[0] == captured.settings[1] == {"temperature": 0.1}
+
+
+async def test_tools_available_with_model_settings_only(container, deploy_no_arg_tools):
+    """Setting only model_settings (no tool_overrides) must not strip constructor tools from the agent."""
+    agent, captured = _deploy_agent(container, tools=list(deploy_no_arg_tools))
+    prepare_worker(container)
+    client = container.get(Client)
+    async with TestKafkaBroker(container.get(KafkaBroker)):
+        await client.execute_node("hello", agent.subscribe_topics[0], model_settings={"temperature": 0.5})
+    assert captured.settings[0] == {"temperature": 0.5}
+    expected = {tool.tool_schema.name for tool in deploy_no_arg_tools}
+    assert set(captured.tool_names[0]) == expected
+
+
+async def test_tool_overrides_and_model_settings_combined(container, deploy_no_arg_tools):
+    """Setting both tool_overrides and model_settings on a single call: both take effect."""
+    agent, captured = _deploy_agent(container)
+    prepare_worker(container)
+    client = container.get(Client)
+    async with TestKafkaBroker(container.get(KafkaBroker)):
+        await client.execute_node(
+            "hello",
+            agent.subscribe_topics[0],
+            tool_overrides=deploy_no_arg_tools,
+            model_settings={"temperature": 0.7},
+        )
+    assert captured.settings[0] == {"temperature": 0.7}
+    expected = {tool.tool_schema.name for tool in deploy_no_arg_tools}
+    assert set(captured.tool_names[0]) == expected

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -45,14 +45,13 @@ def _deploy_agent(
     tier1: ModelSettings | dict[str, Any] | None = None,
     tier2: ModelSettings | dict[str, Any] | None = None,
     tools: list[ToolNodeDef] | None = None,
-    topic: str = "test_model_settings_agent.input",
 ) -> tuple[Agent, _Capture]:
     worker = container.get(Worker)
     model, captured = _make_capture_model(tier1)
     agent = Agent(
         "test_model_settings_agent",
         system_prompt="You are a helpful AI assistant.",
-        subscribe_topics=topic,
+        subscribe_topics="test_model_settings_agent.input",
         publish_topic="test_model_settings_agent.output",
         model_client=model,
         model_settings=tier2,


### PR DESCRIPTION
## Summary

- Adds a per-invocation `model_settings` kwarg on `Client.invoke_node` / `Client.execute_node` and on the `Agent` constructor (`BaseAgentNodeDef`), mirroring `pydantic_ai.Agent.run()`'s built-in parameter.
- Three-tier shallow merge with pydantic_ai's own precedence: **model client < Agent constructor < per-call wire**. Pydantic_ai's vendored `merge_model_settings` handles all merging — no merge code added on our side.
- Per-call settings ride on `OverridesState.model_settings` alongside existing `tool_overrides`. Fails fast at the client boundary (`json.dumps(..., allow_nan=False)`) so non-JSON-serializable values raise `ValueError` at the call site rather than being silently corrupted on the Kafka wire.

Non-breaking: all new kwargs default to `None`; `model_settings=None` produces byte-identical downstream calls. Cross-version Kafka compat preserved (new field is `Optional` + `extra="ignore"` on both producer and consumer sides).

## Test plan

- [x] All 4077 tests pass (`uv run pytest tests/`)
- [x] `tests/test_model_settings.py` (new, 14 cases) covers:
  - Each tier alone reaches the model when others unset
  - Tier 2 beats Tier 1 when Tier 3 unset; Tier 3 wins when all three set
  - Disjoint keys merge cleanly across all tiers
  - Fail-fast: top-level non-serializable, nested non-serializable, NaN, Infinity
  - Empty dict `{}` behaves like `None`; omitted kwarg is byte-identical to `None`
  - Constructor tools survive `model_settings`-only overrides
  - `tool_overrides` + `model_settings` combinable on a single call
- [x] `tests/conftest.py` `make_overrides_state_factory` extended with `model-settings-only`, `model-settings-nested`, `both-overrides` → `test_envelope_serialization_roundtrip` gets wire roundtrip coverage of the new field (including nested `extra_body`, `stop_sequences`, `logit_bias`) for free
- [x] `mypy calfkit/` clean
- [x] `ruff check .` / `ruff format --check .` clean