### PR TITLE
fix: key _pending_batches by frame_id to fix parallel tool calling collisions

### DIFF
--- a/calfkit/models/session_context.py
+++ b/calfkit/models/session_context.py
@@ -89,6 +89,7 @@ class BaseSessionRunContext(BaseModel, Generic[StateT, DepsT]):
 
     _emitter_node_id: str | None = PrivateAttr(default=None)
     _emitter_node_kind: str | None = PrivateAttr(default=None)
+    _frame_id: str | None = PrivateAttr(default=None)
 
     @property
     def emitter_node_id(self) -> str | None:
@@ -109,6 +110,22 @@ class BaseSessionRunContext(BaseModel, Generic[StateT, DepsT]):
         ``x-calf-emitter-kind`` Kafka header.
         """
         return self._emitter_node_kind
+
+    @property
+    def frame_id(self) -> str | None:
+        """Per-invocation identifier of the current call frame on the workflow stack.
+
+        Set by ``BaseNodeDef.prepare_context`` from
+        ``envelope.internal_workflow_state.current_frame.frame_id``. Every
+        ``Call`` published by the framework pushes a fresh ``CallFrame`` with a
+        UUID7-generated ``frame_id``, so parallel invocations of the same node
+        (which share a single ``correlation_id``) are still uniquely
+        identifiable per invocation. Used by the agent to key its in-memory
+        parallel tool-batch aggregation dict so concurrent fan-outs do not
+        collide. Backed by a ``PrivateAttr`` so it never rides on the wire and
+        cannot be spoofed via the model constructor.
+        """
+        return self._frame_id
 
 
 SessionRunContext = BaseSessionRunContext[State, Deps]

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -66,8 +66,54 @@ class BaseAgentNodeDef(
             model_settings=cast(ModelSettings | None, model_settings),
         )
 
+    @staticmethod
+    def _require_frame_id_for_write(ctx: SessionRunContext) -> str:
+        """Resolve the per-invocation frame_id when WRITING a new parallel batch.
+
+        ``ctx.frame_id`` is populated by ``BaseNodeDef.prepare_context`` from
+        ``envelope.internal_workflow_state.current_frame.frame_id``. It is the
+        only correct key for ``_pending_batches`` because parallel invocations
+        of the same agent share a single ``correlation_id`` — see
+        :meth:`_parallel_state_aggregation` for the collision scenario this
+        defends against. A ``None`` value at write time means the agent was
+        invoked outside the framework's prepare-context path (e.g. a test
+        driving ``run()`` directly without seeding ``_frame_id``); raising is
+        the right call because silently bucketing every batch under ``None``
+        would re-introduce the exact bug this keying is designed to prevent.
+
+        Read-side lookups tolerate ``None`` (treated as "no batch present")
+        because the only way a read can find a ``None``-keyed entry is if a
+        write was previously allowed to use ``None`` — which this guard
+        prevents at the source.
+        """
+        frame_id = ctx.frame_id
+        if frame_id is None:
+            raise RuntimeError(
+                "ctx.frame_id is None — parallel tool-batch dispatch requires a "
+                "frame_id, normally populated by BaseNodeDef.prepare_context from "
+                "the inbound envelope's current_frame. If you are driving run() "
+                "directly in a test that fans out a parallel batch, set "
+                "ctx._frame_id before invoking."
+            )
+        return frame_id
+
     def _parallel_state_aggregation(self, ctx: SessionRunContext) -> None:
-        batch = self._pending_batches.get(ctx.deps.correlation_id)
+        # Keyed on ``ctx.frame_id`` (per-invocation), NOT ``ctx.deps.correlation_id``:
+        # a supervisor that fans out two ``Call``s to the same agent topic shares one
+        # ``correlation_id`` across both invocations. Each invocation publishes onto
+        # its own fresh ``CallFrame`` (UUID7 ``frame_id``), so the per-invocation
+        # frame is the only key that keeps concurrent batches from clobbering each
+        # other in this dict.
+        #
+        # ``ctx.frame_id`` may be ``None`` when ``run()`` is driven outside the
+        # framework's prepare-context path (unit tests of non-parallel branches).
+        # In that case the dict lookup misses cleanly — no aggregation needed
+        # because no batch could have been written under ``None`` (the
+        # write-side guard rejects ``None``).
+        frame_id = ctx.frame_id
+        if frame_id is None:
+            return
+        batch = self._pending_batches.get(frame_id)
         if batch is not None:
             for tool_call_id in batch.expected_tool_call_ids:
                 if tool_call_id not in batch.collected_results and tool_call_id in ctx.state.tool_results:
@@ -77,7 +123,7 @@ class BaseAgentNodeDef(
                 for tool_call_id, tool_call_result in batch.collected_results.items():
                     batch.base_state.add_tool_result(tool_call_id, tool_call_result)
                 ctx.state = batch.base_state
-                del self._pending_batches[ctx.deps.correlation_id]
+                del self._pending_batches[frame_id]
 
     async def run(self, ctx: SessionRunContext) -> NodeResult[State]:
         tools_registry = dict[str, BaseToolNodeSchema]()
@@ -102,7 +148,10 @@ class BaseAgentNodeDef(
 
         if not self.sequential_only_mode:
             self._parallel_state_aggregation(ctx)
-            batch = self._pending_batches.get(ctx.deps.correlation_id)
+            # ``ctx.frame_id`` may be ``None`` in tests driving ``run()`` outside
+            # the framework's prepare-context path; treat that as "no batch".
+            # See ``_require_frame_id_for_write`` for why write-side rejects None.
+            batch = self._pending_batches.get(ctx.frame_id) if ctx.frame_id is not None else None
             if batch and not batch.is_complete:
                 return Silent()
 
@@ -183,7 +232,7 @@ class BaseAgentNodeDef(
                     remaining = [tc for tc in latest_tool_calls if tc.tool_call_id not in ctx.state.tool_results]
                     raise RuntimeError(
                         f"[{ctx.deps.correlation_id[:8]}] Parallel mode reached incomplete tool calls outside aggregation gate. "
-                        f"node={self.name} remaining_ids={[tc.tool_call_id for tc in remaining]}. "
+                        f"node={self.name} frame_id={ctx.frame_id} remaining_ids={[tc.tool_call_id for tc in remaining]}. "
                         f"This indicates lost PendingToolBatch state (e.g. partition rebalance or process restart)."
                     )
 
@@ -356,7 +405,7 @@ class BaseAgentNodeDef(
                     for tc in pending_tool_calls
                 ]
 
-                self._pending_batches[ctx.deps.correlation_id] = PendingToolBatch(
+                self._pending_batches[self._require_frame_id_for_write(ctx)] = PendingToolBatch(
                     expected_tool_call_ids=frozenset(launch_tool_call_ids),
                     base_state=ctx.state.model_copy(deep=True),
                 )

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -189,8 +189,7 @@ class BaseAgentNodeDef(
             # rejects None.
             if ctx.frame_id is None:
                 logger.warning(
-                    "[%s] run(): ctx.frame_id is None on node=%s; cannot look up "
-                    "parallel batch — treating as no batch.",
+                    "[%s] run(): ctx.frame_id is None on node=%s; cannot look up parallel batch — treating as no batch.",
                     ctx.deps.correlation_id[:8],
                     self.name,
                 )

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -104,14 +104,23 @@ class BaseAgentNodeDef(
         # its own fresh ``CallFrame`` (UUID7 ``frame_id``), so the per-invocation
         # frame is the only key that keeps concurrent batches from clobbering each
         # other in this dict.
-        #
-        # ``ctx.frame_id`` may be ``None`` when ``run()`` is driven outside the
-        # framework's prepare-context path (unit tests of non-parallel branches).
-        # In that case the dict lookup misses cleanly — no aggregation needed
-        # because no batch could have been written under ``None`` (the
-        # write-side guard rejects ``None``).
         frame_id = ctx.frame_id
         if frame_id is None:
+            # ``BaseNodeDef.prepare_context`` unconditionally mirrors
+            # ``current_frame.frame_id`` (which has a ``default_factory``) onto
+            # ``ctx._frame_id``, so a None here means ``run()`` was driven outside
+            # the framework handler — either a unit test or a subclass that
+            # bypasses ``prepare_context``. Warn loudly so a future regression in
+            # the handler path surfaces immediately instead of silently skipping
+            # aggregation and potentially advancing past a real batch.
+            logger.warning(
+                "[%s] _parallel_state_aggregation: ctx.frame_id is None on node=%s; "
+                "skipping aggregation. prepare_context is the only legitimate "
+                "population path for _frame_id — a None value here indicates run() "
+                "was driven outside the framework handler.",
+                ctx.deps.correlation_id[:8],
+                self.name,
+            )
             return
         batch = self._pending_batches.get(frame_id)
         if batch is not None:
@@ -124,6 +133,31 @@ class BaseAgentNodeDef(
                     batch.base_state.add_tool_result(tool_call_id, tool_call_result)
                 ctx.state = batch.base_state
                 del self._pending_batches[frame_id]
+        else:
+            # Stray-reply / lost-batch detection: more than one tool_result for the
+            # current ``latest_tool_calls`` is present, but no batch is registered
+            # for this frame_id. The agent would have written a batch on dispatch
+            # (single-tool dispatch in parallel mode is the one legitimate
+            # no-batch path, hence the ``> 1`` floor to suppress that false
+            # positive). Likely causes: lost batch from partition rebalance or
+            # process restart, stray/duplicate delivery, or a routing error.
+            # Replies will not be aggregated; if any tool_call_ids remain
+            # incomplete the existing guard at the bottom of ``run()`` raises
+            # ``RuntimeError`` — this warning fires in the all-arrived-together
+            # race that would otherwise silently advance.
+            completed_latest = [tc for tc in ctx.state.latest_tool_calls() if tc.tool_call_id in ctx.state.tool_results]
+            if len(completed_latest) > 1:
+                logger.warning(
+                    "[%s] no PendingToolBatch for frame_id=%s on node=%s but %d completed "
+                    "tool replies present (tool_call_ids=%s); replies will NOT be "
+                    "aggregated. Likely a lost batch (partition rebalance or process "
+                    "restart), stray/duplicate delivery, or a routing error.",
+                    ctx.deps.correlation_id[:8],
+                    frame_id,
+                    self.name,
+                    len(completed_latest),
+                    [tc.tool_call_id for tc in completed_latest],
+                )
 
     async def run(self, ctx: SessionRunContext) -> NodeResult[State]:
         tools_registry = dict[str, BaseToolNodeSchema]()
@@ -148,10 +182,21 @@ class BaseAgentNodeDef(
 
         if not self.sequential_only_mode:
             self._parallel_state_aggregation(ctx)
-            # ``ctx.frame_id`` may be ``None`` in tests driving ``run()`` outside
-            # the framework's prepare-context path; treat that as "no batch".
-            # See ``_require_frame_id_for_write`` for why write-side rejects None.
-            batch = self._pending_batches.get(ctx.frame_id) if ctx.frame_id is not None else None
+            # Defense-in-depth: ``_parallel_state_aggregation`` already warns
+            # and returns early on a None ``frame_id``, but a future refactor
+            # that calls this branch independently must not silently mask the
+            # missing key. See ``_require_frame_id_for_write`` for why write-side
+            # rejects None.
+            if ctx.frame_id is None:
+                logger.warning(
+                    "[%s] run(): ctx.frame_id is None on node=%s; cannot look up "
+                    "parallel batch — treating as no batch.",
+                    ctx.deps.correlation_id[:8],
+                    self.name,
+                )
+                batch = None
+            else:
+                batch = self._pending_batches.get(ctx.frame_id)
             if batch and not batch.is_complete:
                 return Silent()
 

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -162,10 +162,12 @@ class BaseNodeDef(BaseNodeSchema):
         emitter_node_kind: str | None = None,
     ) -> SessionRunContext:
         ctx = envelope.context.model_copy(deep=True)
-        if envelope.internal_workflow_state.current_frame.overrides:
-            ctx.state.overrides = envelope.internal_workflow_state.current_frame.overrides
+        current_frame = envelope.internal_workflow_state.current_frame
+        if current_frame.overrides:
+            ctx.state.overrides = current_frame.overrides
         ctx._emitter_node_id = emitter_node_id
         ctx._emitter_node_kind = emitter_node_kind
+        ctx._frame_id = current_frame.frame_id
         return ctx
 
     def _emitter_headers(self) -> dict[str, str]:

--- a/tests/test_tool_errors.py
+++ b/tests/test_tool_errors.py
@@ -46,11 +46,22 @@ from calfkit.nodes import Agent, ToolNodeDef
 # ---------------------------------------------------------------------------
 
 
-def _make_ctx(state: State, correlation_id: str = "cid-tool-errors-00000000") -> SessionRunContext:
-    return SessionRunContext(
+def _make_ctx(
+    state: State,
+    correlation_id: str = "cid-tool-errors-00000000",
+    frame_id: str | None = None,
+) -> SessionRunContext:
+    ctx = SessionRunContext(
         state=state,
         deps=Deps(correlation_id=correlation_id, provided_deps={}),
     )
+    # ``_frame_id`` is a ``PrivateAttr`` populated by ``BaseNodeDef.prepare_context``
+    # in the live path; tests that drive ``agent.run`` directly must set it
+    # here when they exercise parallel-mode aggregation (which keys
+    # ``_pending_batches`` on ``frame_id``).
+    if frame_id is not None:
+        ctx._frame_id = frame_id
+    return ctx
 
 
 def _register_tool_call(state: State, *, tool_name: str, tool_call_id: str, args: dict | None = None) -> ToolCallPart:
@@ -394,6 +405,7 @@ async def test_agent_parallel_mode_marker_in_batch_triggers_error_after_aggregat
     )
 
     correlation_id = "cid-parallel-mixed"
+    frame_id = "frame-parallel-mixed"
     success_id = "tc-parallel-ok"
     fail_id = "tc-parallel-fail"
 
@@ -401,7 +413,7 @@ async def test_agent_parallel_mode_marker_in_batch_triggers_error_after_aggregat
     _register_tool_call(base_state, tool_name="happy_tool", tool_call_id=success_id)
     _register_tool_call(base_state, tool_name="buggy_tool", tool_call_id=fail_id)
 
-    agent._pending_batches[correlation_id] = PendingToolBatch(
+    agent._pending_batches[frame_id] = PendingToolBatch(
         expected_tool_call_ids=frozenset({success_id, fail_id}),
         base_state=base_state,
     )
@@ -423,7 +435,7 @@ async def test_agent_parallel_mode_marker_in_batch_triggers_error_after_aggregat
         ),
     )
 
-    ctx = _make_ctx(inflight_state, correlation_id=correlation_id)
+    ctx = _make_ctx(inflight_state, correlation_id=correlation_id, frame_id=frame_id)
 
     with pytest.raises(ToolExecutionError) as exc_info:
         await agent.run(ctx)
@@ -448,6 +460,7 @@ async def test_agent_parallel_mode_waits_for_incomplete_batch():
     )
 
     correlation_id = "cid-parallel-partial"
+    frame_id = "frame-parallel-partial"
     pending_id = "tc-parallel-pending"
     fail_id = "tc-parallel-partial-fail"
 
@@ -455,7 +468,7 @@ async def test_agent_parallel_mode_waits_for_incomplete_batch():
     _register_tool_call(base_state, tool_name="slow_tool", tool_call_id=pending_id)
     _register_tool_call(base_state, tool_name="buggy_tool", tool_call_id=fail_id)
 
-    agent._pending_batches[correlation_id] = PendingToolBatch(
+    agent._pending_batches[frame_id] = PendingToolBatch(
         expected_tool_call_ids=frozenset({pending_id, fail_id}),
         base_state=base_state,
     )
@@ -472,7 +485,7 @@ async def test_agent_parallel_mode_waits_for_incomplete_batch():
         ),
     )
 
-    ctx = _make_ctx(inflight_state, correlation_id=correlation_id)
+    ctx = _make_ctx(inflight_state, correlation_id=correlation_id, frame_id=frame_id)
 
     result = await agent.run(ctx)
     assert isinstance(result, Silent), f"expected Silent while batch incomplete, got {type(result).__name__}"
@@ -996,6 +1009,7 @@ async def test_agent_parallel_mode_logs_all_failures_before_raising(caplog):
     )
 
     correlation_id = "cid-multi-fail"
+    frame_id = "frame-multi-fail"
     first_id = "tc-first-fail"
     second_id = "tc-second-fail"
 
@@ -1003,7 +1017,7 @@ async def test_agent_parallel_mode_logs_all_failures_before_raising(caplog):
     _register_tool_call(base_state, tool_name="buggy_a", tool_call_id=first_id)
     _register_tool_call(base_state, tool_name="buggy_b", tool_call_id=second_id)
 
-    agent._pending_batches[correlation_id] = PendingToolBatch(
+    agent._pending_batches[frame_id] = PendingToolBatch(
         expected_tool_call_ids=frozenset({first_id, second_id}),
         base_state=base_state,
     )
@@ -1030,7 +1044,7 @@ async def test_agent_parallel_mode_logs_all_failures_before_raising(caplog):
         ),
     )
 
-    ctx = _make_ctx(inflight_state, correlation_id=correlation_id)
+    ctx = _make_ctx(inflight_state, correlation_id=correlation_id, frame_id=frame_id)
 
     with caplog.at_level(logging.ERROR, logger="calfkit.nodes.agent"):
         with pytest.raises(ToolExecutionError):
@@ -1490,3 +1504,185 @@ async def test_agent_corrupt_marker_with_missing_tool_name_uses_sentinel():
     assert err.exc_type == "CorruptFailedToolCallMarker"
     assert err.tool_name == "<unknown>"
     assert err.tool_call_id == tool_call_id
+
+
+# ---------------------------------------------------------------------------
+# Parallel-same-agent invocations: ``_pending_batches`` is keyed by ``frame_id``,
+# not ``correlation_id``. A supervisor that fans out two ``Call``s to the same
+# agent shares one correlation_id across both invocations — keying on
+# correlation_id used to silently collide the batches and wedge one of them.
+# ---------------------------------------------------------------------------
+
+
+async def test_pending_batches_keyed_by_frame_id_not_correlation_id():
+    # Direct unit-level regression for the collision bug. Two parallel
+    # invocations of the same agent (same correlation_id, different frame_ids)
+    # must each track their own PendingToolBatch independently, and a reply
+    # for invocation A's tool_call_ids must aggregate into A's batch only.
+    agent = Agent(
+        "agent_parallel_same",
+        system_prompt="x",
+        subscribe_topics="agent_parallel_same.input",
+        publish_topic="agent_parallel_same.output",
+        model_client=TestModel(),
+    )
+
+    correlation_id = "cid-shared-by-both"
+
+    # Invocation A
+    frame_a = "frame-A"
+    a_tool_id = "tc-A-1"
+    base_state_a = State()
+    _register_tool_call(base_state_a, tool_name="tool_a", tool_call_id=a_tool_id)
+    agent._pending_batches[frame_a] = PendingToolBatch(
+        expected_tool_call_ids=frozenset({a_tool_id}),
+        base_state=base_state_a,
+    )
+
+    # Invocation B (same correlation_id, different frame_id, disjoint tool_call_ids)
+    frame_b = "frame-B"
+    b_tool_id = "tc-B-1"
+    base_state_b = State()
+    _register_tool_call(base_state_b, tool_name="tool_b", tool_call_id=b_tool_id)
+    agent._pending_batches[frame_b] = PendingToolBatch(
+        expected_tool_call_ids=frozenset({b_tool_id}),
+        base_state=base_state_b,
+    )
+
+    # Both batches coexist — keying on correlation_id would have overwritten one.
+    assert set(agent._pending_batches.keys()) == {frame_a, frame_b}, (
+        f"both per-invocation batches must coexist; got keys={list(agent._pending_batches.keys())}"
+    )
+    assert agent._pending_batches[frame_a].expected_tool_call_ids == frozenset({a_tool_id})
+    assert agent._pending_batches[frame_b].expected_tool_call_ids == frozenset({b_tool_id})
+
+    # Reply for invocation A arrives. ctx carries A's frame_id.
+    a_reply_state = State()
+    _register_tool_call(a_reply_state, tool_name="tool_a", tool_call_id=a_tool_id)
+    a_reply_state.add_tool_result(
+        a_tool_id,
+        ToolReturn(return_value="a-done", metadata={"tool_call_id": a_tool_id}),
+    )
+    ctx_a = _make_ctx(a_reply_state, correlation_id=correlation_id, frame_id=frame_a)
+
+    agent._parallel_state_aggregation(ctx_a)
+
+    # A's batch completed and was popped; B's must be untouched.
+    assert frame_a not in agent._pending_batches, "A's batch must be popped after completion"
+    assert frame_b in agent._pending_batches, "B's batch must NOT be affected by A's reply"
+    assert agent._pending_batches[frame_b].collected_results == {}, "B's batch must not have collected any of A's results"
+
+    # Now B's reply arrives.
+    b_reply_state = State()
+    _register_tool_call(b_reply_state, tool_name="tool_b", tool_call_id=b_tool_id)
+    b_reply_state.add_tool_result(
+        b_tool_id,
+        ToolReturn(return_value="b-done", metadata={"tool_call_id": b_tool_id}),
+    )
+    ctx_b = _make_ctx(b_reply_state, correlation_id=correlation_id, frame_id=frame_b)
+
+    agent._parallel_state_aggregation(ctx_b)
+
+    assert frame_b not in agent._pending_batches, "B's batch must be popped after completion"
+
+
+async def test_parallel_replies_with_wrong_frame_id_do_not_aggregate():
+    # Defense-in-depth: if a tool reply arrives carrying an unrelated frame_id
+    # (e.g. a stale message, a routing error, a reply destined for some other
+    # agent invocation), the aggregator must not absorb its tool_results into
+    # the wrong batch. The batch under the correct frame_id must remain
+    # untouched.
+    agent = Agent(
+        "agent_wrong_frame",
+        system_prompt="x",
+        subscribe_topics="agent_wrong_frame.input",
+        publish_topic="agent_wrong_frame.output",
+        model_client=TestModel(),
+    )
+
+    real_frame = "frame-real"
+    real_tool_id = "tc-real-1"
+    base_state = State()
+    _register_tool_call(base_state, tool_name="tool_real", tool_call_id=real_tool_id)
+    agent._pending_batches[real_frame] = PendingToolBatch(
+        expected_tool_call_ids=frozenset({real_tool_id}),
+        base_state=base_state,
+    )
+
+    # A reply arrives carrying tool_results for ``real_tool_id`` but a
+    # different frame_id — must NOT aggregate into the real batch.
+    wrong_frame = "frame-unrelated"
+    inflight_state = State()
+    _register_tool_call(inflight_state, tool_name="tool_real", tool_call_id=real_tool_id)
+    inflight_state.add_tool_result(
+        real_tool_id,
+        ToolReturn(return_value="leaked", metadata={"tool_call_id": real_tool_id}),
+    )
+    ctx = _make_ctx(inflight_state, frame_id=wrong_frame)
+
+    agent._parallel_state_aggregation(ctx)
+
+    # Real batch is untouched.
+    assert real_frame in agent._pending_batches
+    assert agent._pending_batches[real_frame].collected_results == {}
+
+
+def test_prepare_context_populates_frame_id_from_envelope():
+    # Plumbing regression: ``prepare_context`` must read
+    # ``current_frame.frame_id`` into ``ctx._frame_id`` so that
+    # ``_pending_batches`` lookups in ``agent.run`` see the right key. Without
+    # this, ``ctx.frame_id`` returns ``None`` and every parallel batch lives
+    # under a single ``None`` key, re-introducing the collision bug at runtime.
+    import asyncio
+
+    from calfkit.models.envelope import Envelope
+    from calfkit.models.session_context import CallFrame, CallFrameStack, WorkflowState
+
+    agent = Agent(
+        "agent_prep_ctx",
+        system_prompt="x",
+        subscribe_topics="agent_prep_ctx.input",
+        publish_topic="agent_prep_ctx.output",
+        model_client=TestModel(),
+    )
+
+    frame = CallFrame(
+        target_topic="agent_prep_ctx.input",
+        callback_topic="caller.return",
+    )
+    wf = WorkflowState(call_stack=CallFrameStack(_internal_list=[frame]))
+    envelope = Envelope(
+        context=SessionRunContext(
+            state=State(),
+            deps=Deps(correlation_id="cid-prep", provided_deps={}),
+        ),
+        internal_workflow_state=wf,
+    )
+
+    ctx = asyncio.run(agent.prepare_context(envelope))
+    assert ctx.frame_id == frame.frame_id, f"prepare_context must mirror current_frame.frame_id onto ctx; got {ctx.frame_id!r} vs {frame.frame_id!r}"
+
+
+def test_frame_id_survives_envelope_json_round_trip():
+    # The CallFrame's frame_id must survive Envelope JSON serialization
+    # verbatim — otherwise per-invocation aggregation keys would diverge across
+    # the Kafka boundary and the collision-bug fix would be ineffective in
+    # production (only in-process tests would see correct behavior).
+    from calfkit.models.envelope import Envelope
+    from calfkit.models.session_context import CallFrame, CallFrameStack, WorkflowState
+
+    frame = CallFrame(
+        target_topic="some.topic",
+        callback_topic="caller.return",
+    )
+    wf = WorkflowState(call_stack=CallFrameStack(_internal_list=[frame]))
+    envelope = Envelope(
+        context=SessionRunContext(
+            state=State(),
+            deps=Deps(correlation_id="cid-rt", provided_deps={}),
+        ),
+        internal_workflow_state=wf,
+    )
+
+    restored = Envelope.model_validate_json(envelope.model_dump_json())
+    assert restored.internal_workflow_state.current_frame.frame_id == frame.frame_id


### PR DESCRIPTION
## Summary

`BaseAgentNodeDef._pending_batches` was keyed on `correlation_id` alone, which silently collides when the same agent is invoked multiple times in parallel under one correlation_id (e.g. a supervisor returning `[Call(agent.in, ...), Call(agent.in, ...)]`). The second invocation's `PendingToolBatch` overwrites the first, and the first wedges forever because its tool replies aggregate against the wrong `expected_tool_call_ids` set.

Re-keys on `CallFrame.frame_id`, the per-invocation uuid7 already minted by `WorkflowState.invoke_frame` whenever the framework publishes a `Call`. This is the natural unique identifier of a single invocation — it's how the existing call/return semantics distinguish frames on the stack — so we're using a primitive that already exists rather than inventing one.

This is a **prep change** for a future migration of the aggregation store to a Kafka-log-backed (Faust Table) implementation. Keying changes here so the substrate swap is purely about durability, not semantics.

## Changes

- `calfkit/models/session_context.py` — adds `_frame_id: str | None` `PrivateAttr` + `frame_id` property on `BaseSessionRunContext`, mirroring the existing `_emitter_node_id` pattern (off-the-wire, can't be spoofed via constructor).
- `calfkit/nodes/base.py` — `prepare_context` populates `ctx._frame_id` from `envelope.internal_workflow_state.current_frame.frame_id`.
- `calfkit/nodes/agent.py` — all three `_pending_batches` sites re-keyed. Adds `_require_frame_id_for_write` helper: write-side raises on a missing frame_id (a `None` bucket would silently re-introduce the collision), read-side tolerates `None` and misses cleanly.
- `tests/test_tool_errors.py` — three pre-existing tests updated to use `frame_id`; `_make_ctx` extended with optional `frame_id` param.

## New tests

1. `test_pending_batches_keyed_by_frame_id_not_correlation_id` — headline regression: two batches under the same correlation_id but different frame_ids coexist and aggregate independently.
2. `test_parallel_replies_with_wrong_frame_id_do_not_aggregate` — defense-in-depth: a reply carrying an unrelated frame_id does not absorb into the wrong batch.
3. `test_prepare_context_populates_frame_id_from_envelope` — plumbing gate.
4. `test_frame_id_survives_envelope_json_round_trip` — wire-format regression gate, since the fix is ineffective in production if `frame_id` doesn't round-trip.

## Test plan

- [ ] CI: `uv run pytest` (full suite — sub-agent reports 4,207 passing locally, mypy + ruff clean)
- [ ] Manual: confirm no production path can reach `_require_frame_id_for_write` with `frame_id=None`; `prepare_context` is called unconditionally before `run()` in `base.py:266-274`, so this is safe — worth a second pair of eyes.
- [ ] Review the asymmetric None-handling rationale (raise on write, allow on read) for whether it should be documented elsewhere (e.g. in `BaseAgentNodeDef`'s class docstring).