### PR TITLE
fix: (agent,tool) surface tool exceptions to the agent instead of hanging

### DIFF
--- a/calfkit/exceptions.py
+++ b/calfkit/exceptions.py
@@ -1,2 +1,52 @@
 class DeserializationError(Exception):
     """Raised when client-side output deserialization fails."""
+
+
+class ToolExecutionError(Exception):
+    """The original traceback is not preserved across the Kafka boundary; it is
+    logged at the worker that ran the tool. ``exc_type`` and ``exc_message`` are
+    the only forensic data available at the agent.
+    """
+
+    def __init__(self, *, tool_name: str, tool_call_id: str, exc_type: str, exc_message: str):
+        self.tool_name = tool_name
+        self.tool_call_id = tool_call_id
+        self.exc_type = exc_type
+        self.exc_message = exc_message
+        super().__init__(f"Tool {tool_name!r} (call_id={tool_call_id}) raised {exc_type}: {exc_message}")
+
+    def __reduce__(self):
+        # Bypass keyword-only ``__init__`` during reconstruction by routing
+        # through a module-level helper that uses ``__new__``. A naive
+        # ``(self.__class__, (), state)`` reduction would call ``__init__()``
+        # with no args and fail because the keyword arguments are required.
+        return (
+            _reconstruct_tool_execution_error,
+            (),
+            {
+                "tool_name": self.tool_name,
+                "tool_call_id": self.tool_call_id,
+                "exc_type": self.exc_type,
+                "exc_message": self.exc_message,
+            },
+        )
+
+    def __setstate__(self, state):
+        self.tool_name = state["tool_name"]
+        self.tool_call_id = state["tool_call_id"]
+        self.exc_type = state["exc_type"]
+        self.exc_message = state["exc_message"]
+        Exception.__init__(
+            self,
+            f"Tool {self.tool_name!r} (call_id={self.tool_call_id}) raised {self.exc_type}: {self.exc_message}",
+        )
+
+
+def _reconstruct_tool_execution_error() -> "ToolExecutionError":
+    """Create a bare ``ToolExecutionError`` for reconstruction via ``__setstate__``.
+
+    Bypasses the keyword-only ``__init__`` so state restoration can populate
+    fields directly. Must be module-level (not a lambda or local closure) so
+    it can be located by fully-qualified name during deserialization.
+    """
+    return ToolExecutionError.__new__(ToolExecutionError)

--- a/calfkit/exceptions.py
+++ b/calfkit/exceptions.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+
 class DeserializationError(Exception):
     """Raised when client-side output deserialization fails."""
 
@@ -15,7 +18,7 @@ class ToolExecutionError(Exception):
         self.exc_message = exc_message
         super().__init__(f"Tool {tool_name!r} (call_id={tool_call_id}) raised {exc_type}: {exc_message}")
 
-    def __reduce__(self):
+    def __reduce__(self) -> tuple[Any, ...]:
         # Bypass keyword-only ``__init__`` during reconstruction by routing
         # through a module-level helper that uses ``__new__``. A naive
         # ``(self.__class__, (), state)`` reduction would call ``__init__()``
@@ -31,7 +34,12 @@ class ToolExecutionError(Exception):
             },
         )
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: dict[str, Any] | None) -> None:
+        # ``__reduce__`` above always provides a dict, but the supertype
+        # signature allows ``None`` (Liskov); treat ``None`` as a no-op so
+        # subclasses constructed without state don't crash.
+        if state is None:
+            return
         self.tool_name = state["tool_name"]
         self.tool_call_id = state["tool_call_id"]
         self.exc_type = state["exc_type"]

--- a/calfkit/models/state.py
+++ b/calfkit/models/state.py
@@ -1,16 +1,18 @@
 import logging
 from dataclasses import dataclass, field
-from typing import Annotated, Any, Generic
+from typing import Annotated, Any, ClassVar, Generic, Literal
 
-from pydantic import BaseModel, ConfigDict, Discriminator, Field
+from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag, field_validator
 from typing_extensions import TypeVar
 
+from calfkit._vendor.pydantic_ai.exceptions import ModelRetry
 from calfkit._vendor.pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
+    RetryPromptPart,
     ToolCallPart,
+    ToolReturn,
 )
-from calfkit._vendor.pydantic_ai.tools import DeferredToolCallResult as ToolCallResult
 from calfkit.models.node_schema import BaseToolNodeSchema
 from calfkit.models.payload import ContentPart
 
@@ -58,28 +60,103 @@ class CoreMessageState(BaseAgentActivityState):
         self.uncommitted_message = None
 
 
+class FailedToolCall(BaseModel):
+    """Wire-format representation of a tool that raised on the worker side.
+
+    Stored in ``State.tool_results`` in the same slot a successful ``ToolReturn``
+    would occupy; consumers must handle both shapes. The ``marker_kind`` literal
+    is the discriminator tag consulted by ``_calf_tool_result_discriminator`` so
+    this value reconstructs as a typed instance (rather than a plain ``dict``)
+    when ``State`` round-trips through JSON across the Kafka boundary.
+
+    String fields are clamped to bounded lengths (see ``_MAX_LENGTHS``) rather
+    than rejected for wire-size safety: a tool that raises with an enormous
+    ``str(exc)`` must not itself cause construction to raise inside the worker's
+    ``except Exception`` block (which would prevent the failure reply from ever
+    being published and hang the agent).
+    """
+
+    model_config = ConfigDict(extra="ignore", frozen=True)
+    tool_name: str
+    tool_call_id: str = Field(min_length=1)
+    exc_type: str
+    exc_message: str
+    marker_kind: Literal["calfkit-tool-error"] = "calfkit-tool-error"
+
+    _MAX_LENGTHS: ClassVar[dict[str, int]] = {
+        "tool_name": 256,
+        "tool_call_id": 128,
+        "exc_type": 256,
+        "exc_message": 4096,
+    }
+
+    @field_validator("tool_name", "tool_call_id", "exc_type", "exc_message", mode="before")
+    @classmethod
+    def _clamp_string_fields(cls, v: Any, info: Any) -> Any:
+        if isinstance(v, str):
+            limit = cls._MAX_LENGTHS.get(info.field_name)
+            if limit is not None and len(v) > limit:
+                return v[:limit]
+        return v
+
+
+def _calf_tool_result_discriminator(x: Any) -> str | None:
+    """Tag extractor for the ``CalfToolResult`` discriminated union.
+
+    Mirrors ``calfkit._vendor.pydantic_ai.tools._deferred_tool_call_result_discriminator``
+    with an added ``marker_kind`` branch for ``FailedToolCall``. Without this, a
+    serialized marker arrives as a plain ``dict`` after a Kafka hop because the
+    upstream discriminator only recognizes ``kind`` / ``part_kind``.
+
+    Returns only string tags; non-string values are treated as missing so the
+    union falls through to the ``Any`` arm rather than silently misrouting.
+    Keep this in sync with the upstream helper if a new pydantic-ai tag is added.
+    """
+    getter = x.get if isinstance(x, dict) else lambda k: getattr(x, k, None)
+    for key in ("marker_kind", "kind", "part_kind"):
+        v = getter(key)
+        if isinstance(v, str):
+            return v
+    return None
+
+
+CalfToolResult = Annotated[
+    Annotated[ToolReturn, Tag("tool-return")]
+    | Annotated[ModelRetry, Tag("model-retry")]
+    | Annotated[RetryPromptPart, Tag("retry-prompt")]
+    | Annotated[FailedToolCall, Tag("calfkit-tool-error")],
+    Discriminator(_calf_tool_result_discriminator),
+]
+"""Calfkit-side tagged union for values stored in ``State.tool_results``.
+
+Flattens pydantic-ai's ``DeferredToolCallResult`` (``ToolReturn`` / ``ModelRetry``
+/ ``RetryPromptPart``) and adds calfkit's ``FailedToolCall``. Flattening (rather
+than ``DeferredToolCallResult | FailedToolCall``) is required because Pydantic's
+discriminated-union machinery does not compose nested ``Discriminator``
+annotations reliably.
+"""
+
+
 class InFlightToolsState(BaseAgentActivityState):
     """State of all in-progress tool calls and results.
     Tool calls and results are in-progress when all tool calls have not been completed and committed to message history."""  # noqa: E501
 
     model_config = ConfigDict(extra="ignore")
 
-    # Map of tool call IDS to tool calls
     tool_calls: dict[str, ToolCallPart] = Field(default_factory=dict)
 
-    # Map of tool call IDs to tool results
-    tool_results: dict[str, ToolCallResult | Any] = Field(default_factory=dict)
+    tool_results: dict[str, CalfToolResult | Any] = Field(default_factory=dict)
 
     def add_tool_call(self, tool_call: ToolCallPart) -> None:
         self.tool_calls[tool_call.tool_call_id] = tool_call
 
-    def add_tool_result(self, tool_call_id: str, tool_result: ToolCallResult | Any) -> None:
+    def add_tool_result(self, tool_call_id: str, tool_result: CalfToolResult | Any) -> None:
         self.tool_results[tool_call_id] = tool_result
 
     def get_tool_call(self, tool_call_id: str) -> ToolCallPart | None:
         return self.tool_calls.get(tool_call_id)
 
-    def get_tool_result(self, tool_call_id: str) -> ToolCallResult | Any | None:
+    def get_tool_result(self, tool_call_id: str) -> CalfToolResult | Any | None:
         return self.tool_results.get(tool_call_id)
 
     def all_call_ids_complete(self, *call_ids: str) -> bool:
@@ -102,17 +179,6 @@ class State(CoreMessageState, InFlightToolsState):
     overrides: OverridesState | None = None
 
 
-# class State(BaseModel):
-#     """mutable data model to track state of an execution among one or more agents,
-#     sharing correlation id"""
-
-#     model_config = ConfigDict(extra="ignore")
-#     run_state: AgentActivityState = Field(default_factory=AgentActivityState)
-
-
-# ---------------------------------------------------------------------------
-# Experimental PartialState implementation
-# ---------------------------------------------------------------------------
 AgentStateSubsetT = TypeVar("AgentStateSubsetT", CoreMessageState, InFlightToolsState)
 
 PartialState = Annotated[CoreMessageState | InFlightToolsState | Any, Discriminator("kind")]
@@ -135,7 +201,7 @@ class PendingToolBatch:
     base_state: State
 
     # map of tool call IDs to tool call results
-    collected_results: dict[str, ToolCallResult | Any] = field(default_factory=dict)
+    collected_results: dict[str, CalfToolResult | Any] = field(default_factory=dict)
 
     @property
     def is_complete(self) -> bool:

