### PR TITLE
feat: reference JSON Schema for mcp.json

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -36,3 +36,6 @@ jobs:
 
       - name: Run MyPy
         run: uv run mypy calfkit/
+
+      - name: Check mcp.json reference schema is up to date
+        run: uv run calfkit mcp schema --check

--- a/calfkit/cli/mcp.py
+++ b/calfkit/cli/mcp.py
@@ -33,7 +33,10 @@ Exit codes (v1 plan §11 Q17):
 from __future__ import annotations
 
 import asyncio
+import difflib
+import json
 import shlex
+from collections.abc import Callable
 from pathlib import Path
 
 try:
@@ -57,6 +60,51 @@ def _mcp_callback() -> None:
     pattern even when codegen is currently the only subcommand. Future
     subcommands (e.g. 'mcp inspect') will land alongside it.
     """
+
+
+def _emit_text(
+    rendered: str,
+    output: Path,
+    *,
+    check: bool,
+    differ: Callable[[str, str], str],
+    label: str,
+    refresh_cmd: str,
+) -> int:
+    """Write ``rendered`` to ``output`` (or, in ``check`` mode, compare without writing).
+
+    Shared write/``--check`` tail for ``codegen`` and ``schema``. The diff is
+    caller-supplied — ``codegen`` passes its AST-aware ``diff_modules`` while
+    ``schema`` passes a plain ``difflib`` text diff. ``differ(rendered, existing)``
+    must return an empty string when the two are equivalent.
+
+    Returns the exit code (0 ok · 1 drift/missing · 2 io-error).
+    """
+    if check:
+        if not output.exists():
+            typer.echo(f"Drift: {output} does not exist (would create with {label})", err=True)
+            return 1
+        try:
+            existing = output.read_text(encoding="utf-8")
+        except OSError as e:
+            typer.echo(f"Error: cannot read {output}: {e}", err=True)
+            return 2
+        diff = differ(rendered, existing)
+        if diff:
+            typer.echo(f"Drift detected in {output}:", err=True)
+            typer.echo(diff, err=True)
+            typer.echo(f"Re-run without --check to refresh: {refresh_cmd}", err=True)
+            return 1
+        typer.echo(f"OK: {output} is up to date ({label}).")
+        return 0
+    try:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered, encoding="utf-8")
+    except OSError as e:
+        typer.echo(f"Error: cannot write {output}: {e}", err=True)
+        return 2
+    typer.echo(f"Wrote {output} ({label}).")
+    return 0
 
 
 # Public for tests — let test code call codegen logic directly without
@@ -86,39 +134,14 @@ async def _generate_and_write(
 
     rendered = render_module(server_name=server_name, tools=tools, source=source_str)
 
-    if check:
-        if not output.exists():
-            typer.echo(
-                f"Drift: {output} does not exist (would create with {len(tools)} tool(s))",
-                err=True,
-            )
-            return 1
-        try:
-            existing = output.read_text(encoding="utf-8")
-        except OSError as e:
-            typer.echo(f"Error: cannot read {output}: {e}", err=True)
-            return 2
-        diff = diff_modules(expected=rendered, actual=existing)
-        if diff:
-            typer.echo(f"Drift detected in {output}:", err=True)
-            typer.echo(diff, err=True)
-            typer.echo(
-                f"Re-run without --check to refresh: calfkit mcp codegen {server_name} ...",
-                err=True,
-            )
-            return 1
-        typer.echo(f"OK: {output} is up to date ({len(tools)} tool(s)).")
-        return 0
-
-    try:
-        output.parent.mkdir(parents=True, exist_ok=True)
-        output.write_text(rendered, encoding="utf-8")
-    except OSError as e:
-        typer.echo(f"Error: cannot write {output}: {e}", err=True)
-        return 2
-
-    typer.echo(f"Wrote {output} ({len(tools)} tool(s)).")
-    return 0
+    return _emit_text(
+        rendered,
+        output,
+        check=check,
+        differ=lambda expected, actual: diff_modules(expected=expected, actual=actual),
+        label=f"{len(tools)} tool(s)",
+        refresh_cmd=f"calfkit mcp codegen {server_name} ...",
+    )
 
 
 @app.command()
@@ -185,6 +208,47 @@ def codegen(
     )
     if exit_code != 0:
         raise typer.Exit(exit_code)
+
+
+@app.command()
+def schema(
+    output: Path = typer.Option(
+        Path("calfkit/mcp/mcp.schema.json"),
+        "--output",
+        "-o",
+        help="Path to write the reference schema. Default targets the repo checkout (not an installed package).",
+    ),
+    check: bool = typer.Option(
+        False,
+        "--check",
+        help="Exit non-zero if the file would differ from the existing one. Does not write.",
+    ),
+) -> None:
+    """Emit the reference JSON Schema for mcp.json (no MCP server needed)."""
+    from calfkit.mcp import mcp_json_schema
+
+    rendered = json.dumps(mcp_json_schema(), indent=2) + "\n"
+
+    def _text_diff(expected: str, actual: str) -> str:
+        return "".join(
+            difflib.unified_diff(
+                actual.splitlines(keepends=True),
+                expected.splitlines(keepends=True),
+                fromfile="existing",
+                tofile="generated",
+            )
+        )
+
+    code = _emit_text(
+        rendered,
+        output,
+        check=check,
+        differ=_text_diff,
+        label="reference schema",
+        refresh_cmd="calfkit mcp schema",
+    )
+    if code != 0:
+        raise typer.Exit(code)
 
 
 def main() -> None:

--- a/calfkit/cli/mcp.py
+++ b/calfkit/cli/mcp.py
@@ -138,7 +138,7 @@ async def _generate_and_write(
         rendered,
         output,
         check=check,
-        differ=lambda expected, actual: diff_modules(expected=expected, actual=actual),
+        differ=diff_modules,
         label=f"{len(tools)} tool(s)",
         refresh_cmd=f"calfkit mcp codegen {server_name} ...",
     )

--- a/calfkit/mcp/__init__.py
+++ b/calfkit/mcp/__init__.py
@@ -15,6 +15,7 @@ The factory is also re-exported at the calfkit top level as
 ``from calfkit import mcp`` for ergonomic compact-form imports.
 """
 
+from calfkit.mcp._config import mcp_json_schema
 from calfkit.mcp._factory import McpServers, mcp
 from calfkit.mcp._server import McpServer
 from calfkit.mcp._tool_def import McpToolAnnotations, McpToolDef
@@ -25,4 +26,5 @@ __all__ = [
     "McpToolAnnotations",
     "McpToolDef",
     "mcp",
+    "mcp_json_schema",
 ]

--- a/calfkit/mcp/_config.py
+++ b/calfkit/mcp/_config.py
@@ -89,9 +89,10 @@ class StdioServerConfig(BaseModel):
     """Input model for a stdio MCP server spec (validation + schema source)."""
 
     model_config = ConfigDict(extra="ignore")  # drop-in leniency; also suppresses additionalProperties
-    # ``type`` is decorative for validation: transport is resolved before we
-    # validate (see ``_validate_server``), so this field never drives the
-    # stdio-vs-http choice. It exists ONLY to document/autocomplete the key.
+    # ``type``, when present, selects the transport — and thus which model and
+    # required fields apply (see ``_validate_server``); when omitted it is
+    # inferred from ``command``/``url``. The ``Literal`` also documents and
+    # autocompletes the accepted values in the emitted schema.
     type: Literal["stdio"] | None = Field(default=None, description="Optional; inferred from `command` when omitted.")
     command: str = Field(min_length=1, description="Executable to spawn. Supports $VAR/${VAR} expansion.")
     args: list[str] = Field(default_factory=list, description="CLI args; each supports $VAR.")
@@ -103,14 +104,19 @@ class HttpServerConfig(BaseModel):
     """Input model for an HTTP MCP server spec (validation + schema source)."""
 
     model_config = ConfigDict(extra="ignore")  # drop-in leniency; also suppresses additionalProperties
-    # ``type`` is decorative for validation: transport is resolved before we
-    # validate (see ``_validate_server``), so this field never drives the
-    # stdio-vs-http choice. It exists ONLY to document/autocomplete the key.
+    # ``type``, when present, selects the transport — and thus which model and
+    # required fields apply (see ``_validate_server``); when omitted it is
+    # inferred from ``command``/``url``. The ``Literal`` also documents and
+    # autocompletes the accepted values in the emitted schema.
     type: Literal["http", "sse"] | None = Field(default=None, description="`http` (or legacy `sse`); inferred from `url`.")
     url: str = Field(min_length=1, description="Streamable-HTTP endpoint. Supports $VAR.")
     headers: dict[str, str] | None = Field(default=None, description="Request headers; values support $VAR.")
 
 
