### PR TITLE
feat: MCP capability wire model, discovery config, and client URL retention

### DIFF
--- a/calfkit/client/base.py
+++ b/calfkit/client/base.py
@@ -58,6 +58,7 @@ class BaseClient:
         *,
         provisioning: ProvisioningConfig | None = None,
         startup_ensurer: StartupTopicEnsurer | None = None,
+        server_urls: str | None = None,
     ) -> None:
         """Initialize the client with pre-configured components.
 
@@ -97,6 +98,10 @@ class BaseClient:
         # subscriber consumes. ``connect`` builds it with the reply topic already
         # declared; direct construction gets a fresh, empty one.
         self._startup_ensurer = startup_ensurer if startup_ensurer is not None else StartupTopicEnsurer(config=self._provisioning)
+        # Retained for zero-config control-plane consumers (e.g. MCP capability
+        # discovery): the one URL the user provided, normalized. None when the
+        # client was hand-built rather than created via connect().
+        self._server_urls = server_urls
 
     @classmethod
     def connect(
@@ -143,6 +148,15 @@ class BaseClient:
         """
         if server_urls is None:
             server_urls = os.getenv("CALF_HOST_URL") or "localhost"
+        # Materialize ONCE into a list (a one-shot iterable must not be drained
+        # twice), and keep the two consumers' forms straight:
+        # - the broker gets the LIST — FastStream wraps a str into [str], and
+        #   aiokafka never comma-splits inside a list element, so a joined
+        #   string here would mangle multi-host into one bad address;
+        # - the retained property is the comma-joined STRING — correct for
+        #   consumers that hand it to aiokafka directly (which splits strings),
+        #   e.g. the ktables control plane.
+        server_list = [server_urls] if isinstance(server_urls, str) else list(server_urls)
 
         # Raw security kwargs were accepted pre-#180 (for calfkit's own admin
         # client); now all kwargs flow straight to KafkaBroker, which rejects
@@ -174,7 +188,7 @@ class BaseClient:
         ensurer.declare([reply_topic], framework=True)
 
         broker_connection = _PreStartHookBroker(
-            server_urls,
+            server_list,
             middlewares=[ContextInjectionMiddleware],
             pre_start=ensurer.run,
             **broker_kwargs,
@@ -190,12 +204,22 @@ class BaseClient:
             emitter_id=_new_client_emitter_id(client_id),
             provisioning=provisioning,
             startup_ensurer=ensurer,
+            server_urls=",".join(server_list),
         )
 
     @property
     def broker(self) -> KafkaBroker:
         """The underlying ``KafkaBroker`` connection."""
         return self._connection
+
+    @property
+    def server_urls(self) -> str | None:
+        """The bootstrap server URL(s) this client was connected with.
+
+        Normalized to a comma-joined string. ``None`` for clients built
+        directly via ``__init__`` rather than :meth:`connect`.
+        """
+        return self._server_urls
 
     @property
     def reply_topic(self) -> str:

