### PR TITLE
feat: CLI add `calfkit run` to run nodes without Worker boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ python invoke.py
 
 ### Run nodes without the boilerplate (dev CLI)
 
-Steps 3–5 wrap each node in `Client.connect(...)` → `Worker(...)` → `worker.run()`. For local development you can skip that and point the `calfkit` CLI at a node instead — like running a FastAPI app with `fastapi dev`.
+Steps 3–4 wrap each node in `Client.connect(...)` → `Worker(...)` → `worker.run()`. For local development you can skip that and point the `calfkit` CLI at a node instead — like running a FastAPI app with `fastapi dev`.
 
 Install the CLI extra:
 
@@ -260,7 +260,7 @@ Common flags:
 | `--group-id` | Kafka consumer-group override applied to every node. |
 | `--env-file` | dotenv file to load (defaults to `./.env` if present). |
 
-> **Development only.** This is a convenience for running nodes locally; production deployments should use an explicit `Worker` (steps 3–5) so startup, scaling, and topic governance stay under your control. Targets must be importable from where you run the command — run from your project root, or pass `--app-dir`.
+> **Development only.** This is a convenience for running nodes locally; production deployments should use an explicit `Worker` (steps 3–4) so startup, scaling, and topic governance stay under your control. Targets must be importable from where you run the command — run from your project root, or pass `--app-dir`.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ Calfkit is a Python SDK that builds event-stream agents out-the-box. You get the
 ### 1. Install
 
 ```bash
-pip install calfkit
+pip install "calfkit[cli]"
 ```
+
+The `[cli]` extra adds the `calfkit` command used below to run nodes during development. (The library itself is just `pip install calfkit`.)
 
 <br>
 
@@ -97,10 +99,11 @@ You will be provided a Calfkit broker API to deploy your agents instead of setti
 > created on first use. Most hardened/managed brokers have that **disabled**, in
 > which case producers and consumers silently stall on a missing topic. Calfkit
 > ships an **EXPERIMENTAL, opt-in** topic provisioner (off by default) for the
-> dev/CI case: `Client.connect("localhost:9092", provisioning=ProvisioningConfig(enabled=True))`.
-> It is a development convenience (`replication_factor=1`, no ACLs) — **review it
-> before production**, where topic creation is typically ops-governed. See
-> [`docs/topic-provisioning.md`](docs/topic-provisioning.md).
+> dev/CI case — pass `--provision` to `calfkit run` below (or
+> `Client.connect("localhost:9092", provisioning=ProvisioningConfig(enabled=True))`
+> in code). It is a development convenience (`replication_factor=1`, no ACLs) —
+> **review it before production**, where topic creation is typically ops-governed.
+> See [`docs/topic-provisioning.md`](docs/topic-provisioning.md).
 
 <br>
 
@@ -110,30 +113,19 @@ Define and deploy a tool as an independent service. Tools are not owned by or co
 
 ```python
 # weather_tool.py
-import asyncio
 from calfkit.nodes import agent_tool
-from calfkit.client import Client
-from calfkit.worker import Worker
 
 # Define a tool — the @agent_tool decorator turns any function into a deployable tool node
 @agent_tool
 def get_weather(location: str) -> str:
     """Get the current weather at a location"""
     return f"It's sunny in {location}"
-
-async def main():
-    client = Client.connect("localhost:9092")  # Connect to Kafka broker
-    worker = Worker(client, nodes=[get_weather])  # Initialize a worker with the tool node
-    await worker.run()  # (Blocking call) Deploy the service to start serving traffic
-
-if __name__ == "__main__":
-    asyncio.run(main())
 ```
 
-Run the file to deploy the tool service:
+Deploy the tool as a service. `calfkit run` points at a `module:attr` target and starts a worker for you — no `Client`/`Worker` wiring required:
 
 ```shell
-python weather_tool.py
+calfkit run weather_tool:get_weather
 ```
 
 <br>
@@ -144,11 +136,8 @@ Deploy the agent as its own service. The `Agent` handles LLM chat, tool orchestr
 
 ```python
 # agent_service.py
-import asyncio
 from calfkit.nodes import Agent
 from calfkit.providers import OpenAIResponsesModelClient
-from calfkit.client import Client
-from calfkit.worker import Worker
 from weather_tool import get_weather  # Import the tool definition (reusable)
 
 agent = Agent(
@@ -158,14 +147,6 @@ agent = Agent(
     model_client=OpenAIResponsesModelClient(model_name="gpt-5.4-nano"),
     tools=[get_weather],  # Register tool definitions with the agent
 )
-
-async def main():
-    client = Client.connect("localhost:9092")  # Connect to Kafka broker
-    worker = Worker(client, nodes=[agent])  # Initialize a worker with the agent node
-    await worker.run()  # (Blocking call) Deploy the service to start serving traffic
-
-if __name__ == "__main__":
-    asyncio.run(main())
 ```
 
 Set your OpenAI API key:
@@ -174,10 +155,10 @@ Set your OpenAI API key:
 export OPENAI_API_KEY=sk-...
 ```
 
-Run the file to deploy the agent service:
+Deploy the agent as its own service (run it alongside the tool service from step 3):
 
 ```shell
-python agent_service.py
+calfkit run agent_service:agent
 ```
 
 <br>
@@ -197,7 +178,7 @@ async def main():
     # Send a request and await the response
     result = await client.execute_node(
         "What's the weather in Tokyo?",
-        "agent.input",  # The topic the agent subscribes to
+        "weather_agent.input",  # The topic the agent subscribes to
     )
     print(f"Assistant: {result.output}")
 
@@ -213,54 +194,31 @@ python invoke.py
 
 <br>
 
-### Run nodes without the boilerplate (dev CLI)
+### Deploying to production
 
-Steps 3–4 wrap each node in `Client.connect(...)` → `Worker(...)` → `worker.run()`. For local development you can skip that and point the `calfkit` CLI at a node instead — like running a FastAPI app with `fastapi dev`.
-
-Install the CLI extra:
-
-```bash
-pip install calfkit[cli]
-```
-
-Point it at a `module:attr` target (a dotted Python import path, where `attr` is a node or a list of nodes):
-
-```shell
-# Run the weather tool node defined in weather_tool.py
-calfkit run weather_tool:get_weather
-
-# Run several nodes in one worker (e.g. an agent and its tools)
-calfkit run agent_service:agent weather_tool:get_weather
-
-# Auto-restart on code changes
-calfkit run agent_service:agent --reload
-```
-
-Because the CLI imports your module and runs the node for you, the node file no longer needs a `main()` or `asyncio.run(...)` — just define the node at module scope:
+`calfkit run` is a **development** convenience — it imports your module and starts a worker for you (and `--reload` restarts it on edits). For production, deploy each node with an explicit `Worker` so startup, scaling, and topic governance stay under your control:
 
 ```python
-# weather_tool.py — the whole file
-from calfkit.nodes import agent_tool
+# serve_tool.py — deploy the tool as its own service
+import asyncio
+from calfkit.client import Client
+from calfkit.worker import Worker
+from weather_tool import get_weather
 
-@agent_tool
-def get_weather(location: str) -> str:
-    """Get the current weather at a location"""
-    return f"It's sunny in {location}"
+async def main():
+    client = Client.connect("localhost:9092")  # Connect to Kafka broker
+    worker = Worker(client, nodes=[get_weather])  # One service per node
+    await worker.run()  # (Blocking) serve until stopped
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
-Common flags:
+```shell
+python serve_tool.py
+```
 
-| Flag | Description |
-| --- | --- |
-| `--host`, `-H` | Kafka bootstrap server(s), comma-separated. Precedence: this flag > `$CALF_HOST_URL` > `localhost`. |
-| `--provision` | Opt-in dev topic auto-creation (experimental; off by default). |
-| `--reload` | Watch source files and restart the worker on change. |
-| `--reload-dir` | Directory to watch with `--reload` (repeatable; defaults to the current directory). |
-| `--app-dir` | Directory added to the import path for resolving targets (defaults to the current directory). |
-| `--group-id` | Kafka consumer-group override applied to every node. |
-| `--env-file` | dotenv file to load (defaults to `./.env` if present). |
-
-> **Development only.** This is a convenience for running nodes locally; production deployments should use an explicit `Worker` (steps 3–4) so startup, scaling, and topic governance stay under your control. Targets must be importable from where you run the command — run from your project root, or pass `--app-dir`.
+See the **[CLI reference](docs/cli.md)** for every `calfkit run` flag (`--host`, `--provision`, `--reload`, `--app-dir`, …) and the other `calfkit` commands (`mcp`, `topics`).
 
 <br>
 
@@ -468,7 +426,11 @@ See [`docs/mcp-overview.md`](docs/mcp-overview.md) for the quickstart, deploymen
 
 ## Documentation
 
-Full documentation is coming soon. In the meantime, this README serves as the primary reference for getting started with Calfkit.
+Full documentation is coming soon. In the meantime, this README serves as the primary reference for getting started with Calfkit. Deeper guides live in [`docs/`](docs/):
+
+- [CLI reference](docs/cli.md) — `calfkit run`, `mcp`, and `topics` commands
+- [MCP adaptor](docs/mcp-overview.md) — expose MCP servers as calfkit tools
+- [Topic provisioning](docs/topic-provisioning.md) — experimental dev topic auto-creation
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,57 @@ python invoke.py
 
 <br>
 