--- a/calfkit/models/state.py
+++ b/calfkit/models/state.py
@@ -112,9 +112,8 @@ def _calf_tool_result_discriminator(x: Any) -> str | None:
     union falls through to the ``Any`` arm rather than silently misrouting.
     Keep this in sync with the upstream helper if a new pydantic-ai tag is added.
     """
-    getter = x.get if isinstance(x, dict) else lambda k: getattr(x, k, None)
     for key in ("marker_kind", "kind", "part_kind"):
-        v = getter(key)
+        v = x.get(key) if isinstance(x, dict) else getattr(x, key, None)
         if isinstance(v, str):
             return v
     return None

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -2,6 +2,8 @@ import logging
 from collections.abc import Callable
 from typing import Any, ClassVar, Generic, cast
 
+from pydantic import ValidationError
+
 from calfkit._protocol import NodeKind
 from calfkit._types import AgentOutputT
 from calfkit._vendor.pydantic_ai import Agent as InternalAgentLoop
@@ -11,18 +13,17 @@ from calfkit._vendor.pydantic_ai.output import OutputSpec
 from calfkit._vendor.pydantic_ai.settings import ModelSettings
 from calfkit._vendor.pydantic_ai.tools import DeferredToolResults
 from calfkit._vendor.pydantic_ai.toolsets.external import ExternalToolset
+from calfkit.exceptions import ToolExecutionError
 from calfkit.models import Call, DataPart, NodeResult, ReturnCall, State, TailCall, TextPart
 from calfkit.models.actions import Silent
 from calfkit.models.node_schema import BaseToolNodeSchema
 from calfkit.models.session_context import SessionRunContext
-from calfkit.models.state import PendingToolBatch
+from calfkit.models.state import FailedToolCall, PendingToolBatch
 from calfkit.nodes.base import BaseNodeDef, GateFunction
-from calfkit.nodes.tool import ToolNodeDef
+from calfkit.nodes.tool import BaseToolNodeDef, ToolNodeDef, _safe_exc_message
 from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
 
 logger = logging.getLogger(__name__)
-
-NoneType = type(None)
 
 
 class BaseAgentNodeDef(
@@ -85,11 +86,17 @@ class BaseAgentNodeDef(
         elif self.tools:
             tools_registry = {tool.tool_schema.name: tool for tool in self.tools}
 
+        # ``latest_tool_calls()`` walks ``message_history`` in reverse on each call;
+        # cache once for all pre-model uses. The post-model use after
+        # ``result.new_messages()`` is extended into history must re-call to see
+        # the model's new tool calls.
+        latest_tool_calls = ctx.state.latest_tool_calls()
+
         logger.debug(
             "[%s] agent run entered node=%s pending_tool_calls=%d history_len=%d",
             ctx.deps.correlation_id[:8],
             self.name,
-            len(ctx.state.latest_tool_calls()),
+            len(latest_tool_calls),
             len(ctx.state.message_history),
         )
 
@@ -99,7 +106,32 @@ class BaseAgentNodeDef(
             if batch and not batch.is_complete:
                 return Silent()
 
-        latest_tool_calls = ctx.state.latest_tool_calls()
+        # Collect all FailedToolCall results in this turn so operators see every
+        # failure in a parallel batch; raise on the first after logging all.
+        failed_tool_calls: list[FailedToolCall] = []
+        for tc in latest_tool_calls:
+            result = ctx.state.tool_results.get(tc.tool_call_id)
+            if isinstance(result, FailedToolCall):
+                failed_tool_calls.append(result)
+        if failed_tool_calls:
+            for failure in failed_tool_calls:
+                logger.error(
+                    "[%s] tool execution error detected node=%s tool=%s tool_call_id=%s exc_type=%s exc_message=%s",
+                    ctx.deps.correlation_id[:8],
+                    self.name,
+                    failure.tool_name,
+                    failure.tool_call_id,
+                    failure.exc_type,
+                    failure.exc_message,
+                )
+            first = failed_tool_calls[0]
+            raise ToolExecutionError(
+                tool_name=first.tool_name,
+                tool_call_id=first.tool_call_id,
+                exc_type=first.exc_type,
+                exc_message=first.exc_message,
+            )
+
         tool_results = None
 
         if len(latest_tool_calls) > 0:
@@ -141,14 +173,13 @@ class BaseAgentNodeDef(
             model_settings=run_model_settings,
         )
         if isinstance(result.output, DeferredToolRequests):
-            # The LLM called one or more tools
             logger.debug(
                 "[%s] model returned DeferredToolRequests tool_count=%d node=%s",
                 ctx.deps.correlation_id[:8],
                 len(result.output.calls),
                 self.name,
             )
-            messages = result.new_messages()  # preserve conversation history
+            messages = result.new_messages()
             ctx.state.message_history.extend(messages)
             latest_tool_calls = ctx.state.latest_tool_calls()
 
@@ -166,7 +197,9 @@ class BaseAgentNodeDef(
                             tool_call_id=tool_call.tool_call_id,
                         ),
                     )
-                elif tool_node.subscribe_topics is None:
+                    continue
+
+                if tool_node.subscribe_topics is None:
                     logger.error(
                         "tool=%s is unreachable. No subscribe topics were provided for the tool node.",
                         tool_call.tool_name,
@@ -179,8 +212,81 @@ class BaseAgentNodeDef(
                             tool_call_id=tool_call.tool_call_id,
                         ),
                     )
+                    continue
 
-            if ctx.state.all_call_ids_complete(*[tc.tool_call_id for tc in latest_tool_calls]):  # All tool calls were invalid, we need to retry.
+                # Parse args from the LLM's emission. Applies to ALL dispatch
+                # paths so that malformed-JSON args from override (schema-only)
+                # tools are also surfaced as RetryPromptPart instead of escaping
+                # to the worker's hard FailedToolCall path.
+                try:
+                    args = tool_call.args_as_dict()
+                except (ValueError, AssertionError) as e:
+                    content = f"Malformed tool arguments: {type(e).__name__}: {e}"
+                    logger.warning(
+                        "[%s] tool=%s args parse failed at dispatch: %s",
+                        ctx.deps.correlation_id[:8],
+                        tool_call.tool_name,
+                        content,
+                    )
+                    ctx.state.add_tool_result(
+                        tool_call.tool_call_id,
+                        RetryPromptPart(
+                            content=content,
+                            tool_name=tool_call.tool_name,
+                            tool_call_id=tool_call.tool_call_id,
+                        ),
+                    )
+                    continue
+
+                # Validate against the schema if we have a runtime validator.
+                # Override-mode schemas (BaseToolNodeSchema-only) skip this step
+                # and dispatch unvalidated; this is the documented carve-out.
+                if isinstance(tool_node, BaseToolNodeDef):
+                    try:
+                        tool_node.validate_call_args(args)
+                    except ValidationError as e:
+                        content = e.errors(include_url=False, include_context=False)
+                        logger.warning(
+                            "[%s] tool=%s arg validation failed at dispatch: %s",
+                            ctx.deps.correlation_id[:8],
+                            tool_call.tool_name,
+                            content,
+                        )
+                        ctx.state.add_tool_result(
+                            tool_call.tool_call_id,
+                            RetryPromptPart(
+                                content=content,
+                                tool_name=tool_call.tool_name,
+                                tool_call_id=tool_call.tool_call_id,
+                            ),
+                        )
+                        continue
+                    except Exception as e:
+                        # A user-authored Pydantic ``field_validator`` raised
+                        # something other than ``ValidationError`` (e.g.
+                        # ``RuntimeError``, ``TypeError``, a custom exception).
+                        # Surface as ``RetryPromptPart`` so the LLM can retry
+                        # rather than letting the exception escape ``run()`` and
+                        # silently hang the caller.
+                        validator_content = f"Tool argument validator raised {type(e).__name__}: {_safe_exc_message(e)}"
+                        logger.warning(
+                            "[%s] tool=%s arg validator raised %s; surfacing as RetryPromptPart",
+                            ctx.deps.correlation_id[:8],
+                            tool_call.tool_name,
+                            type(e).__name__,
+                            exc_info=True,
+                        )
+                        ctx.state.add_tool_result(
+                            tool_call.tool_call_id,
+                            RetryPromptPart(
+                                content=validator_content,
+                                tool_name=tool_call.tool_name,
+                                tool_call_id=tool_call.tool_call_id,
+                            ),
+                        )
+                        continue
+
+            if ctx.state.all_call_ids_complete(*[tc.tool_call_id for tc in latest_tool_calls]):
                 # TODO: maybe consider a node retry return type that doesn't require round trip to itself.
                 # Tailcall to itself is a roundtrip.
                 logger.debug("[%s] all tool calls invalid, TailCall retry node=%s", ctx.deps.correlation_id[:8], self.name)

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -218,15 +218,23 @@ class BaseAgentNodeDef(
                 # paths so that malformed-JSON args from override (schema-only)
                 # tools are also surfaced as RetryPromptPart instead of escaping
                 # to the worker's hard FailedToolCall path.
+                #
+                # ``args_as_dict()`` can raise more than just ValueError /
+                # AssertionError: ``pydantic_core.from_json`` raises TypeError
+                # when ``args`` is a non-string/non-bytes value (e.g. an int or
+                # list emitted by an off-spec provider). Catch broadly so any
+                # parse failure surfaces as an LLM-retryable RetryPromptPart
+                # rather than escaping ``run()`` and hanging the caller.
                 try:
                     args = tool_call.args_as_dict()
-                except (ValueError, AssertionError) as e:
-                    content = f"Malformed tool arguments: {type(e).__name__}: {e}"
+                except Exception as e:
+                    content = f"Malformed tool arguments: {type(e).__name__}: {_safe_exc_message(e)}"
                     logger.warning(
                         "[%s] tool=%s args parse failed at dispatch: %s",
                         ctx.deps.correlation_id[:8],
                         tool_call.tool_name,
                         content,
+                        exc_info=True,
                     )
                     ctx.state.add_tool_result(
                         tool_call.tool_call_id,

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -282,17 +282,17 @@ class BaseAgentNodeDef(
                     try:
                         tool_node.validate_call_args(args)
                     except ValidationError as e:
-                        content = e.errors(include_url=False, include_context=False)
+                        validation_errors = e.errors(include_url=False, include_context=False)
                         logger.warning(
                             "[%s] tool=%s arg validation failed at dispatch: %s",
                             ctx.deps.correlation_id[:8],
                             tool_call.tool_name,
-                            content,
+                            validation_errors,
                         )
                         ctx.state.add_tool_result(
                             tool_call.tool_call_id,
                             RetryPromptPart(
-                                content=content,
+                                content=validation_errors,
                                 tool_name=tool_call.tool_name,
                                 tool_call_id=tool_call.tool_call_id,
                             ),

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -108,11 +108,40 @@ class BaseAgentNodeDef(
 
         # Collect all FailedToolCall results in this turn so operators see every
         # failure in a parallel batch; raise on the first after logging all.
+        # Also defend against corrupt marker dicts: a payload with the calfkit
+        # marker tag that fails ``FailedToolCall`` validation (e.g. schema drift
+        # during rolling deploy, a required field added without default, a
+        # tampered wire payload) round-trips through the union's ``| Any`` arm
+        # as a plain ``dict``. Synthesize a typed marker so the silent-failure
+        # path closes — operators still see the raise and the corrupt-keys
+        # context.
         failed_tool_calls: list[FailedToolCall] = []
         for tc in latest_tool_calls:
             result = ctx.state.tool_results.get(tc.tool_call_id)
             if isinstance(result, FailedToolCall):
                 failed_tool_calls.append(result)
+            elif isinstance(result, dict) and result.get("marker_kind") == "calfkit-tool-error":
+                logger.error(
+                    "[%s] corrupt FailedToolCall marker detected node=%s tool_call_id=%s raw_keys=%s; "
+                    "likely schema drift or version skew across the Kafka boundary",
+                    ctx.deps.correlation_id[:8],
+                    self.name,
+                    tc.tool_call_id,
+                    sorted(result.keys()),
+                )
+                # Synthesize a typed marker with sentinel fields known to pass
+                # FailedToolCall's validators. tc.tool_call_id is the LLM-emitted
+                # correlation key; fall back to "<missing>" if it's empty so
+                # ``min_length=1`` doesn't itself raise.
+                raw_tool_name = result.get("tool_name")
+                failed_tool_calls.append(
+                    FailedToolCall(
+                        tool_name=raw_tool_name if isinstance(raw_tool_name, str) and raw_tool_name else "<unknown>",
+                        tool_call_id=tc.tool_call_id or "<missing>",
+                        exc_type="CorruptFailedToolCallMarker",
+                        exc_message=f"Marker dict failed validation as FailedToolCall (likely schema drift); raw_keys={sorted(result.keys())}",
+                    )
+                )
         if failed_tool_calls:
             for failure in failed_tool_calls:
                 logger.error(

--- a/calfkit/nodes/tool.py
+++ b/calfkit/nodes/tool.py
@@ -3,6 +3,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any, ClassVar
 
+import pydantic_core
 from typing_extensions import Self
 
 from calfkit._protocol import NodeKind
@@ -109,6 +110,15 @@ class ToolNodeDef(BaseToolNodeDef):
         # but is not yet rate-limited on the deferred path.
         try:
             result = await self._tool.function_schema.call(tool_call_part.args_as_dict(), tool_call_ctx)
+            # Construct the ToolReturn and eagerly verify it is wire-safe BEFORE
+            # storing in state. FastStream's envelope serialization at publish
+            # time would raise PydanticSerializationError on a non-serializable
+            # return_value, killing the worker handler before the reply
+            # publishes — the silent-hang failure mode this module exists to
+            # prevent. By serializing inside the try block, any failure flows
+            # through ``except Exception`` below and surfaces as a FailedToolCall.
+            tool_return = ToolReturn(return_value=result, metadata={"tool_call_id": tool_call_part.tool_call_id})
+            pydantic_core.to_json(tool_return)
         except ModelRetry as e:
             logger.warning(
                 "[%s] tool=%s raised ModelRetry: %s",
@@ -173,10 +183,9 @@ class ToolNodeDef(BaseToolNodeDef):
             ctx.state.add_tool_result(tool_call_part.tool_call_id, marker)
             return ReturnCall[State](state=ctx.state)
 
-        ctx.state.add_tool_result(
-            tool_call_part.tool_call_id,
-            ToolReturn(return_value=result, metadata={"tool_call_id": tool_call_part.tool_call_id}),
-        )
+        # ``tool_return`` was constructed and serialization-verified inside the
+        # try block above; reuse it rather than constructing twice.
+        ctx.state.add_tool_result(tool_call_part.tool_call_id, tool_return)
 
         logger.debug("[%s] tool completed tool=%s", ctx.deps.correlation_id[:8], self.name)
         return ReturnCall[State](state=ctx.state)

--- a/calfkit/nodes/tool.py
+++ b/calfkit/nodes/tool.py
@@ -151,12 +151,22 @@ class ToolNodeDef(BaseToolNodeDef):
                     tool_call_part.tool_call_id,
                     type(construct_err).__name__,
                 )
-                # Hardcoded sentinel fallback: every field is a known-valid literal
-                # so construction itself cannot raise. The reply still publishes so
-                # the agent isn't left hanging on the original tool_call_id.
+                # Fallback: preserve real ``tool_name`` / ``tool_call_id`` from
+                # ``tool_call_part`` when they are valid strings (so operators
+                # don't lose the correlation key in the raised ToolExecutionError);
+                # only substitute sentinels for fields that are themselves
+                # problematic. ``isinstance(..., str)`` and truthy guards keep
+                # construction total even if the originals are the cause of the
+                # primary failure (e.g. empty ``tool_call_id``).
+                fallback_tool_name = (
+                    tool_call_part.tool_name if isinstance(tool_call_part.tool_name, str) and tool_call_part.tool_name else "<unknown>"
+                )
+                fallback_tool_call_id = (
+                    tool_call_part.tool_call_id if isinstance(tool_call_part.tool_call_id, str) and tool_call_part.tool_call_id else "<missing>"
+                )
                 marker = FailedToolCall(
-                    tool_name="<unknown>",
-                    tool_call_id="<missing>",
+                    tool_name=fallback_tool_name,
+                    tool_call_id=fallback_tool_call_id,
                     exc_type="FailedToolCallConstructionError",
                     exc_message=f"Failed to construct primary marker: {_safe_exc_message(construct_err)}",
                 )

--- a/calfkit/nodes/tool.py
+++ b/calfkit/nodes/tool.py
@@ -7,13 +7,34 @@ from typing_extensions import Self
 
 from calfkit._protocol import NodeKind
 from calfkit._vendor.pydantic_ai import Tool
-from calfkit._vendor.pydantic_ai.messages import ToolReturn
+from calfkit._vendor.pydantic_ai.exceptions import ModelRetry
+from calfkit._vendor.pydantic_ai.messages import RetryPromptPart, ToolReturn
 from calfkit.models import SessionRunContext, Silent, State, ToolContext
 from calfkit.models.actions import NodeResult, ReturnCall
 from calfkit.models.node_schema import BaseToolNodeSchema
+from calfkit.models.state import FailedToolCall
 from calfkit.nodes.base import BaseNodeDef, GateFunction
 
 logger = logging.getLogger(__name__)
+
+
+def _safe_exc_message(e: BaseException) -> str:
+    """Best-effort string of an exception, robust against broken ``__str__``.
+
+    A bare ``str(e)`` can itself raise (if the exception's ``__str__`` is
+    broken or its args don't coerce). Inside the worker's ``except Exception``
+    block that would propagate out, prevent the FailedToolCall from being
+    constructed, and re-introduce the silent-hang failure mode this module
+    exists to prevent. Mirrors stdlib ``traceback._some_str`` with a ``repr``
+    fallback.
+    """
+    try:
+        return str(e)
+    except Exception:
+        try:
+            return repr(e)
+        except Exception:
+            return f"<unprintable {type(e).__name__}>"
 
 
 @dataclass
@@ -21,6 +42,20 @@ class BaseToolNodeDef(BaseToolNodeSchema, BaseNodeDef):
     _node_kind: ClassVar[NodeKind] = "tool"
     _tool: Tool
     gates: list[GateFunction] = field(default_factory=list)
+
+    def validate_call_args(self, args_dict: dict[str, Any]) -> Any:
+        """Validate ``args_dict`` against this tool's argument schema.
+
+        Raises ``pydantic.ValidationError`` on mismatch. Used by the agent to
+        fail-fast on LLM-produced malformed args before dispatching the call
+        across the Kafka boundary.
+
+        Note: tools with unannotated parameters (which default to ``Any`` in
+        pydantic-ai's function-schema) or with ``**kwargs`` (where extra fields
+        are allowed) bypass meaningful validation here — the worker-side
+        ``except Exception`` catch is the safety net for those.
+        """
+        return self._tool.function_schema.validator.validate_python(args_dict)
 
 
 class ToolNodeDef(BaseToolNodeDef):
@@ -69,24 +104,65 @@ class ToolNodeDef(BaseToolNodeDef):
             run_id=ctx.deps.correlation_id,
         )
 
-        # TODO: add some retry mechanism and max_retry logic here.
-        # Note, retry logic should be configurable via client side
-        result = await self._tool.function_schema.call(tool_call_part.args_as_dict(), tool_call_ctx)
+        # TODO(#143): bounded retries / backoff for non-ModelRetry exceptions.
+        # ModelRetry below provides LLM-visible retry per pydantic-ai semantics
+        # but is not yet rate-limited on the deferred path.
+        try:
+            result = await self._tool.function_schema.call(tool_call_part.args_as_dict(), tool_call_ctx)
+        except ModelRetry as e:
+            logger.warning(
+                "[%s] tool=%s raised ModelRetry: %s",
+                ctx.deps.correlation_id[:8],
+                self.name,
+                e.message,
+            )
+            ctx.state.add_tool_result(
+                tool_call_part.tool_call_id,
+                RetryPromptPart(
+                    content=e.message,
+                    tool_name=tool_call_part.tool_name,
+                    tool_call_id=tool_call_part.tool_call_id,
+                ),
+            )
+            return ReturnCall[State](state=ctx.state)
+        except Exception as e:
+            logger.exception(
+                "[%s] tool=%s tool_call_id=%s raised %s; surfacing FailedToolCall to agent",
+                ctx.deps.correlation_id[:8],
+                self.name,
+                tool_call_part.tool_call_id,
+                type(e).__name__,
+            )
+            # Construct the marker defensively: a validator on FailedToolCall (e.g.,
+            # min_length on tool_call_id) could itself raise inside this except block
+            # and re-introduce the silent-hang failure mode we exist to prevent.
+            try:
+                marker: FailedToolCall = FailedToolCall(
+                    tool_name=tool_call_part.tool_name,
+                    tool_call_id=tool_call_part.tool_call_id,
+                    exc_type=type(e).__name__,
+                    exc_message=_safe_exc_message(e),
+                )
+            except Exception as construct_err:
+                logger.exception(
+                    "[%s] tool=%s tool_call_id=%s failed to construct FailedToolCall (%s); using fallback sentinel marker",
+                    ctx.deps.correlation_id[:8],
+                    self.name,
+                    tool_call_part.tool_call_id,
+                    type(construct_err).__name__,
+                )
+                # Hardcoded sentinel fallback: every field is a known-valid literal
+                # so construction itself cannot raise. The reply still publishes so
+                # the agent isn't left hanging on the original tool_call_id.
+                marker = FailedToolCall(
+                    tool_name="<unknown>",
+                    tool_call_id="<missing>",
+                    exc_type="FailedToolCallConstructionError",
+                    exc_message=f"Failed to construct primary marker: {_safe_exc_message(construct_err)}",
+                )
+            ctx.state.add_tool_result(tool_call_part.tool_call_id, marker)
+            return ReturnCall[State](state=ctx.state)
 
-        # tool_result = ToolReturnPart(
-        #     tool_name=tool_call_part.tool_name,
-        #     content=result,
-        #     tool_call_id=tool_call_part.tool_call_id,
-        # )
-
-        # multimodal support is possible via `content`, for example:
-        # ToolReturn(
-        #       return_value="Screenshot captured successfully for https://example.com",
-        #       content=[
-        #           "Here is the screenshot:",
-        #           BinaryContent(data=png_bytes, media_type="image/png"),
-        #       ],
-        #   )
         ctx.state.add_tool_result(
             tool_call_part.tool_call_id,
             ToolReturn(return_value=result, metadata={"tool_call_id": tool_call_part.tool_call_id}),

--- a/tests/test_tool_errors.py
+++ b/tests/test_tool_errors.py
@@ -1373,3 +1373,120 @@ async def test_fallback_marker_preserves_real_tool_name_and_id_when_valid(monkey
     # exc_type marks this as a fallback marker.
     assert stored.exc_type == "FailedToolCallConstructionError"
     assert "Failed to construct primary marker" in stored.exc_message
+
+
+# ---------------------------------------------------------------------------
+# Unserializable tool return values must not silently hang the worker
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_unserializable_return_value_becomes_failed_tool_call():
+    # Regression: a tool returning a non-JSON-serializable value (a user class,
+    # an unmapped stdlib type, etc.) would pass through ``ToolReturn(__init__)``
+    # but raise ``PydanticSerializationError`` at FastStream's envelope publish
+    # boundary — killing the worker handler before any reply published, which
+    # is the silent-hang failure mode this module exists to prevent. The worker
+    # must eagerly verify wire-safety and surface a FailedToolCall instead.
+
+    class _NotJsonSerializable:
+        pass
+
+    def returns_unserializable(ctx: ToolContext) -> object:
+        return _NotJsonSerializable()
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=returns_unserializable,
+        subscribe_topics="tool.unserializable.input",
+        publish_topic="tool.unserializable.output",
+    )
+
+    state = State()
+    tool_call_id = "tc-unserializable-001"
+    _register_tool_call(state, tool_name="returns_unserializable", tool_call_id=tool_call_id)
+    ctx = _make_ctx(state)
+
+    result = await tool_node.run(ctx, tool_call_id)
+    assert isinstance(result, ReturnCall), f"expected ReturnCall (no hang), got {type(result).__name__}"
+
+    stored = ctx.state.tool_results.get(tool_call_id)
+    assert isinstance(stored, FailedToolCall), f"expected FailedToolCall, got {type(stored).__name__}"
+    assert stored.exc_type == "PydanticSerializationError"
+    assert "Unable to serialize" in stored.exc_message
+
+    # And critically: the state must now JSON-round-trip cleanly so the actual
+    # Kafka publish wouldn't itself raise.
+    state.model_dump_json()
+
+
+# ---------------------------------------------------------------------------
+# Corrupt FailedToolCall marker dict (schema drift / version skew) must raise
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_detects_corrupt_marker_dict_and_raises():
+    # Regression: an entry in ``tool_results`` that carries the calfkit marker
+    # tag but fails FailedToolCall validation (e.g. a required field added in
+    # a newer schema; a stale message replayed; a tampered payload) round-trips
+    # through ``CalfToolResult | Any`` as a plain dict. The agent's isinstance
+    # check would silently miss it without this defense.
+    agent = Agent(
+        "agent_corrupt_marker",
+        system_prompt="x",
+        subscribe_topics="agent_corrupt_marker.input",
+        publish_topic="agent_corrupt_marker.output",
+        model_client=TestModel(),
+    )
+
+    state = State()
+    tool_call_id = "tc-corrupt-001"
+    _register_tool_call(state, tool_name="buggy", tool_call_id=tool_call_id)
+    # Insert a raw dict carrying the marker tag but missing required fields;
+    # bypass model validation by writing directly to the dict.
+    state.tool_results[tool_call_id] = {
+        "marker_kind": "calfkit-tool-error",
+        "tool_name": "buggy",
+        "tool_call_id": tool_call_id,
+        # missing exc_type, exc_message
+    }
+    ctx = _make_ctx(state)
+
+    with pytest.raises(ToolExecutionError) as exc_info:
+        await agent.run(ctx)
+
+    err = exc_info.value
+    assert err.exc_type == "CorruptFailedToolCallMarker"
+    assert err.tool_call_id == tool_call_id
+    # Real tool_name from the dict is preserved when valid.
+    assert err.tool_name == "buggy"
+    # Diagnostic message names the corruption shape.
+    assert "schema drift" in err.exc_message or "raw_keys" in err.exc_message
+
+
+async def test_agent_corrupt_marker_with_missing_tool_name_uses_sentinel():
+    # Defense-in-depth: a corrupt marker dict missing even ``tool_name`` must
+    # still produce a typed raise rather than crashing the agent. Sentinel
+    # value substituted.
+    agent = Agent(
+        "agent_corrupt_no_name",
+        system_prompt="x",
+        subscribe_topics="agent_corrupt_no_name.input",
+        publish_topic="agent_corrupt_no_name.output",
+        model_client=TestModel(),
+    )
+
+    state = State()
+    tool_call_id = "tc-corrupt-noname"
+    _register_tool_call(state, tool_name="some_tool", tool_call_id=tool_call_id)
+    state.tool_results[tool_call_id] = {
+        "marker_kind": "calfkit-tool-error",
+        # missing tool_name, exc_type, exc_message
+    }
+    ctx = _make_ctx(state)
+
+    with pytest.raises(ToolExecutionError) as exc_info:
+        await agent.run(ctx)
+
+    err = exc_info.value
+    assert err.exc_type == "CorruptFailedToolCallMarker"
+    assert err.tool_name == "<unknown>"
+    assert err.tool_call_id == tool_call_id

--- a/tests/test_tool_errors.py
+++ b/tests/test_tool_errors.py
@@ -1,0 +1,1278 @@
+"""Unit-scope contracts for the ``FailedToolCall`` / ``ToolExecutionError``
+flow. Tests bypass ``TestKafkaBroker`` and ``Client`` and call ``run()``
+directly so the marker/exception contracts are isolated from the messaging
+layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import pickle  # nosec B403 - used in test for regression coverage of ToolExecutionError picklability
+from typing import Annotated
+
+import pytest
+from pydantic import BeforeValidator, ValidationError
+
+from calfkit._vendor.pydantic_ai.exceptions import ModelRetry
+from calfkit._vendor.pydantic_ai.messages import (
+    ModelMessage,
+    ModelResponse,
+    RetryPromptPart,
+    ToolCallPart,
+    ToolReturn,
+)
+from calfkit._vendor.pydantic_ai.messages import (
+    TextPart as ModelTextPart,
+)
+from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
+from calfkit._vendor.pydantic_ai.models.test import TestModel
+from calfkit.exceptions import ToolExecutionError
+from calfkit.models import SessionRunContext, ToolContext
+from calfkit.models.actions import Call, ReturnCall, Silent, TailCall
+from calfkit.models.node_schema import BaseToolNodeSchema
+from calfkit.models.session_context import Deps
+from calfkit.models.state import (
+    FailedToolCall,
+    OverridesState,
+    PendingToolBatch,
+    State,
+    _calf_tool_result_discriminator,
+)
+from calfkit.nodes import Agent, ToolNodeDef
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx(state: State, correlation_id: str = "cid-tool-errors-00000000") -> SessionRunContext:
+    return SessionRunContext(
+        state=state,
+        deps=Deps(correlation_id=correlation_id, provided_deps={}),
+    )
+
+
+def _register_tool_call(state: State, *, tool_name: str, tool_call_id: str, args: dict | None = None) -> ToolCallPart:
+    part = ToolCallPart(tool_name=tool_name, args=args or {}, tool_call_id=tool_call_id)
+    state.add_tool_call(part)
+    # message_history is needed for state.latest_tool_calls() to resolve.
+    state.message_history.append(ModelResponse(parts=[part]))
+    return part
+
+
+def _final_text_model() -> FunctionModel:
+    def _fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[ModelTextPart("done")])
+
+    return FunctionModel(_fn)
+
+
+def _model_emits_tool_calls(tool_calls: list[ToolCallPart]) -> FunctionModel:
+    """FunctionModel that always responds with the given tool calls.
+
+    Used to deterministically drive the agent dispatch loop for arg-validation
+    tests — the LLM round is replaced by a fixed ``ModelResponse(parts=...)``.
+    """
+
+    def _fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=list(tool_calls))
+
+    return FunctionModel(_fn)
+
+
+# ---------------------------------------------------------------------------
+# Worker-side: ToolNodeDef.run captures exceptions into typed results
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_raises_arbitrary_exception_stores_error_marker():
+    def boom(ctx: ToolContext) -> str:
+        raise ValueError("bad")
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=boom,
+        subscribe_topics="tool.boom.input",
+        publish_topic="tool.boom.output",
+    )
+
+    state = State()
+    tool_call_id = "tc-arb-001"
+    _register_tool_call(state, tool_name="boom", tool_call_id=tool_call_id)
+    ctx = _make_ctx(state)
+
+    result = await tool_node.run(ctx, tool_call_id)
+
+    # The reply path must still publish so the agent gets unblocked.
+    assert isinstance(result, ReturnCall), f"expected ReturnCall, got {type(result).__name__}"
+
+    stored = ctx.state.tool_results.get(tool_call_id)
+    assert isinstance(stored, FailedToolCall), f"expected FailedToolCall in tool_results, got {type(stored).__name__}: {stored!r}"
+    assert stored.exc_type == "ValueError"
+    assert stored.exc_message == "bad"
+    assert stored.tool_name == "boom"
+    assert stored.tool_call_id == tool_call_id
+    assert stored.marker_kind == "calfkit-tool-error"
+    # Pin that ReturnCall.state IS the same state holding the marker — a
+    # regression that returned ReturnCall(state=State()) would otherwise pass.
+    assert result.state.tool_results[tool_call_id] is stored
+
+
+async def test_tool_raises_model_retry_stores_retry_prompt():
+    def please_retry(ctx: ToolContext) -> str:
+        raise ModelRetry("please slow down")
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=please_retry,
+        subscribe_topics="tool.please_retry.input",
+        publish_topic="tool.please_retry.output",
+    )
+
+    state = State()
+    tool_call_id = "tc-retry-001"
+    _register_tool_call(state, tool_name="please_retry", tool_call_id=tool_call_id)
+    ctx = _make_ctx(state)
+
+    result = await tool_node.run(ctx, tool_call_id)
+
+    assert isinstance(result, ReturnCall), f"expected ReturnCall, got {type(result).__name__}"
+
+    stored = ctx.state.tool_results.get(tool_call_id)
+    assert isinstance(stored, RetryPromptPart), f"expected RetryPromptPart, got {type(stored).__name__}: {stored!r}"
+    # The marker must NOT be used for ModelRetry — that would short-circuit
+    # the LLM-visible retry behavior we explicitly preserve.
+    assert not isinstance(stored, FailedToolCall)
+    assert stored.content == "please slow down"
+    assert stored.tool_name == "please_retry"
+    assert stored.tool_call_id == tool_call_id
+    assert result.state.tool_results[tool_call_id] is stored
+
+
+async def test_tool_success_unchanged():
+    def happy(ctx: ToolContext) -> str:
+        return "ok"
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=happy,
+        subscribe_topics="tool.happy.input",
+        publish_topic="tool.happy.output",
+    )
+
+    state = State()
+    tool_call_id = "tc-happy-001"
+    _register_tool_call(state, tool_name="happy", tool_call_id=tool_call_id)
+    ctx = _make_ctx(state)
+
+    result = await tool_node.run(ctx, tool_call_id)
+
+    assert isinstance(result, ReturnCall), f"expected ReturnCall, got {type(result).__name__}"
+
+    stored = ctx.state.tool_results.get(tool_call_id)
+    assert isinstance(stored, ToolReturn), f"expected ToolReturn, got {type(stored).__name__}: {stored!r}"
+    assert not isinstance(stored, FailedToolCall)
+    assert not isinstance(stored, RetryPromptPart)
+    assert stored.return_value == "ok"
+    assert result.state.tool_results[tool_call_id] is stored
+
+
+# ---------------------------------------------------------------------------
+# Agent-side: BaseAgentNodeDef.run raises on observed error marker
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_detects_error_marker_and_raises_tool_execution_error():
+    agent = Agent(
+        "agent_under_test",
+        system_prompt="x",
+        subscribe_topics="agent_under_test.input",
+        publish_topic="agent_under_test.output",
+        model_client=TestModel(),
+    )
+
+    state = State()
+    tool_call_id = "id1"
+    tool_name = "t"
+    _register_tool_call(state, tool_name=tool_name, tool_call_id=tool_call_id)
+    state.add_tool_result(
+        tool_call_id,
+        FailedToolCall(
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+            exc_type="ValueError",
+            exc_message="boom",
+        ),
+    )
+    ctx = _make_ctx(state)
+
+    with pytest.raises(ToolExecutionError) as exc_info:
+        await agent.run(ctx)
+
+    err = exc_info.value
+    assert err.tool_name == tool_name
+    assert err.tool_call_id == tool_call_id
+    assert err.exc_type == "ValueError"
+    assert err.exc_message == "boom"
+
+
+async def test_agent_success_path_unchanged():
+    agent = Agent(
+        "agent_success",
+        system_prompt="x",
+        subscribe_topics="agent_success.input",
+        publish_topic="agent_success.output",
+        model_client=_final_text_model(),
+    )
+
+    state = State()
+    tool_call_id = "tc-success-001"
+    tool_name = "happy_tool"
+    _register_tool_call(state, tool_name=tool_name, tool_call_id=tool_call_id)
+    state.add_tool_result(
+        tool_call_id,
+        ToolReturn(return_value="ok", metadata={"tool_call_id": tool_call_id}),
+    )
+    ctx = _make_ctx(state)
+
+    result = await agent.run(ctx)
+
+    # Pin the happy-path shape: a successful tool result followed by a terminal
+    # model response should end the agent run with a ReturnCall, not Silent,
+    # TailCall, or an exception. Locks the regression gate against accidental
+    # short-circuits.
+    assert isinstance(result, ReturnCall), f"expected ReturnCall, got {type(result).__name__}"
+
+
+# ---------------------------------------------------------------------------
+# Wire-compatibility: marker survives JSON round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_marker_survives_json_round_trip_in_state():
+    # Regression guard: without _calf_tool_result_discriminator the marker
+    # arrives as a plain dict and the agent's isinstance check silently fails.
+    state = State()
+    tool_call_id = "tc-roundtrip-001"
+    tool_name = "buggy_tool"
+    _register_tool_call(state, tool_name=tool_name, tool_call_id=tool_call_id)
+    state.add_tool_result(
+        tool_call_id,
+        FailedToolCall(
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+            exc_type="ValueError",
+            exc_message="bad",
+        ),
+    )
+
+    restored = State.model_validate_json(state.model_dump_json())
+
+    result = restored.tool_results[tool_call_id]
+    assert isinstance(result, FailedToolCall)
+    assert result.tool_name == tool_name
+    assert result.tool_call_id == tool_call_id
+    assert result.exc_type == "ValueError"
+    assert result.exc_message == "bad"
+    assert result.marker_kind == "calfkit-tool-error"
+
+
+def test_existing_tool_result_types_survive_json_round_trip():
+    # Regression for the union flatten: pydantic-ai's tagged types must still
+    # round-trip. ModelRetry isn't checked here because it never reaches state
+    # — when a tool raises it, the worker stores a RetryPromptPart instead.
+    state = State()
+
+    success_id = "tc-rt-success"
+    _register_tool_call(state, tool_name="happy", tool_call_id=success_id)
+    state.add_tool_result(success_id, ToolReturn(return_value="ok", metadata={"tool_call_id": success_id}))
+
+    retry_id = "tc-rt-retry"
+    _register_tool_call(state, tool_name="retryable", tool_call_id=retry_id)
+    state.add_tool_result(
+        retry_id,
+        RetryPromptPart(content="please retry", tool_name="retryable", tool_call_id=retry_id),
+    )
+
+    restored = State.model_validate_json(state.model_dump_json())
+
+    assert isinstance(restored.tool_results[success_id], ToolReturn)
+    assert restored.tool_results[success_id].return_value == "ok"
+
+    assert isinstance(restored.tool_results[retry_id], RetryPromptPart)
+    assert restored.tool_results[retry_id].content == "please retry"
+
+
+async def test_agent_raises_on_marker_after_json_round_trip():
+    # End-to-end wire-compat: marker survives JSON, agent still raises.
+    agent = Agent(
+        "agent_roundtrip",
+        system_prompt="x",
+        subscribe_topics="agent_roundtrip.input",
+        publish_topic="agent_roundtrip.output",
+        model_client=TestModel(),
+    )
+
+    state = State()
+    tool_call_id = "tc-rt-error-001"
+    tool_name = "buggy_tool"
+    _register_tool_call(state, tool_name=tool_name, tool_call_id=tool_call_id)
+    state.add_tool_result(
+        tool_call_id,
+        FailedToolCall(
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+            exc_type="ValueError",
+            exc_message="boom",
+        ),
+    )
+
+    wired_state = State.model_validate_json(state.model_dump_json())
+    ctx = _make_ctx(wired_state)
+
+    with pytest.raises(ToolExecutionError) as exc_info:
+        await agent.run(ctx)
+
+    err = exc_info.value
+    assert err.tool_name == tool_name
+    assert err.tool_call_id == tool_call_id
+    assert err.exc_type == "ValueError"
+    assert err.exc_message == "boom"
+
+
+async def test_agent_ignores_stale_marker_not_in_latest_tool_calls():
+    # The detection loop is scoped to ``latest_tool_calls()`` so a marker for
+    # a tool_call_id that belongs to a previous turn (still lingering in
+    # ``tool_results``) does NOT re-fire. Without this scope, a higher layer
+    # that catches ``ToolExecutionError`` and retries would loop forever on
+    # the stale entry.
+    agent = Agent(
+        "agent_stale",
+        system_prompt="x",
+        subscribe_topics="agent_stale.input",
+        publish_topic="agent_stale.output",
+        model_client=_final_text_model(),
+    )
+
+    state = State()
+    current_id = "tc-current-ok"
+    _register_tool_call(state, tool_name="happy_tool", tool_call_id=current_id)
+    state.add_tool_result(
+        current_id,
+        ToolReturn(return_value="ok", metadata={"tool_call_id": current_id}),
+    )
+
+    # Inject a stale FailedToolCall for a tool_call_id that is NOT in the
+    # current ModelResponse, i.e. not returned by latest_tool_calls().
+    stale_id = "tc-stale-fail"
+    state.tool_results[stale_id] = FailedToolCall(
+        tool_name="old_tool",
+        tool_call_id=stale_id,
+        exc_type="ValueError",
+        exc_message="from-a-previous-turn",
+    )
+
+    ctx = _make_ctx(state)
+
+    result = await agent.run(ctx)
+    assert isinstance(result, ReturnCall), f"expected ReturnCall, got {type(result).__name__}"
+
+
+# ---------------------------------------------------------------------------
+# Parallel fanout: success + failure in the same batch
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_parallel_mode_marker_in_batch_triggers_error_after_aggregation():
+    # Parallel mode: the agent waits for both tool replies via
+    # _parallel_state_aggregation, then the error check fires once the batch
+    # is complete.
+    agent = Agent(
+        "agent_parallel",
+        system_prompt="x",
+        subscribe_topics="agent_parallel.input",
+        publish_topic="agent_parallel.output",
+        model_client=TestModel(),
+    )
+
+    correlation_id = "cid-parallel-mixed"
+    success_id = "tc-parallel-ok"
+    fail_id = "tc-parallel-fail"
+
+    base_state = State()
+    _register_tool_call(base_state, tool_name="happy_tool", tool_call_id=success_id)
+    _register_tool_call(base_state, tool_name="buggy_tool", tool_call_id=fail_id)
+
+    agent._pending_batches[correlation_id] = PendingToolBatch(
+        expected_tool_call_ids=frozenset({success_id, fail_id}),
+        base_state=base_state,
+    )
+
+    inflight_state = State()
+    _register_tool_call(inflight_state, tool_name="happy_tool", tool_call_id=success_id)
+    _register_tool_call(inflight_state, tool_name="buggy_tool", tool_call_id=fail_id)
+    inflight_state.add_tool_result(
+        success_id,
+        ToolReturn(return_value="ok", metadata={"tool_call_id": success_id}),
+    )
+    inflight_state.add_tool_result(
+        fail_id,
+        FailedToolCall(
+            tool_name="buggy_tool",
+            tool_call_id=fail_id,
+            exc_type="ValueError",
+            exc_message="boom",
+        ),
+    )
+
+    ctx = _make_ctx(inflight_state, correlation_id=correlation_id)
+
+    with pytest.raises(ToolExecutionError) as exc_info:
+        await agent.run(ctx)
+
+    err = exc_info.value
+    assert err.tool_call_id == fail_id
+    assert err.tool_name == "buggy_tool"
+    assert err.exc_type == "ValueError"
+    assert err.exc_message == "boom"
+
+
+async def test_agent_parallel_mode_waits_for_incomplete_batch():
+    # Companion check: if only one of two tools has replied, the agent must
+    # return Silent() without raising — even when the one that did reply is
+    # a FailedToolCall. The error check is gated on batch completion.
+    agent = Agent(
+        "agent_parallel_partial",
+        system_prompt="x",
+        subscribe_topics="agent_parallel_partial.input",
+        publish_topic="agent_parallel_partial.output",
+        model_client=TestModel(),
+    )
+
+    correlation_id = "cid-parallel-partial"
+    pending_id = "tc-parallel-pending"
+    fail_id = "tc-parallel-partial-fail"
+
+    base_state = State()
+    _register_tool_call(base_state, tool_name="slow_tool", tool_call_id=pending_id)
+    _register_tool_call(base_state, tool_name="buggy_tool", tool_call_id=fail_id)
+
+    agent._pending_batches[correlation_id] = PendingToolBatch(
+        expected_tool_call_ids=frozenset({pending_id, fail_id}),
+        base_state=base_state,
+    )
+
+    inflight_state = State()
+    _register_tool_call(inflight_state, tool_name="buggy_tool", tool_call_id=fail_id)
+    inflight_state.add_tool_result(
+        fail_id,
+        FailedToolCall(
+            tool_name="buggy_tool",
+            tool_call_id=fail_id,
+            exc_type="ValueError",
+            exc_message="early",
+        ),
+    )
+
+    ctx = _make_ctx(inflight_state, correlation_id=correlation_id)
+
+    result = await agent.run(ctx)
+    assert isinstance(result, Silent), f"expected Silent while batch incomplete, got {type(result).__name__}"
+
+
+# ---------------------------------------------------------------------------
+# BaseException carve-out: shutdown / cancellation signals must propagate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "exc_factory",
+    [
+        pytest.param(lambda: KeyboardInterrupt(), id="keyboard-interrupt"),
+        pytest.param(lambda: SystemExit(1), id="system-exit"),
+        pytest.param(lambda: asyncio.CancelledError(), id="cancelled-error"),
+    ],
+)
+async def test_tool_base_exceptions_propagate(exc_factory):
+    # The worker catches Exception, NOT BaseException. KeyboardInterrupt,
+    # SystemExit, and asyncio.CancelledError must propagate so operators can
+    # terminate workers and FastStream can perform graceful shutdown.
+    raised = exc_factory()
+
+    def boom(ctx: ToolContext) -> str:
+        raise raised
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=boom,
+        subscribe_topics="tool.boom_base.input",
+        publish_topic="tool.boom_base.output",
+    )
+
+    state = State()
+    tool_call_id = "tc-base-001"
+    _register_tool_call(state, tool_name="boom", tool_call_id=tool_call_id)
+    ctx = _make_ctx(state)
+
+    with pytest.raises(type(raised)):
+        await tool_node.run(ctx, tool_call_id)
+
+    # No marker should be stored — the exception must not be silently captured.
+    assert tool_call_id not in ctx.state.tool_results
+
+
+# ---------------------------------------------------------------------------
+# Agent-side arg validation: malformed LLM tool args become RetryPromptParts
+# before any Kafka dispatch, preserving pydantic-ai's fix-and-retry semantics.
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_validates_args_and_adds_retry_prompt_on_bad_args():
+    # Pins the core contract: when the LLM produces args that fail the tool's
+    # pydantic validator, the agent must not dispatch — instead it stores a
+    # RetryPromptPart so the LLM sees the validation error on the next turn.
+    def typed_tool(ctx: ToolContext, x: int) -> str:
+        return f"got {x}"
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=typed_tool,
+        subscribe_topics="tool.typed_tool.input",
+        publish_topic="tool.typed_tool.output",
+    )
+
+    tool_call_id = "tc-bad"
+    bad_call = ToolCallPart(tool_name="typed_tool", args={"x": "not-a-number"}, tool_call_id=tool_call_id)
+
+    agent = Agent(
+        "agent_validate_bad",
+        system_prompt="x",
+        subscribe_topics="agent_validate_bad.input",
+        publish_topic="agent_validate_bad.output",
+        model_client=_model_emits_tool_calls([bad_call]),
+        tools=[tool_node],
+    )
+
+    ctx = _make_ctx(State())
+    result = await agent.run(ctx)
+
+    # All (one) tool calls invalid → the agent TailCalls itself to give the LLM
+    # another turn with the retry prompt visible in tool_results.
+    assert isinstance(result, TailCall), f"expected TailCall, got {type(result).__name__}"
+
+    stored = ctx.state.tool_results.get(tool_call_id)
+    assert isinstance(stored, RetryPromptPart), f"expected RetryPromptPart, got {type(stored).__name__}: {stored!r}"
+    assert stored.tool_name == "typed_tool"
+    assert stored.tool_call_id == tool_call_id
+    # Content is the pydantic-ai-style error list (list of dicts) — must be
+    # non-empty so the LLM has something to act on.
+    assert stored.content, f"expected non-empty validation error content, got {stored.content!r}"
+
+
+async def test_agent_dispatches_valid_args_unchanged():
+    # Regression: valid args must continue to dispatch unchanged — the
+    # validation branch must not add false positives or interfere with the
+    # normal Kafka hop. No tool_results entry is added (still pending reply).
+    def typed_tool(ctx: ToolContext, x: int) -> str:
+        return f"got {x}"
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=typed_tool,
+        subscribe_topics="tool.typed_tool.input",
+        publish_topic="tool.typed_tool.output",
+    )
+
+    tool_call_id = "tc-good"
+    good_call = ToolCallPart(tool_name="typed_tool", args={"x": 5}, tool_call_id=tool_call_id)
+
+    agent = Agent(
+        "agent_validate_good",
+        system_prompt="x",
+        subscribe_topics="agent_validate_good.input",
+        publish_topic="agent_validate_good.output",
+        model_client=_model_emits_tool_calls([good_call]),
+        tools=[tool_node],
+    )
+
+    ctx = _make_ctx(State())
+    result = await agent.run(ctx)
+
+    # Single valid call → sequential dispatch via Call (no parallel batch).
+    assert isinstance(result, Call), f"expected Call, got {type(result).__name__}"
+    assert tool_call_id not in ctx.state.tool_results
+
+
+async def test_agent_partial_validation_failure_dispatches_valid_calls():
+    # Partial-failure: in a mixed batch, the invalid call lands as a
+    # RetryPromptPart and the valid call dispatches normally. Without this
+    # behavior a single bad arg from the LLM would block the whole batch.
+    def tool_a(ctx: ToolContext, x: int) -> str:
+        return f"a={x}"
+
+    def tool_b(ctx: ToolContext, y: str) -> str:
+        return f"b={y}"
+
+    tool_a_node = ToolNodeDef.create_tool_node(
+        func=tool_a,
+        subscribe_topics="tool.tool_a.input",
+        publish_topic="tool.tool_a.output",
+    )
+    tool_b_node = ToolNodeDef.create_tool_node(
+        func=tool_b,
+        subscribe_topics="tool.tool_b.input",
+        publish_topic="tool.tool_b.output",
+    )
+
+    valid_id = "tc-valid"
+    invalid_id = "tc-invalid"
+    valid_call = ToolCallPart(tool_name="tool_a", args={"x": 5}, tool_call_id=valid_id)
+    # y is typed str but the LLM emitted an int → pydantic rejects.
+    invalid_call = ToolCallPart(tool_name="tool_b", args={"y": 42}, tool_call_id=invalid_id)
+
+    agent = Agent(
+        "agent_partial",
+        system_prompt="x",
+        subscribe_topics="agent_partial.input",
+        publish_topic="agent_partial.output",
+        model_client=_model_emits_tool_calls([valid_call, invalid_call]),
+        tools=[tool_a_node, tool_b_node],
+    )
+
+    ctx = _make_ctx(State())
+    result = await agent.run(ctx)
+
+    # The invalid call must surface as a RetryPromptPart in tool_results so
+    # the LLM sees the typed feedback once the valid call completes.
+    stored_invalid = ctx.state.tool_results.get(invalid_id)
+    assert isinstance(stored_invalid, RetryPromptPart), (
+        f"expected RetryPromptPart for invalid call, got {type(stored_invalid).__name__}: {stored_invalid!r}"
+    )
+    assert stored_invalid.tool_name == "tool_b"
+    assert stored_invalid.tool_call_id == invalid_id
+
+    # The valid call must not be pre-populated in tool_results — it's pending
+    # the worker reply.
+    assert valid_id not in ctx.state.tool_results
+
+    # Only one valid pending call remains, so the agent takes the sequential
+    # dispatch branch (len(pending_tool_calls) == 1 → single Call, not list).
+    if isinstance(result, list):
+        target_ids = [call.input_args[0] for call in result if isinstance(call, Call)]
+        assert valid_id in target_ids, f"expected Call targeting {valid_id}, got input_args {target_ids}"
+    else:
+        assert isinstance(result, Call), f"expected Call, got {type(result).__name__}"
+        assert result.input_args is not None and result.input_args[0] == valid_id, (
+            f"expected Call targeting {valid_id}, got input_args {result.input_args!r}"
+        )
+
+
+async def test_agent_skips_validation_for_schema_only_override_tools():
+    # Override carve-out: BaseToolNodeSchema (wire-only, no validator) skips
+    # the validation branch entirely. Without this carve-out, an override
+    # toolset would crash on every dispatch because there is no validator to
+    # call. Pins the documented limitation so a future refactor that adds
+    # validation for overrides updates this test deliberately.
+    def typed_tool(ctx: ToolContext, x: int) -> str:
+        return f"got {x}"
+
+    full_tool_node = ToolNodeDef.create_tool_node(
+        func=typed_tool,
+        subscribe_topics="tool.typed_tool.input",
+        publish_topic="tool.typed_tool.output",
+    )
+
+    # Construct a wire-only schema mirroring the real tool but lacking the
+    # _tool/validator attribute. It must take the override path in agent.run.
+    schema_only = BaseToolNodeSchema(
+        node_id="tool_typed_tool",
+        subscribe_topics=list(full_tool_node.subscribe_topics),
+        publish_topic=full_tool_node.publish_topic,
+        tool_schema=full_tool_node.tool_schema,
+    )
+
+    tool_call_id = "tc-override"
+    # Args that would fail validation if the validator ran.
+    bad_call = ToolCallPart(tool_name="typed_tool", args={"x": "not-a-number"}, tool_call_id=tool_call_id)
+
+    agent = Agent(
+        "agent_override_skip",
+        system_prompt="x",
+        subscribe_topics="agent_override_skip.input",
+        publish_topic="agent_override_skip.output",
+        model_client=_model_emits_tool_calls([bad_call]),
+        tools=[full_tool_node],
+    )
+
+    state = State()
+    state.overrides = OverridesState(override_agent_tools=[schema_only])
+    ctx = _make_ctx(state)
+    result = await agent.run(ctx)
+
+    # No RetryPromptPart — validation was skipped, so the call dispatches.
+    assert tool_call_id not in ctx.state.tool_results
+    assert isinstance(result, Call), f"expected Call, got {type(result).__name__}"
+    assert result.input_args is not None and result.input_args[0] == tool_call_id
+
+
+async def test_agent_handles_malformed_json_args_as_retry_prompt():
+    # Regression for the widened dispatch-validation catch: when the LLM emits
+    # args as a malformed JSON string, args_as_dict() raises ValueError. The
+    # agent must store a RetryPromptPart rather than crashing the run.
+    def typed_tool(ctx: ToolContext, x: int) -> str:
+        return f"got {x}"
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=typed_tool,
+        subscribe_topics="tool.typed.input",
+        publish_topic="tool.typed.output",
+    )
+
+    bad_call = ToolCallPart(
+        tool_name="typed_tool",
+        args="not-valid-json",
+        tool_call_id="tc-malformed",
+    )
+
+    agent = Agent(
+        "agent_malformed",
+        system_prompt="x",
+        subscribe_topics="agent_malformed.input",
+        publish_topic="agent_malformed.output",
+        model_client=_model_emits_tool_calls([bad_call]),
+        tools=[tool_node],
+    )
+
+    ctx = _make_ctx(State())
+    result = await agent.run(ctx)
+
+    assert isinstance(result, TailCall), f"expected TailCall (all calls invalid), got {type(result).__name__}"
+
+    stored = ctx.state.tool_results.get("tc-malformed")
+    assert isinstance(stored, RetryPromptPart), f"expected RetryPromptPart, got {type(stored).__name__}"
+    assert "Malformed tool arguments" in str(stored.content), f"content should mention malformed args, got {stored.content!r}"
+
+
+async def test_agent_handles_non_dict_json_args_as_retry_prompt():
+    # Companion to the malformed-JSON case: a JSON array (not a dict) trips
+    # args_as_dict's `assert isinstance(args, dict)`, raising AssertionError.
+    # The same widened catch must convert it into a RetryPromptPart.
+    def typed_tool(ctx: ToolContext, x: int) -> str:
+        return f"got {x}"
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=typed_tool,
+        subscribe_topics="tool.typed.input",
+        publish_topic="tool.typed.output",
+    )
+
+    bad_call = ToolCallPart(
+        tool_name="typed_tool",
+        args="[1,2,3]",
+        tool_call_id="tc-array",
+    )
+
+    agent = Agent(
+        "agent_nondict",
+        system_prompt="x",
+        subscribe_topics="agent_nondict.input",
+        publish_topic="agent_nondict.output",
+        model_client=_model_emits_tool_calls([bad_call]),
+        tools=[tool_node],
+    )
+
+    ctx = _make_ctx(State())
+    result = await agent.run(ctx)
+
+    assert isinstance(result, TailCall)
+    stored = ctx.state.tool_results.get("tc-array")
+    assert isinstance(stored, RetryPromptPart)
+    assert "Malformed tool arguments" in str(stored.content)
+
+
+async def test_tool_long_exception_message_is_clamped_not_rejected():
+    # Regression: previously a >4096-char exc_message caused FailedToolCall
+    # construction to raise ValidationError inside the worker's except block,
+    # hanging the run. The clamping validator must silently truncate instead.
+    long_msg = "x" * 5000
+
+    def boom_with_long_msg(ctx: ToolContext) -> str:
+        raise ValueError(long_msg)
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=boom_with_long_msg,
+        subscribe_topics="tool.boom_long.input",
+        publish_topic="tool.boom_long.output",
+    )
+
+    state = State()
+    tool_call_id = "tc-long-msg-001"
+    _register_tool_call(state, tool_name="boom_with_long_msg", tool_call_id=tool_call_id)
+    ctx = _make_ctx(state)
+
+    result = await tool_node.run(ctx, tool_call_id)
+
+    assert isinstance(result, ReturnCall), f"expected ReturnCall (no hang), got {type(result).__name__}"
+
+    stored = ctx.state.tool_results.get(tool_call_id)
+    assert isinstance(stored, FailedToolCall)
+    assert stored.exc_type == "ValueError"
+    # exc_message must be clamped to 4096, not the full 5000.
+    assert len(stored.exc_message) == 4096, f"expected clamped to 4096 chars, got {len(stored.exc_message)}"
+    assert stored.exc_message == "x" * 4096
+
+
+# ---------------------------------------------------------------------------
+# Discriminator: direct unit coverage of _calf_tool_result_discriminator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        ({"marker_kind": "calfkit-tool-error"}, "calfkit-tool-error"),
+        ({"kind": "tool-return"}, "tool-return"),
+        ({"kind": "model-retry"}, "model-retry"),
+        ({"part_kind": "retry-prompt"}, "retry-prompt"),
+        # marker_kind takes precedence over kind / part_kind
+        ({"marker_kind": "calfkit-tool-error", "kind": "tool-return"}, "calfkit-tool-error"),
+        # Non-string tag values are ignored (returns None, falls through to Any arm)
+        ({"kind": 42}, None),
+        ({"kind": None}, None),
+        ({"marker_kind": ["x"]}, None),
+        # Unknown shapes return None
+        ({}, None),
+        ({"unknown": "shape"}, None),
+        # Non-dict, non-object inputs return None
+        ("hello", None),
+        (None, None),
+        (42, None),
+    ],
+)
+def test_calf_tool_result_discriminator_tags_dict_payloads(payload, expected):
+    assert _calf_tool_result_discriminator(payload) == expected
+
+
+def test_calf_tool_result_discriminator_reads_object_attributes():
+    # Object inputs (already-constructed model instances) must resolve via
+    # attribute lookup, not just dict key lookup.
+    marker = FailedToolCall(
+        tool_name="t",
+        tool_call_id="id1",
+        exc_type="V",
+        exc_message="m",
+    )
+    assert _calf_tool_result_discriminator(marker) == "calfkit-tool-error"
+
+
+# ---------------------------------------------------------------------------
+# BaseToolNodeDef.validate_call_args: direct coverage
+# ---------------------------------------------------------------------------
+
+
+def test_validate_call_args_passes_valid_args():
+    def typed_tool(ctx: ToolContext, x: int) -> str:
+        return f"got {x}"
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=typed_tool,
+        subscribe_topics="tool.typed.input",
+        publish_topic="tool.typed.output",
+    )
+
+    result = tool_node.validate_call_args({"x": 5})
+    # Validator may return the coerced/validated args; we just confirm no raise.
+    assert result is not None
+
+
+def test_validate_call_args_raises_on_wrong_type():
+    def typed_tool(ctx: ToolContext, x: int) -> str:
+        return f"got {x}"
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=typed_tool,
+        subscribe_topics="tool.typed.input",
+        publish_topic="tool.typed.output",
+    )
+
+    with pytest.raises(ValidationError):
+        tool_node.validate_call_args({"x": "not-an-int"})
+
+
+def test_validate_call_args_raises_on_missing_required_arg():
+    def typed_tool(ctx: ToolContext, x: int, y: str) -> str:
+        return f"{x}-{y}"
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=typed_tool,
+        subscribe_topics="tool.typed.input",
+        publish_topic="tool.typed.output",
+    )
+
+    with pytest.raises(ValidationError):
+        tool_node.validate_call_args({"x": 5})  # missing y
+
+
+# ---------------------------------------------------------------------------
+# Adversarial worker-side regressions: broken __str__, logger.exception
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_exception_with_broken_str_still_produces_failed_tool_call():
+    # Regression: a bare str(e) on the worker can itself raise if the
+    # exception's __str__ is broken. That would propagate out of except Exception
+    # and re-introduce the silent-hang failure mode the feature prevents.
+    class BadStrError(Exception):
+        def __str__(self) -> str:
+            raise RuntimeError("cannot stringify")
+
+    def boom(ctx: ToolContext) -> str:
+        raise BadStrError()
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=boom,
+        subscribe_topics="tool.bad_str.input",
+        publish_topic="tool.bad_str.output",
+    )
+
+    state = State()
+    tool_call_id = "tc-bad-str-001"
+    _register_tool_call(state, tool_name="boom", tool_call_id=tool_call_id)
+    ctx = _make_ctx(state)
+
+    result = await tool_node.run(ctx, tool_call_id)
+
+    assert isinstance(result, ReturnCall), f"expected ReturnCall, got {type(result).__name__}"
+
+    stored = ctx.state.tool_results.get(tool_call_id)
+    assert isinstance(stored, FailedToolCall), f"expected FailedToolCall, got {type(stored).__name__}"
+    assert stored.exc_type == "BadStrError"
+    # exc_message should be a non-empty string (the safe fallback content)
+    assert stored.exc_message, f"expected non-empty exc_message, got {stored.exc_message!r}"
+
+
+async def test_tool_worker_logs_exception_with_traceback(caplog):
+    # The PR explicitly trades client-side observability for worker-side log
+    # diagnostics. Pin that logger.exception (not logger.error) fires so the
+    # traceback is captured — a silent demote to logger.debug would lose the
+    # only forensic surface across the Kafka boundary.
+    def boom(ctx: ToolContext) -> str:
+        raise ValueError("bad-for-logs")
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=boom,
+        subscribe_topics="tool.boom_log.input",
+        publish_topic="tool.boom_log.output",
+    )
+
+    state = State()
+    tool_call_id = "tc-log-001"
+    _register_tool_call(state, tool_name="boom", tool_call_id=tool_call_id)
+    ctx = _make_ctx(state)
+
+    with caplog.at_level(logging.ERROR, logger="calfkit.nodes.tool"):
+        await tool_node.run(ctx, tool_call_id)
+
+    # Find the worker's exception log record.
+    err_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert err_records, "expected at least one ERROR-level log from the worker"
+    # exc_info must be present (logger.exception sets this) so the traceback
+    # is captured across the Kafka boundary.
+    matching = [r for r in err_records if r.exc_info is not None]
+    assert matching, "expected logger.exception with exc_info, got logger.error only"
+    # tool_call_id should be in the log message for correlation.
+    assert any(tool_call_id in r.getMessage() for r in matching), "tool_call_id missing from worker log"
+
+
+# ---------------------------------------------------------------------------
+# Multi-failure parallel batch: every failure must be logged before raising
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_parallel_mode_logs_all_failures_before_raising(caplog):
+    # Regression: a parallel batch with multiple failures must log every one
+    # so operators see all failures, not just the first to be raised.
+    agent = Agent(
+        "agent_multi_fail",
+        system_prompt="x",
+        subscribe_topics="agent_multi_fail.input",
+        publish_topic="agent_multi_fail.output",
+        model_client=TestModel(),
+    )
+
+    correlation_id = "cid-multi-fail"
+    first_id = "tc-first-fail"
+    second_id = "tc-second-fail"
+
+    base_state = State()
+    _register_tool_call(base_state, tool_name="buggy_a", tool_call_id=first_id)
+    _register_tool_call(base_state, tool_name="buggy_b", tool_call_id=second_id)
+
+    agent._pending_batches[correlation_id] = PendingToolBatch(
+        expected_tool_call_ids=frozenset({first_id, second_id}),
+        base_state=base_state,
+    )
+
+    inflight_state = State()
+    _register_tool_call(inflight_state, tool_name="buggy_a", tool_call_id=first_id)
+    _register_tool_call(inflight_state, tool_name="buggy_b", tool_call_id=second_id)
+    inflight_state.add_tool_result(
+        first_id,
+        FailedToolCall(
+            tool_name="buggy_a",
+            tool_call_id=first_id,
+            exc_type="ValueError",
+            exc_message="boom-a",
+        ),
+    )
+    inflight_state.add_tool_result(
+        second_id,
+        FailedToolCall(
+            tool_name="buggy_b",
+            tool_call_id=second_id,
+            exc_type="KeyError",
+            exc_message="boom-b",
+        ),
+    )
+
+    ctx = _make_ctx(inflight_state, correlation_id=correlation_id)
+
+    with caplog.at_level(logging.ERROR, logger="calfkit.nodes.agent"):
+        with pytest.raises(ToolExecutionError):
+            await agent.run(ctx)
+
+    # Both failures must appear in the logs.
+    log_text = caplog.text
+    assert "buggy_a" in log_text and first_id in log_text, "first failure missing from logs"
+    assert "buggy_b" in log_text and second_id in log_text, "second failure missing from logs"
+
+
+# ---------------------------------------------------------------------------
+# ToolExecutionError picklability and FailedToolCall frozen/validation
+# ---------------------------------------------------------------------------
+
+
+def test_tool_execution_error_is_picklable():
+    # Regression: keyword-only __init__ broke pickle. Override __reduce__/__setstate__
+    # to restore picklability so the exception can cross worker boundaries (process
+    # pools, multiprocessing, etc.).
+    err = ToolExecutionError(
+        tool_name="t",
+        tool_call_id="id-1",
+        exc_type="ValueError",
+        exc_message="something",
+    )
+
+    restored = pickle.loads(pickle.dumps(err))
+    assert isinstance(restored, ToolExecutionError)
+    assert restored.tool_name == "t"
+    assert restored.tool_call_id == "id-1"
+    assert restored.exc_type == "ValueError"
+    assert restored.exc_message == "something"
+    assert str(restored) == str(err)
+
+
+def test_failed_tool_call_is_frozen():
+    f = FailedToolCall(
+        tool_name="t",
+        tool_call_id="id-1",
+        exc_type="V",
+        exc_message="m",
+    )
+    with pytest.raises(Exception):
+        f.tool_name = "mutated"  # frozen=True should reject
+
+
+def test_failed_tool_call_rejects_empty_tool_call_id():
+    # tool_call_id is the correlation key; empty values are invalid and must be
+    # rejected at construction.
+    with pytest.raises(ValidationError):
+        FailedToolCall(
+            tool_name="t",
+            tool_call_id="",
+            exc_type="V",
+            exc_message="m",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Override (schema-only) dispatch path: malformed JSON args become RetryPromptPart
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_override_path_malformed_args_become_retry_prompt():
+    # Regression: previously the dispatch loop only ran args_as_dict() inside
+    # the BaseToolNodeDef branch, so override (schema-only) tools dispatched
+    # raw malformed JSON to the worker, where it surfaced as a hard
+    # FailedToolCall instead of an LLM-retryable RetryPromptPart. The
+    # refactored loop parses args on all dispatch paths.
+    def typed_tool(ctx: ToolContext, x: int) -> str:
+        return f"got {x}"
+
+    full_tool_node = ToolNodeDef.create_tool_node(
+        func=typed_tool,
+        subscribe_topics="tool.typed.input",
+        publish_topic="tool.typed.output",
+    )
+
+    schema_only_override = BaseToolNodeSchema(
+        node_id="override_typed_tool",
+        tool_schema=full_tool_node.tool_schema,
+        subscribe_topics=list(full_tool_node.subscribe_topics),
+        publish_topic=full_tool_node.publish_topic,
+    )
+
+    bad_call = ToolCallPart(
+        tool_name="typed_tool",
+        args="not-valid-json",
+        tool_call_id="tc-override-malformed",
+    )
+
+    agent = Agent(
+        "agent_override_malformed",
+        system_prompt="x",
+        subscribe_topics="agent_override_malformed.input",
+        publish_topic="agent_override_malformed.output",
+        model_client=_model_emits_tool_calls([bad_call]),
+        tools=[full_tool_node],
+    )
+
+    state = State(overrides=OverridesState(override_agent_tools=[schema_only_override]))
+    ctx = _make_ctx(state)
+    result = await agent.run(ctx)
+
+    assert isinstance(result, TailCall), f"expected TailCall (all calls invalid), got {type(result).__name__}"
+
+    stored = ctx.state.tool_results.get("tc-override-malformed")
+    assert isinstance(stored, RetryPromptPart)
+    assert "Malformed tool arguments" in str(stored.content)
+
+
+# ---------------------------------------------------------------------------
+# Defensive construction: the worker's failure path must not itself raise
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_failed_marker_construction_falls_back_to_sentinel():
+    # Regression: if the primary FailedToolCall construction raises (e.g.
+    # min_length=1 rejects an empty tool_call_id), the worker must fall back
+    # to a hardcoded sentinel marker and still publish a reply. Without this,
+    # the ValidationError would escape the ``except Exception`` block and
+    # re-introduce the silent-hang failure mode the feature exists to prevent.
+    def boom(ctx: ToolContext) -> str:
+        raise ValueError("original failure")
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=boom,
+        subscribe_topics="tool.fallback.input",
+        publish_topic="tool.fallback.output",
+    )
+
+    state = State()
+    # Empty tool_call_id triggers FailedToolCall's min_length=1 rejection
+    # during primary construction.
+    part = ToolCallPart(tool_name="boom", args={}, tool_call_id="")
+    state.add_tool_call(part)
+    state.message_history.append(ModelResponse(parts=[part]))
+    ctx = _make_ctx(state)
+
+    result = await tool_node.run(ctx, "")
+
+    # Reply still publishes — no silent hang.
+    assert isinstance(result, ReturnCall), f"expected ReturnCall, got {type(result).__name__}"
+
+    # Marker stored under the original tool_call_id key so the agent can find
+    # it via state.tool_results.get(tool_call_id).
+    stored = ctx.state.tool_results.get("")
+    assert isinstance(stored, FailedToolCall), f"expected FailedToolCall, got {type(stored).__name__}"
+    # Fallback uses sentinel field values so operators can distinguish from
+    # a normal marker.
+    assert stored.tool_call_id == "<missing>"
+    assert stored.tool_name == "<unknown>"
+    assert stored.exc_type == "FailedToolCallConstructionError"
+    assert "Failed to construct primary marker" in stored.exc_message
+
+
+# ---------------------------------------------------------------------------
+# Validator raising non-ValidationError must surface as RetryPromptPart
+# ---------------------------------------------------------------------------
+
+
+def _angry_validator(v: int) -> int:
+    raise RuntimeError("angry validator")
+
+
+def _tool_with_bad_validator(ctx: ToolContext, x: Annotated[int, BeforeValidator(_angry_validator)]) -> str:
+    return f"x={x}"
+
+
+async def test_agent_validator_raising_runtime_error_becomes_retry_prompt():
+    # Regression: a Pydantic BeforeValidator (or field_validator) in a tool's
+    # arg schema can raise anything (RuntimeError, TypeError, custom). The
+    # agent's narrow ``except ValidationError`` catch must be widened so these
+    # do not escape ``run()`` and silently hang the caller.
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=_tool_with_bad_validator,
+        subscribe_topics="tool.angry.input",
+        publish_topic="tool.angry.output",
+    )
+
+    bad_call = ToolCallPart(
+        tool_name="_tool_with_bad_validator",
+        args={"x": 5},
+        tool_call_id="tc-angry-001",
+    )
+
+    agent = Agent(
+        "agent_angry_validator",
+        system_prompt="x",
+        subscribe_topics="agent_angry_validator.input",
+        publish_topic="agent_angry_validator.output",
+        model_client=_model_emits_tool_calls([bad_call]),
+        tools=[tool_node],
+    )
+
+    ctx = _make_ctx(State())
+    result = await agent.run(ctx)
+
+    # All (one) calls invalid → TailCall to give the LLM another turn;
+    # critically, no exception escapes the dispatch loop.
+    assert isinstance(result, TailCall), f"expected TailCall, got {type(result).__name__}"
+
+    stored = ctx.state.tool_results.get("tc-angry-001")
+    assert isinstance(stored, RetryPromptPart), f"expected RetryPromptPart, got {type(stored).__name__}"
+    assert "RuntimeError" in str(stored.content)
+
+
+async def test_agent_validator_failure_branch_continues_loop():
+    # Regression for the ``continue`` in the validation-failure branch: a
+    # batch with one invalid and one valid call must produce a RetryPromptPart
+    # for the invalid one AND dispatch the valid one. A missing ``continue``
+    # would let any future code addition below the branch silently execute
+    # on validation-failed iterations.
+    def typed_tool(ctx: ToolContext, x: int) -> str:
+        return f"got {x}"
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=typed_tool,
+        subscribe_topics="tool.typed.input",
+        publish_topic="tool.typed.output",
+    )
+
+    bad_call = ToolCallPart(tool_name="typed_tool", args={"x": "nope"}, tool_call_id="tc-bad-002")
+    good_call = ToolCallPart(tool_name="typed_tool", args={"x": 7}, tool_call_id="tc-good-002")
+
+    agent = Agent(
+        "agent_continue",
+        system_prompt="x",
+        subscribe_topics="agent_continue.input",
+        publish_topic="agent_continue.output",
+        model_client=_model_emits_tool_calls([bad_call, good_call]),
+        tools=[tool_node],
+    )
+
+    ctx = _make_ctx(State())
+    result = await agent.run(ctx)
+
+    # Bad call lands as a RetryPromptPart; good call is dispatched (only one
+    # valid pending call remains, so the agent takes the sequential Call branch).
+    bad_stored = ctx.state.tool_results.get("tc-bad-002")
+    assert isinstance(bad_stored, RetryPromptPart)
+    assert "tc-good-002" not in ctx.state.tool_results, "good call should still be pending dispatch"
+    assert isinstance(result, Call), f"expected Call (good call dispatched), got {type(result).__name__}"