--- a/calfkit/models/capability.py
+++ b/calfkit/models/capability.py
@@ -1,0 +1,73 @@
+"""Capability control-plane wire model (spec §3.2).
+
+A :class:`CapabilityRecord` is one MCP Toolbox's advertisement on the
+capability topic: identity, dispatch topic, and tool definitions, keyed on the
+wire by ``toolbox_id``. Records are calfkit-owned models — never the vendored
+``ToolDefinition`` — because compacted records outlive deploys, so the wire
+shape must not move when the vendored library does.
+
+Reader policy: tolerant (unknown fields ignored — a newer writer may add
+fields), and records with a newer ``schema_version`` decode fine but must be
+*skipped with a log* by the consumer; :func:`is_unsupported_schema` is that
+policy's predicate.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import AwareDatetime, BaseModel, ConfigDict
+
+from calfkit._vendor.pydantic_ai.tools import ToolDefinition
+from calfkit.models.tool_dispatch import ToolBinding
+
+CAPABILITY_SCHEMA_VERSION = 1
+"""The record schema major this reader understands. Bump only on breaking
+wire changes; additive fields ride on the tolerant reader instead."""
+
+
+class CapabilityToolDef(BaseModel):
+    """The minimal tool surface an LLM needs — name, description, JSON schema."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    name: str
+    description: str | None = None
+    parameters_json_schema: dict[str, Any]
+
+
+class CapabilityRecord(BaseModel):
+    """One toolbox's current advertisement; superseded whole by its next publish."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    schema_version: int = CAPABILITY_SCHEMA_VERSION
+    toolbox_id: str
+    dispatch_topic: str
+    tools: list[CapabilityToolDef]
+    published_at: AwareDatetime
+
+
+def is_unsupported_schema(record: CapabilityRecord) -> bool:
+    """True when ``record`` was written by a newer schema major than this
+    reader understands — the consumer must skip it and log, not act on it."""
+    return record.schema_version > CAPABILITY_SCHEMA_VERSION
+
+
+def record_to_bindings(record: CapabilityRecord) -> list[ToolBinding]:
+    """Expand a record into validator-less :class:`ToolBinding`s.
+
+    Wire-crossing tools dispatch unvalidated (the schema-only carve-out): the
+    toolbox's MCP server is the argument validator of record.
+    """
+    return [
+        ToolBinding(
+            tool_def=ToolDefinition(
+                name=tool.name,
+                description=tool.description,
+                parameters_json_schema=tool.parameters_json_schema,
+            ),
+            dispatch_topic=record.dispatch_topic,
+        )
+        for tool in record.tools
+    ]

--- a/calfkit/worker/worker_config.py
+++ b/calfkit/worker/worker_config.py
@@ -4,6 +4,39 @@ from dataclasses import dataclass
 from calfkit.nodes import BaseNodeDef
 
 
+@dataclass(frozen=True)
+class MCPDiscoveryConfig:
+    """Optional tuning for MCP capability discovery (spec §8.3).
+
+    Entirely optional — the control plane is zero-config by design: the
+    capability view and toolbox publishers derive the broker URL from the
+    client the user already connected. Every field here is an escape hatch.
+
+    Args:
+        topic: The cluster-wide compacted capability topic.
+        catchup_timeout: Bound on the worker boot gate awaiting view catch-up;
+            on expiry the worker serves degraded (loudly logged).
+        heartbeat_interval: Seconds between a toolbox's record re-publishes.
+        bootstrap_servers: Override for the control-plane Kafka cluster.
+            ``None`` (default) derives from the connected client — set only
+            for the split-cluster case (control plane on different brokers
+            than the data plane).
+    """
+
+    topic: str = "mcp.capabilities"
+    catchup_timeout: float = 30.0
+    heartbeat_interval: float = 30.0
+    bootstrap_servers: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.catchup_timeout <= 0:
+            raise ValueError(f"catchup_timeout must be > 0, got {self.catchup_timeout}")
+        if self.heartbeat_interval <= 0:
+            raise ValueError(f"heartbeat_interval must be > 0, got {self.heartbeat_interval}")
+        if not self.topic:
+            raise ValueError("topic must be non-empty")
+
+
 @dataclass
 class WorkerConfig:
     node: type[BaseNodeDef]

--- a/docs/designs/mcp-capability-discovery-spec.md
+++ b/docs/designs/mcp-capability-discovery-spec.md
@@ -5,12 +5,12 @@
 
 ## 1. Problem
 
-An `MCPBridge` node fronts one MCP server and services tool calls sent to its
+An `MCPToolbox` node fronts one MCP server and services tool calls sent to its
 dispatch topic (`mcp_server.<name>`). Its tools, however, are only knowable at
 runtime: `list_tools` is an async RPC against a live MCP session that exists
-only after the bridge's resource phase. Agents declare tools at construction
+only after the toolbox's resource phase. Agents declare tools at construction
 time, synchronously, and may run in a **different worker process** than the
-bridge. `MCPBridge.tool_bindings()` therefore raises `NotImplementedError`
+toolbox. `MCPToolbox.tool_bindings()` therefore raises `NotImplementedError`
 today.
 
 This spec defines how runtime-discovered MCP tools become `ToolBinding`s
@@ -20,16 +20,16 @@ available to any agent in the cluster.
 
 | # | Decision | Choice |
 |---|----------|--------|
-| 1 | Topology | Cross-process from day one: bridge and consuming agent may live in different workers |
-| 2 | Mechanism | A single cluster-wide **compacted capability topic**; bridges publish their tool list keyed by bridge id (control plane). Live per-turn queries rejected (§7) |
+| 1 | Topology | Cross-process from day one: toolbox and consuming agent may live in different workers |
+| 2 | Mechanism | A single cluster-wide **compacted capability topic**; toolboxes publish their tool list keyed by toolbox id (control plane). Live per-turn queries rejected (§7) |
 | 3 | Reader | One subscriber + one materialized dict (**Capability View**) per agent-hosting worker, stored in the worker resource bag; agents read it per turn |
-| 4 | Agent declaration | `MCPTools(bridge_id, include=[...], strict=False)` selector placeholders in `tools=[...]` |
+| 4 | Agent declaration | Pass the `MCPToolbox` instance itself in `tools=[...]` (same object that gets deployed via `add_nodes` — the tool-node pattern); `toolbox.select(include=[...], strict=True)` for scoped/strict. Resolved per turn as a deferred selector |
 | 5 | Boot ordering | Worker gates serving on view catch-up (bounded wait ~30s; on timeout, serve + loud log) |
 | 6 | Unresolved selector | Warn + run the turn degraded; `strict=True` fails the turn before the model runs |
 | 7 | Wire format | Calfkit-owned versioned pydantic model; never the vendored `ToolDefinition` |
-| 8 | Liveness | Bridges heartbeat by re-publishing their record (~30s). v1 readers only **log** staleness; behavioral use of staleness (hiding tools, strict-fail) deferred |
-| 9 | Removal | Bridge publishes a tombstone on **clean shutdown**; crash leaves the record standing (staleness signals it). See accepted trade-off in §6 |
-| 10 | Bridge boot failure | Worker boot fails (existing resource-phase semantics: session `initialize()` errors abort startup) |
+| 8 | Liveness | Toolboxes heartbeat by re-publishing their record (~30s). v1 readers only **log** staleness; behavioral use of staleness (hiding tools, strict-fail) deferred |
+| 9 | Removal | Toolbox publishes a tombstone on **clean shutdown**; crash leaves the record standing (staleness signals it). See accepted trade-off in §6 |
+| 10 | Toolbox boot failure | Worker boot fails (existing resource-phase semantics: session `initialize()` errors abort startup) |
 
 ## 3. The control plane
 
@@ -38,19 +38,35 @@ available to any agent in the cluster.
 One topic for the whole cluster (working name `mcp.capabilities`),
 `cleanup.policy=compact`. Compaction is broker-side: the broker retains the
 latest record per **key**; producers and consumers need nothing special.
-Steady-state content ≈ one record per bridge — a small key-value table.
+Steady-state content ≈ one record per toolbox — a small key-value table.
 
 Provisioning: **needs a dedicated creation path.** Verified during design:
 `ProvisioningConfig.topic_configs` is a flat config dict applied to *every*
 data topic the provisioner creates (`provisioner.py:170-172`) — putting
 `cleanup.policy=compact` there would compact all data topics. The capability
 topic must be created with its own config (a dedicated ensurer call, or
-extend `topic_configs` to per-topic-name keying). Ops-governed creation in
-production, consistent with `docs/topic-provisioning.md`. (Doc bug noted:
+extend `topic_configs` to per-topic-name keying). (Doc bug noted:
 `provisioning/config.py:36` says "Per-topic config overrides", which
 misleadingly suggests per-topic-name targeting.)
 
-Data plane (per-bridge call topics, `mcp_server.<name>`) is unchanged and
+Creation responsibility: the dangerous path is **broker auto-creation**
+(implicit materialization with default configs — `cleanup.policy=delete`),
+which is always forbidden; an *explicit* idempotent ensure with the correct
+compact config is safe from either side. Dev/CI (provisioning enabled):
+**both** the toolbox-hosting worker and agent-side readers ensure the topic at
+startup via the same dedicated ensurer (`TopicAlreadyExists` → no-op;
+CreateTopics is atomic, so a boot race is benign) — this removes any
+bring-up-order requirement: a reader that boots first gates instantly on the
+empty topic and picks up the toolbox's record later as a live update.
+Production (provisioning disabled, the default): nobody creates; the topic is
+ops-governed infrastructure (consistent with `docs/topic-provisioning.md`)
+and a missing topic fails reader resource setup loudly. Creation is one-time
+per cluster: topics are durable metadata and survive broker restarts; only
+storage loss (ephemeral dev containers) requires re-creation — which the
+idempotent ensure-on-boot heals. A mis-created policy is repairable in place
+(`cleanup.policy` is a dynamic topic config).
+
+Data plane (per-toolbox call topics, `mcp_server.<name>`) is unchanged and
 strictly separate: the capability topic carries metadata about what exists,
 never tool calls or workflow state.
 
@@ -67,19 +83,19 @@ class CapabilityToolDef(BaseModel):
 
 class CapabilityRecord(BaseModel):
     schema_version: int = 1
-    bridge_id: str
+    toolbox_id: str
     dispatch_topic: str
     tools: list[CapabilityToolDef]
     published_at: AwareDatetime
 ```
 
 Reader policy: tolerant (ignore unknown fields); skip + log records with a
-newer `schema_version`. Kafka message key = `bridge_id` (bytes). Tombstone =
+newer `schema_version`. Kafka message key = `toolbox_id` (bytes). Tombstone =
 null value under the key.
 
-### 3.3 Writer (bridge)
+### 3.3 Writer (toolbox)
 
-The bridge publishes its record:
+The toolbox publishes its record:
 
 1. **On connect** — in `after_startup` (the serving phase exists precisely
    because it has the live broker): `list_tools()` → `CapabilityRecord` →
@@ -104,7 +120,7 @@ subscriber on the capability topic:
 - `auto_offset_reset="earliest"`, **unique per-process group id** — every
   worker replica must replay the full topic; sharing a group would partition
   records across replicas.
-- Handler: last-write-wins upsert `view[bridge_id] = (record, received_at)`;
+- Handler: last-write-wins upsert `view[toolbox_id] = (record, received_at)`;
   delete on tombstone. LWW also absorbs not-yet-compacted duplicates during
   replay.
 - The view lives in the worker resource bag (the faust-table equivalent,
@@ -122,9 +138,9 @@ this is forced anyway, because Kafka never compacts the active segment and
 compaction lags the dirty ratio, so duplicates reach every reader regardless
 (and `TestKafkaBroker`, which doesn't compact, exercises the real semantics).
 Degradation without compaction is replay *size*, not wrongness: heartbeats
-(~2,880 records/bridge/day) mean a misconfigured `cleanup.policy=delete` topic
+(~2,880 records/toolbox/day) mean a misconfigured `cleanup.policy=delete` topic
 still always holds a fresh record inside any sane retention window — boots get
-slower (linearly in retention × bridges), tools never get lost. The genuinely
+slower (linearly in retention × toolboxes), tools never get lost. The genuinely
 non-trivial implementation work is the boot choreography, not the dict: the
 end-offset catch-up check (reaching the aiokafka consumer under FastStream —
 see §8), and consumer identity (prefer `group_id=None` — no committed offsets,
@@ -147,7 +163,7 @@ agent = Agent(
 )
 ```
 
-`MCPTools` is a declarative reference, not a `ToolProvider`: it names a bridge
+`MCPTools` is a declarative reference, not a `ToolProvider`: it names a toolbox
 and optionally filters tool names (the filter is the trust boundary — a server
 suddenly exposing new tools cannot silently enlarge an agent's tool surface).
 `_normalize_tools` keeps selectors aside rather than expanding them.
@@ -160,7 +176,7 @@ validator-less `ToolBinding`s (`tool_def` rebuilt from `CapabilityToolDef`,
 `dispatch_topic` from the record) and merges with static ctor tools. Fresh
 every turn; no agent mutation; no RPC.
 
-Unresolved (bridge absent from view, or `include` name not advertised):
+Unresolved (toolbox absent from view, or `include` name not advertised):
 
 - default: log a warning, run the turn with what resolved;
 - `MCPTools(..., strict=True)`: fail the turn before the model runs.
@@ -173,9 +189,9 @@ and strict-on-stale are explicitly deferred to a v2 decision.
 
 | Event | Control plane | Agent experience |
 |---|---|---|
-| Bridge crashes | Record stands; heartbeats stop | Tools still offered; calls fail visibly (`FailedToolCall`); staleness logged after threshold |
-| Bridge clean shutdown (deploy) | Tombstone, then re-publish on boot | Tools vanish for the deploy window, then return (accepted trade-off, §6) |
-| Bridge decommissioned for good | Tombstone (clean shutdown) | Selector unresolved: warn + degrade, or strict-fail |
+| Toolbox crashes | Record stands; heartbeats stop | Tools still offered; calls fail visibly (`FailedToolCall`); staleness logged after threshold |
+| Toolbox clean shutdown (deploy) | Tombstone, then re-publish on boot | Tools vanish for the deploy window, then return (accepted trade-off, §6) |
+| Toolbox decommissioned for good | Tombstone (clean shutdown) | Selector unresolved: warn + degrade, or strict-fail |
 | MCP server changes tools | `tools/list_changed` → re-publish | Next turn sees the new list |
 | Agent worker boots | Replays topic, gated ~30s | First turn already has full view |
 | Capability topic lagging | Gate timeout → serve + loud log | Possibly missing MCP tools until convergence; warnings on resolve |
@@ -183,7 +199,7 @@ and strict-on-stale are explicitly deferred to a v2 decision.
 ## 6. Accepted trade-off: tombstone-on-clean-shutdown
 
 A rolling deploy (SIGTERM → clean shutdown) tombstones the record, so the
-bridge's tools vanish cluster-wide until the new instance re-publishes —
+toolbox's tools vanish cluster-wide until the new instance re-publishes —
 while a *crash* leaves the advertisement standing. Graceful restarts are thus
 briefly more disruptive than crashes. Accepted consciously (self-cleaning, no
 decommission CLI needed for v1), with the explicit ideal that advertisement
@@ -194,12 +210,12 @@ on. Revisit if deploy-window tool gaps hurt in practice.
 
 - **Live `list_tools` query per turn** (the in-process pattern of pydantic-ai
   / OpenAI Agents SDK): over Kafka this couples every agent turn to every
-  bridge's availability, adds 2×N hops of pre-model latency, and requires new
+  toolbox's availability, adds 2×N hops of pre-model latency, and requires new
   fan-in state machinery in `run()`. Cached variants converge back to a
   change-notification topic — i.e., this design with extra steps. See ADR-0001.
-- **Per-bridge capability topics**: readers would need the topic list up
-  front (defeating discovery) and adding a bridge would churn subscriptions.
-  One topic + keys gives compaction per bridge for free.
+- **Per-toolbox capability topics**: readers would need the topic list up
+  front (defeating discovery) and adding a toolbox would churn subscriptions.
+  One topic + keys gives compaction per toolbox for free.
 - **Faust tables (forked OR embedded as an app in the worker lifecycle)**:
   rejected on both buy-vs-build axes. *Vendor health* (verified on PyPI +
   GitHub 2026-06-09): `faust` dead since 2020-02; `faust-streaming` last
@@ -208,7 +224,7 @@ on. Revisit if deploy-window tool gaps hurt in practice.
   calfkit ships — that remains unreleased, so the PyPI package is broken
   against our lockfile); 147 open issues; drags `mode-streaming`.
   *Interface fit*: faust tables own their internal
-  `{app_id}-{table}-changelog` topic — bridges publish to OUR topic in OUR
+  `{app_id}-{table}-changelog` topic — toolboxes publish to OUR topic in OUR
   versioned format, so embedding faust means either writing into faust
   internals (unsupported) or a copy-agent that double-stores every record
   while the table reduces to `table[k] = v`; and standard tables SHARD keys
@@ -239,10 +255,239 @@ on. Revisit if deploy-window tool gaps hurt in practice.
 - **TTL-expiry instead of tombstones**: rebuilds liveness-checking as hard
   state removal; heartbeat-as-information (reader-side judgment) kept instead.
 
-## 8. Implementation notes (non-normative)
+## 8. Implementation design
 
-- `MCPBridge.tool_bindings()` currently raises `NotImplementedError`; once
-  selectors exist it should keep raising (a bridge is not a sync provider) and
+### 8.1 Module map
+
+| Piece | Location | Contents |
+|---|---|---|
+| Wire models | `calfkit/models/capability.py` | `CapabilityToolDef`, `CapabilityRecord` (§3.2), `CAPABILITY_SCHEMA_VERSION` |
+| Table + writer | **`ktables` (PyPI dependency, >=0.1.1)** | `KafkaTable[CapabilityRecord]` (the Capability View) + `KafkaTableWriter` (toolbox publisher transport) |
+| Selector protocol | `calfkit/models/tool_dispatch.py` | `ToolSelector` protocol (deferred per-turn resolution) — keeps `nodes/agent.py` free of any `calfkit.mcp` import |
+| MCP selector | `calfkit/mcp/mcp_toolbox.py` | `MCPToolbox` itself implements `ToolSelector`; `.select(include=..., strict=...)` returns a frozen internal scoped selector (no user-facing selector class) |
+| Toolbox publisher | `calfkit/mcp/mcp_toolbox.py` | record publish on connect, `tools/list_changed` handler, heartbeat task, shutdown tombstone |
+| Worker wiring | `calfkit/worker/worker.py` (+ config) | auto-registered worker `@resource` when any hosted agent declares selectors |
+
+### 8.2 The table layer is the `ktables` package
+
+The materialized-view mechanics were extracted, hardened (3-round adversarial
+review), and published as the standalone `ktables` package
+(https://pypi.org/project/ktables/ — grown from this design's PoC; calfkit
+now depends on it rather than vendoring). It provides everything §3.4
+requires: group-less full-replay reader with the end-offsets catch-up gate
+(`catchup_timeout`, serve-degraded on expiry), LWW upsert / null-value
+tombstones, poison-record tolerance, reader-death observability
+(`status` ∈ unstarted/loading/caught_up/degraded/failed + `failure`),
+idempotent `acks=all` writer, and explicit idempotent `ensure_topic()`.
+
+The Capability View is therefore literally `KafkaTable[CapabilityRecord]`
+(constructed via `KafkaTable.json(model=CapabilityRecord)`), and calfkit owns
+only: the wire model, `MCPDiscoveryConfig`, the lifecycle wiring (§8.3), the
+toolbox publishing policy (§8.5), and selector resolution (§8.4). Calfkit-side
+version-tolerance (skip + log records with newer `schema_version`) lives in
+the selector-resolution layer, since ktables decodes any valid
+`CapabilityRecord` JSON.
+
+### 8.3 Reader-side wiring (worker)
+
+**No coordination on toolbox ids — by design.** The table is an *unfiltered*
+materialization of the whole capability topic: every toolbox's record,
+cluster-wide, regardless of what any hosted agent asked for (Kafka cannot
+subscribe to a subset of keys, and the data is tiny metadata — §"everyone
+holds the full map"). Agents never register interest in ids; each one simply
+looks up its own selectors' keys per turn. The only cross-node decision is
+binary — does ANY hosted agent declare selectors? — which gates whether the
+worker creates the resource at all. Nothing to negotiate, no refcounts, no
+per-id subscription management.
+
+Wiring sequence:
+
+1. **Agent ctor**: `_normalize_tools` returns `(bindings, selectors)`;
+   selectors (objects implementing `ToolSelector`) are stored on
+   `agent._tool_selectors`. Checked BEFORE the `ToolProvider` structural
+   check, so an `MCPToolbox` in `tools=[...]` is never mistaken for a
+   sync provider.
+2. **`Worker.register_handlers`**: scan hosted nodes for non-empty
+   `_tool_selectors`. If any (and the resource isn't already registered —
+   names are unique per owner, so the guard is a lookup), register a
+   worker-level resource programmatically:
+
+   ```python
+   if any(getattr(n, "_tool_selectors", None) for n in self._nodes):
+       self.resource(CAPABILITY_VIEW_KEY)(self._capability_view_resource)
+
+   async def _capability_view_resource(self, ctx) -> AsyncIterator[Mapping[str, CapabilityRecord]]:
+       cfg = self._mcp_discovery  # MCPDiscoveryConfig
+       table = KafkaTable.json(
+           bootstrap_servers=cfg.bootstrap_servers or self._broker_url(),
+           topic=cfg.topic, model=CapabilityRecord,
+           catchup_timeout=cfg.catchup_timeout,
+           ensure_topic=self._provisioning_enabled(),   # §3.1
+       )
+       await table.start()    # replay + bounded gate; serve-degraded built in
+       yield table            # lands in the WORKER bag → merged into every
+       await table.stop()     #   node's ctx.resources via _effective_resources
+   ```
+
+3. **Per turn**: the agent reads
+   `ctx.resources[CAPABILITY_VIEW_KEY]` — present in every hosted node's
+   view because worker resources merge under node resources. A missing key
+   with selectors declared (agent driven outside a worker, e.g. a bare-`run()`
+   unit test) is a warn-and-degrade, `strict=True` raises.
+
+**Layering rule that falls out: the agent layer never imports ktables.** The
+resolution code types the view as `Mapping[str, CapabilityRecord]` —
+`KafkaTable` satisfies it, and so does a **plain dict**, which is the entire
+agent-side test strategy (no broker, no fakes framework: seed a dict, run a
+turn). Only the worker wiring file touches `ktables`.
+
+**Toolbox-id uniqueness is the existing node-id invariant, not a new one.**
+Two toolboxes sharing a `node_id` would LWW-clobber each other's records —
+the same operational error class as two calf nodes sharing an id/topic today,
+and it surfaces visibly (tool lists flapping between heartbeats). Nothing new
+to enforce; document alongside the existing uniqueness expectation.
+
+**Zero-config by design: the control plane is invisible.** The user provides
+the broker URL exactly once, in the existing pattern:
+
+```python
+client = Client.connect("kafka:9092")          # the only URL the user types
+worker = Worker(client, nodes=[agent, docs_toolbox])
+```
+
+Today `Client.connect` resolves `server_urls` (arg → `CALF_HOST_URL` →
+`"localhost"`, `base.py:144`) but does not retain it. PR A adds retention: the
+resolved value is stored on the client and exposed as a read-only
+`client.server_urls`. Derivation chain, in order:
+
+1. `worker._client.server_urls` — calfkit-owned, no FastStream internals.
+   The toolbox's writer reaches the same value via its `_worker`
+   back-reference (assigned in `add_nodes`, before lifecycle runs).
+2. Fallback for clients not built via `connect()`: a guarded helper reading
+   the broker's `_connection_kwargs["bootstrap_servers"]` (verified present
+   in FastStream 0.6.6; same guarded-internal pattern as `ensurer.py:42`),
+   raising a clear error naming the override if the attribute ever moves.
+3. Explicit `MCPDiscoveryConfig.bootstrap_servers` — pure escape hatch.
+
+`MCPDiscoveryConfig(topic="mcp.capabilities", catchup_timeout=30.0,
+heartbeat_interval=30.0, bootstrap_servers=None)` is therefore entirely
+optional — defaults apply when absent. `bootstrap_servers` remains the
+override for the advanced split-cluster case (control plane on a different
+Kafka cluster than the data plane).
+
+**Security boundary (v1 scope):** retaining the URL deliberately relaxes half
+of the #188 pin (`test_client_never_captures_security_kwargs` documents the
+split) — addressing data may be retained on the client; **credentials may
+not**. Consequence: the v1 control plane targets clusters reachable with
+bootstrap servers alone (dev/PLAINTEXT or network-trusted). Secured-cluster
+support for the control plane is future work via an explicit security
+pass-through on `MCPDiscoveryConfig` — never a client-side capture of raw
+security kwargs.
+
+### 8.4 Agent-side resolution
+
+The toolbox is passed to agents exactly like a tool node — one object, both
+deployable and advertisable (`worker.add_nodes(docs)`; `tools=[docs]`).
+Passing it never touches the MCP session: the agent extracts only the
+deferred lookup key (`node_id`) plus any `.select()` scoping. Cross-process
+works because the agent's worker imports the toolbox *definition* (shared
+codebase) without deploying it — the same way tool-node objects travel today.
+The standalone `MCPTools` class is dropped; `MCPToolbox.tool_bindings()`
+(which raised `NotImplementedError`) is deleted in favor of implementing
+`ToolSelector`. `_normalize_tools` checks selector-ness BEFORE provider-ness
+and sets selectors aside in `self._tool_selectors`.
+
+Selector mechanics: `ToolSelector` (in `tool_dispatch.py`) is
+
+```python
+@runtime_checkable
+class ToolSelector(Protocol):
+    def resolve_tools(self, view: Mapping[str, "CapabilityRecord"]) -> "SelectorResult": ...
+```
+
+`MCPToolbox.resolve_tools` looks up `view.get(self.node_id)`;
+`toolbox.select(include=..., strict=...)` returns a small frozen
+`_ScopedSelector(toolbox_id, include, strict)` delegating to the same code.
+`SelectorResult` carries `bindings` plus structured diagnostics
+(`missing_toolbox`, `missing_tools`, `stale_seconds`, `skipped_newer_schema`)
+so `run()` owns the warn/strict/log policy in one place and tests can assert
+on diagnostics instead of log text. Resolution must also guard
+`record_to_bindings` (a malformed record — e.g. empty `dispatch_topic` —
+decodes under the tolerant reader but fails binding expansion): catch, count
+as a diagnostic, skip-and-log, never crash the turn. Schema-version tolerance (skip + log
+records with a newer major) lives here, since ktables decodes any valid JSON
+into the model.
+
+At the top of `run()`, selectors resolve against
+`ctx.resources["calfkit.mcp.capability_view"]` (`table.get(toolbox_id)`):
+build validator-less `ToolBinding`s from the record (`tool_def` rebuilt from
+`CapabilityToolDef`, `dispatch_topic` from the record), apply the `include`
+filter, then merge into `tools_registry` AFTER static tools with
+**collision = log error + static wins** (a remote server must never silently
+shadow a locally-defined tool). Unresolved selector: warn + degrade;
+`strict=True` raises before the model call. Stale heartbeat (v1): log only.
+
+### 8.5 Toolbox-side publishing
+
+The toolbox owns a `KafkaTableWriter[CapabilityRecord]` (started in its
+resource phase alongside the MCP session; `ensure_topic` gated on
+provisioning). Policy revision vs. the original sketch: publish via the
+ktables writer rather than the worker's FastStream broker — it costs one
+extra producer connection per toolbox worker but buys the idempotent
+`acks=all` defaults and symmetric codecs for free, and keeps the control
+plane fully decoupled from the data plane's broker lifecycle.
+
+In `after_startup`: `list_tools()` → `CapabilityRecord` →
+`writer.set(toolbox_id, record)`; register the `tools/list_changed` message
+handler (re-list + re-`set`); start the heartbeat task (re-`set` every
+`heartbeat_interval`). In `on_shutdown`: cancel heartbeat,
+`writer.delete(toolbox_id)` (§6 trade-off). Boot failure unchanged:
+resource-phase errors abort worker startup.
+
+### 8.6 Delivery plan (3 PRs, TDD each)
+
+0. ~~PoC~~ **DONE** — graduated into the published `ktables` package
+   (>=0.1.1, now a calfkit dependency), hardened via 3-round review.
+1. **PR A — wire model + config**: `calfkit/models/capability.py`
+   (`CapabilityRecord`, `CapabilityToolDef`), `MCPDiscoveryConfig`; pure unit
+   tests (round-trip, version tolerance policy helper).
+2. **PR B — toolbox publisher**: `KafkaTableWriter` resource on `MCPToolbox`,
+   connect/`list_changed`/heartbeat/tombstone hooks; tests with a fake writer
+   (publish assertions) + one real-broker integration test.
+3. **PR C — worker view + selector + agent resolution**: worker `@resource`
+   opening `KafkaTable.json(model=CapabilityRecord)` (auto-registered when a
+   hosted agent declares selectors), `ToolSelector` protocol, `MCPTools`,
+   `run()` resolution/merge/strict; fixes `MCPToolbox.tool_bindings()`'s error
+   message to point at `MCPTools`. Closes the loop; PR #207 leaves draft.
+   (Formerly PRs C+D; merged because the view wiring is now ~20 lines.)
+
+Open detail to settle during PR C: pinning the capability topic to 1
+partition at creation (recommended: yes; total order per key is free).
+(Bootstrap-servers derivation: RESOLVED — zero-config via the broker, §8.3.)
+
+### 8.7 Testing strategy
+
+- **Agent resolution (PR C, no broker):** the view is typed as
+  `Mapping[str, CapabilityRecord]`, so unit tests seed a plain dict into the
+  node's resource bag and drive `run()` with `TestKafkaBroker` as usual —
+  selector hits, include filters, collisions (static wins), unresolved
+  warn/strict, staleness logging, newer-schema skip.
+- **Toolbox publisher (PR B, no broker):** the writer is held as a node
+  resource; tests inject a fake writer (records `set`/`delete` calls) into
+  the bag and assert publish-on-connect / re-publish-on-list_changed /
+  heartbeat cadence (advance via short interval) / tombstone-on-shutdown.
+- **Worker wiring + real pipeline (PR C, broker-gated):** one integration
+  test, skipped without a broker (the ktables test pattern): toolbox worker
+  up → record lands; agent worker up → catch-up gate passes → a turn
+  resolves bindings; toolbox clean-shutdown → tombstone → next turn warns.
+- ktables' own semantics (gate, LWW, tombstones, reader death) are NOT
+  re-tested in calfkit — they're covered by the ktables suite; calfkit tests
+  its policy layers only.
+
+## 9. Implementation notes (non-normative)
+
+- `MCPToolbox.tool_bindings()` currently raises `NotImplementedError`; once
+  selectors exist it should keep raising (a toolbox is not a sync provider) and
   the error message should point at `MCPTools`.
 - The catch-up gate needs consumer end-offset access; FastStream exposes the
   underlying aiokafka consumer per subscriber — verify the cleanest hook

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "typing-extensions>=4.15.0",
     "dishka>=1.9.1",
     "mcp>=1.27.2",
+    "ktables>=0.1.1",
 ]
 
 [project.urls]

--- a/tests/test_capability_models.py
+++ b/tests/test_capability_models.py
@@ -1,0 +1,130 @@
+"""PR A: capability wire model, discovery config, and server_urls retention.
+
+Spec: docs/designs/mcp-capability-discovery-spec.md §3.2 (wire format),
+§8.3 (zero-config bootstrap derivation, MCPDiscoveryConfig defaults).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from calfkit.client.client import Client
+from calfkit.models.capability import (
+    CAPABILITY_SCHEMA_VERSION,
+    CapabilityRecord,
+    CapabilityToolDef,
+    is_unsupported_schema,
+    record_to_bindings,
+)
+from calfkit.models.tool_dispatch import ToolBinding
+from calfkit.worker.worker_config import MCPDiscoveryConfig
+
+
+def make_record(**overrides) -> CapabilityRecord:
+    defaults = dict(
+        toolbox_id="docs_server",
+        dispatch_topic="mcp_server.docs_server",
+        tools=[
+            CapabilityToolDef(
+                name="search",
+                description="Search the docs",
+                parameters_json_schema={"type": "object", "properties": {"q": {"type": "string"}}},
+            ),
+            CapabilityToolDef(name="fetch", parameters_json_schema={"type": "object", "properties": {}}),
+        ],
+        published_at=datetime.now(tz=timezone.utc),
+    )
+    defaults.update(overrides)
+    return CapabilityRecord(**defaults)
+
+
+class TestCapabilityRecordWireFormat:
+    def test_round_trips_through_json(self) -> None:
+        record = make_record()
+        restored = CapabilityRecord.model_validate_json(record.model_dump_json())
+        assert restored == record
+        assert restored.schema_version == CAPABILITY_SCHEMA_VERSION == 1
+
+    def test_tolerant_reader_ignores_unknown_fields(self) -> None:
+        # Records outlive deploys; a NEWER writer may add fields this reader
+        # doesn't know. They must be ignored, not rejected.
+        payload = make_record().model_dump_json()
+        widened = payload[:-1] + ', "future_field": {"x": 1}}'
+        restored = CapabilityRecord.model_validate_json(widened)
+        assert restored.toolbox_id == "docs_server"
+
+    def test_description_is_optional(self) -> None:
+        record = make_record()
+        assert record.tools[1].description is None
+
+    def test_newer_major_schema_is_detected_not_rejected(self) -> None:
+        # Decoding succeeds (ktables applies any valid JSON); the POLICY of
+        # skipping newer-major records lives with the caller via this helper.
+        newer = make_record(schema_version=CAPABILITY_SCHEMA_VERSION + 1)
+        assert is_unsupported_schema(newer)
+        assert not is_unsupported_schema(make_record())
+
+
+class TestRecordToBindings:
+    def test_builds_validatorless_bindings_with_record_topic(self) -> None:
+        record = make_record()
+        bindings = record_to_bindings(record)
+        assert [b.name for b in bindings] == ["search", "fetch"]
+        assert all(isinstance(b, ToolBinding) for b in bindings)
+        assert all(b.dispatch_topic == "mcp_server.docs_server" for b in bindings)
+        # Wire-crossing tools dispatch unvalidated (schema-only carve-out).
+        assert all(b.validator is None for b in bindings)
+
+    def test_tool_def_fields_survive(self) -> None:
+        [search, _] = record_to_bindings(make_record())
+        assert search.tool_def.description == "Search the docs"
+        assert search.tool_def.parameters_json_schema == {"type": "object", "properties": {"q": {"type": "string"}}}
+
+
+class TestMCPDiscoveryConfig:
+    def test_defaults_match_spec(self) -> None:
+        cfg = MCPDiscoveryConfig()
+        assert cfg.topic == "mcp.capabilities"
+        assert cfg.catchup_timeout == 30.0
+        assert cfg.heartbeat_interval == 30.0
+        assert cfg.bootstrap_servers is None  # None = derive from the client
+
+    def test_rejects_non_positive_intervals(self) -> None:
+        with pytest.raises(ValueError):
+            MCPDiscoveryConfig(catchup_timeout=0)
+        with pytest.raises(ValueError):
+            MCPDiscoveryConfig(heartbeat_interval=-1)
+
+
+class TestClientServerUrlsRetention:
+    def test_connect_retains_explicit_url(self) -> None:
+        client = Client.connect("kafka-a:9092")
+        assert client.server_urls == "kafka-a:9092"
+
+    def test_connect_normalizes_multiple_urls(self) -> None:
+        client = Client.connect(["kafka-a:9092", "kafka-b:9092"])
+        assert client.server_urls == "kafka-a:9092,kafka-b:9092"
+
+    def test_connect_retains_env_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CALF_HOST_URL", "env-kafka:9092")
+        client = Client.connect()
+        assert client.server_urls == "env-kafka:9092"
+
+    def test_one_shot_iterable_reaches_broker_intact(self) -> None:
+        # Regression: normalization must not consume a generator before the
+        # broker sees it — the broker must receive real bootstrap servers,
+        # not just the property reporting the right string.
+        client = Client.connect(url for url in ["kafka-a:9092", "kafka-b:9092"])
+        assert client.server_urls == "kafka-a:9092,kafka-b:9092"
+        # The broker must receive the LIST form: FastStream wraps a str into
+        # [str] and aiokafka never comma-splits a list element, so anything
+        # other than both distinct hosts here means multi-host is broken.
+        brokers = client.broker._connection_kwargs["bootstrap_servers"]
+        assert brokers == ["kafka-a:9092", "kafka-b:9092"]
+
+    def test_server_urls_is_read_only(self) -> None:
+        client = Client.connect("kafka-a:9092")
+        with pytest.raises(AttributeError):
+            client.server_urls = "other:9092"  # type: ignore[misc]