+### Run nodes without the boilerplate (dev CLI)
+
+Steps 3–5 wrap each node in `Client.connect(...)` → `Worker(...)` → `worker.run()`. For local development you can skip that and point the `calfkit` CLI at a node instead — like running a FastAPI app with `fastapi dev`.
+
+Install the CLI extra:
+
+```bash
+pip install calfkit[cli]
+```
+
+Point it at a `module:attr` target (a dotted Python import path, where `attr` is a node or a list of nodes):
+
+```shell
+# Run the weather tool node defined in weather_tool.py
+calfkit run weather_tool:get_weather
+
+# Run several nodes in one worker (e.g. an agent and its tools)
+calfkit run agent_service:agent weather_tool:get_weather
+
+# Auto-restart on code changes
+calfkit run agent_service:agent --reload
+```
+
+Because the CLI imports your module and runs the node for you, the node file no longer needs a `main()` or `asyncio.run(...)` — just define the node at module scope:
+
+```python
+# weather_tool.py — the whole file
+from calfkit.nodes import agent_tool
+
+@agent_tool
+def get_weather(location: str) -> str:
+    """Get the current weather at a location"""
+    return f"It's sunny in {location}"
+```
+
+Common flags:
+
+| Flag | Description |
+| --- | --- |
+| `--host`, `-H` | Kafka bootstrap server(s), comma-separated. Precedence: this flag > `$CALF_HOST_URL` > `localhost`. |
+| `--provision` | Opt-in dev topic auto-creation (experimental; off by default). |
+| `--reload` | Watch source files and restart the worker on change. |
+| `--reload-dir` | Directory to watch with `--reload` (repeatable; defaults to the current directory). |
+| `--app-dir` | Directory added to the import path for resolving targets (defaults to the current directory). |
+| `--group-id` | Kafka consumer-group override applied to every node. |
+| `--env-file` | dotenv file to load (defaults to `./.env` if present). |
+
+> **Development only.** This is a convenience for running nodes locally; production deployments should use an explicit `Worker` (steps 3–5) so startup, scaling, and topic governance stay under your control. Targets must be importable from where you run the command — run from your project root, or pass `--app-dir`.
+
+<br>
+
 ### Structured Outputs (Optional)
 
 Agents can be deployed with a `final_output_type` to enforce structured output from the LLM. The output is type-safe and deserialized automatically on the client side.

--- a/calfkit/cli/__init__.py
+++ b/calfkit/cli/__init__.py
@@ -1,8 +1,9 @@
 """calfkit top-level CLI entry point.
 
 Mounts subcommands as typer sub-apps: ``mcp`` (with ``mcp codegen`` /
-``mcp schema``) and ``topics`` (with ``topics provision``). Future
-subcommands land alongside via the same mounting pattern.
+``mcp schema``) and ``topics`` (with ``topics provision``), plus the
+top-level ``run`` command. Future subcommands land alongside via the same
+mounting pattern.
 
 Invoked via the ``calfkit`` console script registered in pyproject.toml's
 ``[project.scripts]``.
@@ -27,11 +28,13 @@ def _build_app() -> Any:
         raise SystemExit("The calfkit CLI requires the 'cli' optional extra. Install with: pip install calfkit[cli]") from e
 
     from calfkit.cli.mcp import app as mcp_app
+    from calfkit.cli.run import run as run_command
     from calfkit.cli.topics import app as topics_app
 
     app = typer.Typer(name="calfkit", help="Calfkit SDK command-line tools.", no_args_is_help=True)
     app.add_typer(mcp_app, name="mcp")
     app.add_typer(topics_app, name="topics")
+    app.command(name="run")(run_command)
     return app
 
 

--- a/calfkit/cli/_loader.py
+++ b/calfkit/cli/_loader.py
@@ -1,0 +1,137 @@
+"""Shared node loader for the calfkit CLI.
+
+Resolves ``module:attr`` specs into a flat list of node objects. Used by both
+``calfkit topics provision`` (``--nodes module:attr``) and ``calfkit run``
+(positional ``module:attr`` targets).
+
+Each ``attr`` may resolve to a single node or an iterable of nodes; iterables
+are expanded. ``McpServer`` instances are treated as scalars even though they
+are iterable (their ``__iter__`` yields tool defs) so a directly-resolved MCP
+server is preserved rather than splatted.
+
+Requires the ``cli`` optional extra (typer). If typer is not installed, the
+import raises with a clear remediation message rather than silently failing.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from collections.abc import Iterable
+from typing import Any
+
+try:
+    import typer
+except ImportError as e:  # pragma: no cover -- exercised manually
+    raise ImportError("the calfkit CLI requires the 'cli' optional extra. Install with: pip install calfkit[cli]") from e
+
+
+def resolve_specs(specs: list[str], *, app_dir: str | None = None) -> list[Any]:
+    """Resolve ``module:attr`` specs into a flat list of resolved objects.
+
+    Each ``attr`` may be a single object or an iterable of objects; iterables
+    (other than ``str``/``bytes`` and ``McpServer``) are expanded. Results are
+    concatenated in the order the specs were supplied.
+
+    Args:
+        specs: ``module:attr`` strings.
+        app_dir: Optional directory inserted at ``sys.path[0]`` before importing
+            so targets are resolvable relative to it (e.g. the project root the
+            user runs the command from). The path is absolutised; duplicates are
+            not re-inserted.
+
+    Raises:
+        typer.Exit: (code 2) on a malformed spec, an import failure, or a
+            missing attribute.
+    """
+    from calfkit.mcp._server import McpServer
+
+    if app_dir is not None:
+        abs_dir = os.path.abspath(app_dir)
+        if abs_dir not in sys.path:
+            sys.path.insert(0, abs_dir)
+
+    resolved: list[Any] = []
+    for spec in specs:
+        module_path, sep, attr = spec.partition(":")
+        if not sep or not module_path or not attr:
+            typer.echo(
+                f"Error: target must be in 'module:attr' form, got {spec!r}.",
+                err=True,
+            )
+            raise typer.Exit(2)
+        try:
+            module = importlib.import_module(module_path)
+        except (ModuleNotFoundError, ImportError) as e:
+            # The module (or one of its imports) does not exist / cannot load.
+            typer.echo(f"Error: cannot import module {module_path!r}: {e}", err=True)
+            raise typer.Exit(2) from e
+        except Exception as e:  # noqa: BLE001 -- side-effect code at import time failed
+            # The module exists but its top-level code raised when executed.
+            typer.echo(
+                f"Error: module {module_path!r} raised during import (side-effect code failed): {e}",
+                err=True,
+            )
+            raise typer.Exit(2) from e
+        try:
+            obj = getattr(module, attr)
+        except AttributeError as e:
+            typer.echo(f"Error: module {module_path!r} has no attribute {attr!r}.", err=True)
+            raise typer.Exit(2) from e
+
+        # A single node has ``subscribe_topics`` but is not itself a plain
+        # iterable of nodes. Strings/bytes are iterable too; an McpServer is
+        # iterable (its ``__iter__`` yields tool defs) but must be kept whole.
+        # Treat all three as scalars; expand everything else iterable.
+        if isinstance(obj, (str, bytes, McpServer)) or not isinstance(obj, Iterable):
+            resolved.append(obj)
+        else:
+            resolved.extend(obj)
+    return resolved
+
+
+def validate_nodes(objs: list[Any]) -> None:
+    """Ensure every object is a node or an ``McpServer``.
+
+    A node is duck-typed by the attributes the worker wiring relies on
+    (``subscribe_topics`` and ``_return_topic``). ``McpServer`` instances are
+    allowed through unconditionally — the worker expands them into per-tool
+    bridges at startup.
+
+    Raises:
+        typer.Exit: (code 2) if any object is neither a node nor an McpServer.
+    """
+    from calfkit.mcp._server import McpServer
+
+    for obj in objs:
+        if isinstance(obj, McpServer):
+            continue
+        missing = [attr for attr in ("subscribe_topics", "_return_topic") if not hasattr(obj, attr)]
+        if missing:
+            typer.echo(
+                f"Error: resolved object {obj!r} is not a node "
+                f"(missing {', '.join(missing)}). Target must point at a "
+                "BaseNodeDef or McpServer (or an iterable of them).",
+                err=True,
+            )
+            raise typer.Exit(2)
+
+
+def dedupe_by_node_id(objs: list[Any]) -> list[Any]:
+    """Drop duplicate nodes by ``node_id``, preserving first-seen order.
+
+    Objects without a ``node_id`` (e.g. ``McpServer``) are keyed by identity so
+    they are always retained.
+    """
+    seen: set[Any] = set()
+    out: list[Any] = []
+    for obj in objs:
+        key = getattr(obj, "node_id", None)
+        if key is None:
+            key = id(obj)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(obj)
+    return out

--- a/calfkit/cli/_loader.py
+++ b/calfkit/cli/_loader.py
@@ -27,7 +27,7 @@ except ImportError as e:  # pragma: no cover -- exercised manually
     raise ImportError("the calfkit CLI requires the 'cli' optional extra. Install with: pip install calfkit[cli]") from e
 
 
-def resolve_specs(specs: list[str], *, app_dir: str | None = None) -> list[Any]:
+def resolve_specs(specs: list[str], *, app_dir: str | None = None, source_label: str = "target") -> list[Any]:
     """Resolve ``module:attr`` specs into a flat list of resolved objects.
 
     Each ``attr`` may be a single object or an iterable of objects; iterables
@@ -40,6 +40,9 @@ def resolve_specs(specs: list[str], *, app_dir: str | None = None) -> list[Any]:
             so targets are resolvable relative to it (e.g. the project root the
             user runs the command from). The path is absolutised; duplicates are
             not re-inserted.
+        source_label: How to name the spec source in error messages (e.g.
+            ``"target"`` for ``calfkit run`` or ``"--nodes"`` for
+            ``calfkit topics provision``).
 
     Raises:
         typer.Exit: (code 2) on a malformed spec, an import failure, or a
@@ -57,7 +60,7 @@ def resolve_specs(specs: list[str], *, app_dir: str | None = None) -> list[Any]:
         module_path, sep, attr = spec.partition(":")
         if not sep or not module_path or not attr:
             typer.echo(
-                f"Error: target must be in 'module:attr' form, got {spec!r}.",
+                f"Error: {source_label} must be in 'module:attr' form, got {spec!r}.",
                 err=True,
             )
             raise typer.Exit(2)
@@ -91,13 +94,17 @@ def resolve_specs(specs: list[str], *, app_dir: str | None = None) -> list[Any]:
     return resolved
 
 
-def validate_nodes(objs: list[Any]) -> None:
+def validate_nodes(objs: list[Any], *, source_label: str = "target") -> None:
     """Ensure every object is a node or an ``McpServer``.
 
     A node is duck-typed by the attributes the worker wiring relies on
     (``subscribe_topics`` and ``_return_topic``). ``McpServer`` instances are
     allowed through unconditionally — the worker expands them into per-tool
     bridges at startup.
+
+    Args:
+        objs: Resolved objects to validate.
+        source_label: How to name the spec source in error messages.
 
     Raises:
         typer.Exit: (code 2) if any object is neither a node nor an McpServer.
@@ -111,11 +118,32 @@ def validate_nodes(objs: list[Any]) -> None:
         if missing:
             typer.echo(
                 f"Error: resolved object {obj!r} is not a node "
-                f"(missing {', '.join(missing)}). Target must point at a "
+                f"(missing {', '.join(missing)}). {source_label} must point at a "
                 "BaseNodeDef or McpServer (or an iterable of them).",
                 err=True,
             )
             raise typer.Exit(2)
