### PR TITLE
feat!: true one-way Client.emit_to_node fire-and-forget (#132)

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,31 @@ result = await client.execute_node(
 )
 ```
 
+**Fire-and-forget** — dispatch work to a node without waiting for (or producing) a reply via `emit_to_node`:
+
+```python
+correlation_id = await client.emit_to_node(
+    "Re-index the catalog.",
+    "indexer.input",
+)
+# Returns the correlation_id immediately; no reply is produced and no
+# client-side reply future is allocated.
+```
+
+`emit_to_node` takes the same input-shaping arguments as `invoke_node` (`deps`, `temp_instructions`, `message_history`, `run_args`, `model_settings`, `tool_overrides`, `correlation_id`) — but no `reply_topic` or `output_type`, since there is nothing to route back or deserialize.
+
+Because there's no reply, **traceability comes from the target node's `publish_topic` broadcast stream**, not a point-to-point callback. Set a `publish_topic` on the node you emit to and tap it with a [consumer node](#consumer-nodes-optional) to observe terminals (`result.output` is populated exactly as it is for `execute_node`). A node with no `publish_topic` produces no observable record for a fire-and-forget send — there is neither a reply nor a broadcast.
+
+Use `emit_to_node` for true one-way sends, `invoke_node` for async dispatch with a handle to await later, and `execute_node` for synchronous request/reply.
+
+> **Bounding `invoke_node` memory** — each pending `invoke_node` handle holds a reply future until it resolves. If a reply is lost or a handle is abandoned, that future leaks. Pass an opt-in TTL to bound it:
+>
+> ```python
+> client = Client.connect("localhost:9092", reply_ttl=30.0)
+> ```
+>
+> When set, an unanswered handle is evicted after `reply_ttl` seconds and `handle.result()` raises `ReplyExpiredError`. The default (`None`) waits indefinitely. `emit_to_node` allocates no future, so the TTL does not apply to it.
+
 <br>
 
 ### Gating Node Invocations (Optional)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,6 +5,7 @@ An index of potential features and changes under consideration for Calf SDK. Eac
 ## Accepted
 
 - [Deps-as-dict refactor](docs/deps-as-dict-refactor.md) — `ctx.deps`/`result.deps` are plain dicts and `correlation_id` is a top-level context attribute (closes #144; breaking)
+- [Fire-and-forget emit](docs/fire-and-forget-emit.md) — true one-way Client.emit_to_node; nullable callback terminal; opt-in reply TTL (closes #132)
 
 ## Proposed
 

--- a/calfkit/client/base.py
+++ b/calfkit/client/base.py
@@ -72,6 +72,7 @@ class BaseClient:
         cls,
         server_urls: str | Iterable[str] | None = None,
         reply_topic: str | None = None,
+        reply_ttl: float | None = None,
         **broker_kwargs: Any,
     ) -> Self:
         """Create a new client connected to a Kafka broker.
@@ -84,6 +85,13 @@ class BaseClient:
                 ``CALF_HOST_URL`` environment variable, then ``"localhost"``.
             reply_topic: Explicit reply topic name. When ``None`` (default), a
                 unique topic is generated using a uuid7 client ID.
+            reply_ttl: Optional seconds after which an un-answered reply future
+                (from :meth:`invoke_node` / :meth:`execute_node`) is evicted with
+                a :class:`~calfkit.exceptions.ReplyExpiredError`. ``None``
+                (default) disables eviction entirely — a deliberate
+                caller-responsibility choice, not a default safety ceiling.
+                Callers who need a bounded pending map under lost replies or
+                abandoned handles must opt in by setting a TTL.
             **broker_kwargs: Additional keyword arguments forwarded to
                 ``KafkaBroker`` (e.g. ``security``, ``client_id``).
 
@@ -105,7 +113,7 @@ class BaseClient:
             **broker_kwargs,
         )
 
-        dispatcher = _ReplyDispatcher()
+        dispatcher = _ReplyDispatcher(reply_ttl=reply_ttl)
         dispatcher.register(broker_connection, reply_topic, group_id)
 
         return cls(broker_connection, reply_topic, dispatcher, emitter_id=_new_client_emitter_id(client_id))
@@ -145,9 +153,44 @@ class BaseClient:
             An invocation handle with an associated future for the reply.
         """
         future = self._dispatcher.expect(correlation_id)
-
         logger.debug("[%s] invoke topic=%s reply=%s", correlation_id[:8], topic, reply_topic)
+        await self._publish_call(
+            topic=topic,
+            correlation_id=correlation_id,
+            callback_topic=reply_topic,
+            state=state,
+            overrides=overrides,
+            run_args=run_args,
+            deps=deps,
+        )
+        return InvocationHandle(
+            correlation_id=correlation_id,
+            topic=topic,
+            reply_topic=reply_topic,
+            _future=future,
+            _output_type=output_type,
+        )
 
+    async def _publish_call(
+        self,
+        *,
+        topic: str,
+        correlation_id: str,
+        callback_topic: str | None,
+        state: State,
+        overrides: OverridesState | None,
+        run_args: Sequence[Any] | None,
+        deps: dict[str, Any] | None,
+    ) -> None:
+        """Build and publish one client-originated call envelope.
+
+        Single-sources the wire shape shared by :meth:`_invoke` (*callback_topic*
+        is the reply topic) and :meth:`_emit` (*callback_topic* is ``None``, so the
+        worker suppresses the terminal point-to-point reply): the lazy
+        connect-guard, the ``CallFrame`` push, the ``Envelope`` build, and the
+        emitter headers. Callers own dispatcher registration — ``_invoke`` calls
+        ``expect()`` *before* this so a reply can never race an unregistered future.
+        """
         if not self._connection._connection:
             await self._connection.start()
 
@@ -155,12 +198,11 @@ class BaseClient:
         call_stack.push(
             CallFrame(
                 target_topic=topic,
-                callback_topic=reply_topic,
+                callback_topic=callback_topic,
                 input_args=run_args,
                 overrides=overrides,
             )
         )
-
         envelope = Envelope(
             internal_workflow_state=WorkflowState(call_stack=call_stack),
             context=SessionRunContext(state=state, deps={} if deps is None else deps),
@@ -172,13 +214,46 @@ class BaseClient:
             headers={HDR_EMITTER: self._emitter_id, HDR_EMITTER_KIND: CLIENT_KIND},
         )
 
-        return InvocationHandle(
-            correlation_id=correlation_id,
+    async def _emit(
+        self,
+        topic: str,
+        correlation_id: str,
+        state: State,
+        overrides: OverridesState | None = None,
+        run_args: Sequence[Any] | None = None,
+        deps: dict[str, Any] | None = None,
+    ) -> str:
+        """Emit a true one-way (fire-and-forget) invocation to a node.
+
+        Mirrors :meth:`_invoke` but allocates **zero** per-call client state and
+        triggers **zero** reply traffic: it does not register a reply future with
+        the dispatcher, does not build an :class:`InvocationHandle`, and pushes a
+        :class:`CallFrame` with ``callback_topic=None`` so the worker suppresses
+        the point-to-point reply on the terminal hop. The result still rides the
+        target node's ``publish_topic`` broadcast channel for traceability.
+
+        Args:
+            topic: Topic to send args to.
+            correlation_id: Correlation ID for this request, returned for tracing.
+            state: The session state.
+            overrides: Runtime overrides (agent tools, model settings).
+            run_args: The args to send to the node's run() method.
+            deps: Provided dependencies.
+
+        Returns:
+            The ``correlation_id`` of the emitted invocation, for tracing.
+        """
+        logger.debug("[%s] emit topic=%s", correlation_id[:8], topic)
+        await self._publish_call(
             topic=topic,
-            reply_topic=reply_topic,
-            _future=future,
-            _output_type=output_type,
+            correlation_id=correlation_id,
+            callback_topic=None,
+            state=state,
+            overrides=overrides,
+            run_args=run_args,
+            deps=deps,
         )
+        return correlation_id
 
     async def close(self) -> None:
         """Shut down the client gracefully.

--- a/calfkit/client/client.py
+++ b/calfkit/client/client.py
@@ -23,9 +23,62 @@ class Client(BaseClient):
 
     Builds on :class:`BaseClient` to provide user-facing methods that accept a
     natural-language prompt, construct the session state, and dispatch to a
-    target node topic. Supports both fire-and-forget (:meth:`invoke_node`) and
-    request/reply (:meth:`execute_node`) patterns.
+    target node topic. Three invocation patterns are supported:
+
+    * **One-way fire-and-forget** (:meth:`emit_to_node`) — publish and return the
+      ``correlation_id`` immediately; no reply future, no reply traffic.
+    * **Async with handle** (:meth:`invoke_node`) — publish and return an
+      :class:`InvocationHandle` whose :meth:`~InvocationHandle.result` is awaited
+      later for the reply.
+    * **Sync request/reply** (:meth:`execute_node`) — publish and await the reply
+      in a single call.
+
+    See :meth:`emit_to_node` for the fire-and-forget traceability model (the
+    target node's ``publish_topic`` broadcast stream).
     """
+
+    def _build_state_and_overrides(
+        self,
+        user_prompt: str,
+        *,
+        correlation_id: str | None,
+        temp_instructions: str | None,
+        message_history: list[ModelMessage] | None,
+        tool_overrides: list[BaseToolNodeSchema] | None,
+        model_settings: ModelSettings | dict[str, Any] | None,
+    ) -> tuple[str, State, OverridesState | None]:
+        """Shared input-shaping for :meth:`invoke_node` / :meth:`emit_to_node`.
+
+        Validates that *model_settings* is JSON-serializable (it crosses the Kafka
+        boundary), defaults *correlation_id* to a fresh uuid7 hex, builds and
+        stages the :class:`State` from *user_prompt* + *message_history*, and
+        builds the :class:`OverridesState` (or ``None`` when neither
+        *tool_overrides* nor *model_settings* is set). Returns
+        ``(correlation_id, state, overrides)``.
+
+        Raises:
+            ValueError: If *model_settings* is not JSON-serializable.
+        """
+        if model_settings is not None:
+            try:
+                json.dumps(model_settings, allow_nan=False)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"model_settings is not JSON-serializable: {exc}. Payload: {model_settings!r}") from exc
+
+        if correlation_id is None:
+            correlation_id = uuid_utils.uuid7().hex
+
+        state = State(message_history=message_history or list(), temp_instructions=temp_instructions)
+        state.stage_message(ModelRequest.user_text_prompt(user_prompt))
+        overrides = (
+            OverridesState(
+                override_agent_tools=tool_overrides,
+                model_settings=dict(model_settings) if model_settings is not None else None,
+            )
+            if tool_overrides is not None or model_settings is not None
+            else None
+        )
+        return correlation_id, state, overrides
 
     @overload
     async def invoke_node(
@@ -77,9 +130,12 @@ class Client(BaseClient):
     ) -> InvocationHandle[Any]:
         """Invoke an agent node asynchronously and return a handle for the reply.
 
-        Constructs a :class:`State` from the provided prompt and message history,
-        publishes it to *topic*, and returns an :class:`InvocationHandle` whose
-        :meth:`~InvocationHandle.result` method can be awaited for the reply.
+        The **async-with-handle** pattern: constructs a :class:`State` from the
+        provided prompt and message history, publishes it to *topic*, and returns
+        an :class:`InvocationHandle` whose :meth:`~InvocationHandle.result` method
+        can be awaited for the reply. For a true one-way send that registers no
+        reply future, use :meth:`emit_to_node`; to publish and await in one call,
+        use :meth:`execute_node`.
 
         Args:
             user_prompt: The user message to send to the agent node.
@@ -109,27 +165,16 @@ class Client(BaseClient):
             An :class:`InvocationHandle` whose ``result()`` resolves to a
             :class:`NodeResult`.
         """
-        if model_settings is not None:
-            try:
-                json.dumps(model_settings, allow_nan=False)
-            except (TypeError, ValueError) as exc:
-                raise ValueError(f"model_settings is not JSON-serializable: {exc}. Payload: {model_settings!r}") from exc
-
-        if correlation_id is None:
-            correlation_id = uuid_utils.uuid7().hex
+        correlation_id, state, overrides = self._build_state_and_overrides(
+            user_prompt,
+            correlation_id=correlation_id,
+            temp_instructions=temp_instructions,
+            message_history=message_history,
+            tool_overrides=tool_overrides,
+            model_settings=model_settings,
+        )
         if reply_topic is None:
             reply_topic = self._reply_topic
-
-        state = State(message_history=message_history or list(), temp_instructions=temp_instructions)
-        state.stage_message(ModelRequest.user_text_prompt(user_prompt))
-        overrides = (
-            OverridesState(
-                override_agent_tools=tool_overrides,
-                model_settings=dict(model_settings) if model_settings is not None else None,
-            )
-            if tool_overrides is not None or model_settings is not None
-            else None
-        )
         return await self._invoke(
             topic=topic,
             reply_topic=reply_topic,
@@ -139,6 +184,76 @@ class Client(BaseClient):
             overrides=overrides,
             deps=deps,
             output_type=output_type,
+        )
+
+    async def emit_to_node(
+        self,
+        user_prompt: str,
+        topic: str,
+        *,
+        tool_overrides: list[BaseToolNodeSchema] | None = None,
+        correlation_id: str | None = None,
+        temp_instructions: str | None = None,
+        message_history: list[ModelMessage] | None = None,
+        run_args: Sequence[Any] | None = None,
+        deps: dict[str, Any] | None = None,
+        model_settings: ModelSettings | dict[str, Any] | None = None,
+    ) -> str:
+        """Emit a true one-way (fire-and-forget) invocation to an agent node.
+
+        The **one-way fire-and-forget** pattern: constructs a :class:`State` from
+        the provided prompt and message history and publishes it to *topic*,
+        returning immediately. Unlike :meth:`invoke_node`, this registers **no**
+        reply future and the worker suppresses the point-to-point callback on the
+        terminal hop, so the call allocates zero per-call client state and
+        triggers zero reply traffic.
+
+        Because no reply is collected, there is no ``reply_topic`` or
+        ``output_type``. The terminal result still rides the target node's
+        ``publish_topic`` broadcast channel for traceability — wire a
+        ``@consumer`` to that topic to observe results. A target node with no
+        ``publish_topic`` leaves no trace of the invocation.
+
+        Args:
+            user_prompt: The user message to send to the agent node.
+            topic: The Kafka topic the target node subscribes to.
+            tool_overrides: Runtime agent tool overrides.
+            correlation_id: Unique identifier to correlate this request with any
+                downstream traces. Auto-generated (uuid7) when ``None``.
+            temp_instructions: Optional system-level instructions injected into
+                the user prompt as a temporary prompt addition.
+            message_history: Prior conversation messages to include for
+                multi-turn context. Defaults to an empty history.
+            run_args: Positional arguments forwarded to the node's ``run()``
+                method.
+            deps: A mapping of dependency keys to values, made available to
+                the node's tools at runtime via the session context.
+            model_settings: Per-call model settings (e.g. ``{"temperature": 0.0}``)
+                that merge over the agent's constructor defaults, which in turn
+                merge over the model client's defaults. Must be JSON-serializable
+                since it travels over Kafka.
+
+        Returns:
+            The ``correlation_id`` of the emitted invocation, for tracing.
+
+        Raises:
+            ValueError: If *model_settings* is not JSON-serializable.
+        """
+        correlation_id, state, overrides = self._build_state_and_overrides(
+            user_prompt,
+            correlation_id=correlation_id,
+            temp_instructions=temp_instructions,
+            message_history=message_history,
+            tool_overrides=tool_overrides,
+            model_settings=model_settings,
+        )
+        return await self._emit(
+            topic=topic,
+            correlation_id=correlation_id,
+            run_args=run_args,
+            state=state,
+            overrides=overrides,
+            deps=deps,
         )
 
     @overload
@@ -232,6 +347,11 @@ class Client(BaseClient):
 
         Raises:
             asyncio.TimeoutError: If *timeout* elapses before a reply arrives.
+            ReplyExpiredError: If the client was created with a ``reply_ttl`` and
+                the reply is evicted before arriving (propagated from
+                :meth:`InvocationHandle.result`). Not raised when ``reply_ttl`` is
+                ``None`` (the default).
+            ValueError: If *model_settings* is not JSON-serializable.
         """
         handle = await self.invoke_node(
             user_prompt,

--- a/calfkit/client/invocation_handle.py
+++ b/calfkit/client/invocation_handle.py
@@ -29,7 +29,16 @@ class InvocationHandle(Generic[OutputT]):
 
         Raises:
             asyncio.TimeoutError: If *timeout* elapses before a reply arrives.
-            RuntimeError: If this handle was created without a future (fire-and-forget).
+            ReplyExpiredError: If the client was created with a ``reply_ttl`` and
+                no reply arrived before it elapsed — the reply future is evicted
+                and this raises instead of waiting forever. Carries the
+                ``correlation_id`` and ``ttl``. Not raised when ``reply_ttl`` is
+                ``None`` (the default), where the await blocks indefinitely.
+            RuntimeError: Defensive guard for a handle constructed without a
+                future. Not reachable in normal use — handles are only built by
+                ``_invoke`` with a real future; true one-way sends use
+                :meth:`Client.emit_to_node`, which returns a ``correlation_id`` and
+                no handle at all.
             DeserializationError: If the expected output part type is missing
                 from ``final_output_parts``.
             pydantic.ValidationError: If ``output_type`` is provided and the

--- a/calfkit/client/reply_dispatcher.py
+++ b/calfkit/client/reply_dispatcher.py
@@ -2,22 +2,50 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
+from dataclasses import dataclass
 from typing import Annotated, Any
 
 from faststream import Context
 from faststream.kafka import KafkaBroker
 
 from calfkit._protocol import HDR_EMITTER, HDR_EMITTER_KIND, decode_header_str
+from calfkit.exceptions import ReplyExpiredError
 from calfkit.models.envelope import Envelope
 
 logger = logging.getLogger(__name__)
 
 
-class _ReplyDispatcher:
-    """Shared reply consumer that dispatches incoming envelopes to futures keyed by correlation_id."""
+@dataclass(frozen=True)
+class _PendingEntry:
+    """A pending reply: its future plus an optional eviction timer.
 
-    def __init__(self) -> None:
-        self._pending: dict[str, asyncio.Future[Envelope]] = {}
+    Frozen so the ``(future, timer)`` pairing cannot be reassigned after
+    construction (mirrors the frozen ``CallFrame``). ``timer`` is the
+    ``asyncio.TimerHandle`` scheduled when a ``reply_ttl`` is configured; it is
+    cancelled once the future completes so a stale timer never fires after
+    resolution.
+    """
+
+    future: asyncio.Future[Envelope]
+    timer: asyncio.TimerHandle | None = None
+
+
+class _ReplyDispatcher:
+    """Shared reply consumer that dispatches incoming envelopes to futures keyed by correlation_id.
+
+    When *reply_ttl* is set, each expected reply is backed by a timer that evicts
+    the pending future with :class:`ReplyExpiredError` once the TTL elapses. The
+    default (``None``) disables eviction entirely: this is a deliberate
+    caller-responsibility choice, not a default safety ceiling — callers who need
+    a bounded ``_pending`` under lost replies or abandoned handles must opt in.
+    """
+
+    def __init__(self, reply_ttl: float | None = None) -> None:
+        if reply_ttl is not None and not (math.isfinite(reply_ttl) and reply_ttl > 0):
+            raise ValueError(f"reply_ttl must be a positive, finite number of seconds or None; got {reply_ttl!r}")
+        self._pending: dict[str, _PendingEntry] = {}
+        self._reply_ttl = reply_ttl
 
     def register(self, broker: KafkaBroker, reply_topic: str, group_id: str) -> None:
         """Register a FastStream subscriber on *reply_topic*. Must be called before ``broker.start()``."""
@@ -28,37 +56,104 @@ class _ReplyDispatcher:
             correlation_id: Annotated[str, Context()],
             headers: Annotated[dict[str, Any], Context("message.headers")],
         ) -> None:
-            # Stash the inbound correlation id + emitter so the context surfaces
-            # them (ctx.correlation_id, NodeResult.emitter_node_id / kind). All are
-            # transport-sourced, never read from the envelope body.
-            envelope.context._stamp_transport(
-                correlation_id=correlation_id,
-                emitter_node_id=decode_header_str(headers.get(HDR_EMITTER)),
-                emitter_node_kind=decode_header_str(headers.get(HDR_EMITTER_KIND)),
-            )
+            # The subscriber only binds transport-sourced values (correlation_id,
+            # headers) and forwards to _on_reply, which holds the dispatch logic
+            # so it is unit-testable without driving the broker.
+            self._on_reply(envelope, correlation_id, headers)
 
-            future = self._pending.pop(correlation_id, None)
-            if future is None:
-                logger.warning("[%s] reply received but no pending future", correlation_id[:8])
-                return
-            if future.cancelled():
-                logger.debug("[%s] reply received but future already cancelled", correlation_id[:8])
-                return
-            future.set_result(envelope)
+    def _on_reply(self, envelope: Envelope, correlation_id: str, headers: dict[str, Any]) -> None:
+        """Route an inbound reply envelope to its pending future by correlation id.
+
+        Split out of the FastStream subscriber closure so the dispatch branches
+        (unknown id → warning; already-done future → quiet drop; otherwise resolve)
+        can be exercised directly. All identity is transport-sourced, never read
+        from the envelope body.
+        """
+        # Stash the inbound correlation id + emitter so the context surfaces them
+        # (ctx.correlation_id, NodeResult.emitter_node_id / kind).
+        envelope.context._stamp_transport(
+            correlation_id=correlation_id,
+            emitter_node_id=decode_header_str(headers.get(HDR_EMITTER)),
+            emitter_node_kind=decode_header_str(headers.get(HDR_EMITTER_KIND)),
+        )
+
+        entry = self._pending.get(correlation_id)
+        if entry is None:
+            logger.warning("[%s] reply received but no pending future", correlation_id[:8])
+            return
+        future = entry.future
+        if future.done():
+            # The future was already resolved or evicted (e.g. ReplyExpiredError
+            # fired before this late reply arrived). Drop it quietly.
+            logger.debug("[%s] reply received but future already done", correlation_id[:8])
+            return
+        future.set_result(envelope)
 
     def expect(self, correlation_id: str) -> asyncio.Future[Envelope]:
-        """Create and return a future for *correlation_id*. Raises if already pending."""
+        """Create and return a future for *correlation_id*. Raises if already pending.
+
+        When ``reply_ttl`` is configured, an eviction timer is scheduled so the
+        future fails with :class:`ReplyExpiredError` if no reply arrives in time.
+        """
         if correlation_id in self._pending:
             raise RuntimeError(f"Duplicate correlation_id: {correlation_id}")
         loop = asyncio.get_running_loop()
         future: asyncio.Future[Envelope] = loop.create_future()
-        self._pending[correlation_id] = future
-        future.add_done_callback(lambda _: self._pending.pop(correlation_id, None))
+        timer: asyncio.TimerHandle | None = None
+        if self._reply_ttl is not None:
+            # Bind the concrete float into the callback so _evict receives a
+            # non-optional ttl — no assert / re-read of self._reply_ttl (which
+            # ``python -O`` would strip; see session_context.correlation_id).
+            timer = loop.call_later(self._reply_ttl, self._evict, correlation_id, self._reply_ttl)
+        self._pending[correlation_id] = _PendingEntry(future=future, timer=timer)
+        future.add_done_callback(lambda _: self._discard(correlation_id))
         return future
 
+    def _evict(self, correlation_id: str, ttl: float) -> None:
+        """Timer callback: fail a still-pending future with ``ReplyExpiredError``."""
+        entry = self._pending.get(correlation_id)
+        if entry is None or entry.future.done():
+            return
+        entry.future.set_exception(ReplyExpiredError(correlation_id, ttl))
+
+    @staticmethod
+    def _retrieve_exception(future: asyncio.Future[Envelope]) -> None:
+        """Mark a done future's exception retrieved so an abandoned (never-awaited)
+        future cannot trigger asyncio's "Future exception was never retrieved" log.
+
+        Idempotent — an awaiting caller still receives the exception — and a no-op
+        for a result-resolved future (``exception()`` returns ``None``). Skipped
+        for a cancelled future, where ``exception()`` would raise
+        ``CancelledError``. The eviction path relies on this read; do not guard it
+        behind ``if exception``.
+        """
+        if future.done() and not future.cancelled():
+            future.exception()
+
+    def _discard(self, correlation_id: str) -> None:
+        """Done-callback: drop the entry, cancel its timer, retrieve any exception."""
+        entry = self._pending.pop(correlation_id, None)
+        if entry is None:
+            return
+        if entry.timer is not None:
+            entry.timer.cancel()
+        self._retrieve_exception(entry.future)
+
     def close(self) -> None:
-        """Cancel all pending futures and clear the registry."""
-        for future in self._pending.values():
-            if not future.done():
-                future.cancel()
+        """Cancel pending timers + futures and clear the registry.
+
+        A future already evicted (done with ``ReplyExpiredError``) but not yet
+        discarded — ``_evict`` schedules ``_discard`` via ``call_soon``, so there
+        is a window where the entry is still registered — has its exception
+        retrieved here, so ``close()`` does not leak the "never retrieved" warning
+        the eviction machinery exists to suppress. Still-pending futures are
+        cancelled.
+        """
+        for entry in self._pending.values():
+            if entry.timer is not None:
+                entry.timer.cancel()
+            if entry.future.done():
+                self._retrieve_exception(entry.future)
+            else:
+                entry.future.cancel()
         self._pending.clear()

--- a/calfkit/exceptions.py
+++ b/calfkit/exceptions.py
@@ -5,6 +5,27 @@ class DeserializationError(Exception):
     """Raised when client-side output deserialization fails."""
 
 
+class ReplyExpiredError(Exception):
+    """Raised when an awaited reply does not arrive within the dispatcher's
+    ``reply_ttl`` and the pending future is evicted.
+
+    Surfacing this (instead of a bare ``CancelledError``) gives callers an
+    actionable signal carrying the offending ``correlation_id`` and the ``ttl``
+    (seconds) that elapsed.
+    """
+
+    def __init__(self, correlation_id: str, ttl: float):
+        self.correlation_id = correlation_id
+        self.ttl = ttl
+        super().__init__(f"No reply for correlation_id={correlation_id!r} within reply_ttl={ttl}s")
+
+    def __reduce__(self) -> tuple[Any, tuple[str, float]]:
+        # The default reduction replays ``self.args`` (the formatted message
+        # string) through ``__init__``, which would fail because the constructor
+        # requires both positional fields. Reconstruct from the real fields.
+        return (self.__class__, (self.correlation_id, self.ttl))
+
+
 class ToolExecutionError(Exception):
     """The original traceback is not preserved across the Kafka boundary; it is
     logged at the worker that ran the tool. ``exc_type`` and ``exc_message`` are

--- a/calfkit/models/session_context.py
+++ b/calfkit/models/session_context.py
@@ -33,7 +33,7 @@ class Stack(Generic[StackItemT]):
 @dataclass(frozen=True)
 class CallFrame:
     target_topic: str
-    callback_topic: str  # return address
+    callback_topic: str | None  # return address; ``None`` = fire-and-forget, no requester to return to
     input_args: Sequence[Any] | None = field(default=None)
     frame_id: str = field(default_factory=lambda: uuid_utils.uuid7().hex)
     overrides: OverridesState | None = field(default=None)
@@ -59,7 +59,7 @@ class WorkflowState(BaseModel):
     def unwind_frame(self) -> CallFrame:
         return self.call_stack.pop()
 
-    def invoke_frame(self, call: _Call, callback_topic: str) -> None:
+    def invoke_frame(self, call: _Call, callback_topic: str | None) -> None:
         if call.target_topic is None:
             raise Exception("")
         frame = CallFrame(

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -218,14 +218,21 @@ class BaseNodeDef(BaseNodeSchema):
                 context=SessionRunContext(state=output.state, deps=envelope.context.deps),
                 internal_workflow_state=envelope.internal_workflow_state,
             )
-            logger.debug("[%s] ReturnCall callback=%s node=%s", correlation_id[:8], frame.callback_topic, self.node_id)
-            await broker.publish(
-                publish_envelope,
-                topic=frame.callback_topic,
-                correlation_id=correlation_id,
-                key=correlation_id.encode(),
-                headers=self._emitter_headers(),
-            )
+            if frame.callback_topic is None:
+                # Fire-and-forget terminal: no requester to return to. Skip the
+                # point-to-point callback publish, but still return
+                # ``publish_envelope`` below so the worker's @publisher broadcasts
+                # the terminal result to ``publish_topic`` (the traceability channel).
+                logger.debug("[%s] ReturnCall no-callback fire-and-forget terminal node=%s", correlation_id[:8], self.node_id)
+            else:
+                logger.debug("[%s] ReturnCall callback=%s node=%s", correlation_id[:8], frame.callback_topic, self.node_id)
+                await broker.publish(
+                    publish_envelope,
+                    topic=frame.callback_topic,
+                    correlation_id=correlation_id,
+                    key=correlation_id.encode(),
+                    headers=self._emitter_headers(),
+                )
 
         elif isinstance(output, TailCall):
             # tailcall optimization: replace current call frame with new tailcall

--- a/docs/fire-and-forget-emit.md
+++ b/docs/fire-and-forget-emit.md
@@ -1,0 +1,192 @@
+# Fire-and-forget emit
+
+| | |
+|---|---|
+| Status | Implemented |
+| Closes | #132 (`Client.invoke_node` is documented as "fire-and-forget" but always allocates per-call reply state and triggers reply traffic) |
+| Breaking | Yes — `feat!` (the wire `CallFrame.callback_topic` becomes nullable; old workers can't read a `None` terminal) |
+
+## Problem
+
+`Client.invoke_node` was advertised as "fire-and-forget", but tracing the wire path
+end-to-end shows it is anything but. Both `invoke_node` and `execute_node` route through
+`BaseClient._invoke`, which **always** registers an `asyncio.Future` in
+`_ReplyDispatcher._pending` (`base.py`) and pushes a `CallFrame` whose `callback_topic` is
+the client's ephemeral reply inbox. That has three costs:
+
+- **Per-call client state.** Every call pins a `Future` keyed by `correlation_id`, even when
+  the caller never awaits it.
+- **Unconditional reply traffic.** The worker's terminal `ReturnCall` **always** publishes a
+  reply to the bottom frame's `callback_topic` — the client's reply inbox. So even a caller
+  who never reads the result causes a full reply serialize + Kafka publish, and the client's
+  own dispatcher consumes it and logs `"reply received but no pending future"`.
+- **A genuine permanent leak.** If a reply is lost / never arrives, or an `invoke_node` handle
+  is abandoned, the future is pinned in `_pending` forever. (`execute_node` self-cleans *only when
+  called with an explicit `timeout`* — its `wait_for(timeout)` cancel evicts the future; with the
+  default `timeout=None` it awaits the future directly and leaks just like `invoke_node`, which
+  never self-cleans.)
+
+There was no true one-way send: no way to dispatch work to a node, allocate zero per-call
+state, and produce zero reply traffic.
+
+## The key architectural fact: two independent output channels
+
+The change is safe — and traceable — because calfkit emits on **two independent output
+channels** per hop:
+
+1. **The callback / reply channel** (`CallFrame.callback_topic`) — a point-to-point return
+   address that routes the terminal result back to whoever requested it (for a client
+   invocation, the client's ephemeral reply inbox).
+2. **The broadcast channel** (`publish_topic`) — every hop's envelope, *including the terminal
+   one carrying `final_output_parts`*, is published to the node's configured `publish_topic`
+   via the worker's `@publisher` wiring.
+
+These fire independently. In the worker's terminal `ReturnCall` branch, the same
+`publish_envelope` is both `publish`ed to the callback topic **and** `return`ed from the
+handler — and the publisher decorator broadcasts that returned envelope to `publish_topic`.
+
+The consequence is the load-bearing insight of this design: **suppressing the callback does
+not lose traceability.** The terminal result still rides `publish_topic` as a durable Kafka
+record — exactly the stream that `@consumer` nodes already tap (see the consumer-node section
+of the README), and exactly how `execute_node` results are already observable. A
+fire-and-forget send is therefore *not* a blind send: its outcome is fully observable on the
+target node's `publish_topic`, just without a point-to-point reply.
+
+The only residual gap is a target node with **no** `publish_topic` configured — then a
+fire-and-forget send is genuinely unobservable. We close that with guidance (below), not new
+API, per maintainer direction.
+
+## Solution
+
+A true one-way client method, `Client.emit_to_node`, that allocates zero per-call state and
+triggers zero reply traffic; a nullable `callback_topic` on the wire so the terminal hop can
+be callback-less; honest docstrings; and an opt-in TTL backstop for the existing handle path.
+
+### 1. Wire model — nullable callback
+
+`CallFrame.callback_topic` becomes `str | None`. `None` means "fire-and-forget; there is no
+requester to return to." `WorkflowState.invoke_frame(call, callback_topic: str | None)` is
+widened to match — it only stores the value, and `TailCall` already re-pushes the inherited
+callback, so a `None` propagates harmlessly down a tail chain. `CallFrame` is a frozen stdlib
+dataclass with no validators, so the pydantic schema accepts `null` and no existing
+constructor call site breaks.
+
+### 2. Worker — tolerate a callback-less terminal
+
+In `_publish_action`'s `ReturnCall` branch (`calfkit/nodes/base.py`), the point-to-point
+publish is guarded:
+
+```python
+frame = envelope.internal_workflow_state.unwind_frame()
+publish_envelope = Envelope(...)
+if frame.callback_topic is not None:
+    await broker.publish(publish_envelope, topic=frame.callback_topic, ...)
+else:
+    logger.debug("[%s] no-callback fire-and-forget terminal node=%s", ...)
+return publish_envelope
+```
+
+The `return publish_envelope` is **unchanged** — the terminal result is still broadcast to
+`publish_topic` (the traceability channel). Tool round-trips use `_return_topic`, never the
+client callback, so only the bottom (client) frame is ever `None`; no intermediate hop is
+affected.
+
+### 3. Client — `emit_to_node`
+
+`BaseClient._emit(...)` mirrors `_invoke` minus `self._dispatcher.expect(...)`, the
+`InvocationHandle`, and the `reply_topic`. It pushes a
+`CallFrame(target_topic=topic, callback_topic=None, ...)`, publishes with the same emitter
+headers as `_invoke`, and **returns the `correlation_id`** (a `str`) for tracing/correlation.
+
+`Client.emit_to_node(...)` takes the same input-shaping arguments as `invoke_node`
+(`tool_overrides`, `temp_instructions`, `message_history`, `run_args`, `deps`,
+`model_settings`, `correlation_id`) **minus** `reply_topic` and `output_type` — both are
+meaningless when there is no reply to route or deserialize. It reuses `invoke_node`'s
+`model_settings` JSON-serializability guard, `State` construction, and `OverridesState` build,
+and returns the `correlation_id`.
+
+The name `emit_to_node` mirrors calfkit's own `Emit` node action ("fire-and-forget publish, no
+reply expected") and forms a clean three-way set:
+
+| Method | Pattern | Returns | Per-call state |
+|---|---|---|---|
+| `emit_to_node` | one-way fire-and-forget | `correlation_id: str` | none |
+| `invoke_node` | async, reply via handle | `InvocationHandle` | a pending `Future` until resolved/evicted |
+| `execute_node` | sync request/reply | `NodeResult` | a pending `Future` (self-cleaning only when called with an explicit `timeout`) |
+
+A runnable end-to-end example lives at [`examples/quickstart/emit.py`](../examples/quickstart/emit.py).
+Pair it with [`examples/quickstart/weather_sink.py`](../examples/quickstart/weather_sink.py) — a
+`@consumer` tapping the agent's `publish_topic` — to watch the fire-and-forget result arrive on the
+broadcast channel even though no point-to-point reply is returned.
+
+### 4. Docstring honesty
+
+The `Client` class docstring and `invoke_node` docstring are relabeled to the three patterns
+above. `invoke_node` is no longer called "fire-and-forget" — it is the *async-with-handle*
+pattern; `emit_to_node` is the true fire-and-forget.
+
+### 5. `publish_topic` guidance for traceability
+
+Because suppressing the callback preserves the `publish_topic` broadcast, the guidance for
+fire-and-forget is simple and concrete:
+
+- **Set a `publish_topic` on any node you `emit_to_node` to** if you want its outcome to be
+  observable. Tap that topic with a `@consumer` node (or any envelope-aware subscriber) to log,
+  persist, or alert on terminals — `result.output` is populated on the terminal hop exactly as
+  it is for `execute_node`.
+- **Residual gap:** a node with no `publish_topic` produces *no* observable record for a
+  fire-and-forget send — there is neither a reply nor a broadcast. This is the one case where
+  `emit_to_node` is genuinely blind. The fix is configuration (add a `publish_topic`), not API;
+  it is called out here so the tradeoff is explicit rather than surprising.
+
+### 6. Opt-in reply TTL backstop
+
+The permanent-leak failure mode (an abandoned `invoke_node` handle, or a lost reply) is
+addressed by an **opt-in** TTL on the reply dispatcher. It is *off by default* — a deliberate
+caller-responsibility choice, not a back-compat concession. Callers who want `_pending` bounded
+under lost replies / abandoned handles **must** set a TTL; there is no silently-applied safety
+ceiling.
+
+- `_ReplyDispatcher.__init__(self, reply_ttl: float | None = None)` — `None` means no eviction.
+- `_pending` holds a `_PendingEntry` (future + optional `asyncio.TimerHandle`) instead of a bare
+  `Future`.
+- `expect()` schedules `loop.call_later(reply_ttl, self._evict, correlation_id)` when a TTL is set.
+- `_evict()` sets `ReplyExpiredError(correlation_id, ttl)` on the future if it is still pending.
+- The done-callback pops the entry, cancels the timer (so a stale timer never fires after the
+  future completes), and retrieves the eviction exception so an abandoned future — one nobody
+  awaits — does not trigger asyncio's "Future exception was never retrieved" log. `_on_reply`
+  (the dispatch logic split out of the `_handle_reply` subscriber closure) guards on
+  `future.done()` so a reply that arrives after eviction is dropped at `debug` rather than warning.
+- `close()` mirrors that retrieval for a future evicted but not yet discarded (the `_evict`→
+  `_discard` `call_soon` window), so shutdown never leaks the same warning.
+- `close()` cancels timers and futures.
+- `reply_ttl` is threaded through `Client.connect(..., reply_ttl=None)` →
+  `_ReplyDispatcher(reply_ttl=...)`.
+
+`ReplyExpiredError` is added to `calfkit/exceptions.py` carrying `correlation_id` and `ttl`, so
+`handle.result()` raises something actionable on eviction instead of a bare `CancelledError`.
+
+`emit_to_node` registers **no** future, so the TTL does not apply to it — it has nothing to
+evict. The TTL exists solely to bound the `invoke_node` handle path.
+
+## Conscious decisions
+
+- **Hard break, no shims.** Per maintainer direction this lands as a `feat!` with a
+  `BREAKING CHANGE:` footer (mirroring `feat!: deps as dict ...`). The wire `callback_topic`
+  becomes nullable; an old worker would not understand a `None` terminal. There is no
+  version-skew shim and no mixed old/new worker+client compatibility layer — deploy a uniform
+  calfkit version (framework-internal envelope; 0.x). Roll workers before clients so a callback-
+  less terminal is never produced against a worker that can't handle it.
+- **TTL defaults to `None`.** Bounding `_pending` is the caller's responsibility and is
+  documented as such. A silent default ceiling would surprise callers who legitimately wait a
+  long time for a reply; an explicit opt-in is honest about the tradeoff.
+- **No defensive copy / no new hang path.** `emit_to_node` reuses the exact `State` /
+  `OverridesState` / publish machinery as `invoke_node`; the only delta is "don't register a
+  future, push a `None` callback." `_invoke` is left intact for the handle path.
+
+## Out of scope / deferred
+
+- **Delayed / scheduled send** (e.g. a Restate-style `WithDelay`) — a possible follow-up; not
+  part of this change.
+- **Wiring the unused `Emit` node action into the `NodeResult` union** so a node (not just a
+  client) can fire-and-forget to another node — deferred.

--- a/examples/quickstart/emit.py
+++ b/examples/quickstart/emit.py
@@ -1,0 +1,26 @@
+import asyncio
+
+from calfkit.client import Client
+
+
+async def main():
+    # ``async with`` shuts the client down cleanly on exit, flushing the Kafka
+    # producer. This matters for fire-and-forget: there is no reply to await
+    # that would otherwise keep the client alive while the send completes.
+    async with Client.connect("localhost:9092") as client:  # Connect to Kafka broker
+        # Fire-and-forget: dispatch the request and return immediately. No reply
+        # is produced and no client-side reply future is allocated — emit_to_node
+        # hands back only the correlation_id, for tracing/logging.
+        correlation_id = await client.emit_to_node(
+            "What's the weather in Tokyo?",
+            "weather_agent.input",  # The topic the agent subscribes to
+        )
+        print(f"Dispatched fire-and-forget — correlation_id={correlation_id}")
+
+    # There is no reply to await. To observe the result, tap the agent's
+    # publish_topic broadcast stream: run weather_sink.py (a @consumer on
+    # weather_agent.output) and watch the terminal output stream by.
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_fire_and_forget.py
+++ b/tests/test_fire_and_forget.py
@@ -1,0 +1,383 @@
+"""Unit-scope contracts for the fire-and-forget (null-callback) terminal, plus
+end-to-end tests for the true one-way ``Client.emit_to_node`` method.
+
+The unit tests drive ``BaseNodeDef._publish_action`` directly with a spy broker
+(mirroring ``tests/test_co_tenant_tool_isolation.py``) so the worker's terminal
+callback-guard is isolated from the messaging layer.
+
+A bottom call frame with ``callback_topic=None`` represents a true
+fire-and-forget invocation: there is no requester to return a point-to-point
+reply to. The worker must therefore NOT publish to a callback topic on the
+terminal ``ReturnCall`` — yet it must still build and return the terminal
+envelope so the result is broadcast to the node's ``publish_topic`` (the
+traceability channel via the worker's ``@publisher`` wiring).
+
+The end-to-end tests mirror ``tests/test_headers.py`` (TestKafkaBroker +
+FunctionModel + ``prepare_worker``): they prove ``emit_to_node`` allocates zero
+per-call client state and that the broadcast ``publish_topic`` channel still
+records the terminal result even though the point-to-point callback is
+suppressed (no reply future, no "no pending future" warning).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from faststream.kafka import KafkaBroker, TestKafkaBroker
+
+from calfkit._vendor.pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, ToolCallPart, ToolReturnPart
+from calfkit._vendor.pydantic_ai.messages import TextPart as ModelTextPart
+from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
+from calfkit.client import Client, NodeResult
+from calfkit.models.actions import ReturnCall
+from calfkit.models.envelope import Envelope
+from calfkit.models.payload import TextPart
+from calfkit.models.session_context import (
+    CallFrame,
+    CallFrameStack,
+    SessionRunContext,
+    WorkflowState,
+)
+from calfkit.models.state import State
+from calfkit.nodes import Agent, agent_tool, consumer
+from calfkit.nodes.base import BaseNodeDef
+from calfkit.worker import Worker
+from tests.providers import prepare_worker
+
+REPLY_DISPATCHER_LOGGER = "calfkit.client.reply_dispatcher"
+
+
+class _TerminalNode(BaseNodeDef):
+    """Minimal concrete node so ``_publish_action`` can be exercised in isolation."""
+
+    async def run(self, ctx: SessionRunContext, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover - unused
+        return ReturnCall(state=ctx.state)
+
+
+def _make_node() -> _TerminalNode:
+    return _TerminalNode(
+        node_id="terminal_node",
+        subscribe_topics=["terminal_node.input"],
+        publish_topic="terminal_node.output",
+    )
+
+
+def _make_envelope(callback_topic: str | None) -> Envelope:
+    stack = CallFrameStack()
+    stack.push(CallFrame(target_topic="terminal_node.input", callback_topic=callback_topic))
+    return Envelope(
+        context=SessionRunContext(state=State(), deps={}),
+        internal_workflow_state=WorkflowState(call_stack=stack),
+    )
+
+
+async def test_return_call_with_null_callback_publishes_no_callback():
+    """A ``ReturnCall`` on a ``callback_topic=None`` frame must NOT publish to any
+    callback topic, yet must still return the terminal envelope carrying the
+    final state (so the broadcast/traceability channel still fires)."""
+    node = _make_node()
+    envelope = _make_envelope(callback_topic=None)
+
+    broker = MagicMock()
+    broker.publish = AsyncMock()
+
+    final_state = State()
+    result = await node._publish_action(ReturnCall(state=final_state), envelope, "cid-ff", broker)
+
+    assert broker.publish.call_count == 0, f"expected no callback publish for null-callback terminal; got {broker.publish.call_count}"
+    # The terminal envelope must still be returned so the worker's @publisher
+    # broadcasts it to publish_topic (the traceability channel).
+    assert isinstance(result, Envelope)
+    assert result.context.state is final_state
+
+
+async def test_return_call_with_non_null_callback_publishes_to_callback():
+    """Contrast: a ``ReturnCall`` on a frame with a real ``callback_topic`` must
+    publish the point-to-point reply to that topic exactly once."""
+    node = _make_node()
+    envelope = _make_envelope(callback_topic="client.reply.inbox")
+
+    broker = MagicMock()
+    broker.publish = AsyncMock()
+
+    result = await node._publish_action(ReturnCall(state=State()), envelope, "cid-cb", broker)
+
+    assert broker.publish.call_count == 1, f"expected exactly one callback publish for non-null callback; got {broker.publish.call_count}"
+    assert broker.publish.call_args.kwargs["topic"] == "client.reply.inbox"
+    assert isinstance(result, Envelope)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: Client.emit_to_node — true one-way fire-and-forget.
+# ---------------------------------------------------------------------------
+
+
+def _text_then_done() -> FunctionModel:
+    def _fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[ModelTextPart("done")])
+
+    return FunctionModel(_fn)
+
+
+async def test_emit_to_node_allocates_no_client_state(container):
+    """Calling ``emit_to_node`` in a loop leaves ``_dispatcher._pending`` empty
+    (no reply future is ever registered) and returns a non-empty uuid-hex
+    correlation_id per call."""
+    worker = container.get(Worker)
+    agent = Agent(
+        "emit_no_state_agent",
+        system_prompt="x",
+        subscribe_topics="emit_no_state_agent.input",
+        publish_topic="emit_no_state_agent.output",
+        model_client=_text_then_done(),
+    )
+    worker.add_nodes(agent)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    correlation_ids: list[str] = []
+    async with TestKafkaBroker(broker):
+        for _ in range(5):
+            cid = await client.emit_to_node("hi", agent.subscribe_topics[0])
+            correlation_ids.append(cid)
+
+    # No future was ever registered: the dispatcher's pending map stays empty.
+    assert client._dispatcher._pending == {}
+    # Each call returns a non-empty uuid hex correlation_id.
+    assert len(correlation_ids) == 5
+    for cid in correlation_ids:
+        assert isinstance(cid, str)
+        assert cid
+        # uuid7().hex is 32 lowercase hex chars.
+        assert len(cid) == 32
+        int(cid, 16)
+    # Correlation ids are unique per call.
+    assert len(set(correlation_ids)) == 5
+
+
+async def test_emit_to_node_traceable_via_publish_topic_but_no_reply(container, caplog):
+    """The terminal result still rides the broadcast ``publish_topic`` channel (a
+    ``@consumer`` observes it with populated output), while the client reply inbox
+    receives nothing — no reply future, and no "no pending future" warning."""
+    received: list[NodeResult] = []
+
+    @consumer(subscribe_topics="emit_trace_agent.output")
+    def sink(result: NodeResult) -> None:
+        received.append(result)
+
+    worker = container.get(Worker)
+    agent = Agent(
+        "emit_trace_agent",
+        system_prompt="x",
+        subscribe_topics="emit_trace_agent.input",
+        publish_topic="emit_trace_agent.output",
+        model_client=_text_then_done(),
+    )
+    worker.add_nodes(agent, sink)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    with caplog.at_level(logging.WARNING, logger=REPLY_DISPATCHER_LOGGER):
+        async with TestKafkaBroker(broker):
+            cid = await client.emit_to_node("hi", agent.subscribe_topics[0])
+
+    # The terminal result reached the broadcast publish_topic channel.
+    final = [r for r in received if any(isinstance(p, TextPart) for p in r.output_parts)]
+    assert final, f"consumer never saw a terminal envelope; saw={received}"
+    assert final[-1].output == "done"
+    assert isinstance(final[-1], NodeResult)
+    assert final[-1].correlation_id == cid
+
+    # The client reply inbox received nothing: no pending future was registered,
+    # so the dispatcher never logged "no pending future".
+    assert client._dispatcher._pending == {}
+    no_pending_warnings = [r for r in caplog.records if "no pending future" in r.getMessage()]
+    assert not no_pending_warnings, f"client reply inbox should receive nothing; got {no_pending_warnings}"
+
+
+# ---------------------------------------------------------------------------
+# emit_to_node input-shaping: it carries its OWN copy of invoke_node's
+# model_settings guard / correlation_id default / OverridesState build / deps
+# passthrough (it does not delegate to invoke_node), so those branches are
+# covered here directly by spying on ``_emit``.
+# ---------------------------------------------------------------------------
+
+
+async def test_emit_to_node_rejects_non_json_serializable_model_settings(container):
+    """The model_settings JSON-serializability guard rejects a non-serializable
+    payload BEFORE publishing — ``_emit`` is never reached."""
+    client = container.get(Client)
+    client._emit = AsyncMock()  # the only publish path; must not be called
+
+    with pytest.raises(ValueError, match="not JSON-serializable"):
+        await client.emit_to_node("hi", "agent.input", model_settings={"bad": object()})
+
+    client._emit.assert_not_called()
+
+
+async def test_emit_to_node_uses_caller_supplied_correlation_id(container):
+    """A caller-supplied correlation_id is returned verbatim and forwarded to ``_emit``."""
+    client = container.get(Client)
+    client._emit = AsyncMock(return_value="given-cid")
+
+    returned = await client.emit_to_node("hi", "agent.input", correlation_id="given-cid")
+
+    assert returned == "given-cid"
+    assert client._emit.await_args.kwargs["correlation_id"] == "given-cid"
+
+
+async def test_emit_to_node_autogenerates_correlation_id_when_none(container):
+    """With no correlation_id, a fresh uuid7 hex is generated, forwarded to ``_emit``,
+    and returned."""
+    client = container.get(Client)
+    client._emit = AsyncMock(side_effect=lambda **kw: kw["correlation_id"])
+
+    returned = await client.emit_to_node("hi", "agent.input")
+
+    assert isinstance(returned, str) and len(returned) == 32
+    int(returned, 16)  # valid hex
+    assert client._emit.await_args.kwargs["correlation_id"] == returned
+
+
+async def test_emit_to_node_builds_overrides_and_forwards_deps_and_run_args(container):
+    """``model_settings`` builds an ``OverridesState`` carried to ``_emit``; ``deps``
+    and ``run_args`` pass through; a ``State`` is constructed for the prompt."""
+    client = container.get(Client)
+    client._emit = AsyncMock(return_value="cid")
+
+    deps = {"tenant": "acme"}
+    await client.emit_to_node(
+        "summarize",
+        "agent.input",
+        deps=deps,
+        model_settings={"temperature": 0.0},
+        run_args=("a", 1),
+    )
+
+    kwargs = client._emit.await_args.kwargs
+    assert kwargs["deps"] == deps
+    assert kwargs["run_args"] == ("a", 1)
+    assert kwargs["overrides"] is not None
+    assert kwargs["overrides"].model_settings == {"temperature": 0.0}
+    assert isinstance(kwargs["state"], State)
+
+
+async def test_emit_to_node_no_overrides_when_unset(container):
+    """With neither tool_overrides nor model_settings, no ``OverridesState`` is built."""
+    client = container.get(Client)
+    client._emit = AsyncMock(return_value="cid")
+
+    await client.emit_to_node("hi", "agent.input")
+
+    assert client._emit.await_args.kwargs["overrides"] is None
+
+
+async def test_emit_to_node_tool_overrides_only_builds_overrides(container):
+    """The tool_overrides-set / model_settings-None arm of the OverridesState OR:
+    overrides carry the tool list and a None model_settings."""
+    tool = agent_tool(lambda: "pong")  # a BaseToolNodeSchema (ToolNodeDef)
+    client = container.get(Client)
+    client._emit = AsyncMock(return_value="cid")
+
+    await client.emit_to_node("hi", "agent.input", tool_overrides=[tool])
+
+    overrides = client._emit.await_args.kwargs["overrides"]
+    assert overrides is not None
+    assert overrides.override_agent_tools == [tool]
+    assert overrides.model_settings is None
+
+
+async def test_emit_to_node_passes_temp_instructions_and_history_into_state(container):
+    """temp_instructions and message_history are carried onto the State handed to ``_emit``."""
+    client = container.get(Client)
+    client._emit = AsyncMock(return_value="cid")
+
+    history: list[ModelMessage] = [ModelRequest.user_text_prompt("earlier turn")]
+    await client.emit_to_node("now", "agent.input", temp_instructions="be brief", message_history=history)
+
+    state = client._emit.await_args.kwargs["state"]
+    assert state.temp_instructions == "be brief"
+    assert history[0] in state.message_history
+
+
+# ---------------------------------------------------------------------------
+# Multi-hop: a tool Call beneath an emitted invocation must still round-trip.
+# Only the bottom (client) frame is None; intermediate tool frames carry the
+# agent's real _return_topic, so the tool's ReturnCall routes back.
+# ---------------------------------------------------------------------------
+
+
+@agent_tool
+def ping() -> str:
+    return "pong"
+
+
+def _calls_ping_then_done() -> FunctionModel:
+    """A model that calls ``ping`` on the first turn, then summarizes once the
+    tool result is in history."""
+
+    def _fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        last = messages[-1]
+        tool_already_ran = isinstance(last, ModelRequest) and any(isinstance(p, ToolReturnPart) for p in last.parts)
+        if tool_already_ran:
+            return ModelResponse(parts=[ModelTextPart("done")])
+        return ModelResponse(parts=[ToolCallPart("ping")])
+
+    return FunctionModel(_fn)
+
+
+async def test_emit_to_node_multi_hop_tool_call_still_terminates_traceably(container, caplog):
+    """emit → agent issues a tool Call → tool ReturnCall routes back via the
+    agent's _return_topic (a NON-None intermediate callback) → agent terminal
+    ReturnCall hits the None bottom frame and suppresses the callback, while the
+    terminal still reaches publish_topic. If None ever leaked into the tool
+    frame's callback the tool round-trip would break and no terminal would
+    arrive — so a passing terminal proves the invariant."""
+    received: list[NodeResult] = []
+
+    @consumer(subscribe_topics="emit_tool_agent.output")
+    def sink(result: NodeResult) -> None:
+        received.append(result)
+
+    worker = container.get(Worker)
+    agent = Agent(
+        "emit_tool_agent",
+        system_prompt="x",
+        subscribe_topics="emit_tool_agent.input",
+        publish_topic="emit_tool_agent.output",
+        model_client=_calls_ping_then_done(),
+        tools=[ping],
+    )
+    worker.add_nodes(agent, ping, sink)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    with caplog.at_level(logging.WARNING, logger=REPLY_DISPATCHER_LOGGER):
+        async with TestKafkaBroker(broker):
+            cid = await client.emit_to_node("hi", agent.subscribe_topics[0])
+
+    # A terminal with real output reached publish_topic → the tool frame's
+    # callback was a real topic, the tool ran, and its ReturnCall routed back.
+    terminals = [r for r in received if any(isinstance(p, TextPart) for p in r.output_parts)]
+    assert terminals, f"no terminal reached publish_topic; the tool round-trip likely broke under emit: {received}"
+    assert terminals[-1].output == "done"
+    assert terminals[-1].correlation_id == cid
+
+    # The agent actually issued the ping tool call.
+    tool_called = any(
+        any(getattr(tc, "tool_name", None) == "ping" for tc in getattr(m, "tool_calls", [])) for r in received for m in r.message_history
+    )
+    assert tool_called, "agent never issued the ping tool call in the captured history"
+
+    # The bottom (client) frame callback was suppressed: no reply future, no warning.
+    assert client._dispatcher._pending == {}
+    assert not [r for r in caplog.records if "no pending future" in r.getMessage()]

--- a/tests/test_reply_dispatcher_ttl.py
+++ b/tests/test_reply_dispatcher_ttl.py
@@ -1,0 +1,303 @@
+"""Unit-scope contracts for the opt-in reply TTL backstop in ``_ReplyDispatcher``.
+
+The TTL is a deliberate, default-off, caller-responsibility feature: when a
+``reply_ttl`` is supplied, an unanswered future is evicted from ``_pending`` and
+fails with :class:`ReplyExpiredError` so an abandoned/lost reply cannot pin
+client state forever. With the default (``None``) there is no eviction at all.
+
+These tests construct ``_ReplyDispatcher`` directly and drive the real
+``asyncio`` timer path (no Kafka), which is the lightest-weight way to exercise
+``expect()`` / ``_evict`` / ``_discard`` end-to-end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import pickle
+
+import pytest
+
+from calfkit.client import Client, InvocationHandle
+from calfkit.client.reply_dispatcher import _PendingEntry, _ReplyDispatcher
+from calfkit.exceptions import ReplyExpiredError
+from calfkit.models.envelope import Envelope
+from calfkit.models.session_context import CallFrameStack, SessionRunContext, WorkflowState
+from calfkit.models.state import State
+
+REPLY_DISPATCHER_LOGGER = "calfkit.client.reply_dispatcher"
+
+
+@pytest.mark.parametrize("bad_ttl", [0, 0.0, -1.0, -0.001, float("nan"), float("inf"), float("-inf")])
+def test_invalid_reply_ttl_rejected(bad_ttl):
+    """``reply_ttl`` must be a positive, finite number of seconds (or ``None``).
+    Zero / negative would evict every future before any reply could arrive; nan /
+    inf produce undefined timer behavior. Reject at construction with a clear error."""
+    with pytest.raises(ValueError, match="reply_ttl"):
+        _ReplyDispatcher(reply_ttl=bad_ttl)
+
+
+def test_valid_reply_ttl_accepted():
+    """A positive finite TTL (and ``None``) construct without error."""
+    assert _ReplyDispatcher(reply_ttl=0.5)._reply_ttl == 0.5
+    assert _ReplyDispatcher(reply_ttl=None)._reply_ttl is None
+    assert _ReplyDispatcher()._reply_ttl is None
+
+
+def test_connect_threads_reply_ttl_to_dispatcher():
+    """``Client.connect(reply_ttl=X)`` reaches the dispatcher — the public knob a
+    user actually touches. A dropped/renamed kwarg would silently produce a
+    TTL-less dispatcher while every direct-dispatcher test stayed green."""
+    client = Client.connect("localhost", reply_ttl=12.5)
+    assert client._dispatcher._reply_ttl == 12.5
+
+
+def test_connect_default_reply_ttl_is_none():
+    """The default leaves eviction disabled (no silent safety ceiling)."""
+    client = Client.connect("localhost")
+    assert client._dispatcher._reply_ttl is None
+
+
+def test_reply_expired_error_is_picklable():
+    """The error must survive a pickle roundtrip (it may cross process/Kafka
+    boundaries) with its ``correlation_id`` and ``ttl`` intact."""
+    error = ReplyExpiredError("cid-abc", 0.25)
+    restored = pickle.loads(pickle.dumps(error))
+    assert isinstance(restored, ReplyExpiredError)
+    assert restored.correlation_id == "cid-abc"
+    assert restored.ttl == 0.25
+    assert str(restored) == str(error)
+
+
+async def test_ttl_evicts_unanswered_future():
+    """With a small ``reply_ttl``, an unanswered future raises ``ReplyExpiredError``
+    after the TTL elapses and its entry is removed from ``_pending``."""
+    ttl = 0.05
+    dispatcher = _ReplyDispatcher(reply_ttl=ttl)
+    cid = "cid-expires"
+
+    future = dispatcher.expect(cid)
+    assert cid in dispatcher._pending
+
+    await asyncio.sleep(ttl * 3)
+
+    assert future.done()
+    with pytest.raises(ReplyExpiredError) as exc_info:
+        future.result()
+    assert exc_info.value.correlation_id == cid
+    assert exc_info.value.ttl == ttl
+    assert dispatcher._pending == {}, "expired entry must be evicted from _pending"
+
+
+async def test_default_no_ttl_never_evicts():
+    """With the default ``reply_ttl=None`` there is no eviction: after the same
+    wait the future is still pending and the entry remains in ``_pending``."""
+    dispatcher = _ReplyDispatcher()
+    cid = "cid-never-evicts"
+
+    future = dispatcher.expect(cid)
+
+    await asyncio.sleep(0.15)
+
+    assert not future.done(), "no TTL means the future must stay pending"
+    assert cid in dispatcher._pending, "no TTL means the entry must remain registered"
+
+
+async def test_normal_completion_cancels_timer():
+    """A reply arriving before the TTL resolves the future, removes the entry, and
+    cancels the scheduled timer so no later ``ReplyExpiredError`` is raised."""
+    ttl = 0.05
+    dispatcher = _ReplyDispatcher(reply_ttl=ttl)
+    cid = "cid-completes"
+
+    future = dispatcher.expect(cid)
+    entry = dispatcher._pending[cid]
+    assert entry.timer is not None
+
+    sentinel = object()
+    future.set_result(sentinel)  # type: ignore[arg-type]
+    # Let the done-callback (_discard) run.
+    await asyncio.sleep(0)
+
+    assert dispatcher._pending == {}, "completed entry must be discarded"
+
+    # Wait past the original TTL; the cancelled timer must not fire / re-raise.
+    await asyncio.sleep(ttl * 3)
+    assert future.result() is sentinel
+    assert dispatcher._pending == {}
+
+
+async def test_evicted_abandoned_future_does_not_log_never_retrieved():
+    """An abandoned ``invoke_node`` handle — a future nobody awaits — must be
+    evicted *silently*.
+
+    The TTL exists precisely for the abandoned-handle case, so eviction must not
+    spam ``asyncio``'s "Future exception was never retrieved" error when the
+    (now unreferenced) future is garbage-collected. The dispatcher is responsible
+    for retrieving the ``ReplyExpiredError`` it sets; an awaiting caller still
+    receives it unchanged.
+    """
+    import gc
+
+    cid = "cid-abandoned"
+    loop = asyncio.get_running_loop()
+    # Capture the FULL context dicts and chain to the previous handler so this
+    # test neither suppresses nor is fooled by a sibling test's stray future
+    # collected during our gc.collect(). The assertion is then scoped to *our*
+    # evicted future via the ReplyExpiredError it would carry — making the test
+    # order-independent.
+    captured: list[dict] = []
+    previous = loop.get_exception_handler()
+
+    def _handler(active_loop, ctx):
+        captured.append(ctx)
+        if previous is not None:
+            previous(active_loop, ctx)
+
+    loop.set_exception_handler(_handler)
+    try:
+        dispatcher = _ReplyDispatcher(reply_ttl=0.02)
+        # Intentionally drop the future reference to simulate an abandoned handle.
+        dispatcher.expect(cid)
+        await asyncio.sleep(0.06)  # let the TTL fire and _discard pop the entry
+        gc.collect()  # force the unreferenced future's __del__
+        await asyncio.sleep(0)  # flush any scheduled exception-handler callback
+    finally:
+        loop.set_exception_handler(previous)
+
+    ours = [ctx for ctx in captured if isinstance(ctx.get("exception"), ReplyExpiredError) and ctx["exception"].correlation_id == cid]
+    assert not ours, f"our evicted abandoned future logged an unretrieved-exception error: {ours}"
+
+
+async def test_invocation_handle_result_raises_reply_expired_on_eviction():
+    """The user-facing TTL contract: awaiting an ``InvocationHandle`` whose reply
+    is evicted raises ``ReplyExpiredError`` (carrying ``correlation_id``/``ttl``),
+    not a bare ``CancelledError``. ``_evict`` sets the exception on the very
+    future ``InvocationHandle.result()`` awaits, so this exercises that real path."""
+    ttl = 0.05
+    dispatcher = _ReplyDispatcher(reply_ttl=ttl)
+    cid = "cid-handle-evict"
+
+    future = dispatcher.expect(cid)
+    handle: InvocationHandle = InvocationHandle(correlation_id=cid, topic="agent.input", reply_topic="reply", _future=future)
+
+    with pytest.raises(ReplyExpiredError) as exc_info:
+        await handle.result()
+
+    assert exc_info.value.correlation_id == cid
+    assert exc_info.value.ttl == ttl
+    assert dispatcher._pending == {}, "evicted entry must be removed from _pending"
+
+
+async def test_late_reply_after_eviction_is_dropped_quietly(caplog):
+    """A reply that arrives for a *registered but already-done* future (the narrow
+    race where eviction set the exception but ``_discard`` has not yet popped the
+    entry) is dropped at DEBUG via the ``future.done()`` guard — NOT surfaced as
+    the "no pending future" WARNING reserved for an unknown correlation_id."""
+    dispatcher = _ReplyDispatcher()
+    cid = "cid-late"
+
+    loop = asyncio.get_running_loop()
+    evicted = loop.create_future()
+    evicted.set_exception(ReplyExpiredError(cid, 0.01))
+    evicted.exception()  # retrieve so this test's own future never warns
+    # Inject the done-but-still-registered state directly (the race window).
+    dispatcher._pending[cid] = _PendingEntry(future=evicted, timer=None)
+
+    envelope = Envelope(
+        context=SessionRunContext(state=State(), deps={}),
+        internal_workflow_state=WorkflowState(call_stack=CallFrameStack()),
+    )
+    with caplog.at_level(logging.DEBUG, logger=REPLY_DISPATCHER_LOGGER):
+        dispatcher._on_reply(envelope, cid, {})
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert not any("no pending future" in m for m in messages), f"late reply must not warn 'no pending future': {messages}"
+    assert any("already done" in m for m in messages), f"expected the DEBUG 'already done' drop: {messages}"
+    assert cid in dispatcher._pending, "the done-future guard must return early without popping the entry"
+
+
+async def test_close_cancels_active_timers():
+    """``close()`` with TTL timers still scheduled cancels both the futures and
+    their timers, so no later ``ReplyExpiredError`` / loop exception fires."""
+    ttl = 0.05
+    dispatcher = _ReplyDispatcher(reply_ttl=ttl)
+
+    f1 = dispatcher.expect("c1")
+    f2 = dispatcher.expect("c2")
+    assert dispatcher._pending["c1"].timer is not None
+    assert dispatcher._pending["c2"].timer is not None
+
+    dispatcher.close()
+
+    assert dispatcher._pending == {}, "close() must clear the registry"
+    assert f1.cancelled() and f2.cancelled(), "close() must cancel pending futures"
+
+    # Wait past the original TTL: the cancelled timers must not fire / re-raise.
+    await asyncio.sleep(ttl * 3)
+    assert f1.cancelled() and f2.cancelled()
+
+
+async def test_close_retrieves_exception_for_already_evicted_future():
+    """REGRESSION: ``close()`` during the evict→discard window must retrieve the
+    eviction exception.
+
+    ``_evict`` sets the exception and schedules ``_discard`` via ``call_soon`` (not
+    synchronously), so there is a window where the future is ``done()`` with
+    ``ReplyExpiredError`` set but still registered and ``_discard`` has not run. If
+    ``close()`` runs in that window without retrieving the exception, asyncio logs
+    "Future exception was never retrieved" on GC — the very warning the TTL
+    machinery exists to suppress. ``test_close_cancels_active_timers`` only covers
+    still-pending futures, so it misses this."""
+    import gc
+
+    cid = "cid-close-window"
+    loop = asyncio.get_running_loop()
+    captured: list[dict] = []
+    previous = loop.get_exception_handler()
+
+    def _handler(active_loop, ctx):
+        captured.append(ctx)
+        if previous is not None:
+            previous(active_loop, ctx)
+
+    loop.set_exception_handler(_handler)
+    try:
+        dispatcher = _ReplyDispatcher(reply_ttl=10.0)
+        dispatcher.expect(cid)  # drop the future ref (abandoned handle)
+        # Force eviction synchronously: sets the exception and schedules _discard
+        # via call_soon, putting us in the window where the future is done() but
+        # still registered and _discard has not yet run.
+        dispatcher._evict(cid, 10.0)
+        assert cid in dispatcher._pending and dispatcher._pending[cid].future.done()
+        dispatcher.close()  # must retrieve the exception in this window
+        gc.collect()
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous)
+
+    ours = [c for c in captured if isinstance(c.get("exception"), ReplyExpiredError) and c["exception"].correlation_id == cid]
+    assert not ours, f"close() leaked an unretrieved eviction exception: {ours}"
+
+
+async def test_duplicate_correlation_id_raises_before_scheduling_a_timer():
+    """``expect()`` rejects a duplicate correlation_id BEFORE creating a
+    future/timer, so the RuntimeError path leaves exactly one entry and no
+    orphaned second timer under the TTL model."""
+    ttl = 0.05
+    dispatcher = _ReplyDispatcher(reply_ttl=ttl)
+    cid = "cid-dup"
+
+    first = dispatcher.expect(cid)
+    with pytest.raises(RuntimeError, match="Duplicate correlation_id"):
+        dispatcher.expect(cid)
+
+    assert list(dispatcher._pending) == [cid], "the rejected second call must not register a second entry"
+    assert dispatcher._pending[cid].future is first
+
+    # Past the TTL: exactly one eviction fires; no orphaned timer raises.
+    await asyncio.sleep(ttl * 3)
+    assert first.done()
+    with pytest.raises(ReplyExpiredError):
+        first.result()
+    assert dispatcher._pending == {}

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -31,6 +31,28 @@ def test_envelope_serialization_roundtrip(make_envelope):
     assert_json_roundtrip(make_envelope)
 
 
+def test_envelope_with_null_callback_topic_roundtrips():
+    """A fire-and-forget bottom call frame (``callback_topic=None``) must survive
+    a real JSON hop unchanged. ``None`` means "no requester to return to"; the
+    nullable wire field is what lets the worker's terminal guard skip the
+    point-to-point callback publish (``BaseNodeDef._publish_action``)."""
+    from calfkit.models.envelope import Envelope
+    from calfkit.models.session_context import CallFrame, CallFrameStack, SessionRunContext, WorkflowState
+    from calfkit.models.state import State
+
+    stack = CallFrameStack()
+    stack.push(CallFrame(target_topic="agent.input", callback_topic=None))
+    envelope = Envelope(
+        context=SessionRunContext(state=State(), deps={}),
+        internal_workflow_state=WorkflowState(call_stack=stack),
+    )
+
+    assert_json_roundtrip(envelope)
+
+    restored = Envelope.model_validate_json(envelope.model_dump_json())
+    assert restored.internal_workflow_state.current_frame.callback_topic is None
+
+
 def test_nested_deps_survive_json_roundtrip_and_correlation_id_stays_off_the_wire():
     """The deps dict (incl. nested/list values) must survive a real JSON hop
     verbatim, while ``correlation_id`` (a transport-sourced PrivateAttr) must NOT


### PR DESCRIPTION
## Summary

Closes #132. Adds a **true one-way fire-and-forget** client method, `Client.emit_to_node`, that allocates **zero** per-call client state and triggers **zero** reply traffic — fixing the misleading "fire-and-forget" contract on `invoke_node` (which always registered an `asyncio.Future` in the reply dispatcher *and* caused the worker to publish a reply nobody consumed).

The key insight that makes this safe: calfkit has **two independent output channels** per hop — the point-to-point **callback/reply** channel (`CallFrame.callback_topic`) and the **broadcast** channel (the node's `publish_topic`). Suppressing the callback does **not** lose traceability, because the terminal result still rides `publish_topic` exactly as it does for `execute_node`. Full rationale in [`docs/fire-and-forget-emit.md`](docs/fire-and-forget-emit.md).

## What changed

- **Wire** (`models/session_context.py`): `CallFrame.callback_topic` is now `str | None`. A `None` bottom (client) frame means "no requester to return to". Only the bottom frame is ever `None` — tool `Call`/`TailCall` frames still carry the agent's `_return_topic`, so tool round-trips are unaffected.
- **Worker** (`nodes/base.py`): the terminal `ReturnCall` skips the point-to-point callback publish when `callback_topic is None`, but still returns the terminal envelope so it is broadcast to `publish_topic`.
- **Client** (`client/client.py`, `client/base.py`): `Client.emit_to_node(...) -> str` returns the `correlation_id`. Input-shaping is single-sourced with `invoke_node` (`_build_state_and_overrides`) and the wire envelope build with `_invoke` (`_publish_call`), so the only delta from `invoke_node` is "register no future, push a `None` callback".
- **Dispatcher** (`client/reply_dispatcher.py`): **opt-in** `reply_ttl` (default `None` — a deliberate caller-responsibility choice, no silent ceiling) evicts abandoned/lost `invoke_node` reply futures with `ReplyExpiredError`. Exception retrieval in `_discard` **and** `close()` ensures eviction never leaks asyncio's "Future exception was never retrieved" warning. `reply_ttl` is validated (positive, finite) at construction.
- **Docs**: design doc, ROADMAP entry, README section, and honest three-pattern docstrings (`emit` / `invoke` / `execute`).

## The three patterns

| Method | Pattern | Returns | Per-call state |
|---|---|---|---|
| `emit_to_node` | one-way fire-and-forget | `correlation_id: str` | none |
| `invoke_node` | async, reply via handle | `InvocationHandle` | a pending `Future` until resolved/evicted |
| `execute_node` | sync request/reply | `NodeResult` | a pending `Future` (self-cleaning only with an explicit `timeout`) |

## ⚠️ Breaking change

`CallFrame.callback_topic` becomes nullable (`str | None`). An **old worker cannot interpret a `None` terminal callback**, so **deploy workers before clients**. No backwards-compatibility shim is provided — this is an intentional hard break (framework-internal envelope, pre-1.0). Commit is `feat!` with a `BREAKING CHANGE:` footer for release-please.

## Testing

New `tests/test_fire_and_forget.py` and `tests/test_reply_dispatcher_ttl.py` (plus a serialization case) cover: null-callback serialization round-trip, the worker terminal guard, no-client-state, `publish_topic` traceability without a reply, the **multi-hop tool-call-beneath-emit round-trip** (proving only the bottom frame is `None`), `ReplyExpiredError` through `InvocationHandle.result()`, the `close()`/evict race regression, the late-reply branch, `reply_ttl` validation + `connect` wiring, and `emit_to_node` input-shaping. Full offline suite green (4675 passed); `mypy` + `ruff` clean.

## Review provenance

Built TDD-first and put through multiple automated review rounds (comprehensive correctness/error-handling/comment/type/test lenses + a simplifier pass), iterated to convergence with zero remaining must-fix. Notable issues caught and fixed along the way: a `close()`/eviction race that leaked the very asyncio warning the TTL machinery suppresses, missing `reply_ttl` validation, and DRY extractions removing the `_invoke`/`_emit` and `invoke_node`/`emit_to_node` duplication.
