### PR TITLE
fix: eliminate ReDoS in vendored google.py file-search regex

### DIFF
--- a/calfkit/_vendor/pydantic_ai/models/google.py
+++ b/calfkit/_vendor/pydantic_ai/models/google.py
@@ -105,7 +105,7 @@ except ImportError as _import_error:
     ) from _import_error
 
 
-_FILE_SEARCH_QUERY_PATTERN = re.compile(r'file_search\.query\(query=(["\'])((?:\\.|(?!\1).)*?)\1\)')
+_FILE_SEARCH_QUERY_PATTERN = re.compile(r'file_search\.query\(query=(["\'])((?:\\.|(?!\1)[^\\])*)\1\)')
 
 
 LatestGoogleModelNames = Literal[

--- a/calfkit/_vendor/vendor.txt
+++ b/calfkit/_vendor/vendor.txt
@@ -12,3 +12,5 @@ pydantic-ai-slim==1.47.0  https://github.com/pydantic/pydantic-ai
 #   - _function_schema.py: _is_call_ctx() recognizes RunContext subclasses
 #   - messages.py: Added `retry_prompt` classmethod to ModelRequest
 #   - models/anthropic.py: UserLocation -> BetaUserLocationParam (anthropic SDK 0.80.0 rename)
+#   - models/google.py: ReDoS fix for _FILE_SEARCH_QUERY_PATTERN, backported from
+#     pydantic-ai#5106 (included upstream since v1.83.0; drop when re-vendoring >=1.83.0)

--- a/tests/test_vendor_google_regex.py
+++ b/tests/test_vendor_google_regex.py
@@ -1,0 +1,95 @@
+"""Regression tests for the vendored `_FILE_SEARCH_QUERY_PATTERN` regex.
+
+The vendored ``pydantic_ai/models/google.py`` module requires ``google-genai``
+at import time, which is not a dependency of this project. To still test the
+exact regex that ships in the vendored source, the pattern literal is
+extracted from the file with ``ast`` instead of importing the module.
+
+Covers the ReDoS fix from upstream pydantic-ai (pydantic/pydantic-ai#5106):
+the original pattern ``(?:\\.|(?!\1).)*?`` backtracks exponentially on inputs
+with many escape sequences and no closing quote.
+"""
+
+import ast
+import re
+import time
+from pathlib import Path
+
+import pytest
+
+import calfkit
+
+_GOOGLE_PY = Path(calfkit.__file__).parent / "_vendor" / "pydantic_ai" / "models" / "google.py"
+
+
+def _load_file_search_query_pattern() -> re.Pattern[str]:
+    """Extract and compile `_FILE_SEARCH_QUERY_PATTERN` from the vendored source."""
+    tree = ast.parse(_GOOGLE_PY.read_text())
+    for node in tree.body:
+        if (
+            isinstance(node, ast.Assign)
+            and any(isinstance(t, ast.Name) and t.id == "_FILE_SEARCH_QUERY_PATTERN" for t in node.targets)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.args[0], ast.Constant)
+            and isinstance(node.value.args[0].value, str)
+        ):
+            return re.compile(node.value.args[0].value)
+    raise AssertionError(f"_FILE_SEARCH_QUERY_PATTERN not found in {_GOOGLE_PY}")
+
+
+@pytest.fixture(scope="module")
+def pattern() -> re.Pattern[str]:
+    return _load_file_search_query_pattern()
+
+
+def test_adversarial_input_completes_quickly(pattern: re.Pattern[str]) -> None:
+    """An unterminated query full of escapes must not trigger exponential backtracking."""
+    adversarial = 'file_search.query(query="' + "\\a" * 100
+    start = time.perf_counter()
+    result = pattern.search(adversarial)
+    elapsed = time.perf_counter() - start
+    assert result is None
+    assert elapsed < 1.0, f"regex took {elapsed:.2f}s on adversarial input; likely ReDoS"
+
+
+@pytest.mark.parametrize(
+    ("code", "expected_quote", "expected_raw_query"),
+    [
+        (
+            'print(file_search.query(query="what is the capital of France?"))',
+            '"',
+            "what is the capital of France?",
+        ),
+        (
+            "print(file_search.query(query='single quoted'))",
+            "'",
+            "single quoted",
+        ),
+        (
+            'file_search.query(query="say \\"hello\\" twice")',
+            '"',
+            'say \\"hello\\" twice',
+        ),
+        (
+            'file_search.query(query="path C:\\\\temp")',
+            '"',
+            "path C:\\\\temp",
+        ),
+        (
+            "file_search.query(query='it\\'s fine')",
+            "'",
+            "it\\'s fine",
+        ),
+    ],
+)
+def test_query_extraction_semantics(pattern: re.Pattern[str], code: str, expected_quote: str, expected_raw_query: str) -> None:
+    """The fixed pattern must capture the same quote and raw query as before."""
+    match = pattern.search(code)
+    assert match is not None
+    assert match.group(1) == expected_quote
+    assert match.group(2) == expected_raw_query
+
+
+def test_no_match_without_closing_quote(pattern: re.Pattern[str]) -> None:
+    match = pattern.search('file_search.query(query="unterminated')
+    assert match is None


### PR DESCRIPTION
## Summary

Fixes CodeQL alert [#1](https://github.com/calf-ai/calfkit-sdk/security/code-scanning/1) (`py/redos`, high severity, CWE-1333/400/730).

`_FILE_SEARCH_QUERY_PATTERN` in the vendored `calfkit/_vendor/pydantic_ai/models/google.py` used:

```python
r'file_search\.query\(query=(["\'])((?:\\.|(?!\1).)*?)\1\)'
```

The second alternative `(?!\1).` can match a backslash that the first alternative `\\.` also matches. This ambiguity causes **exponential backtracking** on inputs starting with `file_search.query(query="` followed by many `\a` sequences with no closing quote. Confirmed empirically before the fix: ~0.5s at 22 repetitions, ~2s at 24, doubling per added repetition.

## Fix

Backport the upstream fix ([pydantic-ai#5106](https://github.com/pydantic/pydantic-ai/pull/5106), shipped upstream since v1.83.0):

```python
r'file_search\.query\(query=(["\'])((?:\\.|(?!\1)[^\\])*)\1\)'
```

Excluding backslashes from the second alternative (`[^\\]`) ensures an unescaped backslash can only ever be consumed by the `\\.` branch, removing the ambiguity and restoring linear-time matching. The now-redundant lazy quantifier `*?` becomes greedy `*`. **Match semantics are unchanged.**

`vendor.txt` records the local modification, noting it can be dropped when re-vendoring pydantic-ai ≥ 1.83.0.

## Testing

Added `tests/test_vendor_google_regex.py`. Since `google-genai` isn't a project dependency, the module can't be imported, so the test extracts the regex literal from the vendored source via `ast`. It verifies:
- the adversarial input (100 escape sequences, no closing quote) completes in well under a second
- query-extraction semantics are preserved (plain, single-quoted, escaped-quote, escaped-backslash cases)
- unterminated queries don't match

Written TDD-style — the adversarial test hung indefinitely on the old regex. `make fix`/`make check` clean; full suite passes (2635 passed, 24 skipped).