--- a/tests/test_provisioning_client.py
+++ b/tests/test_provisioning_client.py
@@ -51,8 +51,18 @@ def test_connect_rejects_raw_sasl_plain_kwargs() -> None:
         Client.connect("localhost:9092", sasl_plain_username="u", sasl_plain_password="p")
 
 
-def test_client_no_longer_exposes_server_urls_or_security_kwargs() -> None:
+def test_client_never_captures_security_kwargs() -> None:
+    """Credentials flow exclusively through FastStream's ``security=`` object
+    (the #188 invariant): the client must never capture raw security kwargs.
+
+    Note: this pin originally also covered ``server_urls``. That half was
+    deliberately relaxed for MCP capability discovery — the client now retains
+    the (non-credential) bootstrap URL it was connected with, so control-plane
+    consumers are zero-config. Addressing data may be retained; security
+    material may not.
+    """
     client = Client.connect("localhost:9092")
 
-    assert not hasattr(client, "server_urls")
     assert not hasattr(client, "security_kwargs")
+    # The retained URL is addressing data only — never credentials.
+    assert client.server_urls == "localhost:9092"


### PR DESCRIPTION
## Summary

PR A of the MCP toolbox discoverability plan (`docs/designs/mcp-capability-discovery-spec.md` §8.6 — the converged spec ships in this PR). Pure foundations, no behavior wired yet.

