### PR TITLE
feat!: MCPToolbox — rename from MCPBridge + capability advertisement

### DIFF
--- a/calfkit/_protocol.py
+++ b/calfkit/_protocol.py
@@ -8,7 +8,7 @@ Do not add imports from ``calfkit.*`` to this module.
 
 from typing import Any, Literal
 
-NodeKind = Literal["node", "agent", "tool", "client", "consumer", "bridge"]
+NodeKind = Literal["node", "agent", "tool", "client", "consumer", "toolbox"]
 """Closed value space for the ``x-calf-emitter-kind`` Kafka header. Subclasses of
 ``BaseNodeDef`` declare their kind via ``_node_kind: ClassVar[NodeKind]``; the
 client publishes with ``CLIENT_KIND`` directly.

--- a/calfkit/exceptions.py
+++ b/calfkit/exceptions.py
@@ -7,7 +7,7 @@ def safe_exc_message(e: BaseException) -> str:
     A bare ``str(e)`` can itself raise (a broken ``__str__``, or args that don't
     coerce). Inside a worker's ``except`` block that would propagate out and prevent
     the failure reply (e.g. a ``FailedToolCall``) from ever being published — the
-    silent-hang failure mode the tool/bridge nodes exist to prevent. Mirrors stdlib
+    silent-hang failure mode the tool/toolbox nodes exist to prevent. Mirrors stdlib
     ``traceback._some_str`` with a ``repr`` fallback.
     """
     try:

--- a/calfkit/mcp/mcp_toolbox.py
+++ b/calfkit/mcp/mcp_toolbox.py
@@ -24,17 +24,17 @@ logger = logging.getLogger(__name__)
 _TransportCM = AbstractAsyncContextManager[tuple[object, object]]
 
 
-class MCPBridge(BaseNodeDef):
-    _node_kind: ClassVar[NodeKind] = "bridge"
+class MCPToolbox(BaseNodeDef):
+    _node_kind: ClassVar[NodeKind] = "toolbox"
 
     def tool_bindings(self) -> list[ToolBinding]:
         # MCP tools are discovered from the live session (list_tools is async,
         # and the session exists only after resource setup), so sync collection
         # at agent-construction time is impossible. Fail fast rather than
-        # return [] — an empty list would silently register the bridge with no
+        # return [] — an empty list would silently register the toolbox with no
         # tools. Async discovery / lazy-provider resolution is a pending design.
         raise NotImplementedError(
-            f"MCPBridge {self.node_id!r} cannot provide tool bindings synchronously; "
+            f"MCPToolbox {self.node_id!r} cannot provide tool bindings synchronously; "
             "MCP tool discovery requires a live session (pending async-provider design)"
         )
 
@@ -47,7 +47,7 @@ class MCPBridge(BaseNodeDef):
             transport = stdio_client(params)
         else:
             raise LifecycleConfigError(
-                f"MCPBridge {self.node_id!r}: unsupported connection_params type {type(params).__name__}; "
+                f"MCPToolbox {self.node_id!r}: unsupported connection_params type {type(params).__name__}; "
                 "expected StreamableHttpParameters or StdioServerParameters"
             )
         async with transport as (read_stream, write_stream):
@@ -66,7 +66,7 @@ class MCPBridge(BaseNodeDef):
 
         The agent reads the result under ``payload.tool_call_id`` and escalates any
         ``FailedToolCall`` to a ``ToolExecutionError`` (it is *not* shown to the model),
