### PR TITLE
feat: agents discover MCP toolbox tools via the capability view

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ In-repo documentation lives under [`docs/`](docs/).
 - **[How to call nodes from a client](docs/client-features.md)** — the three invocation patterns (`execute_node` / `invoke_node` / `emit_to_node`), multi-turn conversations, runtime dependency injection (`deps`), temporary instructions, fire-and-forget, and bounding reply memory with `reply_ttl`.
 - **[How to tap a topic with a consumer node](docs/consumer-nodes.md)** — terminal sinks that run arbitrary Python against every event on a topic; tap an agent's `publish_topic` to log, persist, or fan out.
 - **[How to gate node invocations](docs/gating.md)** — predicate gate stacks that let a node decline an inbound event before `run()` runs (e.g. when agents share an input topic).
+- **[How to give agents MCP tools](docs/mcp-tool-discovery.md)** — deploy an `MCPToolbox` fronting an MCP server and pass it to agents like a tool node; tools are discovered and kept fresh across processes automatically.
 - **[Worker lifecycle & embedding](docs/worker-lifecycle.md)** — open long-lived resources at startup and close them on shutdown, publish presence events, and run with `run()`, the embeddable `start()`/`stop()`, or `async with worker:`.
 
 **Reference:**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,3 +15,16 @@ An index of potential features and changes under consideration for Calf SDK. Eac
 - [Hook System](docs/designs/hooks-design.md) — two-layer middleware proposal for pre/post-run extensibility on nodes
 - [ConsumerContext](docs/designs/consumer-context.md) — node-side context for `@consumer` sinks (moves `resources` off the client-facing `NodeResult`); includes a future-direction note on unifying Tool + Consumer contexts on a shared `NodeContext` base (breaking)
 - [Durable Fan-Out Aggregator] — replace in-process `_pending_batches` with a Kafka-backed compacted-state aggregator for parallel tool calls. Design-time leads (from the 2026-06 Kafka-state survey in `docs/designs/mcp-capability-discovery-spec.md` §7): this is *sharded* per-key state (frame_id-keyed, partition-local, seconds-lived) — the KTable shape, not the capability-view GlobalKTable shape — so **evaluate quix-streams first** (the field's clear maintenance leader: sharded RocksDB stores + changelog + recovery = exactly this problem; caveat: owns its process loop and runs librdkafka, so it would have to be a standalone aggregator service between tool outputs and agent inputs, not embedded in a FastStream worker). Alternatives to weigh against it: batch state carried in the spawning call frame (`internal_workflow_state`; most calf-native, no new infra), or a hand-rolled frame_id-keyed changelog topic with replay-on-rebalance.
+
+### Deferred from MCP capability discovery (deliberate v1 boundaries)
+
+Shipped in PRs #209/#210/#211; each edge below was consciously cut and is
+recorded with rationale in
+[the design spec](docs/designs/mcp-capability-discovery-spec.md):
+
+- [Behavioral staleness](docs/designs/mcp-capability-discovery-spec.md) — v1 only *logs* when a toolbox's capability record goes stale (§2 decision 8, §8.4); v2 would hide stale advertisements from the model and/or let `strict` selectors fail on staleness. The heartbeat data it needs already flows.
+- [Toolbox decommission tooling](docs/designs/mcp-capability-discovery-spec.md) — removal currently happens only via clean shutdown (§6, including the accepted deploy-window tool-gap trade-off); permanent retirement without a final clean shutdown needs an explicit operator command, and the §6 trade-off should be revisited if deploy gaps hurt.
+- [Secured control plane](docs/designs/mcp-capability-discovery-spec.md) — v1 assumes the capability topic is reachable with bootstrap servers alone (§8.3 security boundary: addressing data may be retained on the client, credentials never); SASL/SSL support needs an explicit security pass-through on `MCPDiscoveryConfig`.
+- [MCP session read-timeout backstop](docs/designs/mcp-capability-discovery-spec.md) — the discovery-path deadlock is fixed (§8.5 review notes), but individual `call_tool`/`list_tools` RPCs against a hung MCP server still wait unboundedly; a configurable `read_timeout_seconds` on the `ClientSession` would bound them (interacts with tool-call failure semantics — design before bolting on).
+- [Native toolbox node] — the non-MCP twin of `MCPToolbox`: one deployable node hosting many `@tool`-decorated methods (registry-collected), advertising N bindings on one topic. Sketched during the ToolBinding design sessions; would reuse `ToolProvider` as-is.
+

--- a/calfkit/exceptions.py
+++ b/calfkit/exceptions.py
@@ -137,3 +137,14 @@ def _reconstruct_tool_execution_error() -> "ToolExecutionError":
     it can be located by fully-qualified name during deserialization.
     """
     return ToolExecutionError.__new__(ToolExecutionError)
+
+
+class MCPToolResolutionError(Exception):
+    """A strict MCP tool selector could not be satisfied for this turn.
+
+    Raised by the agent BEFORE the model runs when a selector declared with
+    ``strict=True`` cannot fully resolve against the Capability View (toolbox
+    missing, requested tool not advertised, malformed/newer-schema record, or
+    no view resource at all). Non-strict selectors degrade with a warning
+    instead.
+    """

--- a/calfkit/mcp/mcp_toolbox.py
+++ b/calfkit/mcp/mcp_toolbox.py
@@ -1,8 +1,9 @@
 import asyncio
 import contextlib
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping, Sequence
 from contextlib import AbstractAsyncContextManager
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, ClassVar
 
@@ -18,10 +19,10 @@ from calfkit._vendor.pydantic_ai.messages import ToolReturn
 from calfkit.exceptions import LifecycleConfigError, safe_exc_message
 from calfkit.mcp.mcp_transport import StdioServerParameters, StreamableHttpParameters, http_client, stdio_client
 from calfkit.models.actions import NodeResult, ReturnCall
-from calfkit.models.capability import CapabilityRecord, CapabilityToolDef
+from calfkit.models.capability import CapabilityRecord, CapabilityToolDef, SelectorResult, resolve_capability
 from calfkit.models.session_context import SessionRunContext
 from calfkit.models.state import FailedToolCall, State
-from calfkit.models.tool_dispatch import ToolBinding, ToolCallRef
+from calfkit.models.tool_dispatch import ToolCallRef
 from calfkit.nodes.base import BaseNodeDef
 from calfkit.worker.lifecycle import ResourceSetupContext, ServingContext
 from calfkit.worker.worker_config import MCPDiscoveryConfig
@@ -33,17 +34,6 @@ _TransportCM = AbstractAsyncContextManager[tuple[object, object]]
 
 class MCPToolbox(BaseNodeDef):
     _node_kind: ClassVar[NodeKind] = "toolbox"
-
-    def tool_bindings(self) -> list[ToolBinding]:
-        # MCP tools are discovered from the live session (list_tools is async,
-        # and the session exists only after resource setup), so sync collection
-        # at agent-construction time is impossible. Fail fast rather than
-        # return [] — an empty list would silently register the toolbox with no
-        # tools. Async discovery / lazy-provider resolution is a pending design.
-        raise NotImplementedError(
-            f"MCPToolbox {self.node_id!r} cannot provide tool bindings synchronously; "
-            "MCP tool discovery requires a live session (pending async-provider design)"
-        )
 
     async def _mcp_session(self, ctx: ResourceSetupContext) -> AsyncIterator[ClientSession]:
         params = self._connection_params
@@ -81,6 +71,32 @@ class MCPToolbox(BaseNodeDef):
         self.resource(name=self._writer_resource_key)(self._capability_writer)
         self.after_startup(self._publish_on_startup)
         self.on_shutdown(self._tombstone_on_shutdown)
+
+    # -- tool selection (spec §8.4) --------------------------------------------
+
+    def resolve_tools(self, view: Mapping[str, CapabilityRecord]) -> SelectorResult:
+        """All advertised tools, resolved against the Capability View.
+
+        Implements ``ToolSelector``: passing this toolbox in ``tools=[...]``
+        defers resolution to each agent turn — no session contact, no
+        deployment coupling.
+        """
+        return resolve_capability(view, self.node_id)
+
+    def select(self, *, include: Sequence[str] | None = None, strict: bool = False) -> "_ScopedSelector":
+        """A scoped/strict selector for this toolbox's tools.
+
+        ``include`` pins the exact tool names the agent may see (the trust
+        boundary: a server suddenly advertising new tools cannot enlarge the
+        agent's surface). ``strict=True`` fails the agent's turn when the
+        selection cannot be fully satisfied; the default degrades with a
+        warning.
+        """
+        return _ScopedSelector(
+            toolbox_id=self.node_id,
+            include=tuple(include) if include is not None else None,
+            strict=strict,
+        )
 
     # -- capability publishing (spec §3.3/§8.5) -------------------------------
 
@@ -268,3 +284,15 @@ class MCPToolbox(BaseNodeDef):
 
         ctx.state.add_tool_result(tool_call_id=payload.tool_call_id, tool_result=tool_return)
         return ReturnCall(ctx.state)
+
+
+@dataclass(frozen=True)
+class _ScopedSelector:
+    """Frozen, internal: produced by :meth:`MCPToolbox.select`, never named by users."""
+
+    toolbox_id: str
+    include: tuple[str, ...] | None
+    strict: bool
+
+    def resolve_tools(self, view: Mapping[str, CapabilityRecord]) -> SelectorResult:
+        return resolve_capability(view, self.toolbox_id, include=self.include, strict=self.strict)

--- a/calfkit/mcp/mcp_toolbox.py
+++ b/calfkit/mcp/mcp_toolbox.py
@@ -56,11 +56,9 @@ class MCPToolbox(BaseNodeDef):
         self,
         server_name: str,
         connection_params: StreamableHttpParameters | StdioServerParameters,
-        discovery: MCPDiscoveryConfig | None = None,
     ):
         super().__init__(node_id=server_name, subscribe_topics=[f"mcp_server.{server_name}"])
         self._connection_params = connection_params
-        self._discovery = discovery or MCPDiscoveryConfig()
         self._session_resource_key = f"mcp_session.{server_name}"
         self._writer_resource_key = f"mcp_writer.{server_name}"
         self._heartbeat_task: asyncio.Task[None] | None = None
@@ -71,6 +69,18 @@ class MCPToolbox(BaseNodeDef):
         self.resource(name=self._writer_resource_key)(self._capability_writer)
         self.after_startup(self._publish_on_startup)
         self.on_shutdown(self._tombstone_on_shutdown)
+
+    @property
+    def _discovery(self) -> MCPDiscoveryConfig:
+        """Control-plane config, inherited from the hosting worker.
+
+        The worker is the single config surface (``Worker(...,
+        mcp_discovery=...)``); the toolbox reads it through the ``_worker``
+        back-reference — same pattern as bootstrap derivation. Defaults apply
+        when unhosted (tests, bare construction).
+        """
+        cfg = getattr(self._worker, "_mcp_discovery", None)
+        return cfg if cfg is not None else MCPDiscoveryConfig()
 
     # -- tool selection (spec §8.4) --------------------------------------------
 

--- a/calfkit/models/capability.py
+++ b/calfkit/models/capability.py
@@ -14,13 +14,13 @@ policy's predicate.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict
 
 from calfkit._vendor.pydantic_ai.tools import ToolDefinition
+from calfkit.models.tool_dispatch import SelectorResult as SelectorResult  # re-export: resolution API lives here
 from calfkit.models.tool_dispatch import ToolBinding
 
 CAPABILITY_SCHEMA_VERSION = 1
@@ -78,29 +78,6 @@ def record_to_bindings(record: CapabilityRecord) -> list[ToolBinding]:
 CAPABILITY_VIEW_RESOURCE_KEY = "calfkit.mcp.capability_view"
 """Worker resource-bag key under which the Capability View (a
 ``Mapping[str, CapabilityRecord]``) is published to hosted nodes."""
-
-
-@dataclass(frozen=True)
-class SelectorResult:
-    """Outcome of resolving one MCP tool selector against the Capability View.
-
-    Carries the bindings plus structured diagnostics so the agent owns the
-    warn/strict policy in one place and tests assert on data, not log text.
-    """
-
-    toolbox_id: str
-    strict: bool = False
-    bindings: list[ToolBinding] = field(default_factory=list)
-    missing_toolbox: bool = False
-    missing_tools: tuple[str, ...] = ()
-    skipped_newer_schema: bool = False
-    invalid_record: bool = False
-    stale_seconds: float | None = None
-
-    @property
-    def unresolved(self) -> bool:
-        """True when anything the selector asked for could not be delivered."""
-        return self.missing_toolbox or bool(self.missing_tools) or self.skipped_newer_schema or self.invalid_record
 
 
 def resolve_capability(

--- a/calfkit/models/capability.py
+++ b/calfkit/models/capability.py
@@ -14,6 +14,8 @@ policy's predicate.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict
@@ -71,3 +73,68 @@ def record_to_bindings(record: CapabilityRecord) -> list[ToolBinding]:
         )
         for tool in record.tools
     ]
+
+
+CAPABILITY_VIEW_RESOURCE_KEY = "calfkit.mcp.capability_view"
+"""Worker resource-bag key under which the Capability View (a
+``Mapping[str, CapabilityRecord]``) is published to hosted nodes."""
+
+
+@dataclass(frozen=True)
+class SelectorResult:
+    """Outcome of resolving one MCP tool selector against the Capability View.
+
+    Carries the bindings plus structured diagnostics so the agent owns the
+    warn/strict policy in one place and tests assert on data, not log text.
+    """
+
+    toolbox_id: str
+    strict: bool = False
+    bindings: list[ToolBinding] = field(default_factory=list)
+    missing_toolbox: bool = False
+    missing_tools: tuple[str, ...] = ()
+    skipped_newer_schema: bool = False
+    invalid_record: bool = False
+    stale_seconds: float | None = None
+
+    @property
+    def unresolved(self) -> bool:
+        """True when anything the selector asked for could not be delivered."""
+        return self.missing_toolbox or bool(self.missing_tools) or self.skipped_newer_schema or self.invalid_record
+
+
+def resolve_capability(
+    view: Any,
+    toolbox_id: str,
+    *,
+    include: tuple[str, ...] | None = None,
+    strict: bool = False,
+) -> SelectorResult:
+    """Resolve ``toolbox_id`` (optionally filtered) against the view.
+
+    Never raises on bad records: the tolerant reader admits shapes that fail
+    binding expansion (e.g. empty ``dispatch_topic``); those surface as
+    ``invalid_record`` so a poisoned advertisement cannot crash a turn.
+    """
+    record = view.get(toolbox_id)
+    if record is None:
+        return SelectorResult(toolbox_id=toolbox_id, strict=strict, missing_toolbox=True)
+    if is_unsupported_schema(record):
+        return SelectorResult(toolbox_id=toolbox_id, strict=strict, skipped_newer_schema=True)
+    try:
+        bindings = record_to_bindings(record)
+    except Exception:
+        return SelectorResult(toolbox_id=toolbox_id, strict=strict, invalid_record=True)
+    missing: tuple[str, ...] = ()
+    if include is not None:
+        wanted = set(include)
+        bindings = [b for b in bindings if b.name in wanted]
+        missing = tuple(name for name in include if name not in {b.name for b in bindings})
+    stale = max(0.0, (datetime.now(tz=timezone.utc) - record.published_at).total_seconds())
+    return SelectorResult(
+        toolbox_id=toolbox_id,
+        strict=strict,
+        bindings=bindings,
+        missing_tools=missing,
+        stale_seconds=stale,
+    )

--- a/calfkit/models/tool_dispatch.py
+++ b/calfkit/models/tool_dispatch.py
@@ -1,5 +1,8 @@
-from collections.abc import Callable, Sequence
-from typing import Any, Protocol, runtime_checkable
+from collections.abc import Callable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from calfkit.models.capability import SelectorResult
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.json_schema import SkipJsonSchema
@@ -60,6 +63,43 @@ class ToolProvider(Protocol):
     """
 
     def tool_bindings(self) -> Sequence[ToolBinding]: ...
+
+
+@runtime_checkable
+class ToolSelector(Protocol):
+    """Deferred tool declaration, resolved per turn against the Capability View.
+
+    Implemented by :class:`~calfkit.mcp.mcp_toolbox.MCPToolbox` (and its
+    ``select()`` results): passing the toolbox object to an agent extracts only
+    a lookup key — no session contact, no deployment. The ``view`` is a plain
+    ``Mapping`` so the agent layer needs no ktables import and tests can use
+    dicts.
+    """
+
+    def resolve_tools(self, view: Mapping[str, Any]) -> "SelectorResult": ...
+
+
+def split_tool_declarations(
+    tools: Sequence["ToolProvider | ToolBinding | ToolSelector"] | None,
+) -> tuple[list[ToolBinding], list[ToolSelector]]:
+    """Partition ``tools=`` into immediate bindings and deferred selectors.
+
+    Selector-ness is checked BEFORE provider-ness so a selector type that also
+    grew a ``tool_bindings`` attribute could never be mistakenly expanded at
+    construction time.
+    """
+    bindings: list[ToolBinding] = []
+    selectors: list[ToolSelector] = []
+    for t in tools or ():
+        if isinstance(t, ToolBinding):
+            bindings.append(t)
+        elif isinstance(t, ToolSelector):
+            selectors.append(t)
+        elif isinstance(t, ToolProvider):
+            bindings.extend(t.tool_bindings())
+        else:
+            raise TypeError(f"agent tools must be ToolBinding, ToolProvider, or ToolSelector instances, got {type(t).__name__}: {t!r}")
+    return bindings, selectors
 
 
 def normalize_tool_bindings(tools: Sequence[ToolProvider | ToolBinding] | None) -> list[ToolBinding]:

--- a/calfkit/models/tool_dispatch.py
+++ b/calfkit/models/tool_dispatch.py
@@ -1,8 +1,6 @@
 from collections.abc import Callable, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
-
-if TYPE_CHECKING:
-    from calfkit.models.capability import SelectorResult
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.json_schema import SkipJsonSchema
@@ -65,6 +63,29 @@ class ToolProvider(Protocol):
     def tool_bindings(self) -> Sequence[ToolBinding]: ...
 
 
+@dataclass(frozen=True)
+class SelectorResult:
+    """Outcome of resolving one MCP tool selector against the Capability View.
+
+    Carries the bindings plus structured diagnostics so the agent owns the
+    warn/strict policy in one place and tests assert on data, not log text.
+    """
+
+    toolbox_id: str
+    strict: bool = False
+    bindings: list[ToolBinding] = field(default_factory=list)
+    missing_toolbox: bool = False
+    missing_tools: tuple[str, ...] = ()
+    skipped_newer_schema: bool = False
+    invalid_record: bool = False
+    stale_seconds: float | None = None
+
+    @property
+    def unresolved(self) -> bool:
+        """True when anything the selector asked for could not be delivered."""
+        return self.missing_toolbox or bool(self.missing_tools) or self.skipped_newer_schema or self.invalid_record
+
+
 @runtime_checkable
 class ToolSelector(Protocol):
     """Deferred tool declaration, resolved per turn against the Capability View.
@@ -76,7 +97,7 @@ class ToolSelector(Protocol):
     dicts.
     """
 
-    def resolve_tools(self, view: Mapping[str, Any]) -> "SelectorResult": ...
+    def resolve_tools(self, view: Mapping[str, Any]) -> SelectorResult: ...
 
 
 def split_tool_declarations(

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any, ClassVar, Generic, cast
 
 from pydantic import ValidationError
@@ -13,13 +13,14 @@ from calfkit._vendor.pydantic_ai.output import OutputSpec
 from calfkit._vendor.pydantic_ai.settings import ModelSettings
 from calfkit._vendor.pydantic_ai.tools import DeferredToolResults
 from calfkit._vendor.pydantic_ai.toolsets.external import ExternalToolset
-from calfkit.exceptions import ToolExecutionError, safe_exc_message
+from calfkit.exceptions import MCPToolResolutionError, ToolExecutionError, safe_exc_message
 from calfkit.models import Call, DataPart, NodeResult, ReturnCall, State, TailCall, TextPart
 from calfkit.models.actions import Silent
+from calfkit.models.capability import CAPABILITY_VIEW_RESOURCE_KEY, SelectorResult
 from calfkit.models.payload import ContentPart
 from calfkit.models.session_context import SessionRunContext
 from calfkit.models.state import FailedToolCall, PendingToolBatch
-from calfkit.models.tool_dispatch import ToolBinding, ToolCallRef, ToolProvider, normalize_tool_bindings
+from calfkit.models.tool_dispatch import ToolBinding, ToolCallRef, ToolProvider, ToolSelector, split_tool_declarations
 from calfkit.nodes._projection import project, structured_output_preamble
 from calfkit.nodes.base import BaseNodeDef, GateFunction
 from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
@@ -41,7 +42,7 @@ class BaseAgentNodeDef(
         subscribe_topics: str | list[str],
         publish_topic: str | None = None,
         gates: list[GateFunction] | None = None,
-        tools: Sequence[ToolProvider | ToolBinding] | None = None,
+        tools: Sequence[ToolProvider | ToolBinding | ToolSelector] | None = None,
         model_client: PydanticModelClient,
         final_output_type: OutputSpec[AgentOutputT] = str,  # type: ignore[assignment]
         sequential_only_mode: bool = False,
@@ -49,7 +50,7 @@ class BaseAgentNodeDef(
     ):
         self.final_output_type = final_output_type
         self.system_prompt = system_prompt
-        self.tools: list[ToolBinding] = normalize_tool_bindings(tools)
+        self.tools, self._tool_selectors = split_tool_declarations(tools)
         self.sequential_only_mode = sequential_only_mode
         self._pending_batches: dict[str, PendingToolBatch] = dict()
 
@@ -160,6 +161,58 @@ class BaseAgentNodeDef(
                     [tc.tool_call_id for tc in completed_latest],
                 )
 
+    _STALE_LOG_AFTER_SECONDS = 90.0  # 3x the default heartbeat interval
+
+    def _resolve_selector_tools(self, resources: Mapping[str, Any], tools_registry: dict[str, ToolBinding]) -> None:
+        """Per-turn MCP selector resolution against the Capability View (spec §8.4).
+
+        Merges AFTER static tools with collision = error-log + static wins (a
+        remote server must never silently shadow a locally defined tool).
+        Unresolved selections warn and degrade; ``strict=True`` raises before
+        the model runs. Staleness and newer-schema records are log-only (v1).
+        """
+        view = resources.get(CAPABILITY_VIEW_RESOURCE_KEY)
+        if view is None:
+            if any(getattr(sel, "strict", False) for sel in self._tool_selectors):
+                raise MCPToolResolutionError(
+                    f"agent {self.name!r} declares strict MCP tool selectors but no Capability View "
+                    f"resource ({CAPABILITY_VIEW_RESOURCE_KEY!r}) is available — is this agent hosted "
+                    "by a Worker with MCP discovery active?"
+                )
+            logger.warning(
+                "agent=%s has MCP tool selectors but no Capability View resource; running without MCP tools",
+                self.name,
+            )
+            return
+        for selector in self._tool_selectors:
+            result: SelectorResult = selector.resolve_tools(view)
+            if result.unresolved:
+                detail = (
+                    f"toolbox={result.toolbox_id!r} missing_toolbox={result.missing_toolbox} "
+                    f"missing_tools={result.missing_tools} newer_schema={result.skipped_newer_schema} "
+                    f"invalid_record={result.invalid_record}"
+                )
+                if result.strict:
+                    raise MCPToolResolutionError(f"agent {self.name!r}: strict MCP selection unresolved: {detail}")
+                logger.warning("agent=%s MCP selection partially unresolved (%s); running degraded", self.name, detail)
+            if result.stale_seconds is not None and result.stale_seconds > self._STALE_LOG_AFTER_SECONDS:
+                logger.warning(
+                    "agent=%s toolbox=%s capability record is %.0fs stale (heartbeats missing?); using last-known tools",
+                    self.name,
+                    result.toolbox_id,
+                    result.stale_seconds,
+                )
+            for binding in result.bindings:
+                if binding.name in tools_registry:
+                    logger.error(
+                        "agent=%s MCP tool %r from toolbox=%s collides with a locally configured tool; static wins",
+                        self.name,
+                        binding.name,
+                        result.toolbox_id,
+                    )
+                    continue
+                tools_registry[binding.name] = binding
+
     async def run(self, ctx: SessionRunContext) -> NodeResult[State]:
         tools_registry = dict[str, ToolBinding]()
         if ctx.state.overrides is not None and ctx.state.overrides.override_agent_tools is not None:
@@ -169,6 +222,9 @@ class BaseAgentNodeDef(
             tools_registry = {binding.name: binding for binding in ctx.state.overrides.override_agent_tools}
         elif self.tools:
             tools_registry = {binding.name: binding for binding in self.tools}
+
+        if self._tool_selectors:
+            self._resolve_selector_tools(ctx.resources, tools_registry)
 
         # ``latest_tool_calls()`` walks ``message_history`` in reverse on each call;
         # cache once for all pre-model uses. The post-model use after
@@ -474,7 +530,9 @@ class BaseAgentNodeDef(
             return ReturnCall[State](state=ctx.state)
 
     def add_tools(self, *tools: ToolProvider | ToolBinding) -> None:
-        self.tools.extend(normalize_tool_bindings(tools))
+        bindings, selectors = split_tool_declarations(tools)
+        self.tools.extend(bindings)
+        self._tool_selectors.extend(selectors)
 
     def instructions(self, func: Callable[..., str | None]) -> Callable[..., str | None]:
         """Decorator to define dynamic instruction functions that can build instructions at runtime."""

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -161,6 +161,21 @@ class BaseAgentNodeDef(
                     [tc.tool_call_id for tc in completed_latest],
                 )
 
+    def _maybe_resolve_selectors(self, ctx: SessionRunContext, tools_registry: dict[str, ToolBinding]) -> None:
+        """Selector resolution gate: per-run overrides pin the EXACT tool
+        surface for the turn, so MCP selectors are skipped entirely when
+        ``override_agent_tools`` is present (a strict selector must not be
+        able to fail a turn the caller scoped away from MCP)."""
+        if not self._tool_selectors:
+            return
+        if ctx.state.overrides is not None and ctx.state.overrides.override_agent_tools is not None:
+            logger.debug(
+                "agent=%s per-run tool overrides active; skipping MCP selector resolution for this turn",
+                self.name,
+            )
+            return
+        self._resolve_selector_tools(ctx.resources, tools_registry)
+
     _STALE_LOG_AFTER_SECONDS = 90.0  # 3x the default heartbeat interval
 
     def _resolve_selector_tools(self, resources: Mapping[str, Any], tools_registry: dict[str, ToolBinding]) -> None:
@@ -223,8 +238,7 @@ class BaseAgentNodeDef(
         elif self.tools:
             tools_registry = {binding.name: binding for binding in self.tools}
 
-        if self._tool_selectors:
-            self._resolve_selector_tools(ctx.resources, tools_registry)
+        self._maybe_resolve_selectors(ctx, tools_registry)
 
         # ``latest_tool_calls()`` walks ``message_history`` in reverse on each call;
         # cache once for all pre-model uses. The post-model use after
@@ -529,7 +543,15 @@ class BaseAgentNodeDef(
                 ctx.state.final_output_parts = parts
             return ReturnCall[State](state=ctx.state)
 
-    def add_tools(self, *tools: ToolProvider | ToolBinding) -> None:
+    def add_tools(self, *tools: ToolProvider | ToolBinding | ToolSelector) -> None:
+        """Add tools after construction.
+
+        Note: a ToolSelector added AFTER the hosting worker's
+        ``register_handlers()`` has run will not get a Capability View
+        resource (view registration snapshots hosted nodes once, like topic
+        provisioning) — it degrades per the unresolved-selector policy.
+        Declare selectors before registering, or at construction.
+        """
         bindings, selectors = split_tool_declarations(tools)
         self.tools.extend(bindings)
         self._tool_selectors.extend(selectors)

--- a/calfkit/worker/worker.py
+++ b/calfkit/worker/worker.py
@@ -194,10 +194,8 @@ class Worker(LifecycleHookMixin):
             ensure_topic=self._client._provisioning.enabled,
         )
         await table.start()
-        try:
-            yield table
-        finally:
-            await table.stop()
+        yield table
+        await table.stop()
 
     def register_handlers(self) -> None:
         """Register FastStream subscribers + publishers for every node.

--- a/calfkit/worker/worker.py
+++ b/calfkit/worker/worker.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import AsyncIterator
 from contextlib import AsyncExitStack
 from types import TracebackType
 from typing import Any
@@ -8,6 +9,7 @@ from faststream import FastStream
 from typing_extensions import Self
 
 from calfkit.client import Client
+from calfkit.models.capability import CAPABILITY_VIEW_RESOURCE_KEY, CapabilityRecord
 from calfkit.nodes import BaseNodeDef
 from calfkit.provisioning import topics_for_nodes
 from calfkit.worker.lifecycle import (
@@ -20,6 +22,7 @@ from calfkit.worker.lifecycle import (
     _resource_cm,
     _span_cm,
 )
+from calfkit.worker.worker_config import MCPDiscoveryConfig
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +64,7 @@ class Worker(LifecycleHookMixin):
         extra_subscribe_kwargs: dict[str, Any] = {},
         id: str | None = None,
         name: str | None = None,
+        mcp_discovery: MCPDiscoveryConfig | None = None,
     ):
         """Initialize a worker.
 
@@ -76,12 +80,17 @@ class Worker(LifecycleHookMixin):
                 Validated non-empty; a uuid7 hex is generated when ``None``.
                 Read-only after construction — mirrors ``BaseClient.emitter_id``.
             name: Display-only label; defaults to ``id``. Never put on the wire.
+            mcp_discovery: Optional tuning for MCP capability discovery
+                (topic, catch-up timeout, bootstrap override). Entirely
+                optional — the Capability View is auto-registered with
+                defaults whenever a hosted agent declares MCP tool selectors.
         """
         if id is not None and not id.strip():
             raise ValueError("id must be a non-empty string or None")
         if name is not None and not name.strip():
             raise ValueError("name must be a non-empty string or None")
         self._client = client
+        self._mcp_discovery = mcp_discovery if mcp_discovery is not None else MCPDiscoveryConfig()
         self._max_workers = max_workers
         self._group_id = group_id
         self._extra_publish_kwargs = extra_publish_kwargs
@@ -139,6 +148,57 @@ class Worker(LifecycleHookMixin):
         node._worker = self
         self._nodes.append(node)
 
+    def _maybe_register_capability_view(self) -> None:
+        """Auto-register the MCP Capability View resource (spec §8.3).
+
+        Zero user wiring: iff any hosted node declares MCP tool selectors, ONE
+        worker-level ``KafkaTable[CapabilityRecord]`` resource is registered
+        (idempotent — guarded by resource-name lookup). The table lands in the
+        worker bag and reaches every node's ``ctx.resources`` via the existing
+        worker-under-node merge.
+        """
+        if not any(getattr(node, "_tool_selectors", None) for node in self._nodes):
+            return
+        if any(name == CAPABILITY_VIEW_RESOURCE_KEY for name, _ in self._resource_cms()):
+            return
+        self.resource(name=CAPABILITY_VIEW_RESOURCE_KEY)(self._capability_view_resource)
+
+    async def _capability_view_resource(self, ctx: ResourceSetupContext["Worker"]) -> AsyncIterator[Any]:
+        """Open the Capability View for this worker's lifetime.
+
+        ``KafkaTable.start()`` IS the boot gate: it replays the capability
+        topic to its start-time end offsets bounded by ``catchup_timeout``
+        (serving degraded, loudly, on expiry) — and because resource setup
+        runs before the broker serves, agents never see a half-built view.
+        """
+        from ktables import KafkaTable  # the one ktables import outside calfkit.mcp
+
+        cfg = self._mcp_discovery
+        bootstrap = cfg.bootstrap_servers or self._client.server_urls
+        if not bootstrap:
+            kwargs = getattr(self._client.broker, "_connection_kwargs", None) or {}
+            servers = kwargs.get("bootstrap_servers")
+            bootstrap = servers if isinstance(servers, str) else ",".join(servers) if servers else None
+        if not bootstrap:
+            raise RuntimeError(
+                "cannot derive Kafka bootstrap servers for the MCP Capability View "
+                "(client built without connect()?); set MCPDiscoveryConfig(bootstrap_servers=...)."
+            )
+        table: KafkaTable[CapabilityRecord] = KafkaTable.json(
+            bootstrap_servers=bootstrap,
+            topic=cfg.topic,
+            model=CapabilityRecord,
+            catchup_timeout=cfg.catchup_timeout,
+            # Readers ensure only in dev/CI (spec §3.1); production topics are
+            # ops-governed and a missing topic fails setup loudly.
+            ensure_topic=self._client._provisioning.enabled,
+        )
+        await table.start()
+        try:
+            yield table
+        finally:
+            await table.stop()
+
     def register_handlers(self) -> None:
         """Register FastStream subscribers + publishers for every node.
 
@@ -149,6 +209,7 @@ class Worker(LifecycleHookMixin):
         if self._prepared:
             logger.debug("register_handlers() called again; skipping (already prepared)")
             return
+        self._maybe_register_capability_view()
         # Record the nodes we are about to register as the single source of
         # truth for ``_declare_startup_topics``. Snapshot (not alias) so later
         # ``add_nodes`` calls can't retroactively widen the provisioned set

--- a/docs/designs/mcp-capability-discovery-spec.md
+++ b/docs/designs/mcp-capability-discovery-spec.md
@@ -371,7 +371,10 @@ resolved value is stored on the client and exposed as a read-only
 
 `MCPDiscoveryConfig(topic="mcp.capabilities", catchup_timeout=30.0,
 heartbeat_interval=30.0, bootstrap_servers=None)` is therefore entirely
-optional — defaults apply when absent. `bootstrap_servers` remains the
+optional — defaults apply when absent. **The worker is the single config
+surface**: toolboxes take no discovery config of their own and inherit the
+hosting worker's via the `_worker` back-reference (defaults when unhosted) —
+one config door into the control plane, not two. `bootstrap_servers` remains the
 override for the advanced split-cluster case (control plane on a different
 Kafka cluster than the data plane).
 
@@ -426,6 +429,12 @@ filter, then merge into `tools_registry` AFTER static tools with
 **collision = log error + static wins** (a remote server must never silently
 shadow a locally-defined tool). Unresolved selector: warn + degrade;
 `strict=True` raises before the model call. Stale heartbeat (v1): log only.
+
+**Overrides pin the tool surface (decided post-review, 2026-06-10):** when a
+caller supplies per-run `override_agent_tools`, selector resolution is
+skipped entirely for that turn — an override means "exactly these tools", so
+MCP tools never inject into an overridden turn and a strict selector cannot
+fail it.
 
 ### 8.5 Toolbox-side publishing
 

--- a/docs/mcp-tool-discovery.md
+++ b/docs/mcp-tool-discovery.md
@@ -1,17 +1,25 @@
 # How to give agents MCP tools
 
-An `MCPToolbox` node fronts one MCP server: it owns the live MCP session,
-services tool calls sent to its topic, and automatically advertises its tools
-to agents anywhere in the cluster. You deploy it like any node and pass it to
-agents like any tool — there is no discovery configuration in the happy path.
+To let agents call tools served by an MCP server, deploy one `MCPToolbox` node
+per server and pass that toolbox object to each agent's `tools=[...]` — like a
+tool node. Discovery is automatic and cross-process: the toolbox advertises
+its tools on a control-plane topic, and each agent's worker keeps a local view
+of it. There is no discovery configuration in the happy path. (For why it
+works this way, see the
+[design spec](designs/mcp-capability-discovery-spec.md).)
 
 ## Deploy a toolbox
 
 ```python
-from calfkit.mcp import StreamableHttpParameters
+from calfkit.client.client import Client
 from calfkit.mcp.mcp_toolbox import MCPToolbox
+from calfkit.mcp.mcp_transport import StreamableHttpParameters
+from calfkit.worker.worker import Worker
 
-docs = MCPToolbox("docs_server", connection_params=StreamableHttpParameters(url="https://docs.example.com/mcp"))
+docs = MCPToolbox(
+    "docs_server",
+    connection_params=StreamableHttpParameters(url="https://docs.example.com/mcp"),
+)
 
 client = Client.connect("kafka:9092")
 worker = Worker(client, nodes=[docs])
@@ -19,16 +27,16 @@ await worker.run()
 ```
 
 On startup the toolbox connects to the MCP server, lists its tools, and
-advertises them on the capability topic (`mcp.capabilities`), re-advertising
-whenever the server's tool list changes and as a periodic heartbeat. If the
-MCP server is unreachable at startup, the worker fails to boot — fix the
-connection rather than running dark.
+advertises them on the capability topic (default `mcp.capabilities`). It
+re-advertises whenever the server reports a tool-list change and as a
+periodic heartbeat. If the MCP server is unreachable at startup, the worker
+fails to boot — fix the connection rather than running dark.
 
 ## Give the tools to an agent — same or different process
 
-Pass the toolbox object in `tools=[...]`, exactly like a tool node. Passing it
-never touches the MCP session and does not deploy the toolbox — agents in
-another process just import the same definition:
+Pass the toolbox object in `tools=[...]`. Passing it never contacts the MCP
+session and does not deploy the toolbox; an agent in another process imports
+the same definition:
 
 ```python
 from my_service.toolboxes import docs   # shared module; deployed elsewhere
@@ -42,11 +50,11 @@ agent = Agent(
 worker = Worker(client, nodes=[agent])   # capability view auto-registers
 ```
 
-The agent's worker detects the declaration and maintains a local view of the
-capability topic (gated at boot so the first turn already sees it). Tools
-resolve fresh at the start of every agent turn, so a toolbox that comes up
-later, or changes its tools, is picked up on the next turn — no restarts, no
-bring-up order.
+The agent's worker detects the declaration and maintains the local capability
+view, gated at boot so the first turn already sees it. Selections re-resolve
+at the start of every agent turn, so a toolbox that comes up later — or
+changes its tools — is picked up on the next turn. No restarts, no bring-up
+order.
 
 ## Scope or require the selection
 
@@ -55,25 +63,29 @@ tools=[docs.select(include=["search", "fetch"])]      # only these tools
 tools=[docs.select(include=["search"], strict=True)]  # fail the turn if unavailable
 ```
 
-`include` pins the exact tool names the agent may see — a server suddenly
-advertising new tools cannot enlarge the agent's surface. By default an
-unresolved selection logs a warning and the turn runs with the tools that did
-resolve; `strict=True` raises before the model runs instead.
+Use `include` to pin the exact tool names the agent may see — a server that
+starts advertising new tools cannot enlarge the agent's surface. By default an
+unresolved selection logs a warning and the turn runs with whatever resolved;
+use `strict=True` to raise before the model runs instead.
 
-If a toolbox-provided tool name collides with a locally configured tool, the
-local tool wins and an error is logged — a remote server never silently
-shadows your own tools.
+If a toolbox tool name collides with a locally configured tool, the local tool
+wins and an error is logged.
 
-## Operational notes
+## Handle outages and topic creation
 
-- **Outages:** a crashed toolbox keeps its advertisement (calls to it fail
-  visibly; agents keep last-known tools). A *clean shutdown* removes the
+- A **crashed** toolbox keeps its advertisement: agents keep their last-known
+  tools and calls fail visibly. A **clean shutdown** removes the
   advertisement until the toolbox restarts.
-- **Topic creation:** with provisioning enabled (dev/CI), toolbox and agent
-  workers both create the compacted capability topic idempotently — no
-  bring-up order. In production, create it out-of-band (`cleanup.policy=compact`,
-  RF≥3) like any governed topic; see [topic-provisioning](./topic-provisioning.md).
-- **Tuning (all optional):** `Worker(..., mcp_discovery=MCPDiscoveryConfig(...))`
-  and `MCPToolbox(..., discovery=...)` — topic name, boot catch-up timeout,
-  heartbeat interval, and a bootstrap-servers override for running the
-  capability topic on a separate cluster.
+- With provisioning enabled (dev/CI), toolbox and agent workers both create
+  the compacted capability topic idempotently — bring up either side first.
+  In production, create the topic out-of-band (`cleanup.policy=compact`,
+  RF≥3) like any governed topic; see
+  [topic provisioning](topic-provisioning.md).
+
+## Tune it (optional)
+
+Every knob has a working default. `Worker(..., mcp_discovery=
+MCPDiscoveryConfig(...))` and `MCPToolbox(..., discovery=...)` accept: the
+topic name, the boot catch-up timeout, the heartbeat interval, and a
+`bootstrap_servers` override for running the capability topic on a separate
+Kafka cluster.

--- a/docs/mcp-tool-discovery.md
+++ b/docs/mcp-tool-discovery.md
@@ -84,8 +84,8 @@ wins and an error is logged.
 
 ## Tune it (optional)
 
-Every knob has a working default. `Worker(..., mcp_discovery=
-MCPDiscoveryConfig(...))` and `MCPToolbox(..., discovery=...)` accept: the
-topic name, the boot catch-up timeout, the heartbeat interval, and a
-`bootstrap_servers` override for running the capability topic on a separate
-Kafka cluster.
+Every knob has a working default, and there is one config surface:
+`Worker(..., mcp_discovery=MCPDiscoveryConfig(...))` — the topic name, the
+boot catch-up timeout, the heartbeat interval, and a `bootstrap_servers`
+override for running the capability topic on a separate Kafka cluster.
+Toolboxes inherit the config of the worker that hosts them.

--- a/docs/mcp-tool-discovery.md
+++ b/docs/mcp-tool-discovery.md
@@ -1,0 +1,79 @@
+# How to give agents MCP tools
+
+An `MCPToolbox` node fronts one MCP server: it owns the live MCP session,
+services tool calls sent to its topic, and automatically advertises its tools
+to agents anywhere in the cluster. You deploy it like any node and pass it to
+agents like any tool — there is no discovery configuration in the happy path.
+
+## Deploy a toolbox
+
+```python
+from calfkit.mcp import StreamableHttpParameters
+from calfkit.mcp.mcp_toolbox import MCPToolbox
+
+docs = MCPToolbox("docs_server", connection_params=StreamableHttpParameters(url="https://docs.example.com/mcp"))
+
+client = Client.connect("kafka:9092")
+worker = Worker(client, nodes=[docs])
+await worker.run()
+```
+
+On startup the toolbox connects to the MCP server, lists its tools, and
+advertises them on the capability topic (`mcp.capabilities`), re-advertising
+whenever the server's tool list changes and as a periodic heartbeat. If the
+MCP server is unreachable at startup, the worker fails to boot — fix the
+connection rather than running dark.
+
+## Give the tools to an agent — same or different process
+
+Pass the toolbox object in `tools=[...]`, exactly like a tool node. Passing it
+never touches the MCP session and does not deploy the toolbox — agents in
+another process just import the same definition:
+
+```python
+from my_service.toolboxes import docs   # shared module; deployed elsewhere
+
+agent = Agent(
+    "researcher",
+    subscribe_topics="researcher.input",
+    model_client=model,
+    tools=[weather_tool, docs],          # all of the toolbox's tools
+)
+worker = Worker(client, nodes=[agent])   # capability view auto-registers
+```
+
+The agent's worker detects the declaration and maintains a local view of the
+capability topic (gated at boot so the first turn already sees it). Tools
+resolve fresh at the start of every agent turn, so a toolbox that comes up
+later, or changes its tools, is picked up on the next turn — no restarts, no
+bring-up order.
+
+## Scope or require the selection
+
+```python
+tools=[docs.select(include=["search", "fetch"])]      # only these tools
+tools=[docs.select(include=["search"], strict=True)]  # fail the turn if unavailable
+```
+
+`include` pins the exact tool names the agent may see — a server suddenly
+advertising new tools cannot enlarge the agent's surface. By default an
+unresolved selection logs a warning and the turn runs with the tools that did
+resolve; `strict=True` raises before the model runs instead.
+
+If a toolbox-provided tool name collides with a locally configured tool, the
+local tool wins and an error is logged — a remote server never silently
+shadows your own tools.
+
+## Operational notes
+
+- **Outages:** a crashed toolbox keeps its advertisement (calls to it fail
+  visibly; agents keep last-known tools). A *clean shutdown* removes the
+  advertisement until the toolbox restarts.
+- **Topic creation:** with provisioning enabled (dev/CI), toolbox and agent
+  workers both create the compacted capability topic idempotently — no
+  bring-up order. In production, create it out-of-band (`cleanup.policy=compact`,
+  RF≥3) like any governed topic; see [topic-provisioning](./topic-provisioning.md).
+- **Tuning (all optional):** `Worker(..., mcp_discovery=MCPDiscoveryConfig(...))`
+  and `MCPToolbox(..., discovery=...)` — topic name, boot catch-up timeout,
+  heartbeat interval, and a bootstrap-servers override for running the
+  capability topic on a separate cluster.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "typing-extensions>=4.15.0",
     "dishka>=1.9.1",
     "mcp>=1.27.2",
-    "ktables>=0.1.1",
+    "ktables>=0.1.2",
 ]
 
 [project.urls]

--- a/tests/integration/test_mcp_toolbox_capability.py
+++ b/tests/integration/test_mcp_toolbox_capability.py
@@ -97,3 +97,73 @@ async def test_publish_heartbeat_and_tombstone_roundtrip(capability_topic: str) 
 
     with pytest.raises(StopAsyncIteration):
         await anext(writer_gen)  # close the writer bracket
+
+
+async def test_end_to_end_toolbox_to_agent_resolution(capability_topic: str) -> None:
+    """Spec §8.7: toolbox publishes -> worker view catches up -> agent turn
+    resolves bindings -> clean shutdown tombstones -> next turn degrades."""
+    from calfkit.client.client import Client
+    from calfkit.models.capability import CAPABILITY_VIEW_RESOURCE_KEY
+    from calfkit.nodes.agent import Agent
+    from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
+    from calfkit.worker.worker import Worker
+    from calfkit.worker.worker_config import MCPDiscoveryConfig
+
+    class FakeModel(PydanticModelClient):
+        @property
+        def model_name(self) -> str:
+            return "fake"
+
+        @property
+        def system(self) -> str:
+            return "fake"
+
+        async def request(self, *args: object, **kwargs: object) -> object:
+            raise NotImplementedError
+
+    discovery = MCPDiscoveryConfig(topic=capability_topic, heartbeat_interval=5.0, bootstrap_servers=BOOTSTRAP)
+
+    # Toolbox side (as if hosted in another worker): real writer, real publish.
+    toolbox = MCPToolbox("docs_server", connection_params=StreamableHttpParameters(url="http://unused.local/mcp"), discovery=discovery)
+    writer_gen = toolbox._capability_writer(None)  # type: ignore[arg-type]
+    writer = await anext(writer_gen)
+    toolbox.resources[toolbox._writer_resource_key] = writer
+    toolbox.resources[toolbox._session_resource_key] = FakeSession()
+    toolbox_ctx = ServingContext(toolbox, toolbox.resources, broker=None)  # type: ignore[arg-type]
+    await toolbox._publish_on_startup(toolbox_ctx)
+
+    # Agent side: a separate process in production — here a Worker whose
+    # auto-registered view resource we enter for real.
+    agent = Agent(
+        "researcher",
+        subscribe_topics="researcher.in",
+        model_client=FakeModel(),
+        tools=[toolbox.select(include=["search"])],
+    )
+    client = Client.connect(BOOTSTRAP)
+    worker = Worker(client, nodes=[agent], mcp_discovery=discovery)
+    worker._maybe_register_capability_view()
+    [(name, genfn)] = [(n, g) for n, g in worker._resource_cms() if n == CAPABILITY_VIEW_RESOURCE_KEY]
+    view_gen = genfn(None)  # type: ignore[arg-type]
+    table = await anext(view_gen)
+    try:
+        # Catch-up gate already passed inside start(); the record is visible.
+        registry: dict = {}
+        agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: table, **agent._effective_resources()}, registry)
+        assert sorted(registry) == ["search"]
+        assert registry["search"].dispatch_topic == "mcp_server.docs_server"
+
+        # Clean shutdown tombstones; the next turn degrades (warns, empty).
+        await toolbox._tombstone_on_shutdown(toolbox_ctx)
+        for _ in range(200):
+            if "docs_server" not in table:
+                break
+            await asyncio.sleep(0.01)
+        registry2: dict = {}
+        agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: table}, registry2)
+        assert registry2 == {}
+    finally:
+        with pytest.raises(StopAsyncIteration):
+            await anext(view_gen)
+        with pytest.raises(StopAsyncIteration):
+            await anext(writer_gen)

--- a/tests/integration/test_mcp_toolbox_capability.py
+++ b/tests/integration/test_mcp_toolbox_capability.py
@@ -48,11 +48,13 @@ async def test_publish_heartbeat_and_tombstone_roundtrip(capability_topic: str) 
     toolbox = MCPToolbox(
         "docs_server",
         connection_params=StreamableHttpParameters(url="http://unused.local/mcp"),
-        discovery=MCPDiscoveryConfig(
-            topic=capability_topic,
-            heartbeat_interval=0.05,
-            bootstrap_servers=BOOTSTRAP,  # no Worker in this test: explicit override path
-        ),
+    )
+    # Config flows from the hosting worker; stub it (no Worker in this test).
+    from types import SimpleNamespace
+
+    toolbox._worker = SimpleNamespace(
+        _mcp_discovery=MCPDiscoveryConfig(topic=capability_topic, heartbeat_interval=0.05, bootstrap_servers=BOOTSTRAP),
+        _client=None,
     )
 
     # Resource phase: enter the writer bracket for real (creates the topic).
@@ -124,7 +126,10 @@ async def test_end_to_end_toolbox_to_agent_resolution(capability_topic: str) -> 
     discovery = MCPDiscoveryConfig(topic=capability_topic, heartbeat_interval=5.0, bootstrap_servers=BOOTSTRAP)
 
     # Toolbox side (as if hosted in another worker): real writer, real publish.
-    toolbox = MCPToolbox("docs_server", connection_params=StreamableHttpParameters(url="http://unused.local/mcp"), discovery=discovery)
+    from types import SimpleNamespace
+
+    toolbox = MCPToolbox("docs_server", connection_params=StreamableHttpParameters(url="http://unused.local/mcp"))
+    toolbox._worker = SimpleNamespace(_mcp_discovery=discovery, _client=None)
     writer_gen = toolbox._capability_writer(None)  # type: ignore[arg-type]
     writer = await anext(writer_gen)
     toolbox.resources[toolbox._writer_resource_key] = writer
@@ -160,7 +165,7 @@ async def test_end_to_end_toolbox_to_agent_resolution(capability_topic: str) -> 
                 break
             await asyncio.sleep(0.01)
         registry2: dict = {}
-        agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: table}, registry2)
+        agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: table, **agent._effective_resources()}, registry2)
         assert registry2 == {}
     finally:
         with pytest.raises(StopAsyncIteration):

--- a/tests/test_mcp_toolbox_publisher.py
+++ b/tests/test_mcp_toolbox_publisher.py
@@ -59,12 +59,18 @@ def make_tools() -> list[Tool]:
     ]
 
 
-def make_toolbox(**kwargs: Any) -> Any:
-    return MCPToolbox(
+def make_toolbox(discovery: MCPDiscoveryConfig | None = None) -> Any:
+    toolbox = MCPToolbox(
         "docs_server",
         connection_params=StreamableHttpParameters(url="http://unused.local/mcp"),
-        **kwargs,
     )
+    if discovery is not None:
+        # Config flows from the hosting worker (the single config surface);
+        # tests stand in for it with a stub.
+        from types import SimpleNamespace
+
+        toolbox._worker = SimpleNamespace(_mcp_discovery=discovery, _client=None)
+    return toolbox
 
 
 def seed(toolbox: Any, session: FakeSession | None = None, writer: FakeWriter | None = None) -> tuple[FakeSession, FakeWriter]:

--- a/tests/test_tool_selector.py
+++ b/tests/test_tool_selector.py
@@ -131,7 +131,6 @@ class TestAgentResolution:
 
     def make_agent(self, *tools: Any):
         from calfkit.nodes.agent import Agent
-        from tests.test_capability_models import __name__ as _  # noqa: F401
 
         class _FakeModel:
             pass
@@ -199,3 +198,36 @@ class TestAgentResolution:
         strict = self.make_agent(make_toolbox().select(strict=True))
         with pytest.raises(MCPToolResolutionError, match="docs_server"):
             strict._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: {}}, {})
+
+
+class TestOverridesSuppressSelectors:
+    """Per-run overrides pin the exact tool surface: selectors are skipped."""
+
+    def _ctx(self, overrides=None):
+        from calfkit.models.state import OverridesState, State
+        from tests.test_tool_errors import _make_ctx
+
+        state = State()
+        if overrides is not None:
+            state.overrides = OverridesState(override_agent_tools=overrides)
+        ctx = _make_ctx(state)
+        return ctx
+
+    def test_overridden_turn_skips_selectors_even_strict(self) -> None:
+        from calfkit._vendor.pydantic_ai.tools import ToolDefinition
+
+        agent = TestAgentResolution().make_agent(make_toolbox().select(strict=True))
+        override = ToolBinding(tool_def=ToolDefinition(name="pinned"), dispatch_topic="pinned.topic")
+        registry = {"pinned": override}
+        # No Capability View anywhere: a strict selector would raise — but the
+        # override gate must short-circuit before resolution.
+        agent._maybe_resolve_selectors(self._ctx(overrides=[override]), registry)
+        assert list(registry) == ["pinned"]
+
+    def test_non_overridden_turn_resolves(self) -> None:
+        agent = TestAgentResolution().make_agent(make_toolbox())
+        ctx = self._ctx()
+        ctx._resources = {CAPABILITY_VIEW_RESOURCE_KEY: {"docs_server": make_record()}}
+        registry: dict[str, ToolBinding] = {}
+        agent._maybe_resolve_selectors(ctx, registry)
+        assert sorted(registry) == ["fetch", "search"]

--- a/tests/test_tool_selector.py
+++ b/tests/test_tool_selector.py
@@ -1,0 +1,201 @@
+"""PR C: ToolSelector protocol, MCPToolbox-as-selector, and agent resolution.
+
+Spec §8.4: the toolbox instance is passed to agents like a tool node
+(``tools=[docs]``); resolution happens per turn against the Capability View,
+typed as a plain ``Mapping[str, CapabilityRecord]`` — these tests use plain
+dicts as the view (the agent layer never imports ktables).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from calfkit.exceptions import MCPToolResolutionError
+from calfkit.mcp.mcp_toolbox import MCPToolbox
+from calfkit.mcp.mcp_transport import StreamableHttpParameters
+from calfkit.models.capability import (
+    CAPABILITY_SCHEMA_VERSION,
+    CAPABILITY_VIEW_RESOURCE_KEY,
+    CapabilityRecord,
+    CapabilityToolDef,
+    SelectorResult,
+)
+from calfkit.models.tool_dispatch import ToolBinding, ToolProvider, ToolSelector, split_tool_declarations
+
+
+def make_toolbox(name: str = "docs_server") -> MCPToolbox:
+    return MCPToolbox(name, connection_params=StreamableHttpParameters(url="http://unused.local/mcp"))
+
+
+def make_record(toolbox_id: str = "docs_server", *, tool_names: tuple[str, ...] = ("search", "fetch"), **overrides: Any) -> CapabilityRecord:
+    defaults: dict[str, Any] = dict(
+        toolbox_id=toolbox_id,
+        dispatch_topic=f"mcp_server.{toolbox_id}",
+        tools=[CapabilityToolDef(name=n, parameters_json_schema={"type": "object", "properties": {}}) for n in tool_names],
+        published_at=datetime.now(tz=timezone.utc),
+    )
+    defaults.update(overrides)
+    return CapabilityRecord(**defaults)
+
+
+class TestToolboxIsNoLongerAProvider:
+    def test_tool_bindings_stub_is_gone(self) -> None:
+        toolbox = make_toolbox()
+        assert not hasattr(toolbox, "tool_bindings")
+        assert not isinstance(toolbox, ToolProvider)
+
+    def test_toolbox_satisfies_tool_selector(self) -> None:
+        assert isinstance(make_toolbox(), ToolSelector)
+
+
+class TestResolveTools:
+    def test_resolves_all_tools_from_view(self) -> None:
+        toolbox = make_toolbox()
+        view = {"docs_server": make_record()}
+        result = toolbox.resolve_tools(view)
+        assert isinstance(result, SelectorResult)
+        assert [b.name for b in result.bindings] == ["search", "fetch"]
+        assert all(isinstance(b, ToolBinding) and b.validator is None for b in result.bindings)
+        assert all(b.dispatch_topic == "mcp_server.docs_server" for b in result.bindings)
+        assert not result.missing_toolbox and not result.missing_tools
+        assert not result.strict
+
+    def test_missing_toolbox_diagnostic(self) -> None:
+        result = make_toolbox().resolve_tools({})
+        assert result.missing_toolbox
+        assert result.bindings == []
+        assert result.toolbox_id == "docs_server"
+
+    def test_include_filter_and_missing_tools(self) -> None:
+        toolbox = make_toolbox()
+        selector = toolbox.select(include=["search", "nonexistent"])
+        result = selector.resolve_tools({"docs_server": make_record()})
+        assert [b.name for b in result.bindings] == ["search"]
+        assert result.missing_tools == ("nonexistent",)
+
+    def test_strict_flag_propagates(self) -> None:
+        selector = make_toolbox().select(strict=True)
+        assert selector.resolve_tools({}).strict is True
+
+    def test_scoped_selector_is_frozen(self) -> None:
+        selector = make_toolbox().select(include=["search"])
+        with pytest.raises(Exception):
+            selector.strict = True  # type: ignore[misc]
+
+    def test_newer_schema_is_skipped_with_diagnostic(self) -> None:
+        record = make_record(schema_version=CAPABILITY_SCHEMA_VERSION + 1)
+        result = make_toolbox().resolve_tools({"docs_server": record})
+        assert result.skipped_newer_schema
+        assert result.bindings == []
+
+    def test_malformed_record_is_skipped_with_diagnostic(self) -> None:
+        # Tolerant reader admits an empty dispatch_topic; binding expansion
+        # must not crash the turn (spec §8.4 guard).
+        record = make_record(dispatch_topic="")
+        result = make_toolbox().resolve_tools({"docs_server": record})
+        assert result.invalid_record
+        assert result.bindings == []
+
+    def test_stale_seconds_reflects_record_age(self) -> None:
+        old = make_record(published_at=datetime.now(tz=timezone.utc) - timedelta(seconds=120))
+        result = make_toolbox().resolve_tools({"docs_server": old})
+        assert result.stale_seconds is not None and 119 < result.stale_seconds < 130
+
+
+class TestSplitToolDeclarations:
+    def test_separates_bindings_providers_and_selectors(self) -> None:
+        from calfkit.nodes.tool import agent_tool
+
+        def get_weather(city: str) -> str:
+            return city
+
+        tool_node = agent_tool(get_weather)
+        toolbox = make_toolbox()
+        scoped = toolbox.select(include=["search"])
+        raw = tool_node.tool_bindings()[0]
+
+        bindings, selectors = split_tool_declarations([tool_node, toolbox, scoped, raw])
+        assert [b.name for b in bindings] == ["get_weather", "get_weather"]
+        assert selectors == [toolbox, scoped]
+
+    def test_garbage_raises_type_error(self) -> None:
+        with pytest.raises(TypeError, match="ToolBinding|ToolProvider|ToolSelector"):
+            split_tool_declarations(["nope"])
+
+
+class TestAgentResolution:
+    """Drives the agent's per-turn selector resolution against a plain dict."""
+
+    def make_agent(self, *tools: Any):
+        from calfkit.nodes.agent import Agent
+        from tests.test_capability_models import __name__ as _  # noqa: F401
+
+        class _FakeModel:
+            pass
+
+        from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
+
+        class FakeModel(PydanticModelClient):
+            @property
+            def model_name(self) -> str:
+                return "fake"
+
+            @property
+            def system(self) -> str:
+                return "fake"
+
+            async def request(self, *args: object, **kwargs: object) -> object:
+                raise NotImplementedError
+
+        return Agent("a", subscribe_topics="a.in", model_client=FakeModel(), tools=list(tools))
+
+    def test_ctor_sets_aside_selectors(self) -> None:
+        toolbox = make_toolbox()
+        agent = self.make_agent(toolbox)
+        assert agent.tools == []
+        assert agent._tool_selectors == [toolbox]
+
+    def test_resolution_merges_bindings_into_registry(self) -> None:
+        agent = self.make_agent(make_toolbox())
+        registry: dict[str, ToolBinding] = {}
+        agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: {"docs_server": make_record()}}, registry)
+        assert sorted(registry) == ["fetch", "search"]
+
+    def test_collision_static_wins_and_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+        agent = self.make_agent(make_toolbox())
+        static = ToolBinding(
+            tool_def=__import__("calfkit._vendor.pydantic_ai.tools", fromlist=["ToolDefinition"]).ToolDefinition(name="search"),
+            dispatch_topic="static.topic",
+        )
+        registry = {"search": static}
+        with caplog.at_level("ERROR"):
+            agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: {"docs_server": make_record()}}, registry)
+        assert registry["search"] is static  # remote never shadows local
+        assert any("search" in r.message for r in caplog.records)
+        assert "fetch" in registry  # non-colliding remote tool still merged
+
+    def test_missing_view_warns_and_degrades(self, caplog: pytest.LogCaptureFixture) -> None:
+        agent = self.make_agent(make_toolbox())
+        registry: dict[str, ToolBinding] = {}
+        with caplog.at_level("WARNING"):
+            agent._resolve_selector_tools({}, registry)  # no view resource at all
+        assert registry == {}
+        assert any("capability" in r.message.lower() for r in caplog.records)
+
+    def test_missing_view_with_strict_raises(self) -> None:
+        agent = self.make_agent(make_toolbox().select(strict=True))
+        with pytest.raises(MCPToolResolutionError):
+            agent._resolve_selector_tools({}, {})
+
+    def test_unresolved_toolbox_warns_or_raises(self, caplog: pytest.LogCaptureFixture) -> None:
+        lenient = self.make_agent(make_toolbox())
+        with caplog.at_level("WARNING"):
+            lenient._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: {}}, {})
+        assert any("docs_server" in r.message for r in caplog.records)
+
+        strict = self.make_agent(make_toolbox().select(strict=True))
+        with pytest.raises(MCPToolResolutionError, match="docs_server"):
+            strict._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: {}}, {})

--- a/tests/test_worker_capability_view.py
+++ b/tests/test_worker_capability_view.py
@@ -1,0 +1,81 @@
+"""PR C: the worker auto-registers the Capability View when agents need it.
+
+Spec §8.3: one KafkaTable per worker, registered as a worker-level resource
+iff any hosted node declares MCP tool selectors; zero user wiring. These
+tests cover registration mechanics only — the table itself is ktables'
+responsibility, and the live path is the integration test.
+"""
+
+from __future__ import annotations
+
+from calfkit.client.client import Client
+from calfkit.mcp.mcp_toolbox import MCPToolbox
+from calfkit.mcp.mcp_transport import StreamableHttpParameters
+from calfkit.models.capability import CAPABILITY_VIEW_RESOURCE_KEY
+from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
+from calfkit.worker.worker import Worker
+from calfkit.worker.worker_config import MCPDiscoveryConfig
+
+
+class FakeModel(PydanticModelClient):
+    @property
+    def model_name(self) -> str:
+        return "fake"
+
+    @property
+    def system(self) -> str:
+        return "fake"
+
+    async def request(self, *args: object, **kwargs: object) -> object:
+        raise NotImplementedError
+
+
+def make_toolbox() -> MCPToolbox:
+    return MCPToolbox("docs_server", connection_params=StreamableHttpParameters(url="http://unused.local/mcp"))
+
+
+def make_agent(*tools: object):
+    from calfkit.nodes.agent import Agent
+
+    return Agent("a", subscribe_topics="a.in", model_client=FakeModel(), tools=list(tools))
+
+
+def worker_resource_names(worker: Worker) -> list[str]:
+    return [name for name, _ in worker._resource_cms()]
+
+
+class TestCapabilityViewRegistration:
+    def test_registered_when_an_agent_declares_selectors(self) -> None:
+        client = Client.connect("kafka:9092")
+        worker = Worker(client, nodes=[make_agent(make_toolbox())])
+        worker._maybe_register_capability_view()
+        assert CAPABILITY_VIEW_RESOURCE_KEY in worker_resource_names(worker)
+
+    def test_not_registered_without_selectors(self) -> None:
+        client = Client.connect("kafka:9092")
+        worker = Worker(client, nodes=[make_agent()])
+        worker._maybe_register_capability_view()
+        assert CAPABILITY_VIEW_RESOURCE_KEY not in worker_resource_names(worker)
+
+    def test_idempotent_on_repeat_calls(self) -> None:
+        client = Client.connect("kafka:9092")
+        worker = Worker(client, nodes=[make_agent(make_toolbox())])
+        worker._maybe_register_capability_view()
+        worker._maybe_register_capability_view()  # must not raise duplicate-name
+        assert worker_resource_names(worker).count(CAPABILITY_VIEW_RESOURCE_KEY) == 1
+
+    def test_scoped_selectors_also_trigger_registration(self) -> None:
+        client = Client.connect("kafka:9092")
+        worker = Worker(client, nodes=[make_agent(make_toolbox().select(include=["search"]))])
+        worker._maybe_register_capability_view()
+        assert CAPABILITY_VIEW_RESOURCE_KEY in worker_resource_names(worker)
+
+    def test_discovery_config_accepted_on_worker(self) -> None:
+        client = Client.connect("kafka:9092")
+        worker = Worker(client, mcp_discovery=MCPDiscoveryConfig(topic="custom.capabilities"))
+        assert worker._mcp_discovery.topic == "custom.capabilities"
+
+    def test_defaults_when_config_omitted(self) -> None:
+        client = Client.connect("kafka:9092")
+        worker = Worker(client)
+        assert worker._mcp_discovery == MCPDiscoveryConfig()

--- a/tests/test_worker_capability_view.py
+++ b/tests/test_worker_capability_view.py
@@ -8,6 +8,8 @@ responsibility, and the live path is the integration test.
 
 from __future__ import annotations
 
+import pytest
+
 from calfkit.client.client import Client
 from calfkit.mcp.mcp_toolbox import MCPToolbox
 from calfkit.mcp.mcp_transport import StreamableHttpParameters
@@ -79,3 +81,115 @@ class TestCapabilityViewRegistration:
         client = Client.connect("kafka:9092")
         worker = Worker(client)
         assert worker._mcp_discovery == MCPDiscoveryConfig()
+
+
+class FakeKafkaTable:
+    """Stands in for ktables.KafkaTable; records construction and lifecycle."""
+
+    instances: list[FakeKafkaTable] = []
+
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self.started = False
+        self.stopped = False
+        FakeKafkaTable.instances.append(self)
+
+    @classmethod
+    def json(cls, *, model: object, **kwargs: object) -> FakeKafkaTable:
+        return cls(model=model, **kwargs)
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+@pytest.fixture
+def fake_table(monkeypatch: pytest.MonkeyPatch) -> type[FakeKafkaTable]:
+    FakeKafkaTable.instances = []
+    monkeypatch.setattr("ktables.KafkaTable", FakeKafkaTable)
+    return FakeKafkaTable
+
+
+async def drive(worker: Worker):
+    gen = worker._capability_view_resource(None)  # type: ignore[arg-type]
+    table = await anext(gen)
+    return gen, table
+
+
+async def close(gen) -> None:
+    with pytest.raises(StopAsyncIteration):
+        await anext(gen)
+
+
+class TestCapabilityViewResource:
+    async def test_opens_table_with_config_and_lifecycle(self, fake_table: type[FakeKafkaTable]) -> None:
+        client = Client.connect("kafka:9092")
+        worker = Worker(client, mcp_discovery=MCPDiscoveryConfig(topic="custom.caps", catchup_timeout=7.0))
+        gen, table = await drive(worker)
+        assert table.started and not table.stopped
+        assert table.kwargs["topic"] == "custom.caps"
+        assert table.kwargs["catchup_timeout"] == 7.0
+        assert table.kwargs["ensure_topic"] is False  # provisioning disabled by default
+        await close(gen)
+        assert table.stopped
+
+    async def test_bootstrap_explicit_override_wins(self, fake_table: type[FakeKafkaTable]) -> None:
+        client = Client.connect("kafka:9092")
+        worker = Worker(client, mcp_discovery=MCPDiscoveryConfig(bootstrap_servers="cp-kafka:9092"))
+        gen, table = await drive(worker)
+        assert table.kwargs["bootstrap_servers"] == "cp-kafka:9092"
+        await close(gen)
+
+    async def test_bootstrap_derives_from_client(self, fake_table: type[FakeKafkaTable]) -> None:
+        client = Client.connect(["kafka-a:9092", "kafka-b:9092"])
+        worker = Worker(client)
+        gen, table = await drive(worker)
+        assert table.kwargs["bootstrap_servers"] == "kafka-a:9092,kafka-b:9092"
+        await close(gen)
+
+    async def test_bootstrap_falls_back_to_broker_kwargs_list(self, fake_table: type[FakeKafkaTable]) -> None:
+        client = Client.connect("kafka:9092")
+        client._server_urls = None  # hand-built-client scenario
+        worker = Worker(client)
+        gen, table = await drive(worker)
+        assert table.kwargs["bootstrap_servers"] == "kafka:9092"  # joined from broker kwargs
+        await close(gen)
+
+    async def test_bootstrap_falls_back_to_broker_kwargs_str(self, fake_table: type[FakeKafkaTable]) -> None:
+        client = Client.connect("kafka:9092")
+        client._server_urls = None
+        client.broker._connection_kwargs = {"bootstrap_servers": "raw-str:9092"}
+        worker = Worker(client)
+        gen, table = await drive(worker)
+        assert table.kwargs["bootstrap_servers"] == "raw-str:9092"
+        await close(gen)
+
+    async def test_underivable_bootstrap_raises_actionable_error(self, fake_table: type[FakeKafkaTable]) -> None:
+        client = Client.connect("kafka:9092")
+        client._server_urls = None
+        client.broker._connection_kwargs = {}
+        worker = Worker(client)
+        with pytest.raises(RuntimeError, match="bootstrap_servers"):
+            await drive(worker)
+        assert fake_table.instances == []  # failed before construction
+
+    async def test_ensure_topic_follows_provisioning(self, fake_table: type[FakeKafkaTable]) -> None:
+        from calfkit.provisioning import ProvisioningConfig
+
+        client = Client.connect("kafka:9092", provisioning=ProvisioningConfig(enabled=True))
+        worker = Worker(client)
+        gen, table = await drive(worker)
+        assert table.kwargs["ensure_topic"] is True
+        await close(gen)
+
+
+class TestRegisterHandlersIdempotency:
+    def test_second_call_is_a_guarded_no_op(self) -> None:
+        client = Client.connect("kafka:9092")
+        worker = Worker(client)  # zero nodes: registration is broker-free
+        worker.register_handlers()
+        assert worker._prepared
+        worker.register_handlers()  # exercises the already-prepared early return
+        assert worker._prepared


### PR DESCRIPTION
## Summary

PR C — the final PR of the MCP toolbox discoverability plan (spec §8.3/§8.4/§8.6/§8.7; rebased onto main after #210 merged); closes the loop:

```python
docs = MCPToolbox("docs_server", connection_params=params)   # deployed anywhere
agent = Agent(..., tools=[weather, docs.select(include=["search"])])
```

- **ToolSelector protocol + split_tool_declarations** (`tool_dispatch.py`): the toolbox object is passed like a tool node; selectors set aside at construction (checked before providers), resolved per turn.
- **SelectorResult + resolve_capability** (`capability.py`): bindings + structured diagnostics (missing toolbox/tools, newer-schema skip, malformed-record guard, staleness) — policy in one place, tests assert on data.
- **Agent resolution** (`agent.py`): merge after static tools (collision = error-log + static wins), warn/degrade by default, `strict=True` raises `MCPToolResolutionError` pre-model, staleness log-only (v1). **Per-run `override_agent_tools` pins the tool surface — selectors are skipped entirely on overridden turns** (decided + pinned by test). The agent layer never imports ktables: the view is `Mapping[str, CapabilityRecord]`, so all policy tests run against plain dicts.
- **Worker auto-registration** (`worker.py`): iff a hosted node declares selectors, ONE `KafkaTable[CapabilityRecord]` resource opens at boot (`start()` is the catch-up gate; serve-degraded on expiry). Zero config: bootstrap derives from the connected client. `Worker(..., mcp_discovery=MCPDiscoveryConfig(...))` is the **single config surface** — `MCPToolbox` takes no discovery config and inherits its hosting worker's.
- **ktables 0.1.2** (py.typed) — interim mypy override deleted.
- **Docs**: `docs/mcp-tool-discovery.md` how-to (Diátaxis-disciplined; every import execution-verified) + README index entry. `MCPToolbox.tool_bindings()` raising stub is gone.

## Review (2 rounds, converged)
R1: zero criticals; one Important — selectors merged into per-run override registries (spec-silent semantic; escalated, decided: overrides win) — plus four minors, all addressed. R2: converged; the overrides-gate test verified load-bearing by mutant revert; single-config-surface timing verified against lifecycle ordering; no disturbed callsites.

## Tests
20 selector/resolution unit tests (plain-dict views) + 6 worker wiring + end-to-end integration on a real broker (toolbox publish → view catch-up → scoped resolution → clean-shutdown tombstone → degraded next turn). Full suite 2714 unit-passed (2734 incl. integration); 3.10-floor runs on all new tests; `make fix`/`make check` clean.