+
+
+def load_nodes(targets: list[str], *, app_dir: str | None = None, source_label: str = "target") -> list[Any]:
+    """Resolve, validate, and de-duplicate ``targets`` into a non-empty node list.
+
+    The composition used by ``calfkit run`` for both the inline (no-reload) path
+    and the parent-side pre-flight before the reload supervisor starts. Raising
+    on an empty result means a misconfigured run fails fast and loud (exit 2)
+    instead of starting an idle worker.
+
+    Raises:
+        typer.Exit: (code 2) on a bad spec, import failure, non-node object, or
+            if ``targets`` resolve to zero nodes.
+    """
+    objs = resolve_specs(targets, app_dir=app_dir, source_label=source_label)
+    validate_nodes(objs, source_label=source_label)
+    nodes = dedupe_by_node_id(objs)
+    if not nodes:
+        typer.echo("Error: no nodes resolved from the given target(s).", err=True)
+        raise typer.Exit(2)
+    return nodes
 
 
 def dedupe_by_node_id(objs: list[Any]) -> list[Any]:

--- a/calfkit/cli/_run.py
+++ b/calfkit/cli/_run.py
@@ -1,0 +1,116 @@
+"""Runtime glue for ``calfkit run``.
+
+``serve`` is the single entrypoint that turns resolved ``module:attr`` targets
+into a running :class:`~calfkit.worker.Worker`. It is deliberately a
+module-level function taking only picklable arguments (strings / bools) so the
+``--reload`` supervisor can hand it to ``watchfiles.run_process``, which spawns
+it in a fresh process on every file change.
+
+Requires the ``cli`` optional extra (typer). If typer is not installed, the
+import raises with a clear remediation message rather than silently failing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+try:
+    import typer
+except ImportError as e:  # pragma: no cover -- exercised manually
+    raise ImportError("the calfkit CLI requires the 'cli' optional extra. Install with: pip install calfkit[cli]") from e
+
+from calfkit.cli._loader import dedupe_by_node_id, resolve_specs, validate_nodes
+
+
+def _load_env(env_file: str | None) -> None:
+    """Load environment variables from a dotenv file.
+
+    An explicit ``env_file`` is loaded as given; otherwise ``./.env`` is loaded
+    if present. A development convenience so ``OPENAI_API_KEY`` and friends are
+    available without exporting them by hand.
+    """
+    from dotenv import load_dotenv
+
+    if env_file:
+        load_dotenv(env_file)
+    elif os.path.exists(".env"):
+        load_dotenv(".env")
+
+
+def _parse_host(host: str | None) -> str | list[str] | None:
+    """Map the ``--host`` flag to a ``server_urls`` value for ``Client.connect``.
+
+    ``None`` (flag omitted) is passed through unchanged so ``Client.connect``
+    applies its ``CALF_HOST_URL`` → ``localhost`` fallback — preserving the
+    flag > env > localhost precedence. A comma-separated value becomes a list.
+    """
+    if not host:
+        return None
+    parts = [s.strip() for s in host.split(",") if s.strip()]
+    if not parts:
+        return None
+    return parts if len(parts) > 1 else parts[0]
+
+
+def _print_banner(nodes: list[Any], server_urls: str | list[str] | None, provision: bool) -> None:
+    """Print a concise startup banner describing what is being served."""
+    typer.echo("🐮 Calfkit — starting dev worker")
+    typer.echo(f"   broker: {server_urls if server_urls else '$CALF_HOST_URL or localhost'}")
+    typer.echo(f"   topic provisioning: {'on' if provision else 'off'}")
+    for node in nodes:
+        node_id = getattr(node, "node_id", None) or getattr(node, "raw_name", repr(node))
+        kind = getattr(node, "_node_kind", "mcp")
+        line = f"   • {node_id} [{kind}]"
+        subscribe = getattr(node, "subscribe_topics", None)
+        if subscribe:
+            line += f"  subscribe={list(subscribe)}"
+        publish = getattr(node, "publish_topic", None)
+        if publish:
+            line += f"  publish={publish}"
+        typer.echo(line)
+
+
+def serve(
+    targets: list[str],
+    host: str | None,
+    provision: bool,
+    group_id: str | None,
+    env_file: str | None,
+    app_dir: str,
+) -> None:
+    """Resolve targets and run them in a single Worker until stopped.
+
+    Args:
+        targets: ``module:attr`` specs; each attr is a node or iterable of nodes.
+        host: ``--host`` value (see :func:`_parse_host` for precedence).
+        provision: Enable experimental dev topic auto-creation.
+        group_id: Optional Kafka consumer-group override (defaults per-node).
+        env_file: Optional dotenv path (``./.env`` is auto-loaded otherwise).
+        app_dir: Directory inserted on ``sys.path`` for import resolution.
+
+    Raises:
+        typer.Exit: (code 2) on a bad spec, import failure, non-node object, or
+            if the targets resolve to zero nodes.
+    """
+    from calfkit.client import Client
+    from calfkit.provisioning import ProvisioningConfig
+    from calfkit.worker import Worker
+
+    _load_env(env_file)
+
+    objs = resolve_specs(list(targets), app_dir=app_dir)
+    validate_nodes(objs)
+    nodes = dedupe_by_node_id(objs)
+    if not nodes:
+        typer.echo("Error: no nodes resolved from the given target(s).", err=True)
+        raise typer.Exit(2)
+
+    server_urls = _parse_host(host)
+    provisioning = ProvisioningConfig(enabled=True) if provision else None
+    client = Client.connect(server_urls, provisioning=provisioning)
+    worker = Worker(client, nodes=nodes, group_id=group_id)
+
+    _print_banner(nodes, server_urls, provision)
+    asyncio.run(worker.run())

--- a/calfkit/cli/_run.py
+++ b/calfkit/cli/_run.py
@@ -21,7 +21,7 @@ try:
 except ImportError as e:  # pragma: no cover -- exercised manually
     raise ImportError("the calfkit CLI requires the 'cli' optional extra. Install with: pip install calfkit[cli]") from e
 
-from calfkit.cli._loader import dedupe_by_node_id, resolve_specs, validate_nodes
+from calfkit.cli._loader import load_nodes
 
 
 def _load_env(env_file: str | None) -> None:
@@ -30,10 +30,17 @@ def _load_env(env_file: str | None) -> None:
     An explicit ``env_file`` is loaded as given; otherwise ``./.env`` is loaded
     if present. A development convenience so ``OPENAI_API_KEY`` and friends are
     available without exporting them by hand.
+
+    An explicit ``env_file`` that does not exist is surfaced as a warning rather
+    than silently ignored (``load_dotenv`` no-ops on a missing path), so a typo'd
+    ``--env-file`` doesn't turn into a confusing "missing API key" failure later.
     """
     from dotenv import load_dotenv
 
     if env_file:
+        if not os.path.exists(env_file):
+            typer.echo(f"Warning: --env-file {env_file!r} not found; continuing without it.", err=True)
+            return
         load_dotenv(env_file)
     elif os.path.exists(".env"):
         load_dotenv(".env")
@@ -56,8 +63,12 @@ def _parse_host(host: str | None) -> str | list[str] | None:
 
 def _print_banner(nodes: list[Any], server_urls: str | list[str] | None, provision: bool) -> None:
     """Print a concise startup banner describing what is being served."""
+    # Show the broker the worker will actually connect to. When --host is
+    # omitted, mirror Client.connect's own CALF_HOST_URL -> localhost fallback
+    # so the banner reflects the effective target, not a placeholder.
+    broker = server_urls if server_urls else (os.getenv("CALF_HOST_URL") or "localhost")
     typer.echo("🐮 Calfkit — starting dev worker")
-    typer.echo(f"   broker: {server_urls if server_urls else '$CALF_HOST_URL or localhost'}")
+    typer.echo(f"   broker: {broker}")
     typer.echo(f"   topic provisioning: {'on' if provision else 'off'}")
     for node in nodes:
         node_id = getattr(node, "node_id", None) or getattr(node, "raw_name", repr(node))
