### PR TITLE
feat: add ConsumerNodeDef and expose State on NodeResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,57 @@ For tool-node gating, pass `gates=[...]` to `ToolNodeDef.create_tool_node(...)` 
 
 <br>
 
+### Consumer Nodes (Optional)
+
+A **consumer node** is a terminal sink — it subscribes to one or more topics and runs arbitrary Python logic against every event flowing through. Consumers receive the same `NodeResult` that `Client.execute_node()` returns, including the full session state (`tool_calls`, `tool_results`, `message_history`, `metadata`).
+
+Deploy a consumer as its own service. Wire it to an agent's `publish_topic` (or any topic carrying calfkit envelopes) to observe outputs from agents, tools, and intermediate hops:
+
+```python
+# weather_sink.py
+import asyncio
+from calfkit.client import Client, NodeResult
+from calfkit.nodes import consumer
+from calfkit.worker import Worker
+
+@consumer(subscribe_topics="weather_agent.output")
+async def log_weather(result: NodeResult) -> None:
+    if result.output is None:
+        return  # intermediate hop — no final output yet
+    print(f"[{result.correlation_id[:8]}] {result.output}")
+
+async def main():
+    client = Client.connect("localhost:9092")
+    worker = Worker(client, nodes=[log_weather])  # Deploy the consumer node
+    await worker.run()
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Run alongside the agent service:
+
+```shell
+python weather_sink.py
+```
+
+An agent's `publish_topic` emits on **every** state transition — intermediate hops, tool completions, and terminals — so `result.output` is `None` on hops without final output parts. Filter via a gate if you only want agent terminals:
+
+```python
+@consumer(
+    subscribe_topics="weather_agent.output",
+    gates=[lambda ctx: bool(ctx.state.final_output_parts)],
+)
+async def save_final(result: NodeResult) -> None:
+    await db.save(result.output)  # always populated here
+```
+
+**Upstream requirement**: the upstream agent or tool must have a `publish_topic` set for consumers to tap (e.g. add `publish_topic="weather_agent.output"` to the agent in step 4).
+
+**Error policy**: exceptions from the consumer function are logged and swallowed by default so a single bad event can't poison-pill the Kafka offset. Pass `re_raise=True` to fail loud during development.
+
+<br>
+
 ## Documentation
 
 Full documentation is coming soon. In the meantime, this README serves as the primary reference for getting started with Calfkit.

--- a/calfkit/__init__.py
+++ b/calfkit/__init__.py
@@ -2,7 +2,7 @@ from importlib.metadata import version
 
 from calfkit.client import Client, InvocationHandle, NodeResult
 from calfkit.models import ToolContext
-from calfkit.nodes import Agent, BaseNodeDef, GateFunction, NodeDef, ToolNodeDef, agent_tool
+from calfkit.nodes import Agent, BaseNodeDef, ConsumerFn, ConsumerNodeDef, GateFunction, NodeDef, ToolNodeDef, agent_tool, consumer
 from calfkit.providers import AnthropicModelClient, OpenAIModelClient, OpenAIResponsesModelClient
 from calfkit.worker import Worker
 
@@ -18,10 +18,13 @@ __all__ = [
     # nodes
     "Agent",
     "BaseNodeDef",
+    "ConsumerFn",
+    "ConsumerNodeDef",
     "GateFunction",
     "NodeDef",
     "ToolNodeDef",
     "agent_tool",
+    "consumer",
     # providers
     "AnthropicModelClient",
     "OpenAIModelClient",

--- a/calfkit/_protocol.py
+++ b/calfkit/_protocol.py
@@ -8,7 +8,7 @@ Do not add imports from ``calfkit.*`` to this module.
 
 from typing import Any, Literal
 
-NodeKind = Literal["node", "agent", "tool", "client"]
+NodeKind = Literal["node", "agent", "tool", "client", "consumer"]
 """Closed value space for the ``x-calf-emitter-kind`` Kafka header. Subclasses of
 ``BaseNodeDef`` declare their kind via ``_node_kind: ClassVar[NodeKind]``; the
 client publishes with ``CLIENT_KIND`` directly.

--- a/calfkit/client/deserialize.py
+++ b/calfkit/client/deserialize.py
@@ -15,6 +15,9 @@ _UNSET: Any = object()
 def deserialize_to_node_result(
     envelope: Envelope,
     output_type: type[Any] = _UNSET,
+    *,
+    strict: bool = True,
+    type_adapter: TypeAdapter[Any] | None = None,
 ) -> NodeResult[Any]:
     """Project an ``Envelope`` into a client-facing ``NodeResult``.
 
@@ -26,41 +29,57 @@ def deserialize_to_node_result(
               (returned as a raw dict), fall back to ``TextPart.text`` (str).
             * ``str``: extract the first ``TextPart.text``.
             * **anything else**: extract the first ``DataPart.data`` and validate
-              it through ``TypeAdapter(output_type)``.
+              it through ``TypeAdapter(output_type)`` (or *type_adapter* if
+              provided).
+        strict: When ``True`` (default — client semantics), raises
+            :class:`DeserializationError` if ``final_output_parts`` is empty or
+            doesn't contain the expected part type. When ``False`` (consumer
+            semantics), returns ``output=None`` for an empty
+            ``final_output_parts`` (intermediate hop / tool completion);
+            validation errors on *present* parts still propagate.
+        type_adapter: An optional pre-built :class:`pydantic.TypeAdapter` to
+            use for validating ``DataPart.data`` against *output_type*. When
+            ``None`` (default), a new adapter is constructed per call.
+            Consumers pre-build at wiring time so schema-generation errors
+            surface once at construction rather than per envelope.
 
     Returns:
-        A ``NodeResult`` whose ``.output`` is typed according to *output_type*.
+        A ``NodeResult`` whose ``.output`` is typed according to *output_type*
+        (or ``None`` when ``strict=False`` and no parts are present).
 
     Raises:
         DeserializationError: If the expected content part is not found in
-            ``final_output_parts``.
+            ``final_output_parts`` (and either ``strict=True`` or the parts
+            list is non-empty but lacks the expected shape).
+        pydantic.ValidationError: If ``output_type`` is provided and the
+            matching ``DataPart.data`` doesn't validate against it.
+        pydantic.PydanticSchemaGenerationError: If ``type_adapter`` is ``None``
+            and ``output_type`` cannot be schematized by :class:`TypeAdapter`.
     """
     state = envelope.context.state
-    output_parts = state.final_output_parts
-    message_history = state.message_history
-    metadata = state.metadata
     correlation_id = envelope.context.deps.correlation_id
 
-    output = _extract_output(output_parts, output_type)
+    if not state.final_output_parts and not strict:
+        output: Any = None
+    else:
+        output = _extract_output(state.final_output_parts, output_type, type_adapter=type_adapter)
 
     return NodeResult(
         output=output,
-        output_parts=output_parts,
-        message_history=message_history,
-        metadata=metadata,
+        state=state,
         correlation_id=correlation_id,
         emitter_node_id=envelope.context.emitter_node_id,
         emitter_node_kind=envelope.context.emitter_node_kind,
     )
 
 
-def _extract_output(parts: list[Any], output_type: type[Any]) -> Any:
+def _extract_output(parts: list[Any], output_type: type[Any], type_adapter: TypeAdapter[Any] | None = None) -> Any:
     """Extract and optionally deserialize the output from content parts."""
     if output_type is _UNSET:
         return _extract_auto(parts)
     if output_type is str:
         return _extract_text(parts)
-    return _extract_data(parts, output_type)
+    return _extract_data(parts, output_type, type_adapter=type_adapter)
 
 
 def _extract_auto(parts: list[Any]) -> Any:
@@ -82,10 +101,15 @@ def _extract_text(parts: list[Any]) -> str:
     raise DeserializationError("No TextPart found in final_output_parts; expected output_type=str.")
 
 
-def _extract_data(parts: list[Any], output_type: type[Any]) -> Any:
-    """Extract the first DataPart.data and validate via TypeAdapter."""
+def _extract_data(parts: list[Any], output_type: type[Any], type_adapter: TypeAdapter[Any] | None = None) -> Any:
+    """Extract the first DataPart.data and validate via TypeAdapter.
+
+    Uses *type_adapter* if provided; otherwise constructs a new one (which may
+    raise :class:`pydantic.PydanticSchemaGenerationError` if *output_type* is
+    unschematizable).
+    """
     for part in parts:
         if isinstance(part, DataPart):
-            adapter: TypeAdapter[Any] = TypeAdapter(output_type)
+            adapter = type_adapter if type_adapter is not None else TypeAdapter(output_type)
             return adapter.validate_python(part.data)
     raise DeserializationError(f"No DataPart found in final_output_parts; expected output_type={getattr(output_type, '__name__', str(output_type))}.")

--- a/calfkit/client/invocation_handle.py
+++ b/calfkit/client/invocation_handle.py
@@ -30,7 +30,13 @@ class InvocationHandle(Generic[OutputT]):
         Raises:
             asyncio.TimeoutError: If *timeout* elapses before a reply arrives.
             RuntimeError: If this handle was created without a future (fire-and-forget).
-            DeserializationError: If the expected output part type is missing.
+            DeserializationError: If the expected output part type is missing
+                from ``final_output_parts``.
+            pydantic.ValidationError: If ``output_type`` is provided and the
+                reply's ``DataPart.data`` doesn't validate against it.
+            pydantic.PydanticSchemaGenerationError: If ``output_type`` cannot
+                be schematized by :class:`pydantic.TypeAdapter` (e.g. an
+                unsupported generic or non-type value).
         """
         if self._future is None:
             raise RuntimeError("This handle has no associated future — was the client's reply dispatcher configured?")

--- a/calfkit/client/node_result.py
+++ b/calfkit/client/node_result.py
@@ -5,36 +5,99 @@ from typing import Any, Generic
 
 from calfkit._types import OutputT
 from calfkit._vendor.pydantic_ai.messages import ModelMessage
-from calfkit.models import ContentPart
+from calfkit.models import ContentPart, State
 
 
 @dataclass(frozen=True)
 class NodeResult(Generic[OutputT]):
-    """Client-facing projection of an agent node's reply.
+    """Client-facing projection of the session state after a node returns.
 
-    Strips framework internals from the wire-format ``Envelope`` and
-    deserializes ``final_output_parts`` into a typed ``output``.
+    A ``NodeResult`` is what callers receive in two places:
+
+    * :meth:`Client.execute_node` / :meth:`InvocationHandle.result` — the
+      final reply from an agent invocation.
+    * The user function of a :class:`ConsumerNodeDef` — one per envelope on
+      every subscribed topic, including intermediate hops.
+
+    The ``state`` field is the full session :class:`~calfkit.models.State` at
+    the moment this envelope was published, exposing message history, in-flight
+    tool calls/results, application metadata, runtime overrides, and any other
+    state fields. ``message_history``, ``output_parts``, and ``metadata`` are
+    convenience properties that read through ``state``.
+
+    Treat ``NodeResult`` and its ``state`` as read-only. The dataclass is
+    frozen, but ``state`` is a mutable Pydantic model:
+
+    * **Consumer path**: the consumer never republishes (no ``publish_topic``),
+      so mutations have no observable downstream effect. They can still
+      surprise other code holding the same ``NodeResult`` instance.
+    * **Client path** (:meth:`Client.execute_node` / :meth:`InvocationHandle.result`):
+      the caller's lifetime owns the instance — mutations are caller-visible
+      and may corrupt any other code holding a parallel reference (caches,
+      retry layers, etc.).
+
+    ``NodeResult`` is intentionally unhashable (``__hash__ = None``): the
+    underlying ``state`` field is a mutable Pydantic model and cannot be
+    placed in a set or used as a dict key safely. Use ``correlation_id`` if
+    you need a hashable identifier.
     """
 
-    output: OutputT
-    """Deserialized final output (typed via ``output_type``)."""
+    output: OutputT | None
+    """Deserialized final output (typed via ``output_type``).
 
-    output_parts: list[ContentPart]
-    """Raw content parts for advanced introspection."""
+    ``None`` on intermediate hops — envelopes whose ``state.final_output_parts``
+    is empty (e.g. agent hops mid-tool-call, tool completions). Populated when
+    the upstream node emitted a terminal envelope with final output parts.
+    Client-side strict-mode results (the default) always have ``output``
+    populated; consumer-side results may not.
+    """
 
-    message_history: list[ModelMessage]
-    """Full conversation history from the agent session."""
+    state: State
+    """Full session state at this hop. Includes:
 
-    metadata: Any
-    """Application-level metadata attached to the workflow state."""
+    * ``message_history`` — cumulative conversation
+    * ``final_output_parts`` — agent's structured/text output (empty on
+      intermediate hops)
+    * ``tool_calls`` / ``tool_results`` — in-flight tool batch (keyed by
+      ``tool_call_id``)
+    * ``metadata`` — application-level metadata
+    * ``overrides`` — agent tool overrides applied to this invocation (or
+      ``None`` if unset)
+    * ``uncommitted_message`` / ``temp_instructions`` — agent-loop scratch;
+      usually ``None`` on terminal hops, may be populated mid-loop and is not
+      part of the public contract
+    """
 
     correlation_id: str
     """The correlation ID that ties this result to its invocation."""
 
     emitter_node_id: str | None = None
     """Node id of the node that emitted this reply (sourced from the
-    ``x-calf-emitter`` Kafka header on the inbound callback message)."""
+    ``x-calf-emitter`` Kafka header). May be ``None`` if the upstream
+    producer didn't stamp the header (e.g. a non-calfkit publisher)."""
 
     emitter_node_kind: str | None = None
     """Coarse classification of the emitter (one of ``NodeKind``), sourced
-    from the ``x-calf-emitter-kind`` Kafka header."""
+    from the ``x-calf-emitter-kind`` Kafka header. May be ``None`` if not
+    stamped."""
+
+    # NodeResult holds a mutable Pydantic model (state); the dataclass-
+    # synthesized __hash__ would recursively try to hash unhashable fields and
+    # raise at use-time. Declare unhashability explicitly so static type
+    # checkers and runtime introspection agree.
+    __hash__ = None  # type: ignore[assignment]
+
+    @property
+    def output_parts(self) -> list[ContentPart]:
+        """Convenience: ``state.final_output_parts``."""
+        return self.state.final_output_parts
+
+    @property
+    def message_history(self) -> list[ModelMessage]:
+        """Convenience: ``state.message_history``."""
+        return self.state.message_history
+
+    @property
+    def metadata(self) -> Any:
+        """Convenience: ``state.metadata``."""
+        return self.state.metadata

--- a/calfkit/nodes/__init__.py
+++ b/calfkit/nodes/__init__.py
@@ -1,5 +1,6 @@
 from calfkit.nodes.agent import Agent, BaseAgentNodeDef
 from calfkit.nodes.base import BaseNodeDef, GateFunction
+from calfkit.nodes.consumer import ConsumerFn, ConsumerNodeDef, consumer
 from calfkit.nodes.node import NodeDef
 from calfkit.nodes.tool import BaseToolNodeDef, ToolNodeDef, agent_tool
 
@@ -8,8 +9,11 @@ __all__ = [
     "BaseAgentNodeDef",
     "BaseNodeDef",
     "BaseToolNodeDef",
+    "ConsumerFn",
+    "ConsumerNodeDef",
     "GateFunction",
     "NodeDef",
     "ToolNodeDef",
     "agent_tool",
+    "consumer",
 ]

--- a/calfkit/nodes/consumer.py
+++ b/calfkit/nodes/consumer.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Annotated, Any, ClassVar, Generic
+
+from faststream import Context, Response
+from faststream.kafka.annotations import KafkaBroker as BrokerAnnotation
+from pydantic import TypeAdapter, ValidationError
+
+from calfkit._protocol import HDR_EMITTER, HDR_EMITTER_KIND, NodeKind, decode_header_str
+from calfkit._types import OutputT
+from calfkit.client.deserialize import _UNSET, deserialize_to_node_result
+from calfkit.client.node_result import NodeResult
+from calfkit.exceptions import DeserializationError
+from calfkit.models import State
+from calfkit.models.actions import NodeResult as NodeAction
+from calfkit.models.envelope import Envelope
+from calfkit.models.session_context import SessionRunContext
+from calfkit.nodes.base import BaseNodeDef, GateFunction
+
+logger = logging.getLogger(__name__)
+
+
+ConsumerFn = Callable[[NodeResult[OutputT]], None | Awaitable[None]]
+"""Signature of a consumer function: receives the same client-facing
+:class:`~calfkit.client.node_result.NodeResult` that
+:meth:`Client.execute_node` returns. Sync or async.
+
+``result.output`` is ``None`` on intermediate hops (e.g. tool completions, or
+agent state transitions that haven't yet produced a final output). User code
+must tolerate ``None`` or filter via gates. ``result.message_history``,
+``result.emitter_node_id``, and ``result.emitter_node_kind`` are always
+populated."""
+
+
+def _validate_consume_fn(consume_fn: Any) -> None:
+    """Reject consume_fn shapes that would silently no-op at runtime.
+
+    Why: a plain generator or async-generator function passed here would be
+    invoked, return an iterator/asyncgen object (which is neither None nor
+    awaitable), and the user's body would never execute — the consumer would
+    appear to run forever without doing anything. Surface that at construction.
+    """
+    if inspect.isgeneratorfunction(consume_fn):
+        raise TypeError(
+            f"consume_fn must be a regular function or coroutine function; got generator function {getattr(consume_fn, '__name__', consume_fn)!r}"
+        )
+    if inspect.isasyncgenfunction(consume_fn):
+        raise TypeError(
+            f"consume_fn must be a regular function or coroutine function; "
+            f"got async generator function {getattr(consume_fn, '__name__', consume_fn)!r}"
+        )
+
+
+class ConsumerNodeDef(Generic[OutputT], BaseNodeDef):
+    """Terminal sink node: listens on one or more topics and runs arbitrary user
+    logic against a :class:`NodeResult` projected from each inbound envelope.
+
+    Use :func:`consumer` for the fast-path decorator. Instantiate this class
+    directly for class-based composition (mirrors :class:`Agent` /
+    :class:`ToolNodeDef`).
+
+    The consumer is wired to any topic carrying calfkit ``Envelope`` payloads —
+    typically the ``publish_topic`` of an upstream agent or tool. Because that
+    publisher fires on **every** handler hop (intermediate ``Call`` envelopes,
+    tool completions, and final ``ReturnCall`` envelopes alike), the consumer
+    sees the entire transition stream by design. ``result.output`` is populated
+    only when ``final_output_parts`` is present on the envelope (agent
+    terminals); on every other hop it is ``None``. Use a gate to filter:
+
+        gates=[lambda ctx: bool(ctx.state.final_output_parts)]
+
+    Behavior:
+        * Sync and async user functions are both supported.
+        * Gates inherited from :class:`BaseNodeDef` filter pre-run.
+        * Exceptions from the user function are logged and swallowed by
+          default (offset commits, processing continues). See ``re_raise``.
+        * ``asyncio.CancelledError`` always propagates.
+    """
+
+    _node_kind: ClassVar[NodeKind] = "consumer"
+
+    def __init__(
+        self,
+        *,
+        node_id: str,
+        subscribe_topics: str | list[str],
+        consume_fn: ConsumerFn[OutputT],
+        output_type: type[OutputT] = _UNSET,
+        gates: list[GateFunction] | None = None,
+        re_raise: bool = False,
+    ) -> None:
+        """Initialize a consumer node definition.
+
+        Args:
+            node_id: Unique identifier for the node.
+            subscribe_topics: One or more topics to consume from.
+            consume_fn: The user-provided sink function. Receives a single
+                :class:`NodeResult` argument; may be sync or async. Must not
+                be a generator or async-generator function.
+            output_type: Expected Python type for ``result.output`` on hops
+                that carry final output parts. Defaults to auto-detect
+                (``DataPart`` → ``TextPart`` fallback). On hops without
+                ``final_output_parts``, ``result.output`` is ``None``
+                regardless of this setting.
+            gates: Optional pre-run predicates with AND semantics.
+            re_raise: When ``True``, exceptions raised by ``consume_fn``
+                propagate out of the handler. **Important caveat**: the
+                :class:`Worker` registers subscribers with FastStream's
+                default ``AckPolicy.ACK_FIRST``, which commits the Kafka
+                offset *before* the handler runs. So ``re_raise=True`` only
+                restarts the FastStream consumer task and surfaces the
+                exception in logs — the offending message is **not**
+                redelivered, and there is no built-in DLQ. Use this flag for
+                fail-loud development semantics. For true retry/DLQ
+                behavior, configure the broker's ``ack_policy`` explicitly
+                on the :class:`Worker`.
+        """
+        _validate_consume_fn(consume_fn)
+        if not isinstance(subscribe_topics, (list, tuple)):
+            subscribe_topics = [subscribe_topics]
+        super().__init__(
+            node_id=node_id,
+            subscribe_topics=list(subscribe_topics),
+            publish_topic=None,
+            gates=gates,
+        )
+        self._consume_fn = consume_fn
+        self._output_type = output_type
+        self._re_raise = re_raise
+        # Pre-build the TypeAdapter at construction so a schema-generation
+        # error (e.g. an unschematizable output_type) surfaces once at wiring
+        # time rather than per envelope at runtime. Auto-detect and str paths
+        # don't need an adapter.
+        self._type_adapter: TypeAdapter[Any] | None = None
+        if output_type is not _UNSET and output_type is not str:
+            self._type_adapter = TypeAdapter(output_type)
+
+    @property
+    def publish_topic(self) -> None:
+        """Consumers are terminal sinks; always ``None``."""
+        return None
+
+    @publish_topic.setter
+    def publish_topic(self, value: str | None) -> None:
+        # Accept None silently so BaseNodeSchema's dataclass __init__ can run.
+        # Reject everything else: the no-publish invariant must hold for the
+        # life of the instance (Worker would otherwise wire up a publisher).
+        if value is not None:
+            raise AttributeError(f"Cannot set publish_topic={value!r} on {type(self).__name__}: consumers are terminal sinks.")
+
+    async def run(self, ctx: SessionRunContext) -> NodeAction[State]:
+        # Defensive: handler() is overridden and never calls run(). If a future
+        # refactor reaches here, fail loud rather than silently returning Silent.
+        raise AssertionError(f"{type(self).__name__}.run() should never be invoked; handler() is overridden.")
+
+    async def handler(
+        self,
+        envelope: Envelope,
+        correlation_id: Annotated[str, Context()],
+        headers: Annotated[dict[str, Any], Context("message.headers")],
+        broker: BrokerAnnotation,
+        message: Annotated[Any, Context("message")] = None,
+    ) -> Response:
+        raw_emitter = headers.get(HDR_EMITTER)
+        emitter = decode_header_str(raw_emitter)
+        if emitter is None:
+            logger.warning(
+                "[%s] inbound to consumer=%s has no usable %s header (got %s); emitter unknown",
+                correlation_id[:8],
+                self.node_id,
+                HDR_EMITTER,
+                "None" if raw_emitter is None else type(raw_emitter).__name__,
+            )
+        emitter_kind = decode_header_str(headers.get(HDR_EMITTER_KIND))
+        # Pull raw-broker message metadata (topic / partition / offset) for
+        # error-log context. ``getattr`` keeps direct handler() calls (tests)
+        # working even when no broker message is present.
+        raw_msg = getattr(message, "raw_message", None) if message is not None else None
+        in_topic = getattr(raw_msg, "topic", None)
+        in_partition = getattr(raw_msg, "partition", None)
+        in_offset = getattr(raw_msg, "offset", None)
+        logger.debug(
+            "[%s] consumer handler entered node=%s emitter=%s kind=%s topic=%s partition=%s offset=%s",
+            correlation_id[:8],
+            self.node_id,
+            emitter,
+            emitter_kind,
+            in_topic,
+            in_partition,
+            in_offset,
+        )
+        # Consumer is outside the call/return flow, so the inbound call_stack
+        # may be empty (e.g. when tapping publish_topic post-ReturnCall) — we
+        # bypass BaseNodeDef.prepare_context which peeks the stack. Emitter
+        # ids are PrivateAttr (calfkit.models.session_context), so they never
+        # ride on the wire; stamping the inbound context directly is safe.
+        envelope.context._emitter_node_id = emitter
+        envelope.context._emitter_node_kind = emitter_kind
+        ctx = envelope.context
+
+        if not await self._evaluate_gates(ctx, correlation_id):
+            return Response(envelope, headers=self._emitter_headers())
+
+        try:
+            result: NodeResult[OutputT] = deserialize_to_node_result(
+                envelope,
+                self._output_type,
+                strict=False,
+                type_adapter=self._type_adapter,
+            )
+        except (DeserializationError, ValidationError):
+            logger.exception(
+                "[%s] consumer=%s deserialize failed; skipping (emitter=%s kind=%s output_type=%s topic=%s partition=%s offset=%s)",
+                correlation_id[:8],
+                self.node_id,
+                emitter,
+                emitter_kind,
+                getattr(self._output_type, "__name__", repr(self._output_type)),
+                in_topic,
+                in_partition,
+                in_offset,
+            )
+            return Response(envelope, headers=self._emitter_headers())
+        except Exception:
+            # Safety net: anything that slips past the expected exception
+            # tuple (e.g. an unforeseen adapter failure, a Pydantic edge case,
+            # a third-party model integration error) is logged and skipped so
+            # a single bad envelope can't poison-pill the Kafka offset.
+            logger.exception(
+                "[%s] consumer=%s unexpected deserialize error; skipping (emitter=%s kind=%s output_type=%s topic=%s partition=%s offset=%s)",
+                correlation_id[:8],
+                self.node_id,
+                emitter,
+                emitter_kind,
+                getattr(self._output_type, "__name__", repr(self._output_type)),
+                in_topic,
+                in_partition,
+                in_offset,
+            )
+            return Response(envelope, headers=self._emitter_headers())
+
+        try:
+            ret = self._consume_fn(result)
+            # Catch the runtime-only silent-noop shapes that escape
+            # _validate_consume_fn — callable-class generators, plain functions
+            # that return generator/asyncgen objects, etc. In all these cases
+            # ``ret`` is a generator/asyncgen object that is NOT awaitable, so
+            # ``inspect.isawaitable`` would skip it and the body would never run.
+            if inspect.isgenerator(ret) or inspect.isasyncgen(ret):
+                raise TypeError(
+                    f"consume_fn returned a {type(ret).__name__} object; the function body would never execute. "
+                    f"Iterate inside the function or refactor to a coroutine."
+                )
+            if inspect.isawaitable(ret):
+                await ret
+        except asyncio.CancelledError:
+            # Never swallow cooperative cancellation — let the event loop unwind.
+            raise
+        except Exception:
+            logger.exception(
+                "[%s] consumer=%s consume_fn raised (emitter=%s kind=%s topic=%s partition=%s offset=%s)",
+                correlation_id[:8],
+                self.node_id,
+                emitter,
+                emitter_kind,
+                in_topic,
+                in_partition,
+                in_offset,
+            )
+            if self._re_raise:
+                raise
+
+        return Response(envelope, headers=self._emitter_headers())
+
+
+def consumer(
+    *,
+    subscribe_topics: str | list[str],
+    output_type: type[OutputT] = _UNSET,
+    node_id: str | None = None,
+    gates: list[GateFunction] | None = None,
+    re_raise: bool = False,
+) -> Callable[[ConsumerFn[OutputT]], ConsumerNodeDef[OutputT]]:
+    """Decorator turning a function into a deployable consumer node.
+
+    The decorated function receives a single argument: the same
+    :class:`NodeResult` returned by :meth:`Client.execute_node`. Both sync
+    and async functions are supported. Generators / async generators are
+    rejected at decoration time.
+
+    Example::
+
+        @consumer(subscribe_topics="weather_agent.output", output_type=WeatherReport)
+        async def save_weather(result: NodeResult[WeatherReport]) -> None:
+            if result.output is None:
+                return  # intermediate hop — no final output yet
+            await db.save(result.output)
+
+    Args:
+        subscribe_topics: One or more topics to consume from. Typically the
+            ``publish_topic`` of an upstream agent or tool node. The consumer
+            receives the entire transition stream on these topics —
+            intermediate hops surface as ``NodeResult`` with ``output=None``.
+        output_type: Expected Python type for ``result.output`` on hops that
+            carry final output parts. Defaults to auto-detect.
+        node_id: Optional override; defaults to ``consumer_<function name>``.
+        gates: Optional pre-run predicates. A useful idiom for "final outputs
+            only" is ``gates=[lambda ctx: bool(ctx.state.final_output_parts)]``.
+        re_raise: When ``True``, exceptions propagate. See
+            :class:`ConsumerNodeDef` for the ack-policy caveat.
+
+    Returns:
+        A :class:`ConsumerNodeDef` instance ready to register with a
+        :class:`Worker`.
+    """
+
+    def _wrap(fn: ConsumerFn[OutputT]) -> ConsumerNodeDef[OutputT]:
+        return ConsumerNodeDef[OutputT](
+            node_id=node_id or f"consumer_{fn.__name__}",
+            subscribe_topics=subscribe_topics,
+            consume_fn=fn,
+            output_type=output_type,
+            gates=gates,
+            re_raise=re_raise,
+        )
+
+    return _wrap

--- a/examples/quickstart/agent_service.py
+++ b/examples/quickstart/agent_service.py
@@ -11,6 +11,7 @@ agent = Agent(
     "weather_agent",
     system_prompt="You are a helpful assistant.",
     subscribe_topics="weather_agent.input",
+    publish_topic="weather_agent.output",  # Stream outputs for consumer nodes to tap
     model_client=OpenAIResponsesModelClient(model_name="gpt-5.4-nano"),
     tools=[get_weather],  # Register tool definitions with the agent
 )

--- a/examples/quickstart/weather_sink.py
+++ b/examples/quickstart/weather_sink.py
@@ -1,0 +1,42 @@
+"""Independently deployable consumer node.
+
+Listens on the weather agent's ``publish_topic`` and runs arbitrary Python
+against every envelope that flows through it. The decorated function receives
+the same client-facing ``NodeResult`` returned by ``Client.execute_node()``.
+
+Because an agent's ``publish_topic`` carries every state transition (not just
+the final reply), ``result.output`` is ``None`` on intermediate hops — pending
+tool calls, tool returns, agent retries. Filter via a gate if you only want
+agent terminals:
+
+    gates=[lambda ctx: bool(ctx.state.final_output_parts)]
+
+Run alongside the agent service:
+
+    python weather_sink.py
+"""
+
+import asyncio
+
+from calfkit.client import Client, NodeResult
+from calfkit.nodes import consumer
+from calfkit.worker import Worker
+
+
+@consumer(subscribe_topics="weather_agent.output")
+async def log_weather_output(result: NodeResult) -> None:
+    if result.output is None:
+        # Intermediate hop (e.g. agent about to call a tool). Observe and move on.
+        print(f"[{result.correlation_id[:8]}] intermediate hop from {result.emitter_node_id}")
+        return
+    print(f"[{result.correlation_id[:8]}] final from {result.emitter_node_id}: {result.output!r}")
+
+
+async def main() -> None:
+    client = Client.connect("localhost:9092")
+    worker = Worker(client, nodes=[log_weather_output])
+    await worker.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -1,0 +1,1049 @@
+"""End-to-end and unit tests for ConsumerNodeDef and the @consumer decorator.
+
+Mirrors the project pattern: TestKafkaBroker for in-memory routing,
+FunctionModel for deterministic agent runs, no broker mocking for E2E flows.
+
+Direct handler-level tests bypass the broker to pin contracts that
+TestKafkaBroker's propagation semantics make ambiguous (e.g. ``re_raise``).
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+import pytest
+from faststream.kafka import KafkaBroker, TestKafkaBroker
+from pydantic import TypeAdapter
+
+from calfkit._protocol import HDR_EMITTER, HDR_EMITTER_KIND
+from calfkit._vendor.pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    ToolCallPart,
+    ToolReturnPart,
+)
+from calfkit._vendor.pydantic_ai.messages import (
+    TextPart as ModelTextPart,
+)
+from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
+from calfkit.client import Client, NodeResult
+from calfkit.models import SessionRunContext
+from calfkit.models.envelope import Envelope
+from calfkit.models.payload import DataPart, TextPart
+from calfkit.models.session_context import CallFrameStack, Deps, WorkflowState
+from calfkit.models.state import State
+from calfkit.nodes import Agent, ConsumerNodeDef, consumer
+from calfkit.worker import Worker
+from tests.providers import prepare_worker
+
+CONSUMER_LOGGER = "calfkit.nodes.consumer"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _text_then_done() -> FunctionModel:
+    def _fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[ModelTextPart("done")])
+
+    return FunctionModel(_fn)
+
+
+def _wire_agent_with_consumer(container, consumer_node: ConsumerNodeDef) -> Agent:
+    worker = container.get(Worker)
+    agent = Agent(
+        "consumer_test_agent",
+        system_prompt="x",
+        subscribe_topics="consumer_test_agent.input",
+        publish_topic="consumer_test_agent.output",
+        model_client=_text_then_done(),
+    )
+    worker.add_nodes(agent, consumer_node)
+    prepare_worker(container)
+    return agent
+
+
+def _envelope_with_text(text: str, correlation_id: str = "test-cid-00000000") -> Envelope:
+    state = State()
+    state.final_output_parts = [TextPart(text=text)]
+    return Envelope(
+        context=SessionRunContext(state=state, deps=Deps(correlation_id=correlation_id, provided_deps={})),
+        internal_workflow_state=WorkflowState(call_stack=CallFrameStack()),
+    )
+
+
+def _envelope_without_final_parts(correlation_id: str = "test-cid-00000000") -> Envelope:
+    """Intermediate-hop shape: state populated but no final_output_parts."""
+    return Envelope(
+        context=SessionRunContext(state=State(), deps=Deps(correlation_id=correlation_id, provided_deps={})),
+        internal_workflow_state=WorkflowState(call_stack=CallFrameStack()),
+    )
+
+
+def _envelope_with_data(data: dict, correlation_id: str = "test-cid-00000000") -> Envelope:
+    state = State()
+    state.final_output_parts = [DataPart(data=data)]
+    return Envelope(
+        context=SessionRunContext(state=state, deps=Deps(correlation_id=correlation_id, provided_deps={})),
+        internal_workflow_state=WorkflowState(call_stack=CallFrameStack()),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Static / construction-level invariants
+# ---------------------------------------------------------------------------
+
+
+def test_consumer_node_kind_is_consumer():
+    assert ConsumerNodeDef._node_kind == "consumer"
+
+
+def test_decorator_sets_default_node_id_from_fn_name():
+    @consumer(subscribe_topics="t")
+    def my_sink(result: NodeResult) -> None:
+        return None
+
+    assert my_sink.node_id == "consumer_my_sink"
+    assert my_sink.subscribe_topics == ["t"]
+    assert my_sink.publish_topic is None
+
+
+def test_decorator_accepts_explicit_node_id_and_list_topics():
+    @consumer(subscribe_topics=["a", "b"], node_id="custom_id")
+    def my_sink(result: NodeResult) -> None:
+        return None
+
+    assert my_sink.node_id == "custom_id"
+    assert my_sink.subscribe_topics == ["a", "b"]
+
+
+def test_class_form_normalizes_str_topic_to_list():
+    node = ConsumerNodeDef(
+        node_id="x",
+        subscribe_topics="single_topic",
+        consume_fn=lambda r: None,
+    )
+    assert node.subscribe_topics == ["single_topic"]
+    assert node.publish_topic is None
+
+
+def test_publish_topic_setter_rejects_non_none():
+    """Consumers are terminal sinks; the no-publish invariant must hold for
+    the life of the instance to prevent Worker from wiring up a publisher."""
+    node = ConsumerNodeDef(node_id="x", subscribe_topics="t", consume_fn=lambda r: None)
+    with pytest.raises(AttributeError, match="terminal sinks"):
+        node.publish_topic = "sneaky.topic"
+    assert node.publish_topic is None
+
+
+def test_publish_topic_setter_accepts_none():
+    """None must be accepted (BaseNodeSchema's dataclass __init__ sets it)."""
+    node = ConsumerNodeDef(node_id="x", subscribe_topics="t", consume_fn=lambda r: None)
+    node.publish_topic = None  # must not raise
+    assert node.publish_topic is None
+
+
+def test_generator_function_rejected_at_construction():
+    """A generator function would return an iterator from the handler call,
+    which is neither None nor awaitable — the user body would never run."""
+
+    def gen(result):
+        yield result
+
+    with pytest.raises(TypeError, match="generator function"):
+        ConsumerNodeDef(node_id="x", subscribe_topics="t", consume_fn=gen)
+
+
+def test_async_generator_function_rejected_at_construction():
+    async def agen(result):
+        yield result
+
+    with pytest.raises(TypeError, match="async generator function"):
+        ConsumerNodeDef(node_id="x", subscribe_topics="t", consume_fn=agen)
+
+
+async def test_run_raises_assertion_error_if_called():
+    """Defensive guard: handler() is overridden and run() should never be
+    reached. If a future refactor calls it, fail loud."""
+    node = ConsumerNodeDef(node_id="x", subscribe_topics="t", consume_fn=lambda r: None)
+    ctx = SessionRunContext(state=State(), deps=Deps(correlation_id="c", provided_deps={}))
+
+    with pytest.raises(AssertionError, match="never be invoked"):
+        await node.run(ctx)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: consumer receives client-facing NodeResult
+# ---------------------------------------------------------------------------
+
+
+async def test_sync_consumer_receives_node_result_from_agent_output(container):
+    received: list[NodeResult] = []
+
+    @consumer(subscribe_topics="consumer_test_agent.output")
+    def sink(result: NodeResult) -> None:
+        received.append(result)
+
+    agent = _wire_agent_with_consumer(container, sink)
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        await client.execute_node("hi", agent.subscribe_topics[0], timeout=5)
+
+    final = [r for r in received if any(isinstance(p, TextPart) for p in r.output_parts)]
+    assert final, f"consumer never saw an envelope with final output_parts; saw={received}"
+    assert final[-1].output == "done"
+    assert isinstance(final[-1], NodeResult)
+
+
+async def test_async_consumer_receives_node_result_from_agent_output(container):
+    received: list[NodeResult] = []
+
+    @consumer(subscribe_topics="consumer_test_agent.output")
+    async def sink(result: NodeResult) -> None:
+        await asyncio.sleep(0)
+        received.append(result)
+
+    agent = _wire_agent_with_consumer(container, sink)
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        await client.execute_node("hi", agent.subscribe_topics[0], timeout=5)
+
+    final = [r for r in received if any(isinstance(p, TextPart) for p in r.output_parts)]
+    assert final
+    assert final[-1].output == "done"
+
+
+async def test_consumer_sees_upstream_emitter_id_on_result(container):
+    """The NodeResult passed to the consumer carries the upstream node's
+    x-calf-emitter identity (proves we wire emitter headers, not just body)."""
+    received: list[NodeResult] = []
+
+    @consumer(subscribe_topics="consumer_test_agent.output")
+    def sink(result: NodeResult) -> None:
+        received.append(result)
+
+    agent = _wire_agent_with_consumer(container, sink)
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        await client.execute_node("hi", agent.subscribe_topics[0], timeout=5)
+
+    final = [r for r in received if any(isinstance(p, TextPart) for p in r.output_parts)]
+    assert final
+    assert final[-1].emitter_node_id == agent.node_id
+    assert final[-1].emitter_node_kind == "agent"
+
+
+# ---------------------------------------------------------------------------
+# output_type deserialization
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Report:
+    location: str
+    summary: str
+
+
+def _structured_report_model() -> FunctionModel:
+    def _fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        last = messages[-1]
+        if isinstance(last, ModelRequest) and any(isinstance(p, ToolReturnPart) for p in last.parts):
+            return ModelResponse(parts=[ModelTextPart('{"location":"Tokyo","summary":"sunny"}')])
+        return ModelResponse(parts=[ModelTextPart('{"location":"Tokyo","summary":"sunny"}')])
+
+    return FunctionModel(_fn)
+
+
+async def test_consumer_deserializes_output_type_dataclass(container):
+    received: list[NodeResult[Report]] = []
+
+    @consumer(subscribe_topics="structured_agent.output", output_type=Report)
+    def sink(result: NodeResult[Report]) -> None:
+        received.append(result)
+
+    worker = container.get(Worker)
+    structured_agent = Agent[Report](
+        "structured_agent",
+        system_prompt="x",
+        subscribe_topics="structured_agent.input",
+        publish_topic="structured_agent.output",
+        model_client=_structured_report_model(),
+        final_output_type=Report,
+    )
+    worker.add_nodes(structured_agent, sink)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        await client.execute_node("hi", structured_agent.subscribe_topics[0], timeout=5)
+
+    final = [r for r in received if any(isinstance(p, DataPart) for p in r.output_parts)]
+    assert final, f"no final DataPart envelope observed; received={received}"
+    assert isinstance(final[-1].output, Report)
+    assert final[-1].output.location == "Tokyo"
+    assert final[-1].output.summary == "sunny"
+
+
+# ---------------------------------------------------------------------------
+# Intermediate-hop / "consume all outputs" semantics
+# ---------------------------------------------------------------------------
+
+
+async def test_intermediate_hop_passes_to_fn_with_output_none(container, caplog):
+    """An envelope with empty final_output_parts (intermediate agent hop, tool
+    completion) is passed to the user fn with ``result.output is None``. NO
+    error log — intermediate hops are expected, not malformed."""
+    received: list[NodeResult] = []
+
+    @consumer(subscribe_topics="intermediate.topic")
+    def sink(result: NodeResult) -> None:
+        received.append(result)
+
+    worker = container.get(Worker)
+    worker.add_nodes(sink)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+
+    envelope = _envelope_without_final_parts("cid-int-0")
+    with caplog.at_level(logging.ERROR, logger=CONSUMER_LOGGER):
+        async with TestKafkaBroker(broker):
+            await broker.publish(
+                envelope,
+                topic="intermediate.topic",
+                correlation_id="cid-int-0",
+                headers={HDR_EMITTER: "upstream_node", HDR_EMITTER_KIND: "agent"},
+            )
+
+    assert len(received) == 1
+    assert received[0].output is None
+    assert received[0].emitter_node_id == "upstream_node"
+    assert received[0].emitter_node_kind == "agent"
+    assert received[0].output_parts == []
+    deserialize_errors = [r for r in caplog.records if "deserialize failed" in r.getMessage()]
+    assert not deserialize_errors, f"intermediate hop should not log a deserialize error: {deserialize_errors}"
+
+
+async def test_validation_error_on_present_parts_logs_and_skips(container, caplog):
+    """When parts ARE present but don't match the requested ``output_type``,
+    that's a real malformed envelope (or schema drift). User fn is skipped,
+    ERROR is logged with operational context."""
+    invocations: list[str] = []
+
+    @consumer(subscribe_topics="validation.topic", output_type=Report)
+    def sink(result: NodeResult[Report]) -> None:
+        invocations.append("ran")
+
+    worker = container.get(Worker)
+    worker.add_nodes(sink)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+
+    # DataPart present but doesn't match Report dataclass shape → ValidationError.
+    bad_envelope = _envelope_with_data({"unexpected": "shape"}, correlation_id="cid-bad-0")
+    with caplog.at_level(logging.ERROR, logger=CONSUMER_LOGGER):
+        async with TestKafkaBroker(broker):
+            await broker.publish(
+                bad_envelope,
+                topic="validation.topic",
+                correlation_id="cid-bad-0",
+                headers={HDR_EMITTER: "upstream", HDR_EMITTER_KIND: "agent"},
+            )
+
+    assert invocations == []
+    err_records = [r for r in caplog.records if "deserialize failed" in r.getMessage()]
+    assert err_records, "validation error must be logged at ERROR"
+    msg = err_records[0].getMessage()
+    assert "emitter=upstream" in msg
+    assert "output_type=Report" in msg
+
+
+async def test_missing_emitter_header_warns_and_still_invokes_fn(container, caplog):
+    """A consumer wired to a non-calfkit producer (no x-calf-emitter header)
+    should log a warning, invoke the user fn with ``emitter_node_id=None``,
+    and continue. Don't fail-loud on this — it's a legitimate integration."""
+    received: list[NodeResult] = []
+
+    @consumer(subscribe_topics="no_emitter.topic")
+    def sink(result: NodeResult) -> None:
+        received.append(result)
+
+    worker = container.get(Worker)
+    worker.add_nodes(sink)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+
+    envelope = _envelope_with_text("hello", correlation_id="cid-noemit-0")
+    with caplog.at_level(logging.WARNING, logger=CONSUMER_LOGGER):
+        async with TestKafkaBroker(broker):
+            await broker.publish(envelope, topic="no_emitter.topic", correlation_id="cid-noemit-0")
+
+    assert len(received) == 1
+    assert received[0].output == "hello"
+    assert received[0].emitter_node_id is None
+    assert any("emitter unknown" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Multi-topic subscription — runtime E2E
+# ---------------------------------------------------------------------------
+
+
+async def test_consumer_fans_in_across_multiple_topics(container):
+    """Regression guard for ``Worker.register_handlers`` unpacking the topic
+    list: ``broker.subscriber(*topics)`` must wire the consumer to EVERY
+    topic, not just the first."""
+    received: list[NodeResult] = []
+
+    @consumer(subscribe_topics=["fanin.a", "fanin.b"])
+    def sink(result: NodeResult) -> None:
+        received.append(result)
+
+    worker = container.get(Worker)
+    worker.add_nodes(sink)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+
+    env_a = _envelope_with_text("from_a", correlation_id="cid-a")
+    env_b = _envelope_with_text("from_b", correlation_id="cid-b")
+
+    async with TestKafkaBroker(broker):
+        await broker.publish(env_a, topic="fanin.a", correlation_id="cid-a", headers={HDR_EMITTER: "src_a", HDR_EMITTER_KIND: "client"})
+        await broker.publish(env_b, topic="fanin.b", correlation_id="cid-b", headers={HDR_EMITTER: "src_b", HDR_EMITTER_KIND: "client"})
+
+    outputs = {r.output for r in received}
+    assert outputs == {"from_a", "from_b"}, f"expected both topics to fire; got {outputs}"
+
+
+# ---------------------------------------------------------------------------
+# Error handling — direct handler invocation to pin contracts
+# ---------------------------------------------------------------------------
+
+
+async def test_consume_fn_exception_swallowed_by_default_direct():
+    """Direct-handler test: ``re_raise=False`` (default) — exception is
+    logged and the handler returns normally (offset would commit)."""
+    invocations: list[str] = []
+
+    def boom(result: NodeResult) -> None:
+        invocations.append("ran")
+        raise RuntimeError("intentional consumer failure")
+
+    node = ConsumerNodeDef(node_id="boom_sink", subscribe_topics="t", consume_fn=boom)
+
+    envelope = _envelope_with_text("hi", correlation_id="cid-swallow-0")
+    response = await node.handler(
+        envelope,
+        correlation_id="cid-swallow-0",
+        headers={HDR_EMITTER: b"probe", HDR_EMITTER_KIND: b"client"},
+        broker=MagicMock(),
+    )
+
+    assert invocations == ["ran"]
+    # handler returns a Response; the test contract is "did not raise"
+    assert response is not None
+
+
+async def test_consume_fn_exception_re_raises_when_configured_direct():
+    """Direct-handler test: ``re_raise=True`` — exception propagates out of
+    the handler. This is the contract the previous broker-coupled test could
+    not pin (TestKafkaBroker's propagation path is undefined)."""
+    invocations: list[str] = []
+
+    def boom(result: NodeResult) -> None:
+        invocations.append("ran")
+        raise RuntimeError("propagate me")
+
+    node = ConsumerNodeDef(node_id="boom_sink", subscribe_topics="t", consume_fn=boom, re_raise=True)
+
+    envelope = _envelope_with_text("hi", correlation_id="cid-raise-0")
+    with pytest.raises(RuntimeError, match="propagate me"):
+        await node.handler(
+            envelope,
+            correlation_id="cid-raise-0",
+            headers={HDR_EMITTER: b"probe", HDR_EMITTER_KIND: b"client"},
+            broker=MagicMock(),
+        )
+
+    assert invocations == ["ran"]
+
+
+async def test_consume_fn_exception_swallow_emits_error_log(caplog):
+    """Companion to the direct test above: verify the ERROR log carries the
+    operational context (emitter, kind) we promised in the log message."""
+
+    def boom(result: NodeResult) -> None:
+        raise RuntimeError("absorb me")
+
+    node = ConsumerNodeDef(node_id="boom_sink", subscribe_topics="t", consume_fn=boom)
+    envelope = _envelope_with_text("hi", correlation_id="cid-swallow-log-0")
+
+    with caplog.at_level(logging.ERROR, logger=CONSUMER_LOGGER):
+        await node.handler(
+            envelope,
+            correlation_id="cid-swallow-log-0",
+            headers={HDR_EMITTER: b"upstream_x", HDR_EMITTER_KIND: b"agent"},
+            broker=MagicMock(),
+        )
+
+    err = [r for r in caplog.records if "consume_fn raised" in r.getMessage()]
+    assert err, "swallowed exception must emit an ERROR log line"
+    assert "emitter=upstream_x" in err[0].getMessage()
+    assert "kind=agent" in err[0].getMessage()
+
+
+async def test_cancelled_error_always_propagates():
+    """Even with ``re_raise=False``, asyncio.CancelledError must propagate —
+    swallowing cancellation breaks cooperative shutdown."""
+
+    async def cancels(result: NodeResult) -> None:
+        raise asyncio.CancelledError()
+
+    node = ConsumerNodeDef(node_id="cancel_sink", subscribe_topics="t", consume_fn=cancels, re_raise=False)
+    envelope = _envelope_with_text("hi", correlation_id="cid-cancel-0")
+
+    with pytest.raises(asyncio.CancelledError):
+        await node.handler(
+            envelope,
+            correlation_id="cid-cancel-0",
+            headers={HDR_EMITTER: b"probe", HDR_EMITTER_KIND: b"client"},
+            broker=MagicMock(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Gates on the consumer
+# ---------------------------------------------------------------------------
+
+
+async def test_gate_rejection_skips_consume_fn(container):
+    invocations: list[str] = []
+
+    def reject(ctx: SessionRunContext) -> bool:
+        return False
+
+    @consumer(subscribe_topics="consumer_test_agent.output", gates=[reject])
+    def sink(result: NodeResult) -> None:
+        invocations.append("ran")
+
+    agent = _wire_agent_with_consumer(container, sink)
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        result = await client.execute_node("hi", agent.subscribe_topics[0], timeout=5)
+        assert result.output == "done"
+
+    assert invocations == []
+
+
+async def test_gate_acceptance_runs_consume_fn(container):
+    gate_calls: list[str] = []
+    invocations: list[str] = []
+
+    def accept(ctx: SessionRunContext) -> bool:
+        gate_calls.append("g")
+        return True
+
+    @consumer(subscribe_topics="consumer_test_agent.output", gates=[accept])
+    def sink(result: NodeResult) -> None:
+        invocations.append("ran")
+
+    agent = _wire_agent_with_consumer(container, sink)
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        await client.execute_node("hi", agent.subscribe_topics[0], timeout=5)
+
+    assert gate_calls, "gate must fire when consumer receives a message"
+    assert invocations, "gate accepted → consume_fn must run"
+
+
+async def test_final_only_gate_idiom_filters_intermediate(container):
+    """Documented idiom: a gate keyed off ``final_output_parts`` filters out
+    intermediate hops so the user fn only sees agent terminals."""
+    received: list[NodeResult] = []
+
+    def has_final_output(ctx: SessionRunContext) -> bool:
+        return bool(ctx.state.final_output_parts)
+
+    @consumer(subscribe_topics="filtered.topic", gates=[has_final_output])
+    def sink(result: NodeResult) -> None:
+        received.append(result)
+
+    worker = container.get(Worker)
+    worker.add_nodes(sink)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+
+    async with TestKafkaBroker(broker):
+        # Intermediate envelope (no final_output_parts) — gate rejects.
+        await broker.publish(
+            _envelope_without_final_parts("cid-int"),
+            topic="filtered.topic",
+            correlation_id="cid-int",
+            headers={HDR_EMITTER: "upstream", HDR_EMITTER_KIND: "agent"},
+        )
+        # Terminal envelope — gate accepts.
+        await broker.publish(
+            _envelope_with_text("final!", "cid-final"),
+            topic="filtered.topic",
+            correlation_id="cid-final",
+            headers={HDR_EMITTER: "upstream", HDR_EMITTER_KIND: "agent"},
+        )
+
+    assert len(received) == 1
+    assert received[0].output == "final!"
+
+
+# ---------------------------------------------------------------------------
+# NodeResult.state — full session state visibility (the core "state on
+# NodeResult" feature). These tests pin the contract: consumers and clients
+# both see the same projection, with convenience properties reading through.
+# ---------------------------------------------------------------------------
+
+
+async def test_node_result_state_is_envelope_state_no_copy():
+    """``result.state`` is the same instance as ``envelope.context.state``.
+    This pins the "no deep-copy" decision: lifetime is the user fn's scope,
+    not a defensive snapshot."""
+    captured: list[NodeResult] = []
+
+    def sink(result: NodeResult) -> None:
+        captured.append(result)
+
+    node = ConsumerNodeDef(node_id="state_id_check", subscribe_topics="t", consume_fn=sink)
+    envelope = _envelope_with_text("hi", correlation_id="cid-state-id")
+
+    await node.handler(
+        envelope,
+        correlation_id="cid-state-id",
+        headers={HDR_EMITTER: b"upstream", HDR_EMITTER_KIND: b"agent"},
+        broker=MagicMock(),
+    )
+
+    assert len(captured) == 1
+    assert captured[0].state is envelope.context.state
+
+
+async def test_node_result_convenience_properties_read_through_state():
+    """``message_history``, ``output_parts``, and ``metadata`` are properties
+    backed by ``state.*``. They must return the SAME objects, not copies."""
+    captured: list[NodeResult] = []
+
+    def sink(result: NodeResult) -> None:
+        captured.append(result)
+
+    node = ConsumerNodeDef(node_id="props_check", subscribe_topics="t", consume_fn=sink)
+
+    state = State()
+    state.final_output_parts = [TextPart(text="hello")]
+    state.message_history = [ModelRequest.user_text_prompt("hi")]
+    state.metadata = {"app": "demo"}
+    envelope = Envelope(
+        context=SessionRunContext(state=state, deps=Deps(correlation_id="cid-prop", provided_deps={})),
+        internal_workflow_state=WorkflowState(call_stack=CallFrameStack()),
+    )
+
+    await node.handler(
+        envelope,
+        correlation_id="cid-prop",
+        headers={HDR_EMITTER: b"upstream", HDR_EMITTER_KIND: b"agent"},
+        broker=MagicMock(),
+    )
+
+    r = captured[0]
+    assert r.output_parts is r.state.final_output_parts
+    assert r.message_history is r.state.message_history
+    assert r.metadata is r.state.metadata
+
+
+async def test_node_result_is_frozen():
+    """``NodeResult`` is a frozen dataclass; field reassignment must raise."""
+    captured: list[NodeResult] = []
+
+    def sink(result: NodeResult) -> None:
+        captured.append(result)
+
+    node = ConsumerNodeDef(node_id="frozen_check", subscribe_topics="t", consume_fn=sink)
+    envelope = _envelope_with_text("hi", correlation_id="cid-frozen")
+    await node.handler(envelope, correlation_id="cid-frozen", headers={HDR_EMITTER: b"x", HDR_EMITTER_KIND: b"agent"}, broker=MagicMock())
+
+    r = captured[0]
+    with pytest.raises(Exception):  # FrozenInstanceError
+        r.state = State()  # type: ignore[misc]
+    with pytest.raises(Exception):
+        r.output = "different"  # type: ignore[misc]
+
+
+async def test_consumer_sees_tool_results_via_state(container):
+    """The motivating use case: a consumer wired to a tool's output topic
+    (or any topic carrying a post-tool envelope) reads the tool's return
+    value through ``result.state.tool_results`` — the gap NodeResult had
+    before this change."""
+    captured: list[NodeResult] = []
+
+    @consumer(subscribe_topics="tool_results_obs.topic")
+    def sink(result: NodeResult) -> None:
+        captured.append(result)
+
+    worker = container.get(Worker)
+    worker.add_nodes(sink)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+
+    # Hand-build a post-tool envelope: final_output_parts empty (tool hop),
+    # but tool_calls + tool_results populated as the agent would have set them.
+    state = State()
+    tool_call = ToolCallPart(tool_name="get_weather", args={"location": "Tokyo"})
+    state.add_tool_call(tool_call)
+    state.add_tool_result(tool_call.tool_call_id, "sunny in Tokyo")
+    envelope = Envelope(
+        context=SessionRunContext(state=state, deps=Deps(correlation_id="cid-tool", provided_deps={})),
+        internal_workflow_state=WorkflowState(call_stack=CallFrameStack()),
+    )
+
+    async with TestKafkaBroker(broker):
+        await broker.publish(
+            envelope,
+            topic="tool_results_obs.topic",
+            correlation_id="cid-tool",
+            headers={HDR_EMITTER: "tool_get_weather", HDR_EMITTER_KIND: "tool"},
+        )
+
+    assert len(captured) == 1
+    r = captured[0]
+    assert r.output is None  # tool hop — no final_output_parts
+    assert r.emitter_node_kind == "tool"
+    assert tool_call.tool_call_id in r.state.tool_results
+    assert r.state.tool_results[tool_call.tool_call_id] == "sunny in Tokyo"
+    assert tool_call.tool_call_id in r.state.tool_calls
+    assert r.state.tool_calls[tool_call.tool_call_id].tool_name == "get_weather"
+
+
+async def test_client_execute_node_result_carries_state(container):
+    """The client side gets the same state visibility. After
+    ``client.execute_node()`` returns, the caller can inspect the agent's
+    full session state — tool calls, tool results, overrides, etc."""
+    worker = container.get(Worker)
+    agent = Agent(
+        "state_visibility_agent",
+        system_prompt="x",
+        subscribe_topics="state_visibility_agent.input",
+        publish_topic="state_visibility_agent.output",
+        model_client=_text_then_done(),
+    )
+    worker.add_nodes(agent)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        result = await client.execute_node("hi there", agent.subscribe_topics[0], timeout=5)
+
+    assert result.output == "done"
+    # The State projection includes the full conversation, not just the deserialized output.
+    assert isinstance(result.state, State)
+    assert result.state is not None
+    assert len(result.state.message_history) >= 1
+    # final_output_parts should match the convenience property
+    assert result.state.final_output_parts is result.output_parts
+    # Tool dicts exist (empty, since this agent didn't call tools).
+    assert isinstance(result.state.tool_calls, dict)
+    assert isinstance(result.state.tool_results, dict)
+
+
+# ---------------------------------------------------------------------------
+# Hashability — NodeResult must declare itself non-hashable (Critical #1 from
+# iteration 2 review). The dataclass-synthesized __hash__ would recursively
+# hash unhashable fields (Pydantic State, lists) and raise at call time.
+# ---------------------------------------------------------------------------
+
+
+def test_node_result_is_not_hashable():
+    """NodeResult must be explicitly non-hashable (__hash__ = None). Both
+    static type checkers and runtime introspection should see it as
+    unhashable so users get a clean error at type-check time / decoration
+    time rather than a surprise TypeError on first hash() call."""
+    state_ = State()
+    state_.final_output_parts = [TextPart(text="x")]
+    state_.message_history = [ModelRequest.user_text_prompt("hi")]
+    result = NodeResult(output="x", state=state_, correlation_id="cid-hash")
+
+    assert NodeResult.__hash__ is None
+    with pytest.raises(TypeError, match="unhashable"):
+        hash(result)
+    with pytest.raises(TypeError, match="unhashable"):
+        {result}  # set construction
+    with pytest.raises(TypeError, match="unhashable"):
+        {result: 1}  # dict key
+
+
+# ---------------------------------------------------------------------------
+# Strict-mode contract — `strict=True` (client default) must raise
+# DeserializationError on empty `final_output_parts`. The only test coverage
+# of the four strict-flag branches that wasn't pinned in iteration 2.
+# ---------------------------------------------------------------------------
+
+
+def test_strict_mode_raises_on_empty_final_output_parts():
+    from calfkit.client.deserialize import deserialize_to_node_result
+    from calfkit.exceptions import DeserializationError
+
+    envelope = _envelope_without_final_parts("cid-strict-empty")
+    with pytest.raises(DeserializationError, match="No DataPart or TextPart"):
+        deserialize_to_node_result(envelope)  # strict=True default
+
+
+def test_lenient_mode_returns_none_on_empty_final_output_parts():
+    """Companion to the strict test — pins the consumer-mode contract."""
+    from calfkit.client.deserialize import deserialize_to_node_result
+
+    envelope = _envelope_without_final_parts("cid-lenient-empty")
+    result = deserialize_to_node_result(envelope, strict=False)
+    assert result.output is None
+    assert result.state is envelope.context.state
+
+
+# ---------------------------------------------------------------------------
+# Pre-built TypeAdapter — schema-generation errors surface at construction
+# time, not per-envelope (Critical #3 from iteration 2 review).
+# ---------------------------------------------------------------------------
+
+
+def test_unschematizable_output_type_raises_at_construction():
+    """An output_type that pydantic can't schematize must fail at decoration
+    / instantiation, not silently per envelope at runtime."""
+
+    class BadType:
+        # No __init__/annotations and no pydantic config — TypeAdapter
+        # rejects it. This is the kind of programmer bug iteration-2 review
+        # flagged: previously, the consumer would log a stack trace on every
+        # envelope forever.
+        __slots__ = ("_blocker",)
+
+    # Some pydantic versions accept arbitrary classes; this test asserts only
+    # that IF schema generation fails, it fails loudly at construction.
+    try:
+        TypeAdapter(BadType)
+    except Exception:
+        # Verified the type IS unschematizable — assert the consumer surfaces
+        # the same error at __init__ time.
+        with pytest.raises(Exception):
+            ConsumerNodeDef(
+                node_id="bad_type_sink",
+                subscribe_topics="t",
+                consume_fn=lambda r: None,
+                output_type=BadType,
+            )
+    else:
+        pytest.skip("TypeAdapter(BadType) succeeded — can't exercise the failure path on this pydantic version")
+
+
+def test_consumer_reuses_prebuilt_type_adapter(monkeypatch):
+    """When a consumer is constructed with a concrete output_type, the
+    TypeAdapter is built once at __init__ — not per envelope. Counts adapter
+    constructions across multiple deserialize calls."""
+    import sys
+
+    import calfkit.client.deserialize as deserialize_mod
+
+    # `calfkit.nodes.consumer` as a dotted path resolves to the decorator
+    # function (re-exported via __init__) — go through sys.modules to hit the
+    # module itself.
+    consumer_mod = sys.modules["calfkit.nodes.consumer"]
+
+    real_adapter = TypeAdapter
+    construct_count = {"n": 0}
+
+    class _CountingAdapter:
+        def __init__(self, *args, **kwargs):
+            construct_count["n"] += 1
+            self._adapter = real_adapter(*args, **kwargs)
+
+        def validate_python(self, *args, **kwargs):
+            return self._adapter.validate_python(*args, **kwargs)
+
+    monkeypatch.setattr(deserialize_mod, "TypeAdapter", _CountingAdapter)
+    monkeypatch.setattr(consumer_mod, "TypeAdapter", _CountingAdapter)
+
+    @consumer(subscribe_topics="prebuilt.topic", output_type=Report)
+    def sink(result: NodeResult[Report]) -> None:
+        return None
+
+    # The decoration above constructed exactly one adapter.
+    constructions_after_decoration = construct_count["n"]
+    assert constructions_after_decoration == 1
+
+    # Deserialize via the consumer's pre-built adapter several times.
+    env = _envelope_with_data({"location": "Tokyo", "summary": "sunny"}, correlation_id="cid-reuse-1")
+    for _ in range(3):
+        asyncio.run(
+            sink.handler(
+                env,
+                correlation_id="cid-reuse-1",
+                headers={HDR_EMITTER: b"upstream", HDR_EMITTER_KIND: b"agent"},
+                broker=MagicMock(),
+            )
+        )
+
+    # No additional adapters constructed.
+    assert construct_count["n"] == constructions_after_decoration
+
+
+# ---------------------------------------------------------------------------
+# Safety-net Exception catch in the deserialize block — anything that slips
+# past the narrow (DeserializationError, ValidationError) tuple is logged
+# and the envelope is skipped (no offset poison-pill).
+# ---------------------------------------------------------------------------
+
+
+async def test_unexpected_deserialize_exception_is_logged_and_skipped(monkeypatch, caplog):
+    """Simulate an unexpected error inside `deserialize_to_node_result` (e.g.
+    a pydantic edge case or third-party model adapter failure). The safety-
+    net `except Exception` block must catch it, log, and skip — not propagate
+    to FastStream and crash the consumer task."""
+    invocations: list[str] = []
+
+    @consumer(subscribe_topics="safety.topic")
+    def sink(result: NodeResult) -> None:
+        invocations.append("ran")
+
+    # Patch the deserializer used by the consumer module to raise an unrelated
+    # exception type that doesn't match the narrow catch tuple. Go via
+    # sys.modules — the dotted-string path collides with the re-exported
+    # `consumer` decorator function in calfkit.nodes.__init__.
+    import sys
+
+    consumer_mod = sys.modules["calfkit.nodes.consumer"]
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated unforeseen deserialize bug")
+
+    monkeypatch.setattr(consumer_mod, "deserialize_to_node_result", _boom)
+
+    envelope = _envelope_with_text("hi", correlation_id="cid-safety-0")
+    with caplog.at_level(logging.ERROR, logger=CONSUMER_LOGGER):
+        response = await sink.handler(
+            envelope,
+            correlation_id="cid-safety-0",
+            headers={HDR_EMITTER: b"upstream", HDR_EMITTER_KIND: b"agent"},
+            broker=MagicMock(),
+        )
+
+    assert invocations == []
+    assert response is not None
+    safety_records = [r for r in caplog.records if "unexpected deserialize error" in r.getMessage()]
+    assert safety_records, "safety-net Exception catch must log at ERROR"
+    assert safety_records[0].exc_info is not None
+    assert isinstance(safety_records[0].exc_info[1], RuntimeError)
+
+
+# ---------------------------------------------------------------------------
+# Runtime generator detection — `_validate_consume_fn` rejects direct
+# generator/asyncgen functions, but cannot detect callable-class generators
+# or functions that return generator objects. The handler must catch these
+# at the call site and fail loud rather than silently no-op.
+# ---------------------------------------------------------------------------
+
+
+async def test_callable_class_generator_detected_at_call_site():
+    """A class whose ``__call__`` is a generator passes ``_validate_consume_fn``
+    (instance is not a generator function), but produces a generator object
+    when called — body never runs. Detect at the handler's call site."""
+
+    class GenSink:
+        def __call__(self, result):
+            yield result
+
+    invocations: list[str] = []
+
+    def make_gen_sink():
+        gs = GenSink()
+        invocations.append("would-have-run")
+        return gs
+
+    node = ConsumerNodeDef(node_id="gen_sink", subscribe_topics="t", consume_fn=GenSink())
+    envelope = _envelope_with_text("hi", correlation_id="cid-gen-0")
+
+    # With re_raise=False (default), the handler logs and continues.
+    response = await node.handler(
+        envelope,
+        correlation_id="cid-gen-0",
+        headers={HDR_EMITTER: b"upstream", HDR_EMITTER_KIND: b"agent"},
+        broker=MagicMock(),
+    )
+    assert response is not None
+
+    # With re_raise=True, the TypeError propagates.
+    node_raising = ConsumerNodeDef(node_id="gen_sink_raising", subscribe_topics="t", consume_fn=GenSink(), re_raise=True)
+    with pytest.raises(TypeError, match="generator"):
+        await node_raising.handler(
+            envelope,
+            correlation_id="cid-gen-1",
+            headers={HDR_EMITTER: b"upstream", HDR_EMITTER_KIND: b"agent"},
+            broker=MagicMock(),
+        )
+
+
+async def test_function_returning_generator_object_detected_at_call_site():
+    """A plain function that explicitly returns a generator object also slips
+    past `_validate_consume_fn` — detect at the call site."""
+
+    def _wrapper_gen():
+        yield 1
+
+    def sink(result):
+        return _wrapper_gen()
+
+    node = ConsumerNodeDef(node_id="gen_ret", subscribe_topics="t", consume_fn=sink, re_raise=True)
+    envelope = _envelope_with_text("hi", correlation_id="cid-gen-ret")
+
+    with pytest.raises(TypeError, match="generator"):
+        await node.handler(
+            envelope,
+            correlation_id="cid-gen-ret",
+            headers={HDR_EMITTER: b"upstream", HDR_EMITTER_KIND: b"agent"},
+            broker=MagicMock(),
+        )
+
+
+async def test_function_returning_async_generator_object_detected_at_call_site():
+    """Symmetric to the sync generator test — async-generator objects also
+    fail `inspect.isawaitable` and must be caught at the call site."""
+
+    async def _wrapper_agen():
+        yield 1
+
+    def sink(result):
+        return _wrapper_agen()
+
+    node = ConsumerNodeDef(node_id="agen_ret", subscribe_topics="t", consume_fn=sink, re_raise=True)
+    envelope = _envelope_with_text("hi", correlation_id="cid-agen-ret")
+
+    with pytest.raises(TypeError, match="async_generator"):
+        await node.handler(
+            envelope,
+            correlation_id="cid-agen-ret",
+            headers={HDR_EMITTER: b"upstream", HDR_EMITTER_KIND: b"agent"},
+            broker=MagicMock(),
+        )


### PR DESCRIPTION
## Summary

Introduces a **consumer node** primitive for building independent terminal sinks
that observe outputs from any node type (agent terminals, agent intermediate
hops, tool completions), plus a substantial expansion of `NodeResult` to expose
full session state to both consumers and clients.

### New: `ConsumerNodeDef` + `@consumer` decorator

```python
from calfkit.client import Client, NodeResult
from calfkit.nodes import consumer
from calfkit.worker import Worker