- **`calfkit/models/capability.py`** — the control-plane wire format: `CapabilityRecord`/`CapabilityToolDef` (calfkit-owned, versioned, tolerant readers — never the vendored `ToolDefinition` on the wire), `is_unsupported_schema()` as the newer-major skip-policy predicate, and `record_to_bindings()` expanding a record into validator-less `ToolBinding`s.
- **`MCPDiscoveryConfig`** — all-optional escape hatches (`topic`, `catchup_timeout`, `heartbeat_interval`, `bootstrap_servers` for split-cluster); the control plane is zero-config by design.
- **`Client.connect` URL retention** — the resolved bootstrap URL(s) are retained and exposed as read-only `client.server_urls` (comma-joined), so control-plane consumers derive the broker address from the one URL the user already typed. Relaxes the `server_urls` half of the #188 pin — addressing data may be retained, credentials may not (`test_client_never_captures_security_kwargs` documents the split; spec §8.3 records the v1 security scope).
- **`ktables>=0.1.1`** dependency (the published GlobalKTable package backing the capability view in PR C).

## Review (3 rounds, converged)

- R1 critical: normalization drained one-shot iterables before broker construction → broker got `[]` while the property read correctly. Fixed: materialize once.
- R2 critical: comma-joined **string** through FastStream's `KafkaBroker` wraps to `[str]`, which aiokafka never comma-splits → multi-host mangled to one bad address. Fixed: the broker gets the **list**; the retained property stays the comma **string** (correct for direct-aiokafka consumers like ktables — it splits strings). Both forms now regression-tested, including exact-list assertion on the broker kwargs from a generator input.
- R3: converged; provisioning verified to inherit the fix (ensurer reuses the broker's admin client).

## Tests

13 new tests (TDD, RED-first); full suite 2676 passed; `make fix` + `make check` clean.