@@ -94,18 +105,14 @@ def serve(
         typer.Exit: (code 2) on a bad spec, import failure, non-node object, or
             if the targets resolve to zero nodes.
     """
+    _load_env(env_file)
+    nodes = load_nodes(list(targets), app_dir=app_dir)
+
+    # Import the broker-facing modules only after the targets validate, so a
+    # bad spec fails fast without paying these imports.
     from calfkit.client import Client
     from calfkit.provisioning import ProvisioningConfig
     from calfkit.worker import Worker
-
-    _load_env(env_file)
-
-    objs = resolve_specs(list(targets), app_dir=app_dir)
-    validate_nodes(objs)
-    nodes = dedupe_by_node_id(objs)
-    if not nodes:
-        typer.echo("Error: no nodes resolved from the given target(s).", err=True)
-        raise typer.Exit(2)
 
     server_urls = _parse_host(host)
     provisioning = ProvisioningConfig(enabled=True) if provision else None

--- a/calfkit/cli/run.py
+++ b/calfkit/cli/run.py
@@ -1,0 +1,100 @@
+"""``calfkit run`` typer command.
+
+A development convenience that runs one or more node(s) as a worker without the
+``Client``/``Worker``/``run()`` boilerplate — point it at ``module:attr``
+targets and it starts serving, FastAPI-CLI style::
+
+    calfkit run weather_tool:get_weather
+    calfkit run myapp.agents:weather_agent myapp.tools:get_weather --reload
+
+Targets are dotted Python import paths (``module:attr``); each ``attr`` may be
+a single node or an iterable of nodes. All resolved nodes run in one worker.
+
+**Development only.** Requires the ``cli`` optional extra (typer + watchfiles).
+If typer is not installed, the import raises with a clear remediation message.
+"""
+
+from __future__ import annotations
+
+import os
+
+try:
+    import typer
+except ImportError as e:  # pragma: no cover -- exercised manually
+    raise ImportError("the calfkit CLI requires the 'cli' optional extra. Install with: pip install calfkit[cli]") from e
+
+from calfkit.cli._run import serve
+
+
+def run(
+    targets: list[str] = typer.Argument(
+        ...,
+        help="One or more 'module:attr' targets. Each attr is a node or an iterable of nodes.",
+    ),
+    host: str | None = typer.Option(
+        None,
+        "--host",
+        "-H",
+        help="Kafka bootstrap server(s), comma-separated. Precedence: this flag > $CALF_HOST_URL > localhost.",
+    ),
+    provision: bool = typer.Option(
+        False,
+        "--provision",
+        help="Opt-in dev topic auto-creation (EXPERIMENTAL; rf=1, no ACLs). Off by default.",
+    ),
+    reload: bool = typer.Option(
+        False,
+        "--reload",
+        help="Watch source files and restart the worker on change (dev only).",
+    ),
+    reload_dir: list[str] = typer.Option(
+        None,
+        "--reload-dir",
+        help="Directory to watch with --reload (repeatable). Defaults to the current directory.",
+    ),
+    app_dir: str = typer.Option(
+        ".",
+        "--app-dir",
+        help="Directory inserted on sys.path for resolving 'module:attr' targets. Defaults to the current directory.",
+    ),
+    group_id: str | None = typer.Option(
+        None,
+        "--group-id",
+        help="Kafka consumer-group override applied to every node. Defaults to each node's id.",
+    ),
+    env_file: str | None = typer.Option(
+        None,
+        "--env-file",
+        help="Path to a dotenv file to load. Defaults to ./.env if present.",
+    ),
+) -> None:
+    """Run node(s) as a worker until stopped (Ctrl-C)."""
+    # Fast-fail on malformed targets in the parent before spawning a watcher;
+    # full import/resolution happens in serve() (in the child under --reload).
+    for spec in targets:
+        if ":" not in spec:
+            typer.echo(f"Error: target must be in 'module:attr' form, got {spec!r}.", err=True)
+            raise typer.Exit(2)
+
+    abs_app_dir = os.path.abspath(app_dir)
+
+    if reload:
+        # The reload supervisor (parent) only watches files; watchfiles spawns
+        # serve() in a fresh process on every change, re-importing the targets
+        # cleanly. serve must stay a module-level function with picklable args
+        # for the spawn to reconstruct it.
+        from watchfiles import PythonFilter, run_process
+
+        dirs = reload_dir or [os.getcwd()]
+        run_process(
+            *dirs,
+            target=serve,
+            args=(list(targets), host, provision, group_id, env_file, abs_app_dir),
+            watch_filter=PythonFilter(),
+        )
+    else:
+        try:
+            serve(list(targets), host, provision, group_id, env_file, abs_app_dir)
+        except KeyboardInterrupt:
+            # Clean Ctrl-C shutdown — the worker/FastStream already tore down.
+            raise typer.Exit(0) from None

--- a/calfkit/cli/run.py
+++ b/calfkit/cli/run.py
@@ -12,6 +12,18 @@ a single node or an iterable of nodes. All resolved nodes run in one worker.
 
 **Development only.** Requires the ``cli`` optional extra (typer + watchfiles).
 If typer is not installed, the import raises with a clear remediation message.
+
+Exit codes:
+    0 — clean shutdown (Ctrl-C, or the worker stopped on its own)
+    2 — configuration error (bad ``module:attr`` spec, import failure, non-node
+        object, or zero nodes resolved). Surfaced before the worker starts —
+        including under ``--reload``, where the targets are pre-flighted in the
+        parent so a broken config fails fast instead of leaving an idle watcher.
+
+Note: under ``--reload``, a *runtime* failure that only appears once the worker
+is live (e.g. the broker is unreachable) is reported in the child process and
+the supervisor keeps watching for a fix — the standard dev-server reload
+contract. Config errors are caught up front (see above).
 """
 
 from __future__ import annotations
@@ -23,6 +35,7 @@ try:
 except ImportError as e:  # pragma: no cover -- exercised manually
     raise ImportError("the calfkit CLI requires the 'cli' optional extra. Install with: pip install calfkit[cli]") from e
 
+from calfkit.cli._loader import load_nodes
 from calfkit.cli._run import serve
 
 
@@ -69,20 +82,20 @@ def run(
     ),
 ) -> None:
     """Run node(s) as a worker until stopped (Ctrl-C)."""
-    # Fast-fail on malformed targets in the parent before spawning a watcher;
-    # full import/resolution happens in serve() (in the child under --reload).
-    for spec in targets:
-        if ":" not in spec:
-            typer.echo(f"Error: target must be in 'module:attr' form, got {spec!r}.", err=True)
-            raise typer.Exit(2)
-
     abs_app_dir = os.path.abspath(app_dir)
 
     if reload:
+        # Pre-flight the targets in the parent before starting the supervisor so
+        # a misconfigured run fails fast (exit 2) instead of leaving an idle
+        # watcher around a child that never started. This imports the target
+        # module(s) once in the parent; the spawned child re-imports them
+        # cleanly on each restart. (Runtime/broker failures still surface in the
+        # child and restart on the next edit — the standard reload contract.)
+        load_nodes(list(targets), app_dir=abs_app_dir)
+
         # The reload supervisor (parent) only watches files; watchfiles spawns
-        # serve() in a fresh process on every change, re-importing the targets
-        # cleanly. serve must stay a module-level function with picklable args
-        # for the spawn to reconstruct it.
+        # serve() in a fresh process on every change. serve must stay a
+        # module-level function with picklable args for the spawn to reconstruct it.
         from watchfiles import PythonFilter, run_process
 
         dirs = reload_dir or [os.getcwd()]