-        so this is the bridge's hard-failure channel: a dead session, a transport error,
+        so this is the toolbox's hard-failure channel: a dead session, a transport error,
         or a non-wire-safe result. Replying (rather than raising) is what keeps the
         awaiting agent from stalling on its reply-TTL.
         """
@@ -87,7 +87,7 @@ class MCPBridge(BaseNodeDef):
             # raising, which would strand the awaiting agent on its reply-TTL instead
             # of surfacing a ToolExecutionError.
             logger.error(
-                "[%s] no live MCP session for bridge=%s resource=%s tool=%s",
+                "[%s] no live MCP session for toolbox=%s resource=%s tool=%s",
                 ctx.correlation_id[:8],
                 self.node_id,
                 self._session_resource_key,
@@ -104,7 +104,7 @@ class MCPBridge(BaseNodeDef):
             pydantic_core.to_json(tool_return)
         except Exception as e:
             logger.exception(
-                "[%s] mcp tool=%s tool_call_id=%s on bridge=%s raised %s; surfacing FailedToolCall",
+                "[%s] mcp tool=%s tool_call_id=%s on toolbox=%s raised %s; surfacing FailedToolCall",
                 ctx.correlation_id[:8],
                 payload.name,
                 payload.tool_call_id,

--- a/calfkit/mcp/mcp_toolbox.py
+++ b/calfkit/mcp/mcp_toolbox.py
@@ -1,11 +1,16 @@
+import asyncio
+import contextlib
 import logging
 from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager
-from typing import ClassVar
+from datetime import datetime, timezone
+from typing import Any, ClassVar
 
 import pydantic_core
+from ktables import KafkaTableWriter
 from mcp import ClientSession
 from mcp.types import CallToolResult as MCPCallToolResult
+from mcp.types import ToolListChangedNotification
 
 from calfkit._protocol import NodeKind
 from calfkit._registry import handler
@@ -13,11 +18,13 @@ from calfkit._vendor.pydantic_ai.messages import ToolReturn
 from calfkit.exceptions import LifecycleConfigError, safe_exc_message
 from calfkit.mcp.mcp_transport import StdioServerParameters, StreamableHttpParameters, http_client, stdio_client
 from calfkit.models.actions import NodeResult, ReturnCall
+from calfkit.models.capability import CapabilityRecord, CapabilityToolDef
 from calfkit.models.session_context import SessionRunContext
 from calfkit.models.state import FailedToolCall, State
 from calfkit.models.tool_dispatch import ToolBinding, ToolCallRef
 from calfkit.nodes.base import BaseNodeDef
-from calfkit.worker.lifecycle import ResourceSetupContext
+from calfkit.worker.lifecycle import ResourceSetupContext, ServingContext
+from calfkit.worker.worker_config import MCPDiscoveryConfig
 
 logger = logging.getLogger(__name__)
 
@@ -51,15 +58,161 @@ class MCPToolbox(BaseNodeDef):
                 "expected StreamableHttpParameters or StdioServerParameters"
             )
         async with transport as (read_stream, write_stream):
-            async with ClientSession(read_stream, write_stream) as session:
+            async with ClientSession(read_stream, write_stream, message_handler=self._mcp_message_handler) as session:
                 await session.initialize()
                 yield session
 
-    def __init__(self, server_name: str, connection_params: StreamableHttpParameters | StdioServerParameters):
+    def __init__(
+        self,
+        server_name: str,
+        connection_params: StreamableHttpParameters | StdioServerParameters,
+        discovery: MCPDiscoveryConfig | None = None,
+    ):
         super().__init__(node_id=server_name, subscribe_topics=[f"mcp_server.{server_name}"])
         self._connection_params = connection_params
+        self._discovery = discovery or MCPDiscoveryConfig()
         self._session_resource_key = f"mcp_session.{server_name}"
+        self._writer_resource_key = f"mcp_writer.{server_name}"
+        self._heartbeat_task: asyncio.Task[None] | None = None
+        self._relist_tasks: set[asyncio.Task[None]] = set()
+        self._shutting_down = False
+        self._last_record: CapabilityRecord | None = None
         self.resource(name=self._session_resource_key)(self._mcp_session)
+        self.resource(name=self._writer_resource_key)(self._capability_writer)
+        self.after_startup(self._publish_on_startup)
+        self.on_shutdown(self._tombstone_on_shutdown)
+
+    # -- capability publishing (spec §3.3/§8.5) -------------------------------
+
+    def _control_plane_bootstrap(self) -> str:
+        """Bootstrap servers for the capability topic, zero-config (spec §8.3).
+
+        Chain: explicit config override -> the connected client's retained URL
+        -> the broker's connection kwargs (guarded internals fallback).
+        """
+        if self._discovery.bootstrap_servers:
+            return self._discovery.bootstrap_servers
+        client = getattr(self._worker, "_client", None)
+        urls = getattr(client, "server_urls", None)
+        if urls:
+            return str(urls)
+        kwargs = getattr(getattr(client, "broker", None), "_connection_kwargs", None) or {}
+        servers = kwargs.get("bootstrap_servers")
+        if servers:
+            return servers if isinstance(servers, str) else ",".join(servers)
+        raise RuntimeError(
+            f"MCPToolbox {self.node_id!r}: cannot derive Kafka bootstrap servers for the "
+            "capability topic (no worker/client attached). Host this node via Worker, or set "
+            "MCPDiscoveryConfig(bootstrap_servers=...) explicitly."
+        )
+
+    def _provisioning_enabled(self) -> bool:
+        provisioning = getattr(getattr(self._worker, "_client", None), "_provisioning", None)
+        return bool(getattr(provisioning, "enabled", False))
+
+    async def _capability_writer(self, ctx: ResourceSetupContext) -> AsyncIterator[KafkaTableWriter[CapabilityRecord]]:
+        writer: KafkaTableWriter[CapabilityRecord] = KafkaTableWriter.json(
+            bootstrap_servers=self._control_plane_bootstrap(),
+            topic=self._discovery.topic,
+            model=CapabilityRecord,
+            ensure_topic=self._provisioning_enabled(),
+        )
+        await writer.start()
+        yield writer
+        await writer.stop()
+
+    async def _build_record(self, session: Any) -> CapabilityRecord:
+        listing = await session.list_tools()
+        return CapabilityRecord(
+            toolbox_id=self.node_id,
+            dispatch_topic=self.subscribe_topics[0],
+            tools=[
+                CapabilityToolDef(name=tool.name, description=tool.description, parameters_json_schema=tool.inputSchema) for tool in listing.tools
+            ],
+            published_at=datetime.now(tz=timezone.utc),
+        )
+
+    async def _publish_on_startup(self, ctx: ServingContext["MCPToolbox"]) -> None:
+        """Connect-time advertisement + heartbeat start. Raising here aborts
+        worker startup — a toolbox that cannot advertise must fail loudly."""
+        session = ctx.resources[self._session_resource_key]
+        writer = ctx.resources[self._writer_resource_key]
+        record = await self._build_record(session)
+        self._last_record = record
+        await writer.set(self.node_id, record)
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop(writer), name=f"mcp-heartbeat:{self.node_id}")
+
+    async def _heartbeat_loop(self, writer: Any) -> None:
+        # Re-publish the cached record with a fresh timestamp — liveness signal
+        # only; no re-listing (tools/list_changed drives content changes).
+        while True:
+            await asyncio.sleep(self._discovery.heartbeat_interval)
+            record = self._last_record
+            if record is None:
+                continue
+            record = record.model_copy(update={"published_at": datetime.now(tz=timezone.utc)})
+            self._last_record = record
+            try:
+                await writer.set(self.node_id, record)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("toolbox=%s heartbeat publish failed; will retry next interval", self.node_id)
+
+    async def _handle_tools_list_changed(self, notification: ToolListChangedNotification) -> None:
+        """Server signalled a tool-list change: re-list and re-publish."""
+        session = self.resources.get(self._session_resource_key)
+        writer = self.resources.get(self._writer_resource_key)
+        if session is None or writer is None:
+            logger.warning("toolbox=%s tools/list_changed before resources ready; ignoring", self.node_id)
+            return
+        record = await self._build_record(session)
+        self._last_record = record
+        await writer.set(self.node_id, record)
+
+    def _on_relist_done(self, task: asyncio.Task[None]) -> None:
+        self._relist_tasks.discard(task)
+        if not task.cancelled() and task.exception() is not None:
+            logger.error("toolbox=%s tools/list_changed re-publish failed", self.node_id, exc_info=task.exception())
+
+    async def _mcp_message_handler(self, message: Any) -> None:
+        # ClientSession message handler; ServerNotification is a RootModel wrapper.
+        inner = getattr(message, "root", message)
+        if isinstance(inner, ToolListChangedNotification):
+            if self._shutting_down:
+                # The receive loop outlives on_shutdown (session closes in the
+                # resource phase): a late notification must not spawn a re-list
+                # that lands after the tombstone and resurrects the record.
+                logger.debug("toolbox=%s ignoring tools/list_changed during shutdown", self.node_id)
+                return
+            # NEVER await the re-list inline: this handler runs ON the
+            # session's receive loop, and list_tools()'s response is delivered
+            # by that same loop — awaiting here deadlocks the session,
+            # unbounded (no read timeout). Offload and track for shutdown.
+            task = asyncio.create_task(self._handle_tools_list_changed(inner), name=f"mcp-relist:{self.node_id}")
+            self._relist_tasks.add(task)
+            task.add_done_callback(self._on_relist_done)
+
+    async def _tombstone_on_shutdown(self, ctx: ServingContext["MCPToolbox"]) -> None:
+        # Flag FIRST, synchronously (no await above this line): after it is
+        # set, _mcp_message_handler can never create a new re-list task, so
+        # the snapshot below is complete. Then cancel heartbeat AND in-flight
+        # re-lists BEFORE the tombstone: a straggler set() landing after
+        # delete() would resurrect the record.
+        self._shutting_down = True
+        tasks = [self._heartbeat_task, *self._relist_tasks]
+        self._heartbeat_task = None
+        self._relist_tasks.clear()
+        for task in tasks:
+            if task is not None:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+        writer = ctx.resources.get(self._writer_resource_key)
+        if writer is not None:
+            # Clean shutdown = deliberate removal (spec §6); a crash never gets
+            # here, so the record stands and goes stale instead.
+            await writer.delete(self.node_id)
 
     def _fail(self, ctx: SessionRunContext, payload: ToolCallRef, *, exc_type: str, exc_message: str) -> ReturnCall[State]:
         """Record a :class:`FailedToolCall` for ``payload`` and return to the caller.

