### PR TITLE
docs: make CLI command blocks read as terminal; shell-safe [cli] hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ The SDK to build AI agents as orchestratable, event-driven microservices.
 
 Calfkit lets you compose agents as decoupled microservices–agents, tools, workflows–that communicate asynchronously. Add agents to teams without hardcoding any orchestration logic, scale each component independently, and stream agent outputs to any downstream listener. 
 
-```bash
-pip install calfkit
+```console
+$ pip install calfkit
 ```
 
 <br>
@@ -56,8 +56,8 @@ Calfkit is a Python SDK that builds event-stream agents out-the-box. You get the
 
 ### 1. Install
 
-```bash
-pip install "calfkit[cli]"
+```console
+$ pip install "calfkit[cli]"
 ```
 
 The `[cli]` extra adds the `calfkit` command used below to run nodes during development. (The library itself is just `pip install calfkit`.)
@@ -72,8 +72,8 @@ The `[cli]` extra adds the `calfkit` command used below to run nodes during deve
 
 Calfkit uses Kafka as the event broker. Run the following command to clone the [calfkit-broker](https://github.com/calf-ai/calfkit-broker) repo and start a local Kafka broker container:
 
-```shell
-git clone https://github.com/calf-ai/calfkit-broker && cd calfkit-broker && make dev-up
+```console
+$ git clone https://github.com/calf-ai/calfkit-broker && cd calfkit-broker && make dev-up
 ```
 
 Once the broker is ready, open a new terminal tab to continue with the quickstart.
@@ -124,8 +124,8 @@ def get_weather(location: str) -> str:
 
 Deploy the tool as a service. `calfkit run` points at a `module:attr` target and starts a worker for you — no `Client`/`Worker` wiring required:
 
-```shell
-calfkit run weather_tool:get_weather
+```console
+$ calfkit run weather_tool:get_weather
 ```
 
 <br>
@@ -151,14 +151,14 @@ agent = Agent(
 
 Set your OpenAI API key:
 
-```shell
-export OPENAI_API_KEY=sk-...
+```console
+$ export OPENAI_API_KEY=sk-...
 ```
 
 Deploy the agent as its own service (run it alongside the tool service from step 3):
 
-```shell
-calfkit run agent_service:agent
+```console
+$ calfkit run agent_service:agent
 ```
 
 <br>
@@ -188,8 +188,8 @@ if __name__ == "__main__":
 
 Run the file to invoke the agent:
 
-```shell
-python invoke.py
+```console
+$ python invoke.py
 ```
 
 <br>
@@ -214,8 +214,8 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-```shell
-python serve_tool.py
+```console
+$ python serve_tool.py
 ```
 
 See the **[CLI reference](docs/cli.md)** for every `calfkit run` flag (`--host`, `--provision`, `--reload`, `--app-dir`, …) and the other `calfkit` commands (`mcp`, `topics`).
@@ -405,8 +405,8 @@ if __name__ == "__main__":
 
 Run alongside the agent service:
 
-```shell
-python weather_sink.py
+```console
+$ python weather_sink.py
 ```
 
 An agent's `publish_topic` emits on **every** state transition — intermediate hops, tool completions, and terminals — so `result.output` is `None` on hops without final output parts. Filter via a gate if you only want agent terminals:

--- a/calfkit/cli/__init__.py
+++ b/calfkit/cli/__init__.py
@@ -25,7 +25,7 @@ def _build_app() -> Any:
     try:
         import typer
     except ImportError as e:
-        raise SystemExit("The calfkit CLI requires the 'cli' optional extra. Install with: pip install calfkit[cli]") from e
+        raise SystemExit("The calfkit CLI requires the 'cli' optional extra. Install with: pip install \"calfkit[cli]\"") from e
 
     from calfkit.cli.mcp import app as mcp_app
     from calfkit.cli.run import run as run_command

--- a/calfkit/cli/_loader.py
+++ b/calfkit/cli/_loader.py
@@ -24,7 +24,7 @@ from typing import Any
 try:
     import typer
 except ImportError as e:  # pragma: no cover -- exercised manually
-    raise ImportError("the calfkit CLI requires the 'cli' optional extra. Install with: pip install calfkit[cli]") from e
+    raise ImportError("the calfkit CLI requires the 'cli' optional extra. Install with: pip install \"calfkit[cli]\"") from e
 
 
 def resolve_specs(specs: list[str], *, app_dir: str | None = None, source_label: str = "target") -> list[Any]:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,8 +3,8 @@
 The `calfkit` command bundles the SDK's command-line tooling. It is installed
 via the **`cli` optional extra** (it pulls in `typer` and `watchfiles`):
 
-```bash
-pip install "calfkit[cli]"
+```console
+$ pip install "calfkit[cli]"
 ```
 
 If the extra isn't installed, invoking `calfkit` raises a clear remediation
@@ -51,12 +51,12 @@ Targets are resolved with Python's import machinery, so the module must be
 **importable** from where you run the command. By default the current directory
 is placed on the import path (see `--app-dir`), so run from your project root:
 
-```bash
-# project root contains weather_tool.py
-calfkit run weather_tool:get_weather
+```console
+$ # project root contains weather_tool.py
+$ calfkit run weather_tool:get_weather
 
-# nested package (dots, not slashes; no .py suffix)
-calfkit run app.tools.weather:get_weather
+$ # nested package (dots, not slashes; no .py suffix)
+$ calfkit run app.tools.weather:get_weather
 ```
 
 Nested directories work as packages, including
@@ -122,18 +122,18 @@ re-import) on every change.
 
 ### Examples
 
-```bash
-# One tool node
-calfkit run weather_tool:get_weather
+```console
+$ # One tool node
+$ calfkit run weather_tool:get_weather
 
-# An agent and its tool in one worker, against a specific broker
-calfkit run agent_service:agent weather_tool:get_weather --host localhost:9092
+$ # An agent and its tool in one worker, against a specific broker
+$ calfkit run agent_service:agent weather_tool:get_weather --host localhost:9092
 
-# Auto-restart on edits, auto-create dev topics
-calfkit run agent_service:agent --reload --provision
+$ # Auto-restart on edits, auto-create dev topics
+$ calfkit run agent_service:agent --reload --provision
 
-# Resolve targets relative to ./src, load a custom env file
-calfkit run workers:all_nodes --app-dir src --env-file .env.local
+$ # Resolve targets relative to ./src, load a custom env file
+$ calfkit run workers:all_nodes --app-dir src --env-file .env.local
 ```
 
 ### Production deployment
@@ -157,8 +157,8 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-```bash
-python serve_tool.py
+```console
+$ python serve_tool.py
 ```
 
 ---


### PR DESCRIPTION
## Summary

Two small, related developer-experience fixes for the `calfkit` CLI surfaced while reviewing whether a pip/uv user can run `calfkit` without `uv run` (they can — the console-script entry point is correctly registered; this PR only improves the docs and one error message).

### 1. CLI command blocks now read as terminal commands

Standardized every **runnable** terminal command block in `README.md` and `docs/cli.md` on ` ```console ` with a `$ ` prompt — the conventional visual cue that a snippet is typed at a terminal (GitHub renders the `$` prompt distinctly from the command). Previously these blocks were an inconsistent mix of ` ```shell ` (README) and ` ```bash `/` ```text ` (cli.md).

- Multi-line examples get `$` on every input line, **including comment lines**, so comments travel with the command when copied.
- **Usage-synopsis** blocks with placeholders (e.g. `calfkit run TARGET [TARGET ...] [OPTIONS]`, the `mcp`/`topics` synopses) intentionally stay as plain ` ```text ` — they are not meant to be run verbatim, so a `$` prompt would be misleading.

### 2. Shell-safe `[cli]` extra hint in error messages

The two CLI remediation messages now quote the extra: `pip install "calfkit[cli]"`. Unquoted `calfkit[cli]` is glob-expanded by zsh (`zsh: no matches found: calfkit[cli]`), and a user hitting "the CLI requires the 'cli' optional extra" is exactly the person most likely to copy that hint verbatim. The README already quoted it; this aligns the code messages.

- `calfkit/cli/__init__.py` — `SystemExit` raised when launching the CLI without `typer`
- `calfkit/cli/_loader.py` — `ImportError` raised at loader import

## Why

Docs-only + one error-string change; no behavior or API change. Improves first-run DX: commands look like terminal commands, and the install hint is copy-paste-safe on the default macOS shell.

## Testing

- `make fix` and `make check` clean on the branch (ruff lint + format, mypy strict — all pass).
- No tests asserted the old remediation strings (grep confirmed).
- Verified the rendered messages now show the quoted form, and confirmed all `shell`/`bash` terminal fences are converted with balanced code fences in both files.