### PR TITLE
docs: peer node pattern, explanation + Node/NodeRef reference

### DIFF
--- a/docs/peer-node-pattern-reference.md
+++ b/docs/peer-node-pattern-reference.md
@@ -1,0 +1,353 @@
+# Reference: Node / NodeRef API
+
+This page is the technical reference for a canonical implementation of the
+[peer node pattern](peer-node-pattern.md): a node identified by an **identity**
+that can both host work and be invoked through a send-only reference.
+
+The reference is **self-contained and project-independent**. It documents the
+implementation reproduced in full below; that code is the source of truth for
+every statement on this page. Copy it into a single module to run any example
+verbatim.
+
+For *why* the API is shaped this way — why the reference is separate from the
+servant, why calls are asynchronous — see the
+[explanation](peer-node-pattern.md). This page only describes *what* the API is.
+
+---
+
+## The canonical implementation
+
+```python
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Protocol
+
+
+@dataclass(frozen=True)
+class Message:
+    """One unit transferred over a transport."""
+
+    payload: Any
+    reply_to: "NodeRef | None" = None
+
+
+class Transport(Protocol):
+    """Routes messages between identities."""
+
+    async def send(self, identity: str, message: Message) -> None: ...
+
+    def inbox(self, identity: str) -> "asyncio.Queue[Message]": ...
+
+
+class InMemoryTransport:
+    """Single-process Transport backed by per-identity asyncio queues."""
+
+    def __init__(self) -> None:
+        self._inboxes: dict[str, asyncio.Queue[Message]] = {}
+
+    def inbox(self, identity: str) -> asyncio.Queue[Message]:
+        return self._inboxes.setdefault(identity, asyncio.Queue())
+
+    async def send(self, identity: str, message: Message) -> None:
+        self.inbox(identity).put_nowait(message)
+
+
+@dataclass(frozen=True)
+class NodeRef:
+    """A send-only handle to a node, addressed by identity."""
+
+    identity: str
+    transport: Transport
+
+    async def tell(self, payload: Any) -> None:
+        await self.transport.send(self.identity, Message(payload=payload))
+
+    async def ask(self, payload: Any, *, timeout: float | None = None) -> Any:
+        reply_id = f"reply:{uuid.uuid4()}"
+        reply_ref = NodeRef(reply_id, self.transport)
+        await self.transport.send(
+            self.identity, Message(payload=payload, reply_to=reply_ref)
+        )
+        inbox = self.transport.inbox(reply_id)
+        reply = await asyncio.wait_for(inbox.get(), timeout)
+        return reply.payload
+
+
+Handler = Callable[[Any], Awaitable[Any]]
+
+
+class Node:
+    """A servant that hosts a receive loop for one identity."""
+
+    def __init__(
+        self, identity: str, transport: Transport, handler: Handler
+    ) -> None:
+        self._identity = identity
+        self._transport = transport
+        self._handler = handler
+        self._running = False
+
+    @property
+    def identity(self) -> str:
+        return self._identity
+
+    @property
+    def ref(self) -> NodeRef:
+        return NodeRef(self._identity, self._transport)
+
+    @staticmethod
+    def ref_to(identity: str, transport: Transport) -> NodeRef:
+        return NodeRef(identity, transport)
+
+    async def run(self) -> None:
+        if self._running:
+            raise RuntimeError(f"Node {self._identity!r} is already running")
+        self._running = True
+        inbox = self._transport.inbox(self._identity)
+        try:
+            while True:
+                message = await inbox.get()
+                result = await self._handler(message.payload)
+                if message.reply_to is not None:
+                    await message.reply_to.tell(result)
+        finally:
+            self._running = False
+```
+
+---
+
+## `Message`
+
+A frozen dataclass holding one unit of data on a transport.
+
+### Fields
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `payload` | `Any` | — | The application data carried by the message. |
+| `reply_to` | `NodeRef \| None` | `None` | A reference the recipient may use to send a reply. `None` for fire-and-forget messages. |
+
+---
+
+## `Transport`
+
+A `Protocol` describing how messages are routed between identities. Any object
+providing the two members below satisfies it. `InMemoryTransport` is the
+reference single-process implementation.
+
+### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `send` | `async send(identity: str, message: Message) -> None` | Deliver `message` to the inbox of `identity`. |
+| `inbox` | `inbox(identity: str) -> asyncio.Queue[Message]` | Return the inbox queue for `identity`, creating it if absent. |
+
+---
+
+## `InMemoryTransport`
+
+A single-process `Transport` backed by one `asyncio.Queue` per identity. Inboxes
+are created lazily on first access and shared by identity string.
+
+### `InMemoryTransport()`
+
+Takes no arguments. Constructs an empty transport with no inboxes.
+
+### Methods
+
+| Method | Signature | Returns | Description |
+|--------|-----------|---------|-------------|
+| `inbox` | `inbox(identity: str) -> asyncio.Queue[Message]` | the queue for `identity` | Returns the existing inbox for `identity`, or creates and stores a new unbounded `asyncio.Queue` if none exists. |
+| `send` | `async send(identity: str, message: Message) -> None` | `None` | Enqueues `message` on the inbox for `identity` via `put_nowait`. Does not block. |
+
+---
+
+## `NodeRef`
+
+A frozen, hashable, send-only handle to a node. Addresses a node by `identity`
+over a `transport`. A `NodeRef` cannot host a node and cannot stop one; it
+exposes only the two messaging methods below.
+
+### `NodeRef(identity, transport)`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `identity` | `str` | yes | The address of the target node. |
+| `transport` | `Transport` | yes | The transport over which messages are sent. |
+
+### Attributes
+
+| Name | Type | Description |
+|------|------|-------------|
+| `identity` | `str` | The target node's address. |
+| `transport` | `Transport` | The transport used for sends. |
+
+### `tell`
+
+```
+async tell(payload: Any) -> None
+```
+
+Sends `payload` to the target identity as a fire-and-forget message
+(`reply_to` is `None`). Returns once the message is handed to the transport;
+does not wait for the recipient to process it.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `payload` | `Any` | yes | The data to send. |
+
+**Returns:** `None`.
+
+### `ask`
+
+```
+async ask(payload: Any, *, timeout: float | None = None) -> Any
+```
+
+Sends `payload` to the target identity with a fresh single-use reply reference,
+then waits for one reply and returns its payload. The reply reference addresses
+an ephemeral inbox named `reply:<uuid4>`.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `payload` | `Any` | yes | — | The data to send. |
+| `timeout` | `float \| None` | no | `None` | Seconds to wait for a reply. `None` waits indefinitely. |
+
+**Returns:** the `payload` of the reply message (`Any`).
+
+**Raises:** `asyncio.TimeoutError` if no reply arrives within `timeout`.
+
+---
+
+## `Handler`
+
+A type alias for the callable a `Node` invokes per message.
+
+```
+Handler = Callable[[Any], Awaitable[Any]]
+```
+
+A handler receives a message `payload` and returns an awaitable resolving to the
+result. When the originating message carried a `reply_to`, the returned result
+is sent back through it.
+
+---
+
+## `Node`
+
+A servant that owns the receive loop for one identity. Constructed with the
+handler that processes each message. Hands out `NodeRef` handles to itself but is
+never itself a handle.
+
+### `Node(identity, transport, handler)`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `identity` | `str` | yes | The address this node serves. |
+| `transport` | `Transport` | yes | The transport whose inbox for `identity` this node consumes. |
+| `handler` | `Handler` | yes | The coroutine function invoked once per received message. |
+
+### Attributes and properties
+
+| Name | Type | Description |
+|------|------|-------------|
+| `identity` | `str` | Read-only property returning the served address. |
+| `ref` | `NodeRef` | Read-only property returning a `NodeRef` to this node over the same transport. |
+
+### `ref_to`
+
+```
+@staticmethod
+ref_to(identity: str, transport: Transport) -> NodeRef
+```
+
+Constructs a `NodeRef` for an arbitrary `identity` and `transport` without
+constructing a `Node`. Used to obtain a handle to a node hosted elsewhere.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `identity` | `str` | yes | The target address. |
+| `transport` | `Transport` | yes | The transport over which the handle sends. |
+
+**Returns:** a `NodeRef`.
+
+### `run`
+
+```
+async run() -> None
+```
+
+Consumes the transport inbox for this node's identity in a loop. For each
+message: awaits `handler(message.payload)`; if `message.reply_to` is not `None`,
+sends the result through it via `tell`.
+
+The loop runs until the awaiting task is cancelled. On exit (including
+cancellation), the running flag is cleared, after which `run` may be called
+again.
+
+**Returns:** `None` (the coroutine does not return normally; it runs until
+cancelled).
+
+**Raises:**
+
+| Error | Condition |
+|-------|-----------|
+| `RuntimeError` | `run` is called while this node instance is already running. |
+| `asyncio.CancelledError` | The task awaiting `run` is cancelled. Propagates after the running flag is cleared. |
+
+---
+
+## Examples
+
+### Request/response
+
+```python
+async def main() -> None:
+    transport = InMemoryTransport()
+
+    async def handler(payload):
+        return f"handled {payload!r}"
+
+    server = Node("agent-42", transport, handler)
+    task = asyncio.create_task(server.run())
+
+    client = Node.ref_to("agent-42", transport)
+    print(await client.ask("do-work"))        # handled 'do-work'
+
+    task.cancel()
+
+
+asyncio.run(main())
+```
+
+### Fire-and-forget
+
+```python
+ref = Node.ref_to("agent-42", transport)
+await ref.tell("event")                       # returns immediately, no reply
+```
+
+### Local handle from a hosted node
+
+```python
+server = Node("agent-42", transport, handler)
+ref = server.ref                              # NodeRef to server, same transport
+await ref.ask("ping")
+```
+
+### Bounded wait
+
+```python
+try:
+    await ref.ask("slow-task", timeout=2.0)
+except asyncio.TimeoutError:
+    ...                                       # no reply within 2 seconds
+```
+
+---
+
+See also: [About the Peer Node Pattern](peer-node-pattern.md) for the concepts,
+trade-offs, and the reference-vs-servant rationale behind this API.