--- a/calfkit/models/tool_dispatch.py
+++ b/calfkit/models/tool_dispatch.py
@@ -20,7 +20,7 @@ class ToolBinding(BaseModel):
     (:class:`ToolCallRef` below is the invocation-time half). It is exactly the
     surface ``BaseAgentNodeDef.run`` consumes per tool — nothing about the
     providing node (deployment topology, lifecycle, subscribe topics) leaks in,
-    so one node may contribute many bindings (toolbox, MCP bridge) or one
+    so one node may contribute many bindings (a native toolbox, an MCP toolbox) or one
     (function tool node) without any shared base class.
 
     Doubles as the wire model for per-run tool overrides
@@ -53,7 +53,7 @@ class ToolBinding(BaseModel):
 class ToolProvider(Protocol):
     """Structural contract for anything that contributes tools to an agent.
 
-    One provider may yield many bindings (toolbox, MCP bridge) or one (function
+    One provider may yield many bindings (a native toolbox, an MCP toolbox) or one (function
     tool node). ``runtime_checkable`` checks only that ``tool_bindings`` exists —
     the distinctive method name is what keeps unrelated objects from
     duck-typing in accidentally.
@@ -68,7 +68,7 @@ def normalize_tool_bindings(tools: Sequence[ToolProvider | ToolBinding] | None) 
     Raw :class:`ToolBinding` entries pass through verbatim (overrides, tests,
     hand-rolled bindings with no node object in hand); anything satisfying
     :class:`ToolProvider` contributes ``tool_bindings()``, so one provider may
-    yield many bindings (toolbox, MCP bridge). The ``isinstance`` protocol check
+    yield many bindings (a native toolbox, an MCP toolbox). The ``isinstance`` protocol check
     is structural — it only proves a ``tool_bindings`` attribute exists — which
     is why the unmatched arm is a hard ``TypeError`` rather than a skip.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,13 @@ exclude = ["calfkit/_vendor"]
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP"]
 
+# TODO(ktables>=0.1.2): remove once the py.typed marker ships
+# (https://github.com/ryan-yuuu/ktables/pull/6) — ktables IS typed; the
+# published wheel just lacks the PEP 561 marker.
+[[tool.mypy.overrides]]
+module = "ktables.*"
+ignore_missing_imports = true
+
 [tool.mypy]
 python_version = "3.10"
 strict = true

--- a/tests/integration/test_mcp_toolbox_capability.py
+++ b/tests/integration/test_mcp_toolbox_capability.py
@@ -1,0 +1,99 @@
+"""Integration: MCPToolbox publishes real CapabilityRecords a KafkaTable can read.
+
+Real Kafka writer + reader (ktables) against a broker on localhost:9092 —
+skipped when unreachable. The MCP session stays fake (no MCP server needed:
+the session surface used by publishing is just ``list_tools``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import pytest
+from aiokafka.admin import AIOKafkaAdminClient
+from ktables import KafkaTable
+from mcp.types import ListToolsResult, Tool
+
+from calfkit.mcp.mcp_toolbox import MCPToolbox
+from calfkit.mcp.mcp_transport import StreamableHttpParameters
+from calfkit.models.capability import CapabilityRecord
+from calfkit.worker.lifecycle import ServingContext
+from calfkit.worker.worker_config import MCPDiscoveryConfig
+
+BOOTSTRAP = "localhost:9092"
+
+
+class FakeSession:
+    async def list_tools(self) -> ListToolsResult:
+        return ListToolsResult(tools=[Tool(name="search", description="Search", inputSchema={"type": "object", "properties": {}})])
+
+
+@pytest.fixture
+async def capability_topic():
+    admin = AIOKafkaAdminClient(bootstrap_servers=BOOTSTRAP)
+    try:
+        await admin.start()
+    except Exception:
+        pytest.skip(f"no Kafka broker reachable at {BOOTSTRAP}")
+    name = f"calf.test.capabilities.{uuid.uuid4().hex[:8]}"
+    yield name
+    try:
+        await admin.delete_topics([name])
+    finally:
+        await admin.close()
+
+
+async def test_publish_heartbeat_and_tombstone_roundtrip(capability_topic: str) -> None:
+    toolbox = MCPToolbox(
+        "docs_server",
+        connection_params=StreamableHttpParameters(url="http://unused.local/mcp"),
+        discovery=MCPDiscoveryConfig(
+            topic=capability_topic,
+            heartbeat_interval=0.05,
+            bootstrap_servers=BOOTSTRAP,  # no Worker in this test: explicit override path
+        ),
+    )
+
+    # Resource phase: enter the writer bracket for real (creates the topic).
+    writer_gen = toolbox._capability_writer(None)  # type: ignore[arg-type]
+    writer = await anext(writer_gen)
+    toolbox.resources[toolbox._writer_resource_key] = writer
+    toolbox.resources[toolbox._session_resource_key] = FakeSession()
+    ctx = ServingContext(toolbox, toolbox.resources, broker=None)  # type: ignore[arg-type]
+
+    table: KafkaTable[CapabilityRecord] = KafkaTable.json(
+        bootstrap_servers=BOOTSTRAP, topic=capability_topic, model=CapabilityRecord, ensure_topic=False
+    )
+    async with table:
+        try:
+            # Connect-time publish lands in the view.
+            await toolbox._publish_on_startup(ctx)
+            for _ in range(200):
+                if "docs_server" in table:
+                    break
+                await asyncio.sleep(0.01)
+            record = table["docs_server"]
+            assert record.toolbox_id == "docs_server"
+            assert [t.name for t in record.tools] == ["search"]
+
+            # Heartbeat advances published_at in the view.
+            first_seen = record.published_at
+            for _ in range(200):
+                current = table.get("docs_server")
+                if current is not None and current.published_at > first_seen:
+                    break
+                await asyncio.sleep(0.01)
+            current = table["docs_server"]
+            assert current.published_at > first_seen
+        finally:
+            # Clean shutdown: heartbeat stops, tombstone removes the key.
+            await toolbox._tombstone_on_shutdown(ctx)
+        for _ in range(200):
+            if "docs_server" not in table:
+                break
+            await asyncio.sleep(0.01)
+        assert "docs_server" not in table
+
+    with pytest.raises(StopAsyncIteration):
+        await anext(writer_gen)  # close the writer bracket

--- a/tests/test_mcp_toolbox_publisher.py
+++ b/tests/test_mcp_toolbox_publisher.py
@@ -1,0 +1,262 @@
+"""PR B: MCPToolbox advertises its tools on the capability control plane.
+
+Spec §3.3/§8.5: publish on connect (after_startup), re-publish on
+``tools/list_changed`` and as a heartbeat, tombstone on clean shutdown
+(on_shutdown — runs before resource teardown, so the writer is still live).
+
+Tests drive the node's lifecycle hooks directly with fakes seeded into the
+node's own resource bag (worker hooks pass ``ServingContext(owner,
+owner.resources, broker)`` — verified against worker.py), so no broker is
+needed; the real KafkaTableWriter is exercised by the integration test only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from mcp.types import ListToolsResult, Tool, ToolListChangedNotification
+
+from calfkit.models.capability import CapabilityRecord
+from calfkit.worker.lifecycle import ServingContext
+from calfkit.worker.worker_config import MCPDiscoveryConfig
+
+mcp_toolbox = pytest.importorskip("calfkit.mcp.mcp_toolbox")
+MCPToolbox = mcp_toolbox.MCPToolbox
+
+from calfkit.mcp.mcp_transport import StreamableHttpParameters  # noqa: E402
+
+
+class FakeWriter:
+    """Records set/delete calls; quacks like KafkaTableWriter."""
+
+    def __init__(self) -> None:
+        self.sets: list[tuple[str, CapabilityRecord]] = []
+        self.deletes: list[str] = []
+
+    async def set(self, key: str, value: CapabilityRecord) -> None:
+        self.sets.append((key, value))
+
+    async def delete(self, key: str) -> None:
+        self.deletes.append(key)
+
+
+class FakeSession:
+    def __init__(self, tools: list[Tool]) -> None:
+        self._tools = tools
+        self.list_tools_calls = 0
+
+    async def list_tools(self) -> ListToolsResult:
+        self.list_tools_calls += 1
+        return ListToolsResult(tools=self._tools)
+
+
+def make_tools() -> list[Tool]:
+    return [
+        Tool(name="search", description="Search the docs", inputSchema={"type": "object", "properties": {"q": {"type": "string"}}}),
+        Tool(name="fetch", inputSchema={"type": "object", "properties": {}}),
+    ]
+
+
+def make_toolbox(**kwargs: Any) -> Any:
+    return MCPToolbox(
+        "docs_server",
+        connection_params=StreamableHttpParameters(url="http://unused.local/mcp"),
+        **kwargs,
+    )
+
+
+def seed(toolbox: Any, session: FakeSession | None = None, writer: FakeWriter | None = None) -> tuple[FakeSession, FakeWriter]:
+    session = session or FakeSession(make_tools())
+    writer = writer or FakeWriter()
+    toolbox.resources[toolbox._session_resource_key] = session
+    toolbox.resources[toolbox._writer_resource_key] = writer
+    return session, writer
+
+
+def serving_ctx(toolbox: Any) -> ServingContext[Any]:
+    return ServingContext(toolbox, toolbox.resources, broker=None)  # type: ignore[arg-type]
+
+
+async def fire(toolbox: Any, phase: str) -> None:
+    for hook in toolbox._hooks_for(phase):
+        result = hook(serving_ctx(toolbox))
+        if asyncio.iscoroutine(result):
+            await result
+
+
+class TestWriterResource:
+    def test_writer_resource_registered_alongside_session(self) -> None:
+        toolbox = make_toolbox()
+        names = [name for name, _ in toolbox._resource_cms()]
+        assert toolbox._session_resource_key in names
+        assert toolbox._writer_resource_key in names
+
+
+class TestPublishOnStartup:
+    async def test_publishes_record_keyed_by_node_id(self) -> None:
+        toolbox = make_toolbox()
+        session, writer = seed(toolbox)
+        await fire(toolbox, "after_startup")
+        await fire(toolbox, "on_shutdown")  # cancel heartbeat for clean teardown
+
+        [(key, record)] = writer.sets[:1]
+        assert key == "docs_server"
+        assert isinstance(record, CapabilityRecord)
+        assert record.toolbox_id == "docs_server"
+        assert record.dispatch_topic == "mcp_server.docs_server"
+        assert [t.name for t in record.tools] == ["search", "fetch"]
+        assert record.tools[0].parameters_json_schema == {"type": "object", "properties": {"q": {"type": "string"}}}
+        assert record.tools[1].description is None
+        assert record.published_at.tzinfo is not None
+
+
+class TestHeartbeat:
+    async def test_heartbeat_republishes_with_fresh_timestamp(self) -> None:
+        toolbox = make_toolbox(discovery=MCPDiscoveryConfig(heartbeat_interval=0.02))
+        session, writer = seed(toolbox)
+        await fire(toolbox, "after_startup")
+        try:
+            await asyncio.sleep(0.09)
+        finally:
+            await fire(toolbox, "on_shutdown")
+
+        assert len(writer.sets) >= 3  # initial + >=2 heartbeats
+        first, last = writer.sets[0][1], writer.sets[-1][1]
+        assert last.published_at > first.published_at
+        # Heartbeats re-publish the cached tool list — no re-listing.
+        assert session.list_tools_calls == 1
+
+    async def test_heartbeat_stops_on_shutdown(self) -> None:
+        toolbox = make_toolbox(discovery=MCPDiscoveryConfig(heartbeat_interval=0.02))
+        _, writer = seed(toolbox)
+        await fire(toolbox, "after_startup")
+        await fire(toolbox, "on_shutdown")
+        count = len(writer.sets)
+        await asyncio.sleep(0.06)
+        assert len(writer.sets) == count  # nothing published after shutdown
+
+
+class TestTombstoneOnShutdown:
+    async def test_shutdown_deletes_record(self) -> None:
+        toolbox = make_toolbox()
+        _, writer = seed(toolbox)
+        await fire(toolbox, "after_startup")
+        await fire(toolbox, "on_shutdown")
+        assert writer.deletes == ["docs_server"]
+
+
+class ReceiveLoopFakeSession(FakeSession):
+    """Deadlock-faithful: list_tools() cannot complete until the message
+    handler has RETURNED — exactly the real ClientSession receive-loop
+    coupling. An implementation that awaits the re-list inline hangs here."""
+
+    def __init__(self, tools: list[Tool]) -> None:
+        super().__init__(tools)
+        self.handler_returned = asyncio.Event()
+
+    async def list_tools(self) -> ListToolsResult:
+        await self.handler_returned.wait()
+        return await super().list_tools()
+
+
+class TestListChanged:
+    async def test_handler_never_blocks_the_receive_loop(self) -> None:
+        toolbox = make_toolbox()
+        session = ReceiveLoopFakeSession(make_tools())
+        _, writer = seed(toolbox, session=session)
+        notification = ToolListChangedNotification(method="notifications/tools/list_changed")
+
+        # Must return promptly even though list_tools() is gated on our return
+        # — inline awaiting would deadlock (and trip this timeout).
+        await asyncio.wait_for(toolbox._mcp_message_handler(notification), timeout=1.0)
+        session.handler_returned.set()
+        for _ in range(100):
+            if writer.sets:
+                break
+            await asyncio.sleep(0.01)
+        assert writer.sets and writer.sets[-1][0] == "docs_server"
+        await fire(toolbox, "on_shutdown")
+
+    async def test_shutdown_cancels_inflight_relist_so_tombstone_is_final(self) -> None:
+        toolbox = make_toolbox()
+        session = ReceiveLoopFakeSession(make_tools())
+        _, writer = seed(toolbox, session=session)
+        notification = ToolListChangedNotification(method="notifications/tools/list_changed")
+
+        await toolbox._mcp_message_handler(notification)  # re-list now parked
+        await fire(toolbox, "on_shutdown")  # cancels it, then tombstones
+        session.handler_returned.set()  # unpark (too late)
+        await asyncio.sleep(0.05)
+
+        assert writer.deletes == ["docs_server"]
+        assert writer.sets == []  # the cancelled re-list never resurrected the record
+
+    async def test_notification_during_tombstone_awaits_cannot_resurrect(self) -> None:
+        # The session receive loop is still alive while the tombstone awaits
+        # (slow broker round-trip): a notification arriving in that window
+        # must be dropped, not spawn a fresh re-list that lands after delete.
+        class SlowDeleteWriter(FakeWriter):
+            def __init__(self) -> None:
+                super().__init__()
+                self.delete_started = asyncio.Event()
+                self.release_delete = asyncio.Event()
+
+            async def delete(self, key: str) -> None:
+                self.delete_started.set()
+                await self.release_delete.wait()
+                await super().delete(key)
+
+        toolbox = make_toolbox()
+        session = ReceiveLoopFakeSession(make_tools())
+        writer = SlowDeleteWriter()
+        seed(toolbox, session=session, writer=writer)
+        session.handler_returned.set()  # any re-list would complete immediately
+
+        shutdown = asyncio.create_task(fire(toolbox, "on_shutdown"))
+        await asyncio.wait_for(writer.delete_started.wait(), timeout=1.0)
+        # Mid-tombstone notification: must be ignored under the shutdown flag.
+        await toolbox._mcp_message_handler(ToolListChangedNotification(method="notifications/tools/list_changed"))
+        writer.release_delete.set()
+        await shutdown
+        await asyncio.sleep(0.05)
+
+        assert writer.deletes == ["docs_server"]
+        assert writer.sets == []  # nothing resurrected the tombstone
+
+    async def test_list_changed_notification_republishes_fresh_listing(self) -> None:
+        toolbox = make_toolbox()
+        session, writer = seed(toolbox)
+        await fire(toolbox, "after_startup")
+        baseline = len(writer.sets)
+
+        session._tools = [Tool(name="new_tool", inputSchema={"type": "object", "properties": {}})]
+        await toolbox._handle_tools_list_changed(ToolListChangedNotification(method="notifications/tools/list_changed"))
+        await fire(toolbox, "on_shutdown")
+
+        assert len(writer.sets) == baseline + 1
+        assert [t.name for t in writer.sets[-1][1].tools] == ["new_tool"]
+        assert session.list_tools_calls == 2  # re-listed, not cached
+
+
+class TestBootstrapDerivation:
+    def test_explicit_config_override_wins(self) -> None:
+        toolbox = make_toolbox(discovery=MCPDiscoveryConfig(bootstrap_servers="cp-kafka:9092"))
+        assert toolbox._control_plane_bootstrap() == "cp-kafka:9092"
+
+    def test_derives_from_workers_client(self) -> None:
+        class StubClient:
+            server_urls = "kafka-a:9092,kafka-b:9092"
+
+        class StubWorker:
+            _client = StubClient()
+
+        toolbox = make_toolbox()
+        toolbox._worker = StubWorker()  # type: ignore[assignment]
+        assert toolbox._control_plane_bootstrap() == "kafka-a:9092,kafka-b:9092"
+
+    def test_unreachable_raises_actionable_error(self) -> None:
+        toolbox = make_toolbox()  # no worker, no override
+        with pytest.raises(RuntimeError, match="bootstrap_servers"):
+            toolbox._control_plane_bootstrap()

--- a/tests/test_run_unification.py
+++ b/tests/test_run_unification.py
@@ -45,7 +45,7 @@ async def _handle(node: Any, headers: dict[str, Any], env: Envelope | None = Non
 
 def test_tool_call_ref_carries_full_invocation_and_forbids_extra() -> None:
     # The ref is the authoritative invocation source for tool nodes and the
-    # MCP bridge: id, args, and name are all required — a tool invocation is
+    # MCP toolbox: id, args, and name are all required — a tool invocation is
     # serviced from the payload alone, with no ToolCallPart lookup in state.
     ref = ToolCallRef(tool_call_id="tc-1", args={"x": 1}, name="my_tool")
     assert (ref.tool_call_id, ref.args, ref.name) == ("tc-1", {"x": 1}, "my_tool")

--- a/tests/test_tool_binding.py
+++ b/tests/test_tool_binding.py
@@ -4,7 +4,7 @@ A ToolBinding carries exactly what ``BaseAgentNodeDef.run`` consumes per tool:
 the ``ToolDefinition`` advertised to the LLM, the dispatch topic for the
 ``Call``, and an optional args validator. ``ToolProvider`` is the structural
 contract for anything that contributes bindings (tool node, toolbox, MCP
-bridge) — no shared base class required.
+toolbox) — no shared base class required.
 """
 
 import pytest


### PR DESCRIPTION
## Summary

PR B of the MCP toolbox discoverability plan (spec §3.3/§8.5/§8.6 — `docs/designs/mcp-capability-discovery-spec.md`). Two commits:

### 1. `feat!: rename MCPBridge to MCPToolbox` (mechanical, breaking)
The node is passed directly to agents as their tool source in PR C (one object, both deployable and advertisable), so the name follows the role. `mcp_bridge.py` → `mcp_toolbox.py`, **`NodeKind "bridge"` → `"toolbox"`** (the `x-calf-emitter-kind` header value changes — the breaking part), docstring sweep. Zero stale references.

### 2. `feat: MCPToolbox advertises its tools on the capability control plane`
- Node-owned `KafkaTableWriter[CapabilityRecord]` `@resource` (started beside the MCP session; topic ensure gated on provisioning).
- Publishes keyed by `node_id`: **on connect** (`after_startup`; failure aborts worker boot), **on `tools/list_changed`** (session message handler → re-list → re-publish), **heartbeat** (cached record, fresh `published_at`, failures logged + retried), **tombstone on clean shutdown** (crash leaves the record standing — down ≠ gone, §6).
- Zero-config bootstrap: config override → `client.server_urls` → guarded broker-kwargs fallback → actionable error.
- Interim scoped mypy override for ktables until py.typed ships (ryan-yuuu/ktables#6).

## Review (3 rounds, converged)
- R1 critical: the `tools/list_changed` handler awaited `list_tools()` **on the session's receive loop** — unbounded deadlock (the loop it blocks is the one that delivers the response). Fixed: offload to a tracked task; deadlock-faithful test (gated fake fails the inline-await implementation by timeout).
- R2 critical: a notification arriving **during the tombstone's awaits** (receive loop outlives `on_shutdown`) could spawn an unsnapshotted re-list that `set()`s after `delete()` — resurrecting the tombstone. Fixed: synchronous `_shutting_down` flag set before any await; mid-tombstone regression test with a slow-delete writer (verified to fail the unflagged code).
- R3: converged — flag atomicity proven, heartbeat ordering benign, one-way flag matches the single-use worker lifecycle.

## Tests
12 unit (TDD; fakes seeded into the node's own resource bag, incl. two deadlock/race regression tests) + 1 real-broker integration (publish → KafkaTable visibility → heartbeat advance → tombstone removal). Full suite 2688 passed; 3.10-floor run on new tests; `make fix`/`make check` clean.