--- a/tests/test_tool_errors.py
+++ b/tests/test_tool_errors.py
@@ -1180,10 +1180,12 @@ async def test_tool_failed_marker_construction_falls_back_to_sentinel():
     # it via state.tool_results.get(tool_call_id).
     stored = ctx.state.tool_results.get("")
     assert isinstance(stored, FailedToolCall), f"expected FailedToolCall, got {type(stored).__name__}"
-    # Fallback uses sentinel field values so operators can distinguish from
-    # a normal marker.
+    # Fallback preserves real ``tool_name`` (operators need correlation), only
+    # substitutes ``<missing>`` for the empty ``tool_call_id`` that caused
+    # primary construction to fail. ``exc_type`` is the construction-failure
+    # sentinel.
     assert stored.tool_call_id == "<missing>"
-    assert stored.tool_name == "<unknown>"
+    assert stored.tool_name == "boom"
     assert stored.exc_type == "FailedToolCallConstructionError"
     assert "Failed to construct primary marker" in stored.exc_message
 
@@ -1276,3 +1278,98 @@ async def test_agent_validator_failure_branch_continues_loop():
     assert isinstance(bad_stored, RetryPromptPart)
     assert "tc-good-002" not in ctx.state.tool_results, "good call should still be pending dispatch"
     assert isinstance(result, Call), f"expected Call (good call dispatched), got {type(result).__name__}"