--- a/docs/peer-node-pattern.md
+++ b/docs/peer-node-pattern.md
@@ -1,0 +1,289 @@
+# About the Peer Node Pattern
+
+A recurring question in this project is: *we have a `Node` that is deployed to
+serve calls, but it also carries its own identity — so can't the same object be
+used on the client side to invoke the server? Is one object that is both client
+and server a good idea, or an anti-pattern?*
+
+This document is the knowledge base for that question. It is **understanding-oriented**:
+it explains where the pattern comes from, what the established frameworks call it,
+why they all converge on the same shape, and where the genuine trade-offs lie. It
+is not a step-by-step guide and not an API reference — it exists to be read while
+reflecting on a design, not while mid-task.
+
+The short version, which the rest of the document unpacks:
+
+> A node keyed by an **identity** that can both *host* work and *invoke* work is a
+> legitimate, well-established pattern — it is the **actor model with
+> identity-as-address**. The mistake is not having both roles; it is collapsing
+> the *running host* and the *callable handle* into a single type. Every mature
+> framework keeps them separate.
+
+---
+
+## The pattern, and what to call it
+
+There is no single industry term for "one class that is both client and server."
+What you are reaching for already has a name from a different angle: the **actor
+model**, where each actor is reachable through an opaque **address** and is, by
+construction, *both a sender and a receiver of messages*. The unification you
+sensed is real — but it lives in the *behaviour* (an actor sends and receives),
+not in a single do-everything class.
+
+The supporting ideas that orbit this are worth naming, because they recur across
+the literature:
+
+- **Identity-as-address.** The node's identity *is* its routing address. In
+  Erlang/OTP a process can be registered under a name, and any process anywhere
+  sends to it by that name. In Akka the actor's *path* encodes its location and
+  routing. In this project, a node's identity maps to a Kafka topic — same idea,
+  different transport.
+- **Location transparency.** A handle to a node works the same way whether the
+  node is in-process or across the network. This is a *goal*, not a free lunch —
+  see [The limits of location transparency](#the-limits-of-location-transparency).
+- **Reference vs. servant.** The thing you *call through* is distinct from the
+  thing that *does the work*. This is the crux of the whole topic, and the next
+  section is about it.
+- **"Peer."** In peer-to-peer systems a "peer" is a node that is simultaneously
+  client and server. That is a statement about *network topology* (no central
+  server), which is a different claim from "one type plays both roles." The two
+  often get conflated; keeping them apart avoids a lot of confusion.
+
+So the honest answer to "is this a pattern or an anti-pattern?" is: *the pattern
+is sound; one specific way of structuring it is the anti-pattern.*
+
+---
+
+## Why every framework separates the reference from the servant
+
+The single most consistent finding across the established systems is that they
+all split the **handle** (what a caller holds) from the **servant** (what runs
+the work) — and none of them endorse a one-type client+server object. This is not
+a coincidence; the same forces produce the same answer each time.
+
+| System | The callable handle | The running servant |
+|---|---|---|
+| Akka (Typed) | `ActorRef` — immutable, serializable, **send-only**; it cannot stop the actor | the actor and its receive behaviour |
+| Erlang/OTP | a registered **name** (or pid) used via thin `call`/`cast` wrappers | the `gen_server` process and its callbacks |
+| CORBA / RMI | the **stub** — a local proxy | the **servant** that implements the interface |
+| Pyro5 (Python) | `Proxy` — a client-side stand-in | the registered object on the server |
+
+The recurring shape is: a **lightweight, send-only reference** that is cheap to
+pass around and safe to hand to untrusted-ish code, plus a **heavier servant**
+that owns the receive loop and the resources. Akka states the contract most
+sharply — an `ActorRef` *cannot* terminate the actor it points at. The reference
+deliberately exposes *less* than the servant.
+
+### The two forces that drive the split
+
+**1. A handle should not be able to host.** If the only type you have is the full
+node, then any code holding one can call its `run()`/serve method. In a
+message-bus system that is not a harmless mistake: starting a second host on the
+same identity means a second consumer bound to the same topic. Depending on
+consumer-group configuration you get either rebalancing that fights the real
+host, or *two processes handling every message* — duplicated side effects, and a
+bug that is silent until it corrupts something. Removing the host method from the
+handle makes that mistake impossible *by construction* rather than by discipline.
+
+**2. A handle should not pay the servant's construction cost.** Constructing a
+real servant typically opens resources — a database pool, the topic binding, the
+receive buffer. A caller only needs to *send*; it should not be paying to
+allocate server-side machinery it will never use. A pure, identity-only reference
+sidesteps that entirely.
+
+The cleanest expression of the whole idea that the research surfaced is **Akka
+Typed's reply-to reference**: the caller puts *its own* reference inside the
+request message, and the receiver replies through it. No global registry lookup,
+fully composable across hops:
+
+```scala
+// Akka Typed — the canonical shape
+final case class Greet(whom: String, replyTo: ActorRef[Greeted])
+//                                    ^^^^^^^ the caller's own send-only handle
+```
+
+Translated into a self-contained Python sketch that embodies the same
+disciplines — reference ≠ servant, reply-to carried in the message, identity as
+address:
+
+```python
+import asyncio
+from dataclasses import dataclass
+
+# A stand-in "bus": identity -> inbox. In this project the transport is Kafka,
+# and the identity maps to a topic; the shape of the pattern is identical.
+_BUS: dict[str, asyncio.Queue] = {}
+
+
+def _inbox(identity: str) -> asyncio.Queue:
+    return _BUS.setdefault(identity, asyncio.Queue())
+
+
+@dataclass(frozen=True)
+class NodeRef:
+    """The handle. Immutable, serializable, send-only.
+    It deliberately has no run()/serve method — a caller cannot host."""
+
+    identity: str
+
+    async def call(self, payload, reply_to: "NodeRef | None" = None):
+        future: asyncio.Future = asyncio.get_event_loop().create_future()
+        _inbox(self.identity).put_nowait((payload, reply_to, future))
+        return await future
+
+
+class Node:
+    """The servant. Owns the receive loop and (in real life) the resources.
+    It mints references to itself; it is never handed out wholesale."""
+
+    def __init__(self, identity: str) -> None:
+        self._identity = identity
+
+    @property
+    def ref(self) -> NodeRef:                 # local handle to a node I hold
+        return NodeRef(self._identity)
+
+    @staticmethod
+    def ref_to(identity: str) -> NodeRef:     # remote handle from a bare identity
+        return NodeRef(identity)
+
+    async def run(self) -> None:
+        inbox = _inbox(self._identity)
+        while True:
+            payload, reply_to, future = await inbox.get()
+            result = f"[{self._identity}] handled {payload!r}"
+            if reply_to is not None:          # reply through the caller's handle
+                await reply_to.call(result)
+            future.set_result(result)
+```
+
+```python
+async def main() -> None:
+    # Server deployment: build the servant and serve.
+    server = Node("agent-42")
+    asyncio.create_task(server.run())
+
+    # Client side: a send-only handle. It cannot accidentally run().
+    client = Node.ref_to("agent-42")
+    print(await client.call("do-work"))       # [agent-42] handled 'do-work'
+
+
+asyncio.run(main())
+```
+
+---
+
+## "But it's the same codebase" — same class, different instances
+
+A natural objection is: *in a monorepo the `Node` class is importable on both
+sides, so why not just construct a `Node` on the client and call it directly?*
+This is worth answering carefully, because the answer corrects a subtle mental
+slip.
+
+You *can* — nothing forbids `n = Node("agent-42"); n.ref.call(...)`, and that is
+exactly what the local `ref` property is for. The slip is in the phrase "the same
+`Node` object." Sharing a class is a **compile-time** fact. At **runtime** the
+client and the server are two different instances in two different processes; the
+client's `Node("agent-42")` is *not* the server's `Node("agent-42")`. They share
+nothing in memory — only the identity string, which the transport uses to route.
+The client instance's own inbox is never read by anyone.
+
+That is precisely why the host method is dangerous on the client side: it is not
+a no-op. `n.run()` in the client process starts a *real, competing* consumer on
+the shared identity. The handle/servant split exists so that the thing you hold
+on the calling side simply *has no way* to do that.
+
+This also clarifies when the split earns its keep:
+
+- If your servant's constructor is **pure** (it only stores the identity), then
+  building a `Node` on the client to get a reference is harmless, and a collapsed
+  design is defensible.
+- The moment hosting means **owning resources or a consumer slot** — which, for a
+  Kafka-backed node, it almost always does — the split stops being stylistic. A
+  reference that cannot host and cannot allocate server state is the difference
+  between a safe handle and a loaded foot-gun.
+
+---
+
+## Choices and alternatives
+
+Reasonable people draw the line in different places. The trade-offs:
+
+**Collapsed (one type, both `run()` and `call()`).** Maximally DRY and symmetric;
+the simplest thing that can work. Acceptable when the servant constructor is pure
+and hosting carries no cost — for example a pure in-process actor used only for
+testing or a single-process demo. Its cost is that every holder of the object can
+host and can pay construction cost, and intent ("am I a host or a caller?") is
+ambiguous at the call site.
+
+**Separated reference + servant (recommended here).** A send-only `NodeRef` and a
+hosting `Node`, both minted from the same identity. Costs one extra small type.
+Buys: hosting is impossible from a handle, callers don't pay server construction,
+and the type at a call site *tells you* the role. This is the unanimous choice of
+Akka, Erlang/OTP, CORBA/RMI and Pyro5, and it is the right default for
+calfkit-style nodes over Kafka.
+
+**Generated stub + skeleton (gRPC/Thrift-style).** A code generator emits the
+client stub and the server skeleton from a shared interface definition. This is
+the separated model taken to its logical end, with the two halves produced
+mechanically. It buys strong cross-language contracts at the cost of a build step
+and generated code — worthwhile when clients are polyglot, overkill when caller
+and host share a language and a repo.
+
+A note on terminology drift: it is tempting to call the separated design a
+"peer." It can be deployed in a peer-to-peer *topology*, but the separation
+itself is orthogonal to topology. Keep the two ideas distinct when discussing a
+design, or reviews go in circles.
+
+---
+
+## The limits of location transparency
+
+Location transparency — "a handle works the same whether the node is local or
+remote" — is the property that makes the whole pattern feel clean. It is a
+worthwhile *goal*, but treating it as *complete* is the classic distributed-objects
+error.
+
+The verification pass behind this document specifically **refuted** the strong
+claim that actor references make local and remote communication truly identical,
+and it **refuted** the idea that remote-object systems are inherently symmetric
+peers (objects switch roles *sequentially*; they are not magically both at once).
+Both refutations point at the same underlying truth, articulated decades ago in
+Waldo et al.'s *A Note on Distributed Computing* and in Martin Fowler's *First Law
+of Distributed Object Design — "don't distribute your objects"*: a remote call has
+latency, partial failure, and concurrency semantics that a local call does not,
+and an abstraction that hides that boundary too well produces fragile systems.
+
+The practical lesson for this project is not "avoid the pattern." It is: keep the
+remote boundary *honest*. The reference should expose **send/ask** semantics that
+make asynchrony and failure visible (the `await ...call()` in the sketch above is
+explicit for exactly this reason), rather than masquerading as an ordinary local
+method that silently crosses the network.
+
+---
+
+## Where this lands for calfkit
+
+The MCP bridge node — a node that both exposes tools and calls other nodes — is a
+genuine and natural instance of this pattern. The guidance that falls out of the
+above:
+
+- Treat the node's **identity as its address** (it already maps to a Kafka topic).
+- Expose a **send-only reference** for the call side rather than handing callers
+  the full hosting node, so that hosting and resource ownership cannot leak onto
+  the calling path.
+- Keep the call surface **explicitly asynchronous** so the network boundary stays
+  visible.
+
+This is the same conclusion Akka and Erlang reached independently, applied to a
+Kafka transport.
+
+See also: [Reference: Node / NodeRef API](peer-node-pattern-reference.md) for a
+complete, runnable canonical implementation of the types discussed here.
+
+---
+
+*The implementation in the source tree is always the source of truth; the Python
+above is an illustrative sketch of the pattern, not a description of a shipped
+API. If you find a calfkit node whose structure contradicts this document, trust
+the code and flag the doc for reconciliation.*


### PR DESCRIPTION
## What

Adds a project-independent, educational knowledge base for the **peer / symmetric node pattern** — a node keyed by an *identity* that can both host work and be invoked through a handle (the actor model with identity-as-address).

Two Diátaxis-typed docs:

- **`docs/peer-node-pattern.md`** (explanation — understanding-oriented): where the pattern comes from, the canonical terminology, why every mature framework (Akka `ActorRef`, Erlang/OTP `gen_server`, CORBA/RMI stub/servant, Pyro5 `Proxy`) separates the **send-only reference** from the **running servant**, the "same codebase ≠ same instance" subtlety, trade-offs (collapsed vs. separated vs. generated stub/skeleton), and the limits of location transparency.
- **`docs/peer-node-pattern-reference.md`** (reference — information-oriented): a complete, runnable, project-independent canonical `Node` / `NodeRef` / `Transport` implementation with neutral API description (fields, parameters, returns, errors, examples).

## Why

The "can one object be both client and server?" question recurs in design discussions (e.g. the MCP bridge node). This captures the verified answer as a durable resource the project can build on, rather than re-deriving it each time.

## Notes

- Grounded in a deep multi-source research pass; the two claims that failed adversarial verification (full location transparency; remote objects as inherent symmetric peers) are documented as refuted rather than asserted.
- The reference's canonical implementation was **verified by execution** — request/response, fire-and-forget, `ask` timeout (`asyncio.TimeoutError`), the double-run `RuntimeError` guard, and cancellation all behave as documented.
- Docs only — no library code changes. Scoped to a clean branch off `main`; unrelated working-tree WIP was intentionally left out.