+# Schema-generation source ONLY — never validate live data through this.
+# Its ``anyOf`` union resolves stdio-first (and ``extra="ignore"`` lets a stdio
+# spec swallow a stray ``url``), which DISAGREES with the url-first precedence in
+# ``_validate_server``. Per-server validation must go through ``_validate_server``.
 _SERVERS = TypeAdapter(dict[str, StdioServerConfig | HttpServerConfig])
 
 
@@ -263,7 +269,8 @@ def _validate_server(name: str, raw: dict[str, Any]) -> StdioServerConfig | Http
     - Else if ``type == "stdio"`` or ``command`` is present → stdio transport.
     - Otherwise → ``unknown transport`` error.
 
-    ``url`` takes precedence over ``command`` on ambiguous specs (url-first).
+    When ``type`` is omitted, ``url`` takes precedence over ``command`` on
+    ambiguous specs (url-first); an explicit ``type`` always wins.
     Resolving transport *before* validating keeps the friendly
     ``unknown transport`` message out of Pydantic and preserves the
     ``loc[0]`` substring contract relied on by ``test_config.py``.
@@ -287,13 +294,26 @@ def _validate_server(name: str, raw: dict[str, Any]) -> StdioServerConfig | Http
 def _raise_from_validation(name: str, exc: ValidationError) -> NoReturn:
     """Translate a Pydantic ``ValidationError`` into an ``McpConfigError``.
 
-    Keys on ``loc[0]`` (the offending field name) so the rendered ``{field!r}``
-    reproduces the ``'command'`` / ``'args'`` / ``'env'`` / ``'cwd'`` / ``'url'``
-    / ``'headers'`` substrings matched by the regression tests.
+    Renders every offending field (keyed on ``loc[0]``) so the ``{field!r}``
+    rendering reproduces the ``'command'`` / ``'args'`` / ``'env'`` / ``'cwd'``
+    / ``'url'`` / ``'headers'`` substrings matched by the regression tests, and
+    so a multi-problem spec is reported in one pass rather than one-per-rerun.
+
+    The offending *value* (``err['input']``) is deliberately NOT rendered: for a
+    missing-field error Pydantic sets it to the whole expanded spec dict, which
+    can contain ``$VAR``-resolved secrets (env values, Authorization headers).
+    Echoing it would leak credentials into error text, logs, and exception
+    reporters.
     """
-    err = exc.errors()[0]
-    field = err["loc"][0] if err.get("loc") else "<unknown>"
-    raise McpConfigError(f"mcp.json: server {name!r}: invalid {field!r} — {err['msg']} (got {err['input']!r})") from exc
+    errors = exc.errors()
+    if not errors:  # defensive: model_validate never raises an empty error set
+        raise McpConfigError(f"mcp.json: server {name!r}: invalid spec") from exc
+    parts = []
+    for err in errors:
+        loc = err["loc"]
+        field = loc[0] if loc else "<unknown>"
+        parts.append(f"invalid {field!r} — {err['msg']}")
+    raise McpConfigError(f"mcp.json: server {name!r}: {'; '.join(parts)}") from exc
 
 
 def _to_parsed(cfg: StdioServerConfig | HttpServerConfig) -> ParsedMcpServerSpec:

--- a/calfkit/mcp/_config.py
+++ b/calfkit/mcp/_config.py
@@ -35,7 +35,9 @@ import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, NoReturn
+
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
 
 from calfkit.mcp.exceptions import McpConfigError
 
@@ -71,6 +73,66 @@ class ParsedHttpSpec:
 
 
 ParsedMcpServerSpec = ParsedStdioSpec | ParsedHttpSpec
