### PR TITLE
ci: enable CodeQL and dependency review 

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,12 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# TODO: Re-enable when repo is public
 jobs:
   codeql:
     name: CodeQL Analysis
-    if: false 
-    # Disabled - repo not yet public
     runs-on: ubuntu-latest
 
     permissions:
@@ -45,8 +42,7 @@ jobs:
 
   dependency-review:
     name: Dependency Review
-    if: false 
-    # Disabled - repo not yet public. restore github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
## Summary

The `codeql` and `dependency-review` jobs in `.github/workflows/security.yml` were hardcoded with `if: false`, so they were **always skipped** on every push and PR. They were gated off while the repo was private — CodeQL SARIF upload and the Dependency Review API both require GitHub Advanced Security on private repos (free on public repos).

The repo is now public (`calf-ai/calfkit-sdk`), so this unblocks both:

- **`codeql`** — removed `if: false`; now runs on push to `main`, PRs, and the weekly schedule.
- **`dependency-review`** — restored `if: github.event_name == 'pull_request'` (its base↔head manifest diff only works on PR events).
- Dropped the stale `# TODO: Re-enable when repo is public` / "Disabled" comments.

## Notes for first runs

- **Dependency graph** must be enabled (Settings → Code security → Dependency graph) — on by default for public repos. If Dependency Review errors with "not supported," that toggle is the fix.
- **CodeQL**: if the repo also has GitHub's *default* code-scanning setup enabled, the `analyze` upload can conflict ("default setup is enabled"). If so, switch to "Advanced" setup in Settings → Code scanning. No file change needed.

## Checks

`make fix` and `make check` both pass (lint, format, type check all green).