@consumer(subscribe_topics="weather_agent.output")
async def log_weather_output(result: NodeResult) -> None:
    if result.output is None:
        return  # intermediate hop — no final output yet
    await db.save(result.output)

# Deploy as its own service:
worker = Worker(client, nodes=[log_weather_output])
await worker.run()
```

- Mirrors the existing `Agent` / `agent_tool` API surface.
- Subscribes to any topic carrying calfkit envelopes; sees the entire
  transition stream so you can observe tool completions, agent intermediate
  hops, and agent terminals from one sink.
- `result.output` is `None` on hops without `final_output_parts`. Use a gate
  to filter for terminals only:
  `gates=[lambda ctx: bool(ctx.state.final_output_parts)]`.

### Expose `State` on `NodeResult`

Clients and consumers now see message history, in-flight `tool_calls` /
`tool_results`, runtime `overrides`, and other agent-loop state alongside the
deserialized output:

```python
result = await client.execute_node("hi", "weather_agent.input")
result.output            # deserialized final output (or None on intermediate)
result.state.tool_calls  # in-flight tool batch
result.state.tool_results
result.state.overrides
result.message_history   # read-through property → state.message_history
```

`message_history`, `output_parts`, and `metadata` become read-through
properties — backwards-compatible for all existing read access.

### Honest types and error handling

- `output: OutputT | None` reflects runtime reality on intermediate hops.
- `NodeResult.__hash__ = None` — state is unhashable; explicit declaration
  prevents surprising `TypeError` from `set` / `dict` / `functools.lru_cache`
  misuse.
- Pre-built `TypeAdapter` at consumer construction → schema-generation
  errors surface at wiring, not per envelope.
- Narrow primary catch `(DeserializationError, ValidationError)` + a
  safety-net `except Exception` so an unforeseen edge case can't poison-pill
  the Kafka offset.
- Generator / async-generator `consume_fn` rejected at construction AND
  detected at the runtime call site (catches callable-class generators and
  functions that return generator objects).
- Explicit `except asyncio.CancelledError: raise` so cooperative
  cancellation always propagates.
- Error logs carry topic / partition / offset for SRE debugging.
- Honest `re_raise` docstring: FastStream's default `AckPolicy.ACK_FIRST`
  commits the offset before the handler runs, so `re_raise=True` is fail-
  loud-for-development, not retry/DLQ.

### Other

- `strict` flag on `deserialize_to_node_result` — client default raises on
  empty parts; consumer passes `strict=False` for intermediate hops.
- `publish_topic` is now a read-only property on `ConsumerNodeDef`.
- `run()` defensive guard raises `AssertionError` instead of returning
  `Silent()` if accidentally invoked.
- `ConsumerFn`, `ConsumerNodeDef`, `consumer` exported at the top level.
- Quickstart example: `examples/quickstart/weather_sink.py`.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/integration` → **2382 passed**
      (2357 baseline + 25 new tests in `tests/test_consumer.py`)
