### PR TITLE
feat!: remove MCP adaptor

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,50 @@
+name: PR Title
+
+# Lints the pull-request title against Conventional Commits using
+# amannn/action-semantic-pull-request. This repo squash-merges with
+# "Default to PR title for squash merge commits", so the PR title becomes the
+# squash commit subject that release-please parses — an unparseable title
+# silently skips a release (e.g. parentheses in the subject break
+# release-please's strict v17 parser). This check is the guard against that.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate-title:
+    name: Validate PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Conventional Commit types release-please recognizes.
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            test
+            build
+            ci
+            chore
+            revert
+          # Disallow parentheses in the subject. release-please's strict v17
+          # commit parser rejects them (e.g. "feat!: x (a, b)"), parsing zero
+          # commits and silently skipping the release. A "(scope)" after the
+          # type is still allowed — it is matched before the subject.
+          subjectPattern: ^[^()]+$
+          subjectPatternError: >-
+            The PR title subject must not contain parentheses — release-please's
+            commit parser rejects them and the release is silently skipped. Put
+            any structure in a "(scope)" after the type, e.g. "feat(cli): ...".


### PR DESCRIPTION
## What this PR does

1. **Adds a PR-title lint** (`.github/workflows/pr-title.yml`) using the
   industry-standard `amannn/action-semantic-pull-request@v6`, with
   `subjectPattern: ^[^()]+$` to forbid parentheses in the title subject.

2. **Re-triggers the 0.7.0 release.** PR #197 (the MCP adaptor removal) merged,
   but its squash-commit subject had parentheses in the description, which
   release-please v17's strict conventional-commit parser rejects
   (`unexpected token '('`). It therefore parsed **0 commits** and skipped the
   release — the MCP-removal code is on `main`, but 0.7.0 was never cut.

   This repo squash-merges with "Default to PR title for squash merge commits",
   so **this PR's title is the commit release-please parses.** A clean `feat!:`
   subject (no description parens) lets release-please cut 0.7.0 with the MCP
   removal credited.

> ⚠️ The diff here is just the CI workflow — the breaking change (MCP removal)
> already landed in #197. The `feat!:` title is the mechanism to release it.

## Why the lint

A PR-title linter guards the **entire** conventional-commit contract
release-please depends on — not only parens (a typo'd type or a missing colon
silently skips a release too). `subjectPattern: ^[^()]+$` specifically prevents
a recurrence of the #197 failure; a `(scope)` after the type is still allowed,
e.g. `feat(cli): ...`.

## Repo setting to keep on

Keep **Settings → General → "Default to PR title for squash merge commits"**
enabled, so the validated PR title is exactly what lands as the squash commit
(and what release-please reads).

BREAKING CHANGE: The MCP adaptor is removed (landed in #197). `from calfkit import mcp`, `Agent(tools=[McpServer(...)])`, `Worker(idempotency_cache=...)`, the `calfkit mcp` CLI subcommand, and the `mcp` dependency are gone. There is no replacement in this release; pin `calfkit <0.7` if you depend on the MCP adaptor.

Release-As: 0.7.0