@@ -96,5 +109,9 @@ def run(
         try:
             serve(list(targets), host, provision, group_id, env_file, abs_app_dir)
         except KeyboardInterrupt:
-            # Clean Ctrl-C shutdown — the worker/FastStream already tore down.
+            # Ctrl-C in a window where FastStream's own SIGINT handler isn't
+            # active yet (startup/teardown), or on a platform whose event loop
+            # lacks add_signal_handler: treat as a clean stop instead of dumping
+            # a traceback. On the normal path FastStream handles SIGINT itself
+            # and serve() returns without raising — this is the fallback.
             raise typer.Exit(0) from None

--- a/calfkit/cli/topics.py
+++ b/calfkit/cli/topics.py
@@ -34,14 +34,14 @@ Exit codes:
 from __future__ import annotations
 
 import asyncio
-import importlib
-from collections.abc import Iterable
 from typing import Any
 
 try:
     import typer
 except ImportError as e:  # pragma: no cover -- exercised manually
     raise ImportError("calfkit topics provision requires the 'cli' optional extra. Install with: pip install calfkit[cli]") from e
+
+from calfkit.cli._loader import resolve_specs, validate_nodes
 
 app = typer.Typer(
     name="topics",
@@ -56,76 +56,6 @@ def _topics_callback() -> None:
     invocation pattern even when provision is currently the only subcommand.
     Future subcommands will land alongside it.
     """
-
-
-def _resolve_nodes(specs: list[str]) -> list[Any]:
-    """Resolve ``module:attr`` specs into a flat list of node objects.
-
-    Each ``attr`` may be a single node or an iterable of nodes. Results are
-    concatenated in the order the ``--nodes`` flags were supplied.
-
-    Raises:
-        typer.Exit: (code 2) on a malformed spec or import/attribute failure.
-    """
-    resolved: list[Any] = []
-    for spec in specs:
-        module_path, sep, attr = spec.partition(":")
-        if not sep or not module_path or not attr:
-            typer.echo(
-                f"Error: --nodes must be in 'module:attr' form, got {spec!r}.",
-                err=True,
-            )
-            raise typer.Exit(2)
-        try:
-            module = importlib.import_module(module_path)
-        except (ModuleNotFoundError, ImportError) as e:
-            # The module (or one of its imports) does not exist / cannot load.
-            typer.echo(f"Error: cannot import module {module_path!r}: {e}", err=True)
-            raise typer.Exit(2) from e
-        except Exception as e:  # noqa: BLE001 -- side-effect code at import time failed
-            # The module exists but its top-level code raised when executed.
-            typer.echo(
-                f"Error: module {module_path!r} raised during import (side-effect code failed): {e}",
-                err=True,
-            )
-            raise typer.Exit(2) from e
-        try:
-            obj = getattr(module, attr)
-        except AttributeError as e:
-            typer.echo(f"Error: module {module_path!r} has no attribute {attr!r}.", err=True)
-            raise typer.Exit(2) from e
-
-        # A single node has subscribe_topics (str-keyed) but is not itself a
-        # plain iterable of nodes. Strings are iterable too, so treat str/bytes
-        # as scalars. Everything else iterable is expanded.
-        if isinstance(obj, (str, bytes)) or not isinstance(obj, Iterable):
-            resolved.append(obj)
-        else:
-            resolved.extend(obj)
-    return resolved
-
-
-def _validate_nodes(nodes: list[Any]) -> None:
-    """Ensure every resolved object exposes the node attributes the topic-set
-    derivation relies on (``subscribe_topics`` and ``_return_topic``).
-
-    Without this, a ``--nodes`` attr pointing at a non-node object would let an
-    ``AttributeError`` escape ``topics_for_nodes`` as an uncaught exit-1
-    traceback. Surface an actionable exit-2 error instead.
-
-    Raises:
-        typer.Exit: (code 2) if any object is missing a required node attribute.
-    """
-    for obj in nodes:
-        missing = [attr for attr in ("subscribe_topics", "_return_topic") if not hasattr(obj, attr)]
-        if missing:
-            typer.echo(
-                f"Error: resolved object {obj!r} is not a node "
-                f"(missing {', '.join(missing)}). --nodes must point at a "
-                "BaseNodeDef (or an iterable of them).",
-                err=True,
-            )
-            raise typer.Exit(2)
 
 
 def _partition_nodes(objs: list[Any]) -> list[Any]:
@@ -206,9 +136,9 @@ def provision(
         topics_for_nodes,
     )
 
-    resolved = _resolve_nodes(nodes)
+    resolved = resolve_specs(nodes)
     node_list = _partition_nodes(resolved)
-    _validate_nodes(node_list)
+    validate_nodes(node_list)
 
     topics = topics_for_nodes(node_list)
     framework_topics = {node._return_topic for node in node_list}

--- a/calfkit/cli/topics.py
+++ b/calfkit/cli/topics.py
@@ -136,9 +136,9 @@ def provision(
         topics_for_nodes,
     )
 
-    resolved = resolve_specs(nodes)
+    resolved = resolve_specs(nodes, source_label="--nodes")
     node_list = _partition_nodes(resolved)
-    validate_nodes(node_list)
+    validate_nodes(node_list, source_label="--nodes")
 
     topics = topics_for_nodes(node_list)
     framework_topics = {node._return_topic for node in node_list}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,214 @@
+# Calfkit CLI reference
+
+The `calfkit` command bundles the SDK's command-line tooling. It is installed
+via the **`cli` optional extra** (it pulls in `typer` and `watchfiles`):
+
+```bash
+pip install "calfkit[cli]"
+```
+
+If the extra isn't installed, invoking `calfkit` raises a clear remediation
+message instead of failing obscurely.
+
+Commands:
+
+| Command | Purpose |
+| --- | --- |
+| [`calfkit run`](#calfkit-run) | Run node(s) as a worker for local development (no `Worker` boilerplate). |
+| [`calfkit mcp`](#calfkit-mcp) | Generate MCP tool schemas / emit the `mcp.json` reference schema. |
+| [`calfkit topics`](#calfkit-topics) | Best-effort create the Kafka topics a set of nodes reference. |
+
+---
+
+## `calfkit run`
+
+Run one or more nodes as a worker without writing the
+`Client.connect(...)` → `Worker(...)` → `worker.run()` boilerplate — point it at
+a node and it serves, in the spirit of `fastapi dev`.
+
+```text
+calfkit run TARGET [TARGET ...] [OPTIONS]
+```
+
+> **Development only.** `calfkit run` is a convenience for running nodes locally.
+> Production deployments should use an explicit `Worker` so startup, scaling, and
+> topic governance stay under operator control — see
+> [Production deployment](#production-deployment) below.
+
+### Targets
+
+Each `TARGET` is a dotted **`module:attr`** import path (like `uvicorn main:app`):
+
+- `attr` may be a **single node** or an **iterable of nodes** — iterables are
+  expanded, so `mypkg.workers:all_nodes` (a list) works.
+- An [`McpServer`](mcp-overview.md) instance is a valid `attr` too; it is run
+  whole (the worker expands it into per-tool bridges at startup).
+- Pass **multiple targets** to run them in one worker:
+  `calfkit run app.agents:planner app.tools:search`.
+- Targets de-duplicate by `node_id`, so listing the same node twice is harmless.
+
+Targets are resolved with Python's import machinery, so the module must be
+**importable** from where you run the command. By default the current directory
+is placed on the import path (see `--app-dir`), so run from your project root:
+
+```bash
+# project root contains weather_tool.py
+calfkit run weather_tool:get_weather
+
+# nested package (dots, not slashes; no .py suffix)
+calfkit run app.tools.weather:get_weather
+```
+
+Nested directories work as packages, including
+[PEP&nbsp;420 namespace packages](https://peps.python.org/pep-0420/) (no
+`__init__.py` required). If a target module uses **relative imports**
+(`from . import ...`), make it a regular package (add `__init__.py`).
+
+### Node files need no boilerplate
+
+Because `calfkit run` imports your module and runs the node, the file only needs
+the node definition at module scope — no `main()`, no `asyncio.run(...)`, no
+`Worker`:
+
+```python
+# weather_tool.py — the whole file
+from calfkit.nodes import agent_tool
+
+@agent_tool
+def get_weather(location: str) -> str:
+    """Get the current weather at a location"""
+    return f"It's sunny in {location}"
+```
+
+If a file *does* keep its own runnable entrypoint, guard it with
+`if __name__ == "__main__": asyncio.run(...)` — the guard does not fire on
+import, so `calfkit run` ignores it. (A `Worker.run()` left at module top level
+would block the import; keep it under the guard.)
+
+### Options
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--host`, `-H` | `$CALF_HOST_URL` → `localhost` | Kafka bootstrap server(s), comma-separated. Precedence: this flag **>** `$CALF_HOST_URL` **>** `localhost`. |
+| `--provision` | off | Opt-in dev topic auto-creation (**experimental**; `replication_factor=1`, no ACLs). See [Topic provisioning](topic-provisioning.md). |
+| `--reload` | off | Watch source files and restart the worker on change (see [Reload](#reload)). |
+| `--reload-dir` | current dir | Directory to watch with `--reload`. Repeatable. |
+| `--app-dir` | `.` (current dir) | Directory inserted on `sys.path` for resolving `module:attr` targets. |
+| `--group-id` | each node's id | Kafka consumer-group override applied to every node. |
+| `--env-file` | `./.env` if present | dotenv file to load before starting. A *missing explicit* `--env-file` warns (it is not silently ignored). |
+
+### Reload
+
+`--reload` runs the worker under a [watchfiles](https://github.com/samuelcolvin/watchfiles)
+supervisor, the same mechanism `uvicorn`/`fastapi dev` use: a lightweight parent
+process watches `.py` files and re-spawns a fresh worker process (clean
+re-import) on every change.
+
+- **Config errors fail fast.** Before starting the supervisor, the targets are
+  pre-flighted (resolved + validated) in the parent, so a bad `module:attr`, an
+  import error, a non-node object, or zero resolved nodes exits `2` immediately
+  rather than leaving an idle watcher.
+- **Runtime failures restart on edit.** A failure that only appears once the
+  worker is live (e.g. the broker is unreachable) is reported in the child
+  process and the supervisor keeps watching — fix the code and save to retry.
+  This is the standard dev-server reload contract.
+
+### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Clean shutdown (Ctrl-C, or the worker stopped on its own). |
+| `2` | Configuration error — bad `module:attr` spec, import failure, non-node object, or zero nodes resolved (surfaced before the worker starts, including under `--reload`). |
+
+### Examples
+
+```bash
+# One tool node
+calfkit run weather_tool:get_weather
+
+# An agent and its tool in one worker, against a specific broker
+calfkit run agent_service:agent weather_tool:get_weather --host localhost:9092
+
+# Auto-restart on edits, auto-create dev topics
+calfkit run agent_service:agent --reload --provision
+
+# Resolve targets relative to ./src, load a custom env file
+calfkit run workers:all_nodes --app-dir src --env-file .env.local
+```
+
+### Production deployment
+
+`calfkit run` is for development. In production, deploy each node with an
+explicit `Worker`:
+
+```python
+# serve_tool.py
+import asyncio
+from calfkit.client import Client
+from calfkit.worker import Worker
+from weather_tool import get_weather
+
+async def main():
+    client = Client.connect("localhost:9092")
+    worker = Worker(client, nodes=[get_weather])
+    await worker.run()
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+```bash
+python serve_tool.py
+```
+
+---
+
+## `calfkit mcp`
+
+Tooling for the [MCP adaptor](mcp-overview.md) — expose Model Context Protocol
+servers as native calfkit tools.
+
+```text
+calfkit mcp codegen NAME (--command "<stdio cmd>" | --url "<http url>") [--token TOKEN] [--output PATH] [--check]
+calfkit mcp schema [--output PATH] [--check]
+```
+
+- **`codegen`** — start an MCP server (stdio via `--command`, or streamable HTTP
+  via `--url`/`--token`), run `initialize` + `tools/list`, and write a generated
+  Python module of `McpToolDef` constants you import and commit. `--check` exits
+  non-zero on drift without writing (CI mode).
+- **`schema`** — emit the reference JSON Schema for `mcp.json` (no MCP server
+  needed). `--check` compares against the existing file without writing.
+
+Exit codes: `0` success / no drift · `1` drift (`--check`) · `2` error.
+
+See **[docs/mcp-overview.md](mcp-overview.md)** for the full workflow, deployment
+topologies, and `mcp.json` interop.
+
+---
+
+## `calfkit topics`
+
+```text
+calfkit topics provision --nodes module:attr [--nodes module:attr ...] [OPTIONS]
+```
+
+Resolve the Kafka topics a set of nodes reference (subscribe inboxes, framework
+return inboxes, publish topics, and agent tool inputs) and best-effort create
+them — a development convenience for shaping a local/CI broker.
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--nodes` | — (required) | Node source as `module:attr` (a node or an iterable). Repeatable. |
+| `--bootstrap-servers` | `localhost` | Kafka bootstrap server URL(s), comma-separated. |
+| `--partitions` | `1` | Partition count for newly created topics. |
+| `--replication-factor` | `1` | Replication factor for newly created topics (`1` is **not** durable). |
+| `--timeout-ms` | `30000` | Budget for the provisioning operation. |
+| `--dry-run` | off | Resolve and print the topic set without contacting Kafka. |
+
+Exit codes: `0` success / dry-run · `2` error.
+
+> **Experimental / opt-in.** This is a dev convenience (`rf=1`, no ACLs), **not**
+> a production provisioning story. `McpServer` entries are skipped with a note —
+> their topics are provisioned at worker startup from the live MCP session. See
+> **[docs/topic-provisioning.md](topic-provisioning.md)**.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,10 @@ calfkit = "calfkit.cli:main"
 [project.optional-dependencies]
 dev = []
 # Installed via `pip install calfkit[cli]`. Off the critical install path
-# because the CLI is only invoked at schema-generation / provisioning time,
-# not runtime. Gates the whole `calfkit` console script (typer).
-cli = ["typer>=0.12"]
+# because the CLI is only invoked at schema-generation / provisioning /
+# dev-run time, not at library runtime. Gates the whole `calfkit` console
+# script (typer); `watchfiles` powers `calfkit run --reload`.
+cli = ["typer>=0.12", "watchfiles>=0.21"]
 # Backwards-compatible alias for the original extra name; resolves to the same
 # typer dependency via `calfkit[cli]`.
 mcp-codegen = ["calfkit[cli]"]
@@ -112,6 +113,9 @@ dev = [
     # typer is the dep for the `cli` optional extra; dev includes it
     # so the CLI tests can run against the same install.
     "typer>=0.12",
+    # watchfiles powers `calfkit run --reload`; dev includes it so the
+    # CLI reload tests can import and patch it.
+    "watchfiles>=0.21",
 ]
 examples = [
     "plotext>=5.3.2",

--- a/tests/provisioning_cli_nodes.py
+++ b/tests/provisioning_cli_nodes.py
@@ -40,3 +40,13 @@ mixed = [
 # ``subscribe_topics`` / ``_return_topic``). The CLI must reject it with an
 # actionable error rather than letting an AttributeError escape as exit 1.
 not_a_node = object()
+
+# A single McpServer resolved directly (not nested in a list). The loader must
+# return it as-is — an McpServer is iterable (it yields its tool defs), so a
+# naive "expand iterables" pass would wrongly splat it into McpToolDef objects.
+solo_mcp = McpServer.stdio("echo", name="solo_mcp", tools=[])
+
+# An attr that is an empty iterable — resolves to zero nodes. ``calfkit run``
+# must treat "nothing resolved" as an error (exit 2), not silently start an
+# idle worker.
+empty_list: list = []

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -91,11 +91,13 @@ def test_run_reload_hands_serve_to_watchfiles(monkeypatch: pytest.MonkeyPatch) -
 
     monkeypatch.setattr(watchfiles, "run_process", fake_run_process)
 
-    result = CliRunner().invoke(_build_app(), ["run", "mymod:agent", "--reload"])
+    # A real, resolvable target: the parent pre-flights (imports + validates) it
+    # before handing off to the supervisor.
+    result = CliRunner().invoke(_build_app(), ["run", "tests.provisioning_cli_nodes:single", "--reload"])
     assert result.exit_code == 0, result.stdout + result.stderr
     # The supervised target is the real serve engine; targets ride in args[0].
     assert cap["target"] is run_engine.serve
-    assert cap["args"][0] == ["mymod:agent"]
+    assert cap["args"][0] == ["tests.provisioning_cli_nodes:single"]
     # Default watch dir is the cwd.
     assert os.getcwd() in cap["paths"]
 
@@ -114,9 +116,65 @@ def test_run_reload_watch_dir_override(monkeypatch: pytest.MonkeyPatch, tmp_path
     monkeypatch.setattr(watchfiles, "run_process", fake_run_process)
 
     watched = str(tmp_path)  # type: ignore[arg-type]
-    result = CliRunner().invoke(_build_app(), ["run", "mymod:agent", "--reload", "--reload-dir", watched])
+    result = CliRunner().invoke(_build_app(), ["run", "tests.provisioning_cli_nodes:single", "--reload", "--reload-dir", watched])
     assert result.exit_code == 0, result.stdout + result.stderr
     assert cap["paths"] == (watched,)
+
+
+def test_run_reload_bad_target_exits_2_before_supervisor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Under --reload a broken target fails fast (exit 2) and the supervisor
+    (watchfiles.run_process) is never started — no idle watcher around a child
+    that never came up."""
+    import watchfiles
+
+    from calfkit.cli import _build_app
+
+    cap = {"called": False}
+
+    def fake_run_process(*paths: str, **kwargs: object) -> None:
+        cap["called"] = True
+
+    monkeypatch.setattr(watchfiles, "run_process", fake_run_process)
+
+    result = CliRunner().invoke(_build_app(), ["run", "no_colon_here", "--reload"])
+    assert result.exit_code == 2
+    assert "module:attr" in _plain(result.stderr)
+    assert cap["called"] is False
+
+
+def test_run_multiple_targets_forwarded_to_serve(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The variadic positional collects every target and forwards the full list."""
+    import calfkit.cli.run as run_mod
+    from calfkit.cli import _build_app
+
+    cap: dict = {}
+
+    def fake_serve(targets: list[str], host: str | None, provision: bool, group_id: str | None, env_file: str | None, app_dir: str) -> None:
+        cap["targets"] = targets
+
+    monkeypatch.setattr(run_mod, "serve", fake_serve)
+
+    result = CliRunner().invoke(_build_app(), ["run", "a:x", "b:y", "c:z"])
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert cap["targets"] == ["a:x", "b:y", "c:z"]
+
+
+def test_run_custom_app_dir_forwarded_to_serve(monkeypatch: pytest.MonkeyPatch, tmp_path: object) -> None:
+    """--app-dir is absolutised and forwarded to serve."""
+    import calfkit.cli.run as run_mod
+    from calfkit.cli import _build_app
+
+    cap: dict = {}
+
+    def fake_serve(targets: list[str], host: str | None, provision: bool, group_id: str | None, env_file: str | None, app_dir: str) -> None:
+        cap["app_dir"] = app_dir
+
+    monkeypatch.setattr(run_mod, "serve", fake_serve)
+
+    target_dir = str(tmp_path)  # type: ignore[arg-type]
+    result = CliRunner().invoke(_build_app(), ["run", "m:a", "--app-dir", target_dir])
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert cap["app_dir"] == os.path.abspath(target_dir)
 
 
 def test_run_bad_spec_exits_2() -> None:

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -1,0 +1,142 @@
+"""Tests for the ``calfkit run`` typer command and its top-level mounting.
+
+The ``serve`` engine is patched out (it would block on a real broker), so
+these tests assert the command's dispatch: no-reload calls ``serve`` directly,
+``--reload`` hands ``serve`` to ``watchfiles.run_process``, bad specs exit 2,
+and Ctrl-C exits cleanly.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+import pytest
+from typer.testing import CliRunner
+
+_ANSI_SGR = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(s: str) -> str:
+    """Strip ANSI SGR escape codes so substring assertions survive styling."""
+    return _ANSI_SGR.sub("", s)
+
+
+def test_run_mounted_on_top_level_cli() -> None:
+    """The top-level ``calfkit`` app mounts the ``run`` command with its flags."""
+    from calfkit.cli import _build_app
+
+    result = CliRunner().invoke(_build_app(), ["run", "--help"])
+    assert result.exit_code == 0, result.stdout
+    out = _plain(result.stdout)
+    assert "--reload" in out
+    assert "--host" in out
+    assert "--provision" in out
+
+
+def test_run_no_reload_calls_serve(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without --reload, the command calls serve() directly with parsed args."""
+    import calfkit.cli.run as run_mod
+    from calfkit.cli import _build_app
+
+    cap: dict = {}
+
+    def fake_serve(targets: list[str], host: str | None, provision: bool, group_id: str | None, env_file: str | None, app_dir: str) -> None:
+        cap.update(targets=targets, host=host, provision=provision, group_id=group_id, env_file=env_file, app_dir=app_dir)
+
+    monkeypatch.setattr(run_mod, "serve", fake_serve)
+
+    result = CliRunner().invoke(_build_app(), ["run", "mymod:agent"])
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert cap["targets"] == ["mymod:agent"]
+    assert cap["host"] is None
+    assert cap["provision"] is False
+    assert cap["group_id"] is None
+    assert os.path.isabs(cap["app_dir"])
+
+
+def test_run_forwards_flags_to_serve(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--host / --provision / --group-id reach serve()."""
+    import calfkit.cli.run as run_mod
+    from calfkit.cli import _build_app
+
+    cap: dict = {}
+
+    def fake_serve(targets: list[str], host: str | None, provision: bool, group_id: str | None, env_file: str | None, app_dir: str) -> None:
+        cap.update(host=host, provision=provision, group_id=group_id)
+
+    monkeypatch.setattr(run_mod, "serve", fake_serve)
+
+    result = CliRunner().invoke(
+        _build_app(),
+        ["run", "mymod:agent", "--host", "h:9092", "--provision", "--group-id", "g"],
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert cap["host"] == "h:9092"
+    assert cap["provision"] is True
+    assert cap["group_id"] == "g"
+
+
+def test_run_reload_hands_serve_to_watchfiles(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--reload runs serve via watchfiles.run_process (the supervisor), not inline."""
+    import watchfiles
+
+    import calfkit.cli._run as run_engine
+    from calfkit.cli import _build_app
+
+    cap: dict = {}
+
+    def fake_run_process(*paths: str, target: object = None, args: object = None, watch_filter: object = None, **kwargs: object) -> None:
+        cap.update(paths=paths, target=target, args=args, watch_filter=watch_filter)
+
+    monkeypatch.setattr(watchfiles, "run_process", fake_run_process)
+
+    result = CliRunner().invoke(_build_app(), ["run", "mymod:agent", "--reload"])
+    assert result.exit_code == 0, result.stdout + result.stderr
+    # The supervised target is the real serve engine; targets ride in args[0].
+    assert cap["target"] is run_engine.serve
+    assert cap["args"][0] == ["mymod:agent"]
+    # Default watch dir is the cwd.
+    assert os.getcwd() in cap["paths"]
+
+
+def test_run_reload_watch_dir_override(monkeypatch: pytest.MonkeyPatch, tmp_path: object) -> None:
+    """--reload-dir overrides the watched directory."""
+    import watchfiles
+
+    from calfkit.cli import _build_app
+
+    cap: dict = {}
+
+    def fake_run_process(*paths: str, **kwargs: object) -> None:
+        cap["paths"] = paths
+
+    monkeypatch.setattr(watchfiles, "run_process", fake_run_process)
+
+    watched = str(tmp_path)  # type: ignore[arg-type]
+    result = CliRunner().invoke(_build_app(), ["run", "mymod:agent", "--reload", "--reload-dir", watched])
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert cap["paths"] == (watched,)
+
+
+def test_run_bad_spec_exits_2() -> None:
+    """A target without 'module:attr' form errors with exit 2 before serving."""
+    from calfkit.cli import _build_app
+
+    result = CliRunner().invoke(_build_app(), ["run", "no_colon_here"])
+    assert result.exit_code == 2
+    assert "module:attr" in _plain(result.stderr)
+
+
+def test_run_keyboard_interrupt_exits_0(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ctrl-C during a no-reload run shuts down cleanly (exit 0)."""
+    import calfkit.cli.run as run_mod
+    from calfkit.cli import _build_app
+
+    def boom(*args: object, **kwargs: object) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(run_mod, "serve", boom)
+
+    result = CliRunner().invoke(_build_app(), ["run", "mymod:agent"])
+    assert result.exit_code == 0

--- a/tests/test_run_loader.py
+++ b/tests/test_run_loader.py
@@ -127,3 +127,53 @@ def test_dedupe_by_node_id_drops_repeats_preserving_order() -> None:
     objs = resolve_specs([f"{_FIXTURE}:single", f"{_FIXTURE}:single", f"{_FIXTURE}:nodes"])
     deduped = dedupe_by_node_id(objs)
     assert [o.node_id for o in deduped] == ["tool_echo", "tool_alpha", "tool_beta"]
+
+
+def test_dedupe_keeps_distinct_mcp_servers() -> None:
+    """McpServer instances have no node_id, so dedupe keys them by identity and
+    always retains them (it must not collapse all node_id-less objects to one)."""
+    from calfkit.cli._loader import dedupe_by_node_id, resolve_specs
+    from calfkit.mcp._server import McpServer
+
+    # solo_mcp + the McpServer inside `mixed` are two distinct instances.
+    objs = resolve_specs([f"{_FIXTURE}:solo_mcp", f"{_FIXTURE}:mixed"])
+    deduped = dedupe_by_node_id(objs)
+    mcp_servers = [o for o in deduped if isinstance(o, McpServer)]
+    assert len(mcp_servers) == 2
+
+
+def test_resolve_specs_later_bad_spec_exits_2() -> None:
+    """A malformed spec is caught even when it follows a valid one."""
+    from calfkit.cli._loader import resolve_specs
+
+    with pytest.raises(typer.Exit) as exc:
+        resolve_specs([f"{_FIXTURE}:single", "no_colon_here"])
+    assert exc.value.exit_code == 2
+
+
+def test_resolve_specs_source_label_appears_in_error(capsys: pytest.CaptureFixture[str]) -> None:
+    """source_label names the spec source in the malformed-spec message so
+    `topics provision` can say "--nodes" while `run` says "target"."""
+    from calfkit.cli._loader import resolve_specs
+
+    with pytest.raises(typer.Exit):
+        resolve_specs(["no_colon"], source_label="--nodes")
+    err = capsys.readouterr().err
+    assert "--nodes must be in 'module:attr' form" in err
+
+
+def test_load_nodes_resolves_validates_and_dedupes() -> None:
+    """load_nodes returns the deduped node list for valid targets."""
+    from calfkit.cli._loader import load_nodes
+
+    nodes = load_nodes([f"{_FIXTURE}:single", f"{_FIXTURE}:single", f"{_FIXTURE}:nodes"])
+    assert [n.node_id for n in nodes] == ["tool_echo", "tool_alpha", "tool_beta"]
+
+
+def test_load_nodes_empty_resolution_exits_2() -> None:
+    """load_nodes raises exit 2 when targets resolve to zero nodes."""
+    from calfkit.cli._loader import load_nodes
+
+    with pytest.raises(typer.Exit) as exc:
+        load_nodes([f"{_FIXTURE}:empty_list"])
+    assert exc.value.exit_code == 2

--- a/tests/test_run_loader.py
+++ b/tests/test_run_loader.py
@@ -1,0 +1,129 @@
+"""Tests for the shared CLI node loader (``calfkit.cli._loader``).
+
+The loader resolves ``module:attr`` specs into a flat list of node objects and
+is shared by ``calfkit topics provision`` and ``calfkit run``. These tests
+exercise it directly (no CliRunner) against the small in-repo
+``tests.provisioning_cli_nodes`` fixture module.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+import typer
+
+_FIXTURE = "tests.provisioning_cli_nodes"
+
+
+def test_resolve_specs_single_node() -> None:
+    """An attr that is one node resolves to a one-element list."""
+    from calfkit.cli._loader import resolve_specs
+
+    objs = resolve_specs([f"{_FIXTURE}:single"])
+    assert len(objs) == 1
+    assert objs[0].node_id == "tool_echo"
+
+
+def test_resolve_specs_expands_iterable_attr() -> None:
+    """An attr that is a list of nodes is expanded into the result."""
+    from calfkit.cli._loader import resolve_specs
+
+    objs = resolve_specs([f"{_FIXTURE}:nodes"])
+    assert [o.node_id for o in objs] == ["tool_alpha", "tool_beta"]
+
+
+def test_resolve_specs_multiple_specs_concatenate_in_order() -> None:
+    """Multiple specs resolve and concatenate in the order supplied."""
+    from calfkit.cli._loader import resolve_specs
+
+    objs = resolve_specs([f"{_FIXTURE}:single", f"{_FIXTURE}:nodes"])
+    assert [o.node_id for o in objs] == ["tool_echo", "tool_alpha", "tool_beta"]
+
+
+def test_resolve_specs_preserves_directly_resolved_mcp_server() -> None:
+    """A directly-resolved McpServer is returned as-is, not splatted into its
+    tool defs (McpServer is iterable, so a naive expand would break it)."""
+    from calfkit.cli._loader import resolve_specs
+    from calfkit.mcp._server import McpServer
+
+    objs = resolve_specs([f"{_FIXTURE}:solo_mcp"])
+    assert len(objs) == 1
+    assert isinstance(objs[0], McpServer)
+
+
+def test_resolve_specs_bad_spec_exits_2() -> None:
+    """A spec without a ':' raises typer.Exit(2) mentioning the required form."""
+    from calfkit.cli._loader import resolve_specs
+
+    with pytest.raises(typer.Exit) as exc:
+        resolve_specs(["no_colon_here"])
+    assert exc.value.exit_code == 2
+
+
+def test_resolve_specs_missing_module_exits_2() -> None:
+    """An unimportable module raises typer.Exit(2)."""
+    from calfkit.cli._loader import resolve_specs
+
+    with pytest.raises(typer.Exit) as exc:
+        resolve_specs(["tests.does_not_exist_xyz:thing"])
+    assert exc.value.exit_code == 2
+
+
+def test_resolve_specs_missing_attr_exits_2() -> None:
+    """A module that lacks the requested attr raises typer.Exit(2)."""
+    from calfkit.cli._loader import resolve_specs
+
+    with pytest.raises(typer.Exit) as exc:
+        resolve_specs([f"{_FIXTURE}:nonexistent_attr"])
+    assert exc.value.exit_code == 2
+
+
+def test_resolve_specs_app_dir_enables_nested_dotted_import(tmp_path: object, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``app_dir`` puts a directory on sys.path so a nested dotted module that
+    is otherwise unimportable resolves — incl. PEP-420 namespace packages
+    (no __init__.py), matching ``calfkit run subdir.agent_file:agent``."""
+    from calfkit.cli._loader import resolve_specs
+
+    subdir = tmp_path / "subpkg"  # type: ignore[operator]
+    subdir.mkdir()
+    (subdir / "agent_file.py").write_text("from calfkit.nodes import agent_tool\n\n@agent_tool\ndef my_tool(x: int) -> int:\n    return x\n")
+
+    # Isolate sys.path mutation (monkeypatch restores the original list object).
+    monkeypatch.setattr(sys, "path", list(sys.path))
+    before = set(sys.modules)
+    try:
+        objs = resolve_specs(["subpkg.agent_file:my_tool"], app_dir=str(tmp_path))
+    finally:
+        for name in set(sys.modules) - before:
+            sys.modules.pop(name, None)
+
+    assert len(objs) == 1
+    assert objs[0].node_id == "tool_my_tool"
+
+
+def test_validate_nodes_accepts_nodes_and_mcp_servers() -> None:
+    """A mix of real nodes and McpServer instances passes validation."""
+    from calfkit.cli._loader import resolve_specs, validate_nodes
+
+    objs = resolve_specs([f"{_FIXTURE}:mixed"])
+    validate_nodes(objs)  # must not raise
+
+
+def test_validate_nodes_rejects_non_node_exits_2() -> None:
+    """An object that is neither a node nor an McpServer is rejected (exit 2)."""
+    from calfkit.cli._loader import resolve_specs, validate_nodes
+
+    objs = resolve_specs([f"{_FIXTURE}:not_a_node"])
+    with pytest.raises(typer.Exit) as exc:
+        validate_nodes(objs)
+    assert exc.value.exit_code == 2
+
+
+def test_dedupe_by_node_id_drops_repeats_preserving_order() -> None:
+    """Duplicate node_ids collapse to the first occurrence, order preserved."""
+    from calfkit.cli._loader import dedupe_by_node_id, resolve_specs
+
+    objs = resolve_specs([f"{_FIXTURE}:single", f"{_FIXTURE}:single", f"{_FIXTURE}:nodes"])
+    deduped = dedupe_by_node_id(objs)
+    assert [o.node_id for o in deduped] == ["tool_echo", "tool_alpha", "tool_beta"]

--- a/tests/test_run_serve.py
+++ b/tests/test_run_serve.py
@@ -1,0 +1,120 @@
+"""Tests for the ``calfkit run`` serve entrypoint (``calfkit.cli._run.serve``).
+
+``serve`` is the picklable function the reload supervisor spawns and the
+no-reload path calls directly. These tests patch the ``Client``/``Worker``
+seams so no live Kafka broker is required, and assert the wiring: node
+resolution, host precedence, provisioning, and group-id passthrough.
+"""
+
+from __future__ import annotations
+
+import pytest
+import typer
+
+_FIXTURE = "tests.provisioning_cli_nodes"
+
+
+@pytest.fixture
+def captured(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Patch the Client/Worker seams and capture what ``serve`` wires up."""
+    cap: dict = {}
+
+    class FakeClient:
+        @classmethod
+        def connect(cls, server_urls: object = None, **kwargs: object) -> FakeClient:
+            cap["server_urls"] = server_urls
+            cap["provisioning"] = kwargs.get("provisioning")
+            return cls()
+
+    class FakeWorker:
+        def __init__(self, client: object, nodes: object = None, group_id: object = None, **kwargs: object) -> None:
+            cap["nodes"] = nodes
+            cap["group_id"] = group_id
+
+        async def run(self, **kwargs: object) -> None:
+            cap["ran"] = True
+
+    monkeypatch.setattr("calfkit.client.Client", FakeClient)
+    monkeypatch.setattr("calfkit.worker.Worker", FakeWorker)
+    return cap
+
+
+def test_serve_resolves_nodes_and_runs_worker(captured: dict) -> None:
+    """serve resolves the targets, builds a Worker with them, and runs it."""
+    from calfkit.cli._run import serve
+
+    serve([f"{_FIXTURE}:nodes"], host=None, provision=False, group_id=None, env_file=None, app_dir=".")
+
+    assert [n.node_id for n in captured["nodes"]] == ["tool_alpha", "tool_beta"]
+    assert captured["ran"] is True
+
+
+def test_serve_no_host_delegates_to_client_default(captured: dict) -> None:
+    """With no --host, serve passes server_urls=None so Client.connect applies
+    its CALF_HOST_URL -> localhost fallback."""
+    from calfkit.cli._run import serve
+
+    serve([f"{_FIXTURE}:single"], host=None, provision=False, group_id=None, env_file=None, app_dir=".")
+
+    assert captured["server_urls"] is None
+
+
+def test_serve_host_flag_maps_to_server_urls(captured: dict) -> None:
+    """A single --host value is forwarded to Client.connect verbatim."""
+    from calfkit.cli._run import serve
+
+    serve([f"{_FIXTURE}:single"], host="myhost:9092", provision=False, group_id=None, env_file=None, app_dir=".")
+
+    assert captured["server_urls"] == "myhost:9092"
+
+
+def test_serve_host_comma_splits_to_list(captured: dict) -> None:
+    """A comma-separated --host becomes a list of bootstrap servers."""
+    from calfkit.cli._run import serve
+
+    serve([f"{_FIXTURE}:single"], host="a:9092, b:9092", provision=False, group_id=None, env_file=None, app_dir=".")
+
+    assert captured["server_urls"] == ["a:9092", "b:9092"]
+
+
+def test_serve_provision_flag_enables_provisioning(captured: dict) -> None:
+    """--provision passes an enabled ProvisioningConfig; default passes None."""
+    from calfkit.cli._run import serve
+
+    serve([f"{_FIXTURE}:single"], host=None, provision=True, group_id=None, env_file=None, app_dir=".")
+    assert captured["provisioning"] is not None
+    assert captured["provisioning"].enabled is True
+
+
+def test_serve_no_provision_passes_none(captured: dict) -> None:
+    """Without --provision, no provisioning config is passed."""
+    from calfkit.cli._run import serve
+
+    serve([f"{_FIXTURE}:single"], host=None, provision=False, group_id=None, env_file=None, app_dir=".")
+    assert captured["provisioning"] is None
+
+
+def test_serve_group_id_passthrough(captured: dict) -> None:
+    """--group-id is forwarded to the Worker."""
+    from calfkit.cli._run import serve
+
+    serve([f"{_FIXTURE}:single"], host=None, provision=False, group_id="mygroup", env_file=None, app_dir=".")
+    assert captured["group_id"] == "mygroup"
+
+
+def test_serve_empty_resolution_exits_2(captured: dict) -> None:
+    """A target that resolves to zero nodes errors with exit 2."""
+    from calfkit.cli._run import serve
+
+    with pytest.raises(typer.Exit) as exc:
+        serve([f"{_FIXTURE}:empty_list"], host=None, provision=False, group_id=None, env_file=None, app_dir=".")
+    assert exc.value.exit_code == 2
+
+
+def test_serve_prints_banner_with_node_id(captured: dict, capsys: pytest.CaptureFixture[str]) -> None:
+    """serve prints a startup banner naming the resolved node(s)."""
+    from calfkit.cli._run import serve
+
+    serve([f"{_FIXTURE}:single"], host=None, provision=False, group_id=None, env_file=None, app_dir=".")
+    out = capsys.readouterr().out
+    assert "tool_echo" in out

--- a/tests/test_run_serve.py
+++ b/tests/test_run_serve.py
@@ -111,10 +111,137 @@ def test_serve_empty_resolution_exits_2(captured: dict) -> None:
     assert exc.value.exit_code == 2
 
 
-def test_serve_prints_banner_with_node_id(captured: dict, capsys: pytest.CaptureFixture[str]) -> None:
-    """serve prints a startup banner naming the resolved node(s)."""
+def test_serve_prints_banner_with_node_details(captured: dict, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    """The banner names the node, its kind, its topics, provisioning state, and
+    the effective broker (localhost when --host and CALF_HOST_URL are unset)."""
     from calfkit.cli._run import serve
 
+    monkeypatch.delenv("CALF_HOST_URL", raising=False)
     serve([f"{_FIXTURE}:single"], host=None, provision=False, group_id=None, env_file=None, app_dir=".")
     out = capsys.readouterr().out
     assert "tool_echo" in out
+    assert "[tool]" in out
+    assert "echo.in" in out  # subscribe topic
+    assert "echo.out" in out  # publish topic
+    assert "provisioning: off" in out
+    assert "localhost" in out  # effective broker fallback
+
+
+def test_serve_banner_shows_mcp_server(captured: dict, capsys: pytest.CaptureFixture[str]) -> None:
+    """A directly-served McpServer renders in the banner with the [mcp] kind."""
+    from calfkit.cli._run import serve
+
+    serve([f"{_FIXTURE}:solo_mcp"], host=None, provision=False, group_id=None, env_file=None, app_dir=".")
+    out = capsys.readouterr().out
+    assert "solo_mcp" in out
+    assert "[mcp]" in out
+
+
+def test_serve_banner_shows_env_host_when_no_flag(captured: dict, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no --host, the banner reflects CALF_HOST_URL (the effective broker)."""
+    from calfkit.cli._run import serve
+
+    monkeypatch.setenv("CALF_HOST_URL", "envhost:9092")
+    serve([f"{_FIXTURE}:single"], host=None, provision=False, group_id=None, env_file=None, app_dir=".")
+    out = capsys.readouterr().out
+    assert "envhost:9092" in out
+
+
+# ---------------------------------------------------------------------------
+# _parse_host
+# ---------------------------------------------------------------------------
+
+
+def test_parse_host_none_returns_none() -> None:
+    from calfkit.cli._run import _parse_host
+
+    assert _parse_host(None) is None
+
+
+def test_parse_host_empty_returns_none() -> None:
+    from calfkit.cli._run import _parse_host
+
+    assert _parse_host("") is None
+
+
+def test_parse_host_separators_only_returns_none() -> None:
+    """A non-empty value that strips to nothing falls back to None (so env/
+    localhost still win), not an empty/garbage server list."""
+    from calfkit.cli._run import _parse_host
+
+    assert _parse_host(" , ") is None
+
+
+def test_parse_host_single_returns_str() -> None:
+    from calfkit.cli._run import _parse_host
+
+    assert _parse_host("h:9092") == "h:9092"
+
+
+def test_parse_host_comma_returns_list() -> None:
+    from calfkit.cli._run import _parse_host
+
+    assert _parse_host("a:9092, b:9092") == ["a:9092", "b:9092"]
+
+
+# ---------------------------------------------------------------------------
+# _load_env
+# ---------------------------------------------------------------------------
+
+
+def test_load_env_explicit_file_is_loaded(monkeypatch: pytest.MonkeyPatch, tmp_path: object) -> None:
+    """An explicit --env-file that exists is passed to load_dotenv."""
+    import dotenv
+
+    import calfkit.cli._run as run_mod
+
+    env_path = tmp_path / "custom.env"  # type: ignore[operator]
+    env_path.write_text("FOO=bar\n")
+    calls: list[str] = []
+    monkeypatch.setattr(dotenv, "load_dotenv", lambda p: calls.append(p) or True)
+
+    run_mod._load_env(str(env_path))
+    assert calls == [str(env_path)]
+
+
+def test_load_env_missing_explicit_file_warns_and_skips(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """A missing explicit --env-file warns (not silent) and does not load."""
+    import dotenv
+
+    import calfkit.cli._run as run_mod
+
+    calls: list[str] = []
+    monkeypatch.setattr(dotenv, "load_dotenv", lambda p: calls.append(p) or True)
+
+    run_mod._load_env("/no/such/file.env")
+    assert calls == []
+    assert "not found" in capsys.readouterr().err
+
+
+def test_load_env_autoloads_dotenv_when_present(monkeypatch: pytest.MonkeyPatch, tmp_path: object) -> None:
+    """With no explicit file, ./.env is auto-loaded when it exists."""
+    import dotenv
+
+    import calfkit.cli._run as run_mod
+
+    monkeypatch.chdir(tmp_path)  # type: ignore[arg-type]
+    (tmp_path / ".env").write_text("FOO=bar\n")  # type: ignore[operator]
+    calls: list[str] = []
+    monkeypatch.setattr(dotenv, "load_dotenv", lambda p: calls.append(p) or True)
+
+    run_mod._load_env(None)
+    assert calls == [".env"]
+
+
+def test_load_env_no_file_no_autoload(monkeypatch: pytest.MonkeyPatch, tmp_path: object) -> None:
+    """With no explicit file and no ./.env, load_dotenv is not called."""
+    import dotenv
+
+    import calfkit.cli._run as run_mod
+
+    monkeypatch.chdir(tmp_path)  # type: ignore[arg-type]
+    calls: list[str] = []
+    monkeypatch.setattr(dotenv, "load_dotenv", lambda p: calls.append(p) or True)
+
+    run_mod._load_env(None)
+    assert calls == []


### PR DESCRIPTION
## Summary

Adds a development-only CLI command, `calfkit run`, that runs node(s) as a worker without the `Client.connect(...)` → `Worker(...)` → `worker.run()` boilerplate — point it at one or more `module:attr` targets and it serves them, à la `fastapi dev`.

```bash
pip install calfkit[cli]
calfkit run weather_tool:get_weather
calfkit run agent_service:agent weather_tool:get_weather   # multiple → one worker
calfkit run agent_service:agent --reload                    # hot reload
```

## Design decisions (settled with the maintainer)

- **Dotted `module:attr` targets only** — no file paths, no namespace auto-discovery. Each `attr` may be a single node or an iterable of nodes; all resolved nodes run in one `Worker`. Variadic for multiple targets.
- **`--reload` uses `watchfiles.run_process(target=serve, ...)`** — multiprocessing **spawn** + callable target, which is the exact mechanism `uvicorn`'s reloader uses (verified in `uvicorn/_subprocess.py`). This is why `serve()` is a module-level function taking only picklable args: each restart re-imports the targets in a fresh process.
- **`--host` precedence: flag > `\$CALF_HOST_URL` > `localhost`** — the flag value is passed to `Client.connect`; `None` when omitted so `connect`'s existing env→localhost fallback wins.
- **`--provision` opt-in** (experimental dev topic auto-create; off by default), plus `--app-dir`, `--group-id`, `--reload-dir`, `--env-file`.
- **Shared loader** — extracted `calfkit/cli/_loader.py` (`resolve_specs` / `validate_nodes` / `dedupe_by_node_id`); `topics provision` now reuses it (its private copies removed, behavior preserved).

## Files

| File | Change |
| --- | --- |
| `calfkit/cli/_loader.py` | **new** — shared `module:attr` resolver |
| `calfkit/cli/_run.py` | **new** — `serve()`, the picklable spawn entrypoint |
| `calfkit/cli/run.py` | **new** — the `run` typer command |
| `calfkit/cli/__init__.py` | mount `run` via `app.command(name="run")` |
| `calfkit/cli/topics.py` | refactor to use `_loader` |
| `pyproject.toml` | `watchfiles>=0.21` in `cli` extra + dev group |
| `README.md` | new "Run nodes without the boilerplate (dev CLI)" section |

## Test plan (TDD)

New tests (27): `tests/test_run_loader.py`, `tests/test_run_serve.py`, `tests/test_run_cli.py`. Each module was written test-first (red → green). The `topics.py` refactor keeps its existing tests green.

- `make check` clean: ruff lint ✓, format ✓, mypy (strict) ✓
- 64 CLI/refactor tests pass (loader + serve + command + topics + mcp); the real `calfkit run --help` console script works and `calfkit --help` lists `run`.
- The model/integration suite was not run in this environment (`OPENAI_API_KEY` / `TEST_LLM_MODEL_NAME` unset, Kafka gated off); the change is isolated to `calfkit/cli/*`.

> **Note:** dev-only convenience. Production deployments should keep using an explicit `Worker` so startup, scaling, and topic governance stay under operator control.