- [x] `uv run ruff check .` → clean
- [x] `uv run ruff format --check .` → clean
- [x] `uv run mypy calfkit/` → clean
- [x] Construction invariants pinned (default node_id, topic
      normalization, `_node_kind == "consumer"`, `publish_topic`
      immutability, generator rejection, `run()` defensive guard)
- [x] End-to-end via `TestKafkaBroker` + `FunctionModel`: sync and async
      consumers, structured `output_type` dataclass round-trip, upstream
      emitter id, multi-topic fan-in, missing emitter header warning,
      validation error logging, intermediate-hop `output=None`
- [x] Direct-handler tests pin contracts that broker-coupled tests can't:
      `re_raise=True` propagates `RuntimeError`, `re_raise=False` swallows,
      swallow path logs with operational context, `CancelledError` always
      propagates, runtime generator detection, safety-net `Exception` catch
- [x] `NodeResult` contract: state is same instance as envelope's state
      (no deep copy), properties return references not copies, frozen
      dataclass rejects field reassignment, unhashability (set/dict/hash
      all raise), `state.tool_results` visible on tool-emitter hops,
      client-side parity for `state` visibility
- [x] `deserialize_to_node_result`: `strict=True` raises on empty parts,
      `strict=False` returns `output=None` and preserves state identity
- [x] Pre-built `TypeAdapter` reused across multiple envelopes (no per-
      call construction)
- [ ] (Optional) Manual smoke test against a real Kafka broker to confirm
      `Context("message")` exposes raw kafka metadata for log binding