+
+
+# ---------------------------------------------------------------------------
+# args_as_dict() raises TypeError on non-string/non-dict args; must not escape
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_handles_typeerror_args_as_retry_prompt():
+    # Regression: when the LLM emits a ``ToolCallPart.args`` that is neither a
+    # JSON string nor a dict (e.g. an int / list from an off-spec provider),
+    # ``args_as_dict()`` raises ``TypeError`` from ``pydantic_core.from_json``.
+    # The dispatch catch must widen beyond (ValueError, AssertionError) so the
+    # exception does not escape ``run()`` and hang the caller. Surfaces as a
+    # ``RetryPromptPart`` for LLM-visible retry.
+    def typed_tool(ctx: ToolContext, x: int) -> str:
+        return f"got {x}"
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=typed_tool,
+        subscribe_topics="tool.typeerr.input",
+        publish_topic="tool.typeerr.output",
+    )
+
+    # args is an int, not a dict or JSON string — args_as_dict() raises TypeError.
+    bad_call = ToolCallPart(tool_name="typed_tool", args=123, tool_call_id="tc-typeerr")
+
+    agent = Agent(
+        "agent_typeerr",
+        system_prompt="x",
+        subscribe_topics="agent_typeerr.input",
+        publish_topic="agent_typeerr.output",
+        model_client=_model_emits_tool_calls([bad_call]),
+        tools=[tool_node],
+    )
+
+    ctx = _make_ctx(State())
+    result = await agent.run(ctx)
+
+    assert isinstance(result, TailCall), f"expected TailCall, got {type(result).__name__}"
+    stored = ctx.state.tool_results.get("tc-typeerr")
+    assert isinstance(stored, RetryPromptPart)
+    assert "TypeError" in str(stored.content)
+    assert "Malformed tool arguments" in str(stored.content)
+
+
+# ---------------------------------------------------------------------------
+# Sentinel fallback preserves real tool identity when valid
+# ---------------------------------------------------------------------------
+
+
+async def test_fallback_marker_preserves_real_tool_name_and_id_when_valid(monkeypatch):
+    # Regression: when primary FailedToolCall construction fails for any reason
+    # OTHER than empty tool_call_id/tool_name (the previously-documented trigger),
+    # the fallback must still preserve real ``tool_name`` / ``tool_call_id`` so
+    # operators don't lose the correlation key in the raised ToolExecutionError.
+    import calfkit.nodes.tool as tool_module
+
+    _original_marker_cls = tool_module.FailedToolCall
+    _call_count = {"n": 0}
+
+    def _make_failing_then_real(*args, **kwargs):
+        _call_count["n"] += 1
+        if _call_count["n"] == 1:
+            # Simulate ANY construction failure unrelated to the input fields
+            # (e.g., a future schema-evolution constraint).
+            raise RuntimeError("simulated primary construction failure")
+        return _original_marker_cls(*args, **kwargs)
+
+    monkeypatch.setattr(tool_module, "FailedToolCall", _make_failing_then_real)
+
+    def boom(ctx: ToolContext) -> str:
+        raise ValueError("original tool failure")
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=boom,
+        subscribe_topics="tool.preserve.input",
+        publish_topic="tool.preserve.output",
+    )
+
+    state = State()
+    tool_call_id = "real-correlation-id-abc123"
+    _register_tool_call(state, tool_name="boom", tool_call_id=tool_call_id)
+    ctx = _make_ctx(state)
+
+    result = await tool_node.run(ctx, tool_call_id)
+    assert isinstance(result, ReturnCall)
+
+    stored = ctx.state.tool_results.get(tool_call_id)
+    assert isinstance(stored, FailedToolCall)
+    # Real values preserved — operators can still grep the log for the call id.
+    assert stored.tool_call_id == tool_call_id, f"expected real id preserved, got {stored.tool_call_id!r}"
+    assert stored.tool_name == "boom", f"expected real tool_name preserved, got {stored.tool_name!r}"
+    # exc_type marks this as a fallback marker.
+    assert stored.exc_type == "FailedToolCallConstructionError"
+    assert "Failed to construct primary marker" in stored.exc_message