+
+
+# ---------------------------------------------------------------------------
+# Input models (validation + schema source of truth)
+# ---------------------------------------------------------------------------
+#
+# These mirror the *input* shape of an mcp.json server spec (as opposed to
+# the normalised ``Parsed*`` output above). They drive both per-server
+# validation in ``parse_mcp_config`` and the reference schema emitted by
+# ``mcp_json_schema``, so the schema can never drift from the parser.
+
+
+class StdioServerConfig(BaseModel):
+    """Input model for a stdio MCP server spec (validation + schema source)."""
+
+    model_config = ConfigDict(extra="ignore")  # drop-in leniency; also suppresses additionalProperties
+    # ``type`` is decorative for validation: transport is resolved before we
+    # validate (see ``_validate_server``), so this field never drives the
+    # stdio-vs-http choice. It exists ONLY to document/autocomplete the key.
+    type: Literal["stdio"] | None = Field(default=None, description="Optional; inferred from `command` when omitted.")
+    command: str = Field(min_length=1, description="Executable to spawn. Supports $VAR/${VAR} expansion.")
+    args: list[str] = Field(default_factory=list, description="CLI args; each supports $VAR.")
+    env: dict[str, str] | None = Field(default=None, description="Subprocess env overlay; values support $VAR.")
+    cwd: str | None = Field(default=None, description="Subprocess working directory.")
+
+
+class HttpServerConfig(BaseModel):
+    """Input model for an HTTP MCP server spec (validation + schema source)."""
+
+    model_config = ConfigDict(extra="ignore")  # drop-in leniency; also suppresses additionalProperties
+    # ``type`` is decorative for validation: transport is resolved before we
+    # validate (see ``_validate_server``), so this field never drives the
+    # stdio-vs-http choice. It exists ONLY to document/autocomplete the key.
+    type: Literal["http", "sse"] | None = Field(default=None, description="`http` (or legacy `sse`); inferred from `url`.")
+    url: str = Field(min_length=1, description="Streamable-HTTP endpoint. Supports $VAR.")
+    headers: dict[str, str] | None = Field(default=None, description="Request headers; values support $VAR.")
+
+
+_SERVERS = TypeAdapter(dict[str, StdioServerConfig | HttpServerConfig])
+
+
+def mcp_json_schema() -> dict[str, Any]:
+    """Reference JSON Schema (draft 2020-12) for a calfkit ``mcp.json``.
+
+    Permissive: unknown keys are allowed (drop-in leniency), so the schema
+    carries no ``additionalProperties: false``. It is a documentation/editor
+    aid only and is NOT used to validate at runtime — the parser remains the
+    sole runtime validator.
+    """
+    servers_map = _SERVERS.json_schema(ref_template="#/$defs/{model}")
+    defs = servers_map.pop("$defs")
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "calfkit mcp.json",
+        "description": "Reference schema for calfkit McpServers.from_file(...). Unknown keys are ignored.",
+        "type": "object",
+        "required": ["mcpServers"],
+        "properties": {"mcpServers": servers_map},
+        "$defs": defs,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -170,7 +232,7 @@ def parse_mcp_config(config: dict[str, Any] | str | Path) -> dict[str, ParsedMcp
         if not isinstance(raw_spec, dict):
             raise McpConfigError(f"mcp.json: spec for server {name!r} must be an object; got {type(raw_spec).__name__}")
         expanded_spec = expand_env(raw_spec, where=f"mcp.json[{name!r}]")
-        out[name] = _parse_server_spec(name, expanded_spec)
+        out[name] = _to_parsed(_validate_server(name, expanded_spec))
     return out
 
 
@@ -192,65 +254,55 @@ def _load_config_file(path: str | Path) -> dict[str, Any]:
     return parsed
 
 
-def _parse_server_spec(name: str, raw: dict[str, Any]) -> ParsedMcpServerSpec:
-    """Parse one server's spec into a ``ParsedMcpServerSpec``.
+def _validate_server(name: str, raw: dict[str, Any]) -> StdioServerConfig | HttpServerConfig:
+    """Resolve transport, then validate the spec via the matching input model.
 
     Transport detection rule (matches Claude Desktop / Cursor convention):
-    - If ``type == "http"`` (or ``type == "sse"``) → HTTP transport.
+    - If ``type == "http"`` (or legacy ``type == "sse"``) → HTTP transport.
     - Else if ``url`` is present → HTTP transport (inferred).
-    - Else if ``command`` is present → stdio transport.
-    - Otherwise → error.
+    - Else if ``type == "stdio"`` or ``command`` is present → stdio transport.
+    - Otherwise → ``unknown transport`` error.
+
+    ``url`` takes precedence over ``command`` on ambiguous specs (url-first).
+    Resolving transport *before* validating keeps the friendly
+    ``unknown transport`` message out of Pydantic and preserves the
+    ``loc[0]`` substring contract relied on by ``test_config.py``.
     """
-    transport_type = raw.get("type")
-    has_url = "url" in raw
-    has_command = "command" in raw
-
-    if transport_type == "http" or transport_type == "sse" or (transport_type is None and has_url):
-        # SSE is the legacy MCP transport; we treat it as HTTP for the parser
-        # here. The runtime will use streamablehttp_client either way.
-        return _parse_http_spec(name, raw)
-    if transport_type == "stdio" or (transport_type is None and has_command):
-        return _parse_stdio_spec(name, raw)
-
-    raise McpConfigError(
-        f"mcp.json: server {name!r} has unknown transport. Provide either 'command' (stdio) or 'url' (http); got keys={sorted(raw.keys())}"
-    )
-
-
-def _parse_stdio_spec(name: str, raw: dict[str, Any]) -> ParsedStdioSpec:
-    command = raw.get("command")
-    if not isinstance(command, str) or not command:
-        raise McpConfigError(f"mcp.json: stdio server {name!r} requires a non-empty 'command' string; got {command!r}")
-
-    raw_args = raw.get("args", [])
-    if not isinstance(raw_args, list) or not all(isinstance(a, str) for a in raw_args):
-        raise McpConfigError(f"mcp.json: stdio server {name!r} 'args' must be a list of strings; got {raw_args!r}")
-    args = tuple(raw_args)
-
-    raw_env = raw.get("env")
-    env: dict[str, str] | None = None
-    if raw_env is not None:
-        if not isinstance(raw_env, dict) or not all(isinstance(k, str) and isinstance(v, str) for k, v in raw_env.items()):
-            raise McpConfigError(f"mcp.json: stdio server {name!r} 'env' must be a {{string: string}} object")
-        env = dict(raw_env)
-
-    cwd = raw.get("cwd")
-    if cwd is not None and not isinstance(cwd, str):
-        raise McpConfigError(f"mcp.json: stdio server {name!r} 'cwd' must be a string; got {type(cwd).__name__}")
-
-    return ParsedStdioSpec(command=command, args=args, env=env, cwd=cwd)
+    t, has_url, has_command = raw.get("type"), "url" in raw, "command" in raw
+    model: type[StdioServerConfig] | type[HttpServerConfig]
+    if t in ("http", "sse") or (t is None and has_url):
+        model = HttpServerConfig
+    elif t == "stdio" or (t is None and has_command):
+        model = StdioServerConfig
+    else:
+        raise McpConfigError(
+            f"mcp.json: server {name!r} has unknown transport. Provide either 'command' (stdio) or 'url' (http); got keys={sorted(raw.keys())}"
+        )
+    try:
+        return model.model_validate(raw)
+    except ValidationError as exc:
+        _raise_from_validation(name, exc)
 
 
-def _parse_http_spec(name: str, raw: dict[str, Any]) -> ParsedHttpSpec:
-    url = raw.get("url")
-    if not isinstance(url, str) or not url:
-        raise McpConfigError(f"mcp.json: http server {name!r} requires a non-empty 'url' string; got {url!r}")
+def _raise_from_validation(name: str, exc: ValidationError) -> NoReturn:
+    """Translate a Pydantic ``ValidationError`` into an ``McpConfigError``.
 
-    raw_headers = raw.get("headers")
-    headers: dict[str, str] | None = None
-    if raw_headers is not None:
-        if not isinstance(raw_headers, dict) or not all(isinstance(k, str) and isinstance(v, str) for k, v in raw_headers.items()):
-            raise McpConfigError(f"mcp.json: http server {name!r} 'headers' must be a {{string: string}} object")
-        headers = dict(raw_headers)
+    Keys on ``loc[0]`` (the offending field name) so the rendered ``{field!r}``
+    reproduces the ``'command'`` / ``'args'`` / ``'env'`` / ``'cwd'`` / ``'url'``
+    / ``'headers'`` substrings matched by the regression tests.
+    """
+    err = exc.errors()[0]
+    field = err["loc"][0] if err.get("loc") else "<unknown>"
+    raise McpConfigError(f"mcp.json: server {name!r}: invalid {field!r} — {err['msg']} (got {err['input']!r})") from exc
 
-    return ParsedHttpSpec(url=url, headers=headers)
+
+def _to_parsed(cfg: StdioServerConfig | HttpServerConfig) -> ParsedMcpServerSpec:
+    """Normalise a validated input model into the existing ``Parsed*`` output.
+
+    Hand-maintained field copy (the type system does not enforce input↔output
+    congruence — the congruence tests in ``test_config.py`` are the only
+    guard). Keep this adjacent to both model definitions.
+    """
+    if isinstance(cfg, StdioServerConfig):
+        return ParsedStdioSpec(command=cfg.command, args=tuple(cfg.args), env=cfg.env, cwd=cfg.cwd)
+    return ParsedHttpSpec(url=cfg.url, headers=cfg.headers)

--- a/calfkit/mcp/mcp.schema.json
+++ b/calfkit/mcp/mcp.schema.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "calfkit mcp.json",
+  "description": "Reference schema for calfkit McpServers.from_file(...). Unknown keys are ignored.",
+  "type": "object",
+  "required": [
+    "mcpServers"
+  ],
+  "properties": {
+    "mcpServers": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/StdioServerConfig"
+          },
+          {
+            "$ref": "#/$defs/HttpServerConfig"
+          }
+        ]
+      },
+      "type": "object"
+    }
+  },
+  "$defs": {
+    "HttpServerConfig": {
+      "description": "Input model for an HTTP MCP server spec (validation + schema source).",
+      "properties": {
+        "type": {
+          "anyOf": [
+            {
+              "enum": [
+                "http",
+                "sse"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "`http` (or legacy `sse`); inferred from `url`.",
+          "title": "Type"
+        },
+        "url": {
+          "description": "Streamable-HTTP endpoint. Supports $VAR.",
+          "minLength": 1,
+          "title": "Url",
+          "type": "string"
+        },
+        "headers": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Request headers; values support $VAR.",
+          "title": "Headers"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "title": "HttpServerConfig",
+      "type": "object"
+    },
+    "StdioServerConfig": {
+      "description": "Input model for a stdio MCP server spec (validation + schema source).",
+      "properties": {
+        "type": {
+          "anyOf": [
+            {
+              "const": "stdio",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional; inferred from `command` when omitted.",
+          "title": "Type"
+        },
+        "command": {
+          "description": "Executable to spawn. Supports $VAR/${VAR} expansion.",
+          "minLength": 1,
+          "title": "Command",
+          "type": "string"
+        },
+        "args": {
+          "description": "CLI args; each supports $VAR.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Args",
+          "type": "array"
+        },
+        "env": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Subprocess env overlay; values support $VAR.",
+          "title": "Env"
+        },
+        "cwd": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Subprocess working directory.",
+          "title": "Cwd"
+        }
+      },
+      "required": [
+        "command"
+      ],
+      "title": "StdioServerConfig",
+      "type": "object"
+    }
+  }
+}

--- a/docs/mcp-json-schema-reference-design.md
+++ b/docs/mcp-json-schema-reference-design.md
@@ -1,0 +1,253 @@
+# Design: Reference JSON Schema for `mcp.json`
+
+**Status:** Plan (pre-implementation, post-review) · **Component:** `calfkit/mcp` · **Decision:** Option A3 (parser delegates to Pydantic input models). Schema is **wrapped-only**, has **no `$id`**; the `$schema` URL users reference is a docs concern (raw-git, pinned to `main`).
+
+> Revised after four review passes (DX, type-design, adversarial correctness, simplification). Every load-bearing claim below was verified against the pinned toolchain (pydantic 2.12.5, hatchling, ruff `N`, mypy strict). Change log at the end.
+
+---
+
+## 1. Problem & goal
+
+`McpServers.from_file("./mcp.json", schemas=...)` parses a hand-rolled config, but calfkit ships no machine-readable reference for what that file may contain. Users learn the accepted surface only by reading `calfkit/mcp/_config.py`. There is **no official ecosystem schema** for the `mcp.json` *client config* (de-facto convention; clients have diverged — VS Code uses `servers`, others `mcpServers`; Cursor never hosted its `$schema`). A generic ecosystem schema would mislead, because calfkit accepts a **specific subset/variant**:
+
+- **stdio:** `command` (required, non-empty), `args` (list[str]), `env` ({str:str}), `cwd` (str)
+- **http:** `type` (`http`/`sse`), `url` (required, non-empty), `headers` ({str:str})
+- **calfkit-only:** `$VAR` / `${VAR}` / `$$` expansion across all string values
+- accepts wrapped (`{"mcpServers": {...}}`) **or** bare (`{"<name>": {...}}`)
+- ignores unknown keys (so existing `disabled`/`autoApprove` don't break the drop-in)
+
+**Goal:** ship a calfkit-specific reference JSON Schema, generated from a single source of truth (no drift from the parser), consumable as editor IntelliSense via a `$schema` line, plus a CLI emitter with CI drift-checking that mirrors `calfkit mcp codegen`.
+
+**Non-goals:** strict validation that rejects unknown keys (breaks drop-in); SchemaStore registration under the generic `mcp.json` name; runtime validation inside `from_file` (the schema is a documentation aid, **not** a hot-path validator — stated so nobody wires `jsonschema` in later); IntelliSense for the bare form (see §3.5).
+
+## 2. Chosen approach (A3)
+
+`ParsedStdioSpec` / `ParsedHttpSpec` are the parser's **normalized output** (frozen dataclasses, `kind` discriminator, tuple `args`) — not the input shape, so generating a schema from them would describe the wrong thing. A3 introduces **input-shaped Pydantic models** mirroring the accepted surface, routes parsing through them, and normalizes the result back into the existing `Parsed*` dataclasses — so `_factory.py` and all downstream consumers stay untouched. The same two models generate the schema → single source of truth.
+
+```
+parse_mcp_config(config)
+  ├─ _load_config_file (unchanged)                     # str/Path → dict
+  ├─ unwrap mcpServers / bare (unchanged)
+  ├─ name + dict pre-checks (unchanged)                # "non-empty string", "spec for server", "must be an object"
+  └─ per server:
+       ├─ expand_env(raw_spec, where=...) (unchanged)  # $VAR; raises on unset
+       └─ _validate_server(name, expanded)  ──► StdioServerConfig | HttpServerConfig
+            ├─ resolve transport (url-first precedence) or raise "unknown transport"
+            ├─ Model.model_validate(...)  → ValidationError translated to McpConfigError
+            └─ _to_parsed(cfg)  ──► ParsedStdioSpec | ParsedHttpSpec   (unchanged output type)
+```
+
+## 3. Detailed design
+
+### 3.1 Input models (`calfkit/mcp/_config.py`)
+
+Two **real validation models** (used per-server). Module-private by non-export (same convention as the existing `Parsed*`); class names stay clean (no leading underscore) so the schema's `$defs` keys read `StdioServerConfig` / `HttpServerConfig`. There is **no** `McpJsonConfig` and **no** named union alias — both were schema-only and are replaced by a `TypeAdapter` in §3.5.
+
+```python
+from pydantic import BaseModel, ConfigDict, Field
+from typing import Literal
+
+class StdioServerConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore")  # default; explicit for intent (drop-in leniency)
+    type: Literal["stdio"] | None = Field(default=None, description="Optional; inferred from `command` when omitted.")
+    command: str = Field(min_length=1, description="Executable to spawn. Supports $VAR/${VAR} expansion.")
+    args: list[str] = Field(default_factory=list, description="CLI args; each supports $VAR.")
+    env: dict[str, str] | None = Field(default=None, description="Subprocess env overlay; values support $VAR.")
+    cwd: str | None = Field(default=None, description="Subprocess working directory.")
+
+class HttpServerConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    type: Literal["http", "sse"] | None = Field(default=None, description="`http` (or legacy `sse`); inferred from `url`.")
+    url: str = Field(min_length=1, description="Streamable-HTTP endpoint. Supports $VAR.")
+    headers: dict[str, str] | None = Field(default=None, description="Request headers; values support $VAR.")
+```
+
+- `extra="ignore"` ⇒ unknown keys dropped (parser leniency preserved) **and** no `additionalProperties` emitted (editors permit drop-in extras). Verified against current Pydantic docs + live run.
+- `min_length=1` reproduces the "non-empty command/url" rule **and** correctly rejects a `$VAR` that expands to `""` (expansion runs before validation — see §5 test).
+- `type` is decorative for validation (transport is resolved before validate); it exists **only to document/autocomplete the key** in the schema. Comment this at the field so nobody thinks it drives transport selection.
+
+### 3.2 Transport resolution + validation — `_validate_server`
+
+Exact replica of `_parse_server_spec` precedence, folded together with validation so the function returns a validated **instance** (avoids mypy-strict friction from returning `type[A | B]`):
+
+```python
+def _validate_server(name: str, raw: dict[str, Any]) -> StdioServerConfig | HttpServerConfig:
+    t, has_url, has_command = raw.get("type"), "url" in raw, "command" in raw
+    if t in ("http", "sse") or (t is None and has_url):
+        model: type[StdioServerConfig | HttpServerConfig] = HttpServerConfig
+    elif t == "stdio" or (t is None and has_command):
+        model = StdioServerConfig
+    else:
+        raise McpConfigError(
+            f"mcp.json: server {name!r} has unknown transport. Provide either 'command' (stdio) "
+            f"or 'url' (http); got keys={sorted(raw.keys())}"
+        )
+    try:
+        return model.model_validate(raw)
+    except ValidationError as exc:
+        _raise_from_validation(name, exc)  # NoReturn
+```
+
+Preserves **url-first** precedence on ambiguous specs and keeps the friendly `unknown transport` message out of Pydantic. We deliberately **do not** use a Pydantic smart/discriminated union for validation: (a) smart-union order ≠ url-first; (b) `Field(discriminator="type")` is incompatible with `type` being optional (verified `PydanticUserError`); (c) union errors break the `unknown transport` message and the `loc[0]` substring contract. Verified: a 16-case differential against the current `_parse_server_spec` is a zero-mismatch match (incl. both-keys, contradictory/garbage `type`, empty `command:""`).
+
+### 3.3 Error translation — preserve substring contract, no quality regression
+
+Existing tests match **substrings** (`'command'`, `'args'`, `'env'`, `'cwd'`, `'url'`, `'headers'`). Verified: for every failing-path test, `exc.errors()[0]["loc"][0]` is exactly that field name (`args=[1,2,3]` yields 3 errors but `errors()[0]` is the `('args',)` list-level error). Include `input` so the message is **no worse** than today's hand-written ones:
+
+```python
+def _raise_from_validation(name: str, exc: ValidationError) -> NoReturn:
+    err = exc.errors()[0]
+    field = err["loc"][0] if err.get("loc") else "<unknown>"
+    raise McpConfigError(
+        f"mcp.json: server {name!r}: invalid {field!r} — {err['msg']} (got {err['input']!r})"
+    ) from exc
+```
+
+`{field!r}` renders `'command'`, `'args'`, … satisfying every `match=`.
+
+### 3.4 Normalize to existing output (the load-bearing invariant)
+
+```python
+def _to_parsed(cfg: StdioServerConfig | HttpServerConfig) -> ParsedMcpServerSpec:
+    if isinstance(cfg, StdioServerConfig):
+        return ParsedStdioSpec(command=cfg.command, args=tuple(cfg.args), env=cfg.env, cwd=cfg.cwd)
+    return ParsedHttpSpec(url=cfg.url, headers=cfg.headers)
+```
+
+`Parsed*` unchanged ⇒ `_factory.py` (isinstance + splatted-tuple `*spec.args` + `kind`) untouched. **The type system does not enforce input↔output field congruence** — `_to_parsed` is a hand-maintained copy. Mitigation: keep `_to_parsed` adjacent to both type defs, and the §6 round-trip test is **mandatory** (it is the only enforcement; add a field and forget here → only the test fails).
+
+### 3.5 Schema generation — wrapped-only, via `TypeAdapter`, no sacrificial model
+
+```python
+from pydantic import TypeAdapter
+
+_SERVERS = TypeAdapter(dict[str, StdioServerConfig | HttpServerConfig])
+
+def mcp_json_schema() -> dict[str, Any]:
+    """Reference JSON Schema (draft 2020-12) for a calfkit mcp.json. Permissive: unknown keys allowed."""
+    servers_map = _SERVERS.json_schema(ref_template="#/$defs/{model}")  # {type:object, additionalProperties:{anyOf:[$ref,$ref]}, $defs:{...}}
+    defs = servers_map.pop("$defs")
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "calfkit mcp.json",
+        "description": "Reference schema for calfkit McpServers.from_file(...). Unknown keys are ignored.",
+        "type": "object",
+        "required": ["mcpServers"],
+        "properties": {"mcpServers": servers_map},
+        "$defs": defs,
+    }
+```
+
+- **Wrapped-only** (no bare-form `anyOf`). Rationale: `type` is optional ⇒ the server union is a plain `anyOf` of two `$ref`s with no discriminator; nesting that under a second wrapped-vs-bare `anyOf` is exactly the "matches none / matches both" editor noise we want to avoid. The bare form stays **fully accepted by the parser at runtime** — it just doesn't get IntelliSense (and a bare-form file can't carry a top-level `"$schema"` key without colliding with a server named `$schema` anyway). One-line `anyOf` to add later if ever needed (YAGNI now).
+- **No `$id`.** The permissive doc-schema has no external `$ref`s; omitting `$id` keeps the function tiny and avoids baking a repo URL into the committed artifact (the user-facing `$schema` URL is a docs concern — §3.8 / O1).
+- Pure-Pydantic (no `typer`, no MCP spawn) ⇒ lives in `_config.py`, exported from `calfkit.mcp`, usable without the `mcp-codegen` extra.
+- *Verify during impl:* `TypeAdapter(...).json_schema()` emits `$defs` keyed by class name + the `additionalProperties: {anyOf:[$ref,$ref]}` map (independently asserted by two reviewers for the model-schema form; confirm for the TypeAdapter form).
+
+### 3.6 CLI: `calfkit mcp schema`
+
+New subcommand in `calfkit/cli/mcp.py`, mirroring `codegen`'s write/`--check`/exit contract (0 ok · 1 drift/missing · 2 io-error):
+
+```
+calfkit mcp schema [--output PATH=calfkit/mcp/mcp.schema.json] [--check]
+```
+
+- **Deterministic render:** `json.dumps(mcp_json_schema(), indent=2) + "\n"` (no `sort_keys`; Pydantic emits stable order — cross-process determinism verified). A test asserts re-render is byte-identical so `--check` can't flap.
+- **Shared tail:** factor `_emit_text(rendered, output, *, check, refresh_hint) -> int` (existence-check + read + write + exit codes + messages) and have `codegen` use it too. Keep the **diff caller-supplied** — `codegen` passes its AST-aware `diff_modules`; `schema` passes a plain `difflib` text diff. Do **not** force `diff_modules` onto JSON.
+- Help text states the default `--output` targets a **repo checkout** (a pip-installed user running it would write into read-only site-packages and hit the existing exit-2 path — tolerable, the file already ships).
+- The CLI inherits the `mcp-codegen` (typer) extra, same as `codegen`. Library users who only want the schema call `calfkit.mcp.mcp_json_schema()` (no extra needed) — this is the documented headline path; the CLI is a maintainer/CI convenience.
+
+### 3.7 Packaging
+
+Committed artifact at `calfkit/mcp/mcp.schema.json`, **inside the package** (so `pip install` ships it for offline `"$schema": "<local-path>"` use). Verified: hatchling `packages=["calfkit"]` ships `.json` files automatically (a probe wheel was built and inspected) — **no `artifacts` entry needed**, no `.gitignore` exclusion.
+
+### 3.8 Docs
+
+`docs/mcp-overview.md` mcp.json section: add a `"$schema"` example line (raw-git URL pinned to `main` + a note on the in-package local-path alternative), a field-reference table, and a note on `$VAR` + unknown-key leniency. Add a "Reference schema" row to *Functionality at a glance*. The library-function path (`mcp_json_schema()`) is documented as the primary way to obtain the schema programmatically.
+
+## 4. File-by-file change list
+
+| File | Change |
+|---|---|
+| `calfkit/mcp/_config.py` | Add `StdioServerConfig`, `HttpServerConfig`, `_SERVERS` adapter, `_validate_server`, `_raise_from_validation`, `_to_parsed`, `mcp_json_schema`. Rewire `parse_mcp_config` body; delete `_parse_server_spec`/`_parse_stdio_spec`/`_parse_http_spec`. Keep `expand_env`, `_load_config_file`, unwrap + pre-checks, and the `Parsed*` dataclasses verbatim. |
+| `calfkit/mcp/__init__.py` | Export `mcp_json_schema` (only new public symbol). |
+| `calfkit/cli/mcp.py` | Add `schema` command + shared `_emit_text` helper; refactor `codegen`'s tail to use it (diff stays caller-supplied). |
+| `calfkit/mcp/mcp.schema.json` | New committed generated artifact. |
+| `docs/mcp-overview.md` | `$schema` example (raw-git `main` URL + local-path) + field table + feature row. |
+| `pyproject.toml` | Fix stale `[project.urls]` `calf-sdk` → `calfkit-sdk` (side fix; O1). |
+| CI (`.github/workflows/code-checks.yml`) | Add a `calfkit mcp schema --check` step. |
+| `tests/mcp/test_config.py` | **No changes** — regression contract. |
+| `tests/mcp/test_schema.py` | New (see §6). |
+
+## 5. Behavior-preservation matrix (every existing `test_config.py` case — all verified ✅)
+
+| Test group | Path under A3 |
+|---|---|
+| `expand_env_*` (8) | `expand_env` untouched |
+| wrapped / bare shape | unwrap untouched |
+| stdio/http explicit+inferred, sse→http | `_validate_server` precedence (16-case diff: 0 mismatches) |
+| missing transport → `"unknown transport"` | same raise text |
+| stdio missing/empty `command`; non-string `args`/`env`/`cwd` | `min_length`/`missing`/type errors; `loc[0]` = field |
+| http missing `url`; bad `headers` | `loc[0]` = `url`/`headers` |
+| all-optional stdio/http; env subst into env/url/headers; unset→raise | `expand_env` before validate; `_to_parsed` args→tuple |
+| empty name / non-dict spec / non-dict top-level | pre-checks unchanged |
+| file: missing / invalid JSON / non-object | `_load_config_file` unchanged |
+| `Parsed*` frozen | dataclasses unchanged |
+
+Verified: no Pydantic int/bool→str coercion (bad-type inputs rejected as today); no test asserts old phrasing; all 17 `match=` substrings still produced.
+
+## 6. Test plan (`tests/mcp/test_schema.py`)
+
+- **Round-trip field congruence (mandatory):** for representative stdio+http specs, assert `_to_parsed(_validate_server(...))` equals the `Parsed*` produced by `parse_mcp_config` — the sole enforcement of input↔output congruence.
+- **Post-expansion empty command:** `{"command": "$EMPTY"}` with `EMPTY=""` raises (`min_length=1` after expansion), substring `'command'`.
+- **Schema shape:** `mcp_json_schema()` has `$schema`(2020-12), `title`, `required:["mcpServers"]`, `$defs.{StdioServerConfig,HttpServerConfig}`, server union is `anyOf` of two `$ref`s; **no** `additionalProperties:false` anywhere; **no** `$id`.
+- **Permissiveness / structural validity:** example configs (wrapped-stdio, wrapped-http, with-extra-key `disabled`) round-trip through `parse_mcp_config` cleanly; `{}` and a server with neither `command` nor `url` are rejected by the parser. (Assert against the parser — our code — **not** via a `jsonschema` dep.)
+- **Determinism:** `json.dumps(mcp_json_schema(), indent=2)+"\n"` is byte-stable across calls.
+- **CLI `--check`:** exit 0 when committed file matches, 1 on drift/missing (typer `CliRunner`, per `tests/mcp/test_cli.py`).
+- Run full `tests/mcp/` to confirm `test_config.py` passes unchanged.
+
+## 7. Considered & rejected
+
+- **A2 (schema-only models + contract test):** two representations reconciled by a test, not one source of truth. Rejected for A3.
+- **Validate whole config via one model:** changes precedence, loses friendly errors + bare form. Rejected.
+- **Pydantic discriminated union (`Field(discriminator="type")`):** incompatible with optional/inferred `type` (verified error). Rejected; would require making `type` mandatory (worse paste-in DX).
+- **Bare-form `anyOf` in schema:** doubled `anyOf` → editor noise; parser still accepts bare at runtime. Cut.
+- **Sacrificial `McpJsonConfig` BaseModel:** validatable-looking but never validated (foot-gun) + `mcpServers` field trips ruff `N815`. Replaced by `TypeAdapter`.
+- **`union_mode="left_to_right"` / `$id` / `jsonschema` dep / packaging `artifacts`:** each verified to add nothing here. Cut.
+- **Drop `Parsed*`, make Pydantic the output:** larger `_factory.py` blast radius. Rejected.
+
+## 8. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `_to_parsed` input↔output drift (no type-level guard) | mandatory §6 round-trip test; keep converter adjacent to type defs |
+| Pydantic error `loc`/message drift across versions | translator keys only on `loc[0]` (stable); `test_config.py` guards; deps pinned |
+| `--check` flapping on nondeterministic render | pinned `indent`/newline + byte-stability test |
+| `TypeAdapter` schema shape differs from expectation | verify-during-impl note in §3.5; shape test in §6 |
+| `$schema` docs URL unresolvable (wrong slug / private fork) | O1; in-package local-path `$schema` always works offline |
+| mypy-strict friction on transport-resolve typing | `_validate_server` returns an instance, not `type[A|B]`; spike both spellings before committing |
+
+## 9. Resolved decisions
+
+- **O1 — RESOLVED.** Public repo is `calf-ai/calfkit-sdk` (confirmed). Docs `$schema` example:
+  `https://raw.githubusercontent.com/calf-ai/calfkit-sdk/main/calfkit/mcp/mcp.schema.json` (pinned to `main` — stable URL, auto-updating; fine for a permissive doc-schema), with the in-package local-path alternative also documented. Side fix: `pyproject [project.urls]` currently points at the stale `calf-ai/calf-sdk` — correct those to `calfkit-sdk` in the same change.
+
+No open questions remain.
+
+## 10. Implementation sequence (TDD)
+
+**Iron law:** no new production code without a failing test first. New behavior (`mcp_json_schema`, the CLI `schema` command) is strict red→green→refactor. The `parse_mcp_config` rewrite is **refactor-under-contract**: the existing `tests/mcp/test_config.py` (baseline **52 passed**, verified green) must stay green through the rewrite; new edge/congruence tests are added test-first.
+
+Phases are **sequential** (file dependencies: the CLI uses `mcp_json_schema`; the parser reuses its models; the artifact/docs need the CLI). Mechanism verified live: `TypeAdapter(dict[str, Stdio|Http]).json_schema()` yields the expected `$defs`+`anyOf` map with no `additionalProperties:false`; error `loc[0]` is the field name with `input` available.
+
+1. **Core (`_config.py` + `__init__.py` + tests)** — owns `_config.py` end-to-end:
+   - RED→GREEN: write `tests/mcp/test_schema.py` (shape, determinism, no `$id`/no `additionalProperties:false`) → add the two models + `_SERVERS` adapter + `mcp_json_schema()` → green.
+   - Refactor-under-contract: add congruence + post-expansion-empty-command + empty-object-rejected tests → rewire `parse_mcp_config` via `_validate_server`/`_to_parsed`, delete `_parse_*_spec` → **all** of `test_config.py` + new tests green.
+   - Export `mcp_json_schema` from `calfkit/mcp/__init__.py`.
+2. **CLI (`cli/mcp.py` + `test_cli.py`)** — RED→GREEN: write `schema --check`/write tests → add `_emit_text` + `schema` command, refactor `codegen`'s tail onto `_emit_text` (diff stays caller-supplied; codegen keeps `diff_modules`) → green.
+3. **Artifact + docs + meta** — generate `calfkit/mcp/mcp.schema.json` via `uv run calfkit mcp schema`; update `docs/mcp-overview.md`; fix `pyproject [project.urls]`; add CI `--check` step; full `uv run pytest tests/mcp/` + `ruff check` + `mypy` green.
+
+After each phase: `uv run pytest tests/mcp/`, `uv run ruff check`, `uv run mypy` must pass before the next.
+
+## Change log (post-review)
+
+Adopted: drop bare-form schema (wrapped-only); replace `McpJsonConfig`/union alias with `TypeAdapter` (also fixes the `N815` CI blocker and the never-validated-model foot-gun); drop `union_mode`, `$id`, `jsonschema` dep, packaging `artifacts` hedge; fold resolve+validate into `_validate_server` (mypy-strict); include `err['input']` in error messages; pin render determinism; make round-trip congruence test mandatory; add post-expansion-empty-command test; CLI demoted to maintainer/CI tool with `mcp_json_schema()` as the headline library path. Verified-and-kept: dual representation, per-server precedence, `loc[0]` substring contract, `_emit_text` DRY with caller-supplied diff.

--- a/docs/mcp-json-schema-reference-design.md
+++ b/docs/mcp-json-schema-reference-design.md
@@ -1,8 +1,8 @@
 # Design: Reference JSON Schema for `mcp.json`
 
-**Status:** Plan (pre-implementation, post-review) · **Component:** `calfkit/mcp` · **Decision:** Option A3 (parser delegates to Pydantic input models). Schema is **wrapped-only**, has **no `$id`**; the `$schema` URL users reference is a docs concern (raw-git, pinned to `main`).
+**Status:** Implemented (PR #172) · **Component:** `calfkit/mcp` · **Decision:** Option A3 (parser delegates to Pydantic input models). Schema is **wrapped-only**, has **no `$id`**; the `$schema` URL users reference is a docs concern (raw-git, pinned to `main`).
 
-> Revised after four review passes (DX, type-design, adversarial correctness, simplification). Every load-bearing claim below was verified against the pinned toolchain (pydantic 2.12.5, hatchling, ruff `N`, mypy strict). Change log at the end.
+> This is the design record (kept for the rationale and rejected alternatives). It was written pre-implementation and verified across four review passes; the feature is now merged. Where the text below says it "replicates `_parse_server_spec`" or carries "verify during impl" notes, those refer to the design phase — the `_parse_*_spec` helpers have since been **removed**, and that transport-detection behavior now lives in `_validate_server` (`calfkit/mcp/_config.py`). A post-merge PR review also hardened error rendering to avoid leaking `$VAR`-expanded secrets and to surface all validation errors.
 
 ---
 

--- a/docs/mcp-overview.md
+++ b/docs/mcp-overview.md
@@ -261,8 +261,8 @@ servers = McpServers.from_config(my_config_dict, schemas={...})
 #### Editor autocomplete via `$schema`
 
 calfkit ships a reference JSON Schema for `mcp.json`. Add a `"$schema"` key
-to get field autocompletion, inline docs, and validation of the
-calfkit-accepted surface in your editor:
+to get field autocompletion and inline docs for the calfkit-accepted surface
+in your editor (the schema is permissive — it does not reject unknown keys):
 
 ```json
 {
@@ -294,7 +294,7 @@ not the schema. Accepted fields:
 | stdio | `cwd` | string | working directory |
 | http | `url` | string *(required)* | endpoint; `$VAR` expanded |
 | http | `headers` | {string: string} | `$VAR` expanded |
-| either | `type` | `"stdio"` / `"http"` / `"sse"` | optional; inferred from `command`/`url` |
+| either | `type` | `"stdio"` / `"http"` / `"sse"` | optional; inferred from `command`/`url`. `stdio` only on a stdio spec; `http`/`sse` only on an http spec |
 
 Get the schema as a dict programmatically with
 `from calfkit.mcp import mcp_json_schema`. The committed file is regenerated

--- a/docs/mcp-overview.md
+++ b/docs/mcp-overview.md
@@ -49,6 +49,7 @@ MCP adaptor adds value when crossing the calfkit ↔ MCP boundary.
 | stdio + Streamable HTTP transports | ✅ v1 | [Quickstart](#quickstart) |
 | Codegen-generated schemas (`calfkit mcp codegen`) | ✅ v1 | [Step 2](#2-generate-schemas-one-time-committed) |
 | `mcp.json` drop-in (Claude Desktop / Cursor / Cline format) | ✅ v1 | [mcp.json](#many-mcp-servers-via-mcpjson) |
+| Reference JSON Schema for `mcp.json` (`$schema` editor IntelliSense) | ✅ v1 | [mcp.json](#editor-autocomplete-via-schema) |
 | Filters: `.only()` / `.exclude()` / `.where(...)` | ✅ v1 | [Filtering](#filtering-renaming-and-selecting-tools) |
 | Renames: `.prefix()` / `.rename({...})` | ✅ v1 | [Filtering](#filtering-renaming-and-selecting-tools) |
 | Pattern 1 multi-tenancy (`meta=lambda ctx: {...}`) | ✅ v1 | [Per-tenant](#per-tenant-identity) |
@@ -256,6 +257,48 @@ than a file on disk, pass the parsed dict directly:
 ```python
 servers = McpServers.from_config(my_config_dict, schemas={...})
 ```
+
+#### Editor autocomplete via `$schema`
+
+calfkit ships a reference JSON Schema for `mcp.json`. Add a `"$schema"` key
+to get field autocompletion, inline docs, and validation of the
+calfkit-accepted surface in your editor:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/calf-ai/calfkit-sdk/main/calfkit/mcp/mcp.schema.json",
+  "mcpServers": {
+    "gmail": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-gmail"]}
+  }
+}
+```
+
+Offline or on a private fork, point at the copy shipped inside the installed
+package instead of the URL:
+
+```bash
+python -c "import importlib.resources as r; print(r.files('calfkit.mcp') / 'mcp.schema.json')"
+```
+
+The schema is **permissive** — unknown keys (e.g. another client's `disabled`
+/ `autoApprove`) are ignored, not rejected, so an existing `mcp.json` from
+another tool still validates. It documents the wrapped (`mcpServers`) form and
+is an editor aid only; the runtime validator is `McpServers.from_file(...)`,
+not the schema. Accepted fields:
+
+| Transport | Field | Type | Notes |
+|---|---|---|---|
+| stdio | `command` | string *(required)* | executable; `$VAR` expanded |
+| stdio | `args` | string[] | `$VAR` expanded |
+| stdio | `env` | {string: string} | `$VAR` expanded |
+| stdio | `cwd` | string | working directory |
+| http | `url` | string *(required)* | endpoint; `$VAR` expanded |
+| http | `headers` | {string: string} | `$VAR` expanded |
+| either | `type` | `"stdio"` / `"http"` / `"sse"` | optional; inferred from `command`/`url` |
+
+Get the schema as a dict programmatically with
+`from calfkit.mcp import mcp_json_schema`. The committed file is regenerated
+with `calfkit mcp schema`; CI runs `calfkit mcp schema --check` to catch drift.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/calf-ai/calf-sdk"
-Repository = "https://github.com/calf-ai/calf-sdk"
-Issues = "https://github.com/calf-ai/calf-sdk/issues"
+Homepage = "https://github.com/calf-ai/calfkit-sdk"
+Repository = "https://github.com/calf-ai/calfkit-sdk"
+Issues = "https://github.com/calf-ai/calfkit-sdk/issues"
 
 [project.scripts]
 # Top-level calfkit CLI. Currently mounts only the `mcp` subcommand (codegen).

--- a/tests/mcp/test_cli.py
+++ b/tests/mcp/test_cli.py
@@ -7,6 +7,7 @@ server live in the Phase 8 lane.
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 from typing import Any
@@ -243,5 +244,72 @@ def test_cli_codegen_help_shows_flags() -> None:
     assert "--command" in stdout
     assert "--url" in stdout
     assert "--token" in stdout
+    assert "--output" in stdout
+    assert "--check" in stdout
+
+
+# ---------------------------------------------------------------------------
+# schema command (no MCP session needed — pure Pydantic render)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_schema_writes_file(tmp_path: Path) -> None:
+    """``schema --output`` writes a valid 2020-12 JSON Schema and reports it."""
+    output = tmp_path / "mcp.schema.json"
+    result = runner.invoke(app, ["schema", "--output", str(output)])
+    assert result.exit_code == 0, result.stderr
+    assert output.exists()
+    parsed = json.loads(output.read_text(encoding="utf-8"))
+    assert parsed["$schema"].endswith("2020-12/schema")
+    assert "Wrote" in result.stdout
+
+
+def test_cli_schema_check_passes_when_matching(tmp_path: Path) -> None:
+    """Write once, then --check on identical content → exit 0."""
+    output = tmp_path / "mcp.schema.json"
+    runner.invoke(app, ["schema", "--output", str(output)])
+    result = runner.invoke(app, ["schema", "--output", str(output), "--check"])
+    assert result.exit_code == 0
+    assert "up to date" in result.stdout
+
+
+def test_cli_schema_check_fails_when_missing(tmp_path: Path) -> None:
+    """--check against a non-existent file → exit 1 with drift message."""
+    output = tmp_path / "missing.schema.json"
+    result = runner.invoke(app, ["schema", "--output", str(output), "--check"])
+    assert result.exit_code == 1
+    assert "does not exist" in result.stderr
+
+
+def test_cli_schema_check_fails_on_drift(tmp_path: Path) -> None:
+    """--check against drifted content → exit 1 with diff + remediation hint."""
+    output = tmp_path / "mcp.schema.json"
+    output.write_text("{}\n", encoding="utf-8")
+    result = runner.invoke(app, ["schema", "--output", str(output), "--check"])
+    assert result.exit_code == 1
+    assert "Drift detected" in result.stderr
+    assert "+" in result.stderr or "-" in result.stderr
+    assert "calfkit mcp schema" in result.stderr
+
+
+def test_cli_schema_check_does_not_write(tmp_path: Path) -> None:
+    """--check must NOT overwrite the file even when drift is detected."""
+    output = tmp_path / "mcp.schema.json"
+    stale = "# stale\n"
+    output.write_text(stale, encoding="utf-8")
+    runner.invoke(app, ["schema", "--output", str(output), "--check"])
+    assert output.read_text(encoding="utf-8") == stale  # unchanged
+
+
+def test_cli_help_lists_schema() -> None:
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "schema" in _plain(result.stdout)
+
+
+def test_cli_schema_help_shows_flags() -> None:
+    result = runner.invoke(app, ["schema", "--help"])
+    assert result.exit_code == 0
+    stdout = _plain(result.stdout)
     assert "--output" in stdout
     assert "--check" in stdout

--- a/tests/mcp/test_config.py
+++ b/tests/mcp/test_config.py
@@ -14,13 +14,16 @@ Coverage focus:
 from __future__ import annotations
 
 import json
+from dataclasses import fields
 from pathlib import Path
 
 import pytest
 
 from calfkit.mcp._config import (
+    HttpServerConfig,
     ParsedHttpSpec,
     ParsedStdioSpec,
+    StdioServerConfig,
     expand_env,
     parse_mcp_config,
 )
@@ -361,3 +364,78 @@ def test_parse_empty_object_spec_rejected() -> None:
     """A server spec with neither 'command' nor 'url' is an unknown transport."""
     with pytest.raises(McpConfigError, match="unknown transport"):
         parse_mcp_config({"s": {}})
+
+
+def test_parsed_stdio_covers_every_input_model_field() -> None:
+    """Reflective congruence: every non-``type`` input field has a ``Parsed*`` home.
+
+    Guards the silent-drop class of bug — adding a field to the input model
+    without wiring ``_to_parsed`` + the dataclass would otherwise validate and
+    then vanish, caught only if someone hand-extends the congruence test.
+    """
+    stdio_in = set(StdioServerConfig.model_fields) - {"type"}
+    stdio_out = {f.name for f in fields(ParsedStdioSpec)} - {"kind"}
+    assert stdio_in == stdio_out
+    http_in = set(HttpServerConfig.model_fields) - {"type"}
+    http_out = {f.name for f in fields(ParsedHttpSpec)} - {"kind"}
+    assert http_in == http_out
+
+
+# ---------------------------------------------------------------------------
+# parse_mcp_config — transport precedence edge cases (ambiguous / contradictory)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_url_wins_when_both_command_and_url_present() -> None:
+    """Ambiguous spec carrying both keys resolves to HTTP (url-first)."""
+    parsed = parse_mcp_config({"s": {"command": "npx", "url": "https://x/mcp"}})
+    spec = parsed["s"]
+    assert isinstance(spec, ParsedHttpSpec)
+    assert spec.url == "https://x/mcp"
+
+
+def test_parse_explicit_type_overrides_inference() -> None:
+    """An explicit ``type`` selects the transport even against a contradictory key."""
+    # type=stdio with only a url present → routed to stdio, then fails on command.
+    with pytest.raises(McpConfigError, match="'command'"):
+        parse_mcp_config({"s": {"type": "stdio", "url": "https://x/mcp"}})
+
+
+def test_parse_unrecognized_type_with_command_is_unknown_transport() -> None:
+    """A non-empty but invalid ``type`` disables inference (matches legacy behavior)."""
+    with pytest.raises(McpConfigError, match="unknown transport"):
+        parse_mcp_config({"s": {"type": "bogus", "command": "npx"}})
+
+
+# ---------------------------------------------------------------------------
+# parse_mcp_config — error messages: no secret leakage, all problems surfaced
+# ---------------------------------------------------------------------------
+
+
+def test_parse_error_does_not_leak_expanded_secret_stdio(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing-field error must not dump the expanded env (which holds secrets)."""
+    monkeypatch.setenv("MY_SECRET", "supersecret-token-abc123")
+    with pytest.raises(McpConfigError) as exc_info:
+        parse_mcp_config({"s": {"type": "stdio", "env": {"OAUTH": "$MY_SECRET"}}})
+    msg = str(exc_info.value)
+    assert "'command'" in msg  # still names the offending field
+    assert "supersecret-token-abc123" not in msg  # but never leaks the secret
+
+
+def test_parse_error_does_not_leak_expanded_secret_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing-url error must not dump the expanded Authorization header."""
+    monkeypatch.setenv("MY_SECRET", "supersecret-token-abc123")
+    with pytest.raises(McpConfigError) as exc_info:
+        parse_mcp_config({"s": {"type": "http", "headers": {"Authorization": "Bearer $MY_SECRET"}}})
+    msg = str(exc_info.value)
+    assert "'url'" in msg
+    assert "supersecret-token-abc123" not in msg
+
+
+def test_parse_error_surfaces_all_invalid_fields() -> None:
+    """A spec with multiple problems reports every offending field, not just the first."""
+    with pytest.raises(McpConfigError) as exc_info:
+        parse_mcp_config({"s": {"command": "", "cwd": 5}})
+    msg = str(exc_info.value)
+    assert "'command'" in msg
+    assert "'cwd'" in msg

--- a/tests/mcp/test_config.py
+++ b/tests/mcp/test_config.py
@@ -322,3 +322,42 @@ def test_parsed_specs_are_immutable() -> None:
     stdio = parsed["s"]
     with pytest.raises(Exception):  # FrozenInstanceError
         stdio.command = "y"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# parse_mcp_config — input↔output field congruence (post-rewrite contract)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_stdio_field_congruence() -> None:
+    """Every field of a fully-populated stdio spec maps onto ``ParsedStdioSpec``."""
+    parsed = parse_mcp_config({"s": {"command": "npx", "args": ["-y", "x"], "env": {"K": "V"}, "cwd": "/tmp"}})
+    spec = parsed["s"]
+    assert isinstance(spec, ParsedStdioSpec)
+    assert spec.command == "npx"
+    assert spec.args == ("-y", "x")
+    assert isinstance(spec.args, tuple)
+    assert spec.env == {"K": "V"}
+    assert spec.cwd == "/tmp"
+
+
+def test_parse_http_field_congruence() -> None:
+    """Every field of a fully-populated http spec maps onto ``ParsedHttpSpec``."""
+    parsed = parse_mcp_config({"s": {"type": "http", "url": "https://x/mcp", "headers": {"Authorization": "Bearer x"}}})
+    spec = parsed["s"]
+    assert isinstance(spec, ParsedHttpSpec)
+    assert spec.url == "https://x/mcp"
+    assert spec.headers == {"Authorization": "Bearer x"}
+
+
+def test_parse_stdio_command_empty_after_expansion_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ``$VAR`` that expands to '' fails the non-empty command rule."""
+    monkeypatch.setenv("EMPTY", "")
+    with pytest.raises(McpConfigError, match="'command'"):
+        parse_mcp_config({"s": {"command": "$EMPTY"}})
+
+
+def test_parse_empty_object_spec_rejected() -> None:
+    """A server spec with neither 'command' nor 'url' is an unknown transport."""
+    with pytest.raises(McpConfigError, match="unknown transport"):
+        parse_mcp_config({"s": {}})

--- a/tests/mcp/test_schema.py
+++ b/tests/mcp/test_schema.py
@@ -1,0 +1,59 @@
+"""Unit tests for ``calfkit.mcp.mcp_json_schema``.
+
+Coverage focus:
+- The emitted schema is a JSON-Schema draft 2020-12 document with the
+  expected top-level shape (``$schema``, ``title``, ``required``).
+- The ``mcpServers`` map's ``additionalProperties`` is an ``anyOf`` of the
+  two server-config ``$ref``s, with both definitions present in ``$defs``.
+- The schema is permissive: it carries NO ``"additionalProperties": false``
+  anywhere (drop-in extras allowed) and NO ``$id`` key.
+- Rendering is deterministic so a CLI ``--check`` cannot flap.
+"""
+
+from __future__ import annotations
+
+import json
+
+from calfkit.mcp import mcp_json_schema
+
+
+def test_schema_top_level_shape() -> None:
+    schema = mcp_json_schema()
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert isinstance(schema["title"], str) and schema["title"]
+    assert schema["type"] == "object"
+    assert schema["required"] == ["mcpServers"]
+
+
+def test_schema_server_union_is_anyof_of_two_refs() -> None:
+    schema = mcp_json_schema()
+    additional = schema["properties"]["mcpServers"]["additionalProperties"]
+    any_of = additional["anyOf"]
+    assert isinstance(any_of, list)
+    assert len(any_of) == 2
+    refs = {entry["$ref"] for entry in any_of}
+    assert refs == {"#/$defs/StdioServerConfig", "#/$defs/HttpServerConfig"}
+
+
+def test_schema_defs_contain_both_models() -> None:
+    schema = mcp_json_schema()
+    defs = schema["$defs"]
+    assert "StdioServerConfig" in defs
+    assert "HttpServerConfig" in defs
+
+
+def test_schema_has_no_id_key() -> None:
+    assert "$id" not in mcp_json_schema()
+
+
+def test_schema_has_no_additional_properties_false() -> None:
+    """Permissive doc-schema: never forbids unknown keys (drop-in leniency)."""
+    rendered = json.dumps(mcp_json_schema())
+    assert '"additionalProperties": false' not in rendered
+    assert '"additionalProperties":false' not in rendered
+
+
+def test_schema_render_is_deterministic() -> None:
+    first = json.dumps(mcp_json_schema(), indent=2)
+    second = json.dumps(mcp_json_schema(), indent=2)
+    assert first == second

--- a/tests/mcp/test_schema.py
+++ b/tests/mcp/test_schema.py
@@ -13,6 +13,7 @@ Coverage focus:
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from calfkit.mcp import mcp_json_schema
 
@@ -57,3 +58,15 @@ def test_schema_render_is_deterministic() -> None:
     first = json.dumps(mcp_json_schema(), indent=2)
     second = json.dumps(mcp_json_schema(), indent=2)
     assert first == second
+
+
+def test_committed_schema_file_matches_generator() -> None:
+    """The committed ``mcp.schema.json`` must equal the generator's exact output.
+
+    Pins the serialization form (``indent=2`` + trailing newline) that the CLI
+    writes and CI's ``calfkit mcp schema --check`` depends on, so drift is
+    caught locally rather than only in CI.
+    """
+    committed = Path(__file__).resolve().parents[2] / "calfkit" / "mcp" / "mcp.schema.json"
+    expected = json.dumps(mcp_json_schema(), indent=2) + "\n"
+    assert committed.read_text(encoding="utf-8") == expected


### PR DESCRIPTION
## What & why

calfkit parses `mcp.json` but ships no machine-readable reference for what the file may contain — users had to read `_config.py` to learn the accepted surface. There is no official ecosystem schema (the format is a de-facto convention clients have diverged on), and calfkit accepts a specific subset/variant, so a generic schema would mislead.

This adds a **calfkit-specific reference JSON Schema**, generated from a **single source of truth** (the same Pydantic models the parser validates with) so it can never drift, consumable as editor IntelliSense via a `$schema` line, with a CLI emitter and CI drift-check that mirror `calfkit mcp codegen`.

## Changes

- **`_config.py`** — new input models `StdioServerConfig` / `HttpServerConfig`; `parse_mcp_config` routes through them (url-first transport precedence, friendly error translation preserving the existing message substrings) then normalizes to the existing frozen `Parsed*` dataclasses, so `_factory.py` and all consumers are untouched. Adds `mcp_json_schema()` via `TypeAdapter`. Removes the hand-rolled `_parse_*_spec` helpers.
- **`cli/mcp.py`** — `calfkit mcp schema [--output] [--check]`, sharing a new `_emit_text` write/`--check` helper with `codegen` (codegen's AST diff and output strings unchanged).
- **`calfkit/mcp/mcp.schema.json`** — committed package data (ships in wheel + sdist), CI-drift-checked.
- **docs** — `$schema` usage (raw-git URL + offline in-package path) and a field-reference table in `mcp-overview.md`; full design doc under `docs/`.
- **`pyproject.toml`** — fix stale `[project.urls]` (`calf-sdk` → `calfkit-sdk`).
- **CI** — add `calfkit mcp schema --check` to `code-checks.yml`.

## Design notes

- Schema is **wrapped-only** (`mcpServers`) and **permissive** — `extra="ignore"` means unknown keys (another client's `disabled`/`autoApprove`) are documented-away, not rejected, preserving the drop-in promise. It is a documentation/editor aid; the runtime validator remains `McpServers.from_file(...)`.
- The bare-form config is still accepted by the parser at runtime; only IntelliSense is wrapped-only.

## Testing

Built TDD (red→green). `tests/mcp`: **420 passed** — the existing `test_config.py` contract is unchanged (refactor-under-contract), plus new schema/CLI/parser tests. `ruff check`, `ruff format --check`, `mypy calfkit/` all clean. Wheel + sdist verified to ship the schema artifact.