### PR DESCRIPTION
## Summary

Eliminates the silent indefinite hang that previously occurred when an agent-dispatched tool raised an exception. Tool workers now catch failures and ship a typed `FailedToolCall` marker back to the agent; the agent detects the marker and aborts the run with a typed `ToolExecutionError`. Argument validation also runs at the agent before dispatch so malformed LLM-emitted args become a retry-prompt instead of a wasted Kafka round-trip.

## What's in scope

- **Worker side (`calfkit/nodes/tool.py`)** — catches `Exception` raised by the user's tool function; ships a typed `FailedToolCall` marker back so the reply still publishes. Defensive helpers: `_safe_exc_message` (mirrors stdlib `traceback._some_str`) handles exceptions whose `__str__` raises; eager `pydantic_core.to_json` check on the `ToolReturn` catches unserializable return values before FastStream's publish boundary; nested-try fallback handles the rare case where `FailedToolCall` construction itself can't accept the inputs.
- **Agent side (`calfkit/nodes/agent.py`)** — detects `FailedToolCall` markers in `state.tool_results` for the current turn's `latest_tool_calls()` and raises `ToolExecutionError` with all forensic fields preserved. Also defends against corrupt marker dicts (schema drift / version skew) by synthesizing a typed marker so the silent-failure mode closes even when the wire payload fails union validation.
- **Pre-dispatch argument validation** — `BaseToolNodeDef.validate_call_args(args)` runs at the agent before dispatching to the worker. Catches `ValidationError`, `ValueError`/`AssertionError` from `args_as_dict()` (raised by `pydantic_core.from_json` on non-string/non-dict args, including `TypeError` for non-bytes/string inputs), and arbitrary `Exception` from user-authored Pydantic `field_validator`s — all surface as `RetryPromptPart` so the LLM can fix-and-retry.
- **Pydantic-ai `ModelRetry` preserved** as the explicit opt-in path for LLM-visible retry semantics; round-trips as `RetryPromptPart`.
- **New types**: `FailedToolCall` (Pydantic, `frozen=True`, discriminated-union tag, string fields clamp via `_clamp_string_fields` rather than reject), `ToolExecutionError` (picklable across worker boundaries via `__reduce__` / `__setstate__`), `CalfToolResult` (calfkit-side flattening of pydantic-ai's `DeferredToolCallResult` to add `FailedToolCall` as a tagged arm so the marker survives JSON round-trip).
- **`BaseException` carve-out**: `KeyboardInterrupt`, `SystemExit`, `asyncio.CancelledError` propagate uncaught so graceful shutdown still works.

## What's out of scope

- End-to-end error propagation from agent back to the original `client.execute_node()` caller. The client still times out on `ToolExecutionError` rather than receiving a typed exception. Tracked at #143.
- Generic publish-failure defense at `BaseNodeDef` for ALL node subclasses (currently only `ToolNodeDef` has the focused defense). Tracked at #145.

## Notes for reviewers

- The PR went through four rounds of independent multi-agent review (code review, test coverage, silent-failure audit, type design, comment review, code simplification). All verified findings from those rounds have been addressed; remaining items are either phase-2 scope, pre-existing concerns, or quality nits filed as follow-up issues.
- 4,177 unit tests pass; 53 of those are new in `tests/test_tool_errors.py` covering the four declared behaviors, JSON wire round-trip, BaseException propagation, defensive fallback marker, picklability, frozen-ness, discriminator behavior, stale-marker scoping, parallel-batch aggregation, multi-failure logging, validator carve-outs, unserializable returns, and corrupt-marker schema drift.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/integration -q` — 4,177 pass
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [ ] CI green on PR