### PR TITLE
feat: public MCPToolboxRef — reference a toolbox by name; closes issue #212

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,6 @@ uv.lock
 # Internal notes
 notes/
 docs/internal/
-docs/adr/
 
 # Local scratch / experiments
 scratch/

--- a/calfkit/mcp/__init__.py
+++ b/calfkit/mcp/__init__.py
@@ -1,0 +1,17 @@
+"""MCP integration: the hosting toolbox node and its identity-only reference.
+
+`MCPToolbox` hosts an MCP server's tools as a calfkit node (deploy side);
+`MCPToolboxRef` references one by name from anywhere (call side) — they are
+exported together deliberately, the same way a servant and its handle travel
+together in the peer-node pattern.
+"""
+
+from calfkit.mcp.mcp_toolbox import MCPToolbox, MCPToolboxRef
+from calfkit.mcp.mcp_transport import StdioServerParameters, StreamableHttpParameters
+
+__all__ = [
+    "MCPToolbox",
+    "MCPToolboxRef",
+    "StdioServerParameters",
+    "StreamableHttpParameters",
+]

--- a/calfkit/mcp/mcp_toolbox.py
+++ b/calfkit/mcp/mcp_toolbox.py
@@ -87,13 +87,14 @@ class MCPToolbox(BaseNodeDef):
     def resolve_tools(self, view: Mapping[str, CapabilityRecord]) -> SelectorResult:
         """All advertised tools, resolved against the Capability View.
 
-        Implements ``ToolSelector``: passing this toolbox in ``tools=[...]``
-        defers resolution to each agent turn — no session contact, no
-        deployment coupling.
+        Implements ``ToolSelector`` by delegating to this toolbox's ref —
+        passing the toolbox in ``tools=[...]`` and passing
+        ``MCPToolboxRef(name)`` resolve identically; the ref is the canonical
+        resolution path.
         """
-        return resolve_capability(view, self.node_id)
+        return MCPToolboxRef(self.node_id).resolve_tools(view)
 
-    def select(self, *, include: Sequence[str] | None = None, strict: bool = False) -> "_ScopedSelector":
+    def select(self, *, include: Sequence[str] | None = None, strict: bool = False) -> "MCPToolboxRef":
         """A scoped/strict selector for this toolbox's tools.
 
         ``include`` pins the exact tool names the agent may see (the trust
@@ -102,7 +103,7 @@ class MCPToolbox(BaseNodeDef):
         selection cannot be fully satisfied; the default degrades with a
         warning.
         """
-        return _ScopedSelector(
+        return MCPToolboxRef(
             toolbox_id=self.node_id,
             include=tuple(include) if include is not None else None,
             strict=strict,
@@ -297,12 +298,31 @@ class MCPToolbox(BaseNodeDef):
 
 
 @dataclass(frozen=True)
-class _ScopedSelector:
-    """Frozen, internal: produced by :meth:`MCPToolbox.select`, never named by users."""
+class MCPToolboxRef:
+    """The identity-only, deployment-free handle to an MCP toolbox (#212).
+
+    The call-side counterpart to the hosting :class:`MCPToolbox` (the
+    peer-node pattern's reference/servant split): constructible anywhere with
+    just the toolbox's name — no connection params, no secrets — and resolved
+    per agent turn against the Capability View. At the MCP protocol layer the
+    toolbox is the cluster's MCP client; agents never speak MCP at all — they
+    hold one of these.
+
+    ``include`` pins the exact tool names the agent may see; ``strict=True``
+    fails the turn when the selection cannot be fully satisfied (default
+    degrades with a warning). Frozen with value semantics: equal refs compare
+    and hash equal.
+    """
 
     toolbox_id: str
-    include: tuple[str, ...] | None
-    strict: bool
+    include: tuple[str, ...] | None = None
+    strict: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.toolbox_id:
+            raise ValueError("toolbox_id must be non-empty")
+        if self.include is not None and not isinstance(self.include, tuple):
+            object.__setattr__(self, "include", tuple(self.include))
 
     def resolve_tools(self, view: Mapping[str, CapabilityRecord]) -> SelectorResult:
         return resolve_capability(view, self.toolbox_id, include=self.include, strict=self.strict)

--- a/calfkit/models/capability.py
+++ b/calfkit/models/capability.py
@@ -89,6 +89,10 @@ def resolve_capability(
 ) -> SelectorResult:
     """Resolve ``toolbox_id`` (optionally filtered) against the view.
 
+    Public API: this is the resolution kernel behind ``MCPToolboxRef`` and
+    ``MCPToolbox.resolve_tools``; custom ``ToolSelector`` implementations may
+    call it directly.
+
     Never raises on bad records: the tolerant reader admits shapes that fail
     binding expansion (e.g. empty ``dispatch_topic``); those surface as
     ``invalid_record`` so a poisoned advertisement cannot crash a turn.

--- a/calfkit/worker/worker.py
+++ b/calfkit/worker/worker.py
@@ -10,6 +10,7 @@ from typing_extensions import Self
 
 from calfkit.client import Client
 from calfkit.models.capability import CAPABILITY_VIEW_RESOURCE_KEY, CapabilityRecord
+from calfkit.models.tool_dispatch import ToolSelector
 from calfkit.nodes import BaseNodeDef
 from calfkit.provisioning import topics_for_nodes
 from calfkit.worker.lifecycle import (
@@ -137,6 +138,14 @@ class Worker(LifecycleHookMixin):
 
     def _add_node(self, node: BaseNodeDef) -> None:
         """Internal: register a node for hosting."""
+        if not isinstance(node, BaseNodeDef):
+            if isinstance(node, ToolSelector):
+                raise TypeError(
+                    f"{type(node).__name__} is a name-only reference and can't host — construct the "
+                    "hosting node instead (e.g. MCPToolbox(name, connection_params=...)) to deploy. "
+                    "References belong in Agent(tools=[...])."
+                )
+            raise TypeError(f"add_nodes expects BaseNodeDef instances, got {type(node).__name__}: {node!r}")
         # Back-reference so the node's per-message handler can merge this
         # worker's lifecycle resources under its own (see
         # BaseNodeDef._effective_resources / prepare_context). Last writer

--- a/docs/adr/0001-compacted-capability-topic-for-mcp-discovery.md
+++ b/docs/adr/0001-compacted-capability-topic-for-mcp-discovery.md
@@ -1,0 +1,31 @@
+# Compacted control-plane topic for MCP tool discovery, not live queries
+
+MCP tools are only discoverable through an async `list_tools` call on a live
+session owned by the bridge node, but agents — possibly in other worker
+processes — need those tools as `ToolBinding`s every turn. The obvious
+approach (the one pydantic-ai and the OpenAI Agents SDK use in-process) is to
+query the bridge for its tool list at run time. We rejected it: over Kafka, a
+per-turn query makes every bridge a synchronous availability dependency of
+every agent turn, adds request/reply hops before each model call, and needs
+new fan-in state machinery in the agent's chain-of-responsibility handler —
+and the "cache it" variant converges back to needing a change-notification
+topic anyway.
+
+Instead, all bridges publish their current tool list (a versioned,
+calfkit-owned `CapabilityRecord`) to **one cluster-wide compacted topic**,
+keyed by bridge id, re-publishing on `tools/list_changed` and as a ~30s
+heartbeat. Each agent-hosting worker replays that topic into a small
+last-write-wins dict (the Capability View) and agents resolve `MCPTools`
+selectors against it per turn. This is event-carried state transfer — the same
+shape as Kafka Connect's config topic — and it separates the control plane
+(what tools exist, where) from the data plane (the tool calls themselves), so
+a bridge outage degrades only the calls routed to it, never the agents' view
+of the world.
+
+Consequences worth remembering: records outlive deploys indefinitely
+(compaction keeps the latest per key), which is why the wire format is a
+calfkit-owned versioned model rather than the vendored `ToolDefinition`;
+every capability-consuming worker holds the whole cluster's (tiny) tool map;
+and "bridge down" ≠ "tools gone" — removal is an explicit tombstone on clean
+shutdown, while crashes only show up as heartbeat staleness. Full design:
+`docs/designs/mcp-capability-discovery-spec.md`.

--- a/docs/adr/0002-two-type-toolbox-reference-over-union-ctor.md
+++ b/docs/adr/0002-two-type-toolbox-reference-over-union-ctor.md
@@ -1,0 +1,23 @@
+# Two types for MCP toolbox host vs reference, not an ADK-style union constructor
+
+Agents on distributed hosts must reference an MCP toolbox by name without
+holding its connection params (issue #212). We added a public frozen
+`MCPToolboxRef(name, include, strict)` beside the hosting `MCPToolbox` rather
+than making one class whose connection-params union accepts an identity arm
+(Google ADK's `MCPToolset` shape, which was seriously argued for).
+
+Deciding fact: ADK's union arms are capability-invariant — every arm yields a
+client with identical behavior in the same process — while a calfkit union's
+arms would flip capability itself (deployable secret-bearing Kafka servant vs
+inert lookup key), and those differences surface in public operations:
+`add_nodes` must reject one arm, secrets exist in one arm, IDE surface
+differs. When a constructor argument changes what an object is allowed to do,
+that is a type boundary; the union would make deploy-a-reference
+representable and late-failing where two types make it unconstructible. Also
+matches the repo's peer-node pattern doc and the cross-framework
+handle/servant norm (ActorRef, WorkflowHandle, Stub). Retained from the union
+position: `tools=[toolbox]` stays primary via delegation, one docs page, ADK-
+shaped host params, and a teaching error when a ref is deployed. Adjudicated
+2026-06-10 (independent DX review with both positions briefed neutrally);
+spec §8.4 records the summary. No `ref()` method — `select()` mints refs; a
+universal `.ref` verb is deferred to any 1.0 all-node generalization.

--- a/docs/designs/mcp-capability-discovery-spec.md
+++ b/docs/designs/mcp-capability-discovery-spec.md
@@ -395,6 +395,19 @@ Passing it never touches the MCP session: the agent extracts only the
 deferred lookup key (`node_id`) plus any `.select()` scoping. Cross-process
 works because the agent's worker imports the toolbox *definition* (shared
 codebase) without deploying it — the same way tool-node objects travel today.
+**Reference type (added for #212, adjudicated 2026-06-10):** distributed
+agent hosts reference a toolbox by name via the public frozen
+`MCPToolboxRef(toolbox_id, include=None, strict=False)` (exported beside
+`MCPToolbox`; `select()` returns it; the toolbox's own resolution delegates
+to it). A one-class union ctor (ADK-style `connection_params` accepting an
+identity arm) was considered and rejected: ADK's union arms are
+capability-invariant transports, while ours would be capability-variant
+(deployable secret-bearing servant vs inert lookup key) — the differences
+surface in PUBLIC operations (`add_nodes`, secrets, IDE), so they warrant a
+type boundary; `add_nodes(ref)` is rejected eagerly with a teaching error.
+From the union position we kept: co-located `tools=[toolbox]` stays primary,
+one docs page for both types, ADK-shaped host params, intuitive error text.
+
 The standalone `MCPTools` class is dropped; `MCPToolbox.tool_bindings()`
 (which raised `NotImplementedError`) is deleted in favor of implementing
 `ToolSelector`. `_normalize_tools` checks selector-ness BEFORE provider-ness

--- a/docs/mcp-tool-discovery.md
+++ b/docs/mcp-tool-discovery.md
@@ -50,6 +50,25 @@ agent = Agent(
 worker = Worker(client, nodes=[agent])   # capability view auto-registers
 ```
 
+If the agent host doesn't import the toolbox definition — or must not hold
+its connection config at all (secrets stay on the toolbox host) — reference
+the toolbox **by name** instead:
+
+```python
+from calfkit.mcp import MCPToolboxRef
+
+agent = Agent(
+    "researcher",
+    subscribe_topics="researcher.input",
+    model_client=model,
+    tools=[MCPToolboxRef("docs_server", include=("search",))],
+)
+```
+
+A ref is a frozen, identity-only handle: it can never carry connection
+params, and deploying one fails immediately with a pointer to the hosting
+form. (`toolbox.select(...)` returns the same type.)
+
 The agent's worker detects the declaration and maintains the local capability
 view, gated at boot so the first turn already sees it. Selections re-resolve
 at the start of every agent turn, so a toolbox that comes up later — or

--- a/docs/peer-node-pattern.md
+++ b/docs/peer-node-pattern.md
@@ -266,8 +266,8 @@ method that silently crosses the network.
 
 The first shipped instance of this pattern is MCP tooling: `MCPToolbox` is
 the servant (hosts the MCP session, deploys via `add_nodes`), and
-`MCPToolboxRef` is the send-only handle (identity + optional tool scoping,
-zero deployment knowledge) that agents hold in `tools=[...]` — see
+`MCPToolboxRef` is the reference (identity + optional tool scoping, zero
+deployment knowledge — a passive resolution token rather than an RPC proxy) that agents hold in `tools=[...]` — see
 [mcp-tool-discovery](mcp-tool-discovery.md).
 
 The MCP bridge node — a node that both exposes tools and calls other nodes — is a

--- a/docs/peer-node-pattern.md
+++ b/docs/peer-node-pattern.md
@@ -264,6 +264,12 @@ method that silently crosses the network.
 
 ## Where this lands for calfkit
 
+The first shipped instance of this pattern is MCP tooling: `MCPToolbox` is
+the servant (hosts the MCP session, deploys via `add_nodes`), and
+`MCPToolboxRef` is the send-only handle (identity + optional tool scoping,
+zero deployment knowledge) that agents hold in `tools=[...]` — see
+[mcp-tool-discovery](mcp-tool-discovery.md).
+
 The MCP bridge node — a node that both exposes tools and calls other nodes — is a
 genuine and natural instance of this pattern. The guidance that falls out of the
 above:

--- a/tests/test_mcp_toolbox_ref.py
+++ b/tests/test_mcp_toolbox_ref.py
@@ -1,0 +1,124 @@
+"""#212: MCPToolboxRef — the public, identity-only handle to an MCP toolbox.
+
+Distributed agent hosts reference a toolbox by name with zero deployment
+knowledge (no connection params, no secrets). The ref is the call-side
+counterpart to the hosting MCPToolbox (peer-node pattern); `select()` mints
+one from a toolbox instance; the toolbox's own selector behavior delegates to
+its ref so both resolve identically.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from calfkit.models.capability import CapabilityRecord, CapabilityToolDef
+from calfkit.models.tool_dispatch import ToolSelector, split_tool_declarations
+
+
+def make_record(toolbox_id: str = "github", tool_names: tuple[str, ...] = ("search", "create_issue")) -> CapabilityRecord:
+    return CapabilityRecord(
+        toolbox_id=toolbox_id,
+        dispatch_topic=f"mcp_server.{toolbox_id}",
+        tools=[CapabilityToolDef(name=n, parameters_json_schema={"type": "object", "properties": {}}) for n in tool_names],
+        published_at=datetime.now(tz=timezone.utc),
+    )
+
+
+def make_toolbox(name: str = "github"):
+    from calfkit.mcp.mcp_toolbox import MCPToolbox
+    from calfkit.mcp.mcp_transport import StreamableHttpParameters
+
+    return MCPToolbox(name, connection_params=StreamableHttpParameters(url="http://unused.local/mcp"))
+
+
+class TestDirectConstruction:
+    """The whole point of #212: constructible with zero deployment knowledge."""
+
+    def test_resolves_by_name_only(self) -> None:
+        from calfkit.mcp import MCPToolboxRef
+
+        ref = MCPToolboxRef("github")
+        result = ref.resolve_tools({"github": make_record()})
+        assert [b.name for b in result.bindings] == ["search", "create_issue"]
+        assert not result.strict
+
+    def test_include_and_strict_kwargs(self) -> None:
+        from calfkit.mcp import MCPToolboxRef
+
+        ref = MCPToolboxRef("github", include=("search",), strict=True)
+        result = ref.resolve_tools({"github": make_record()})
+        assert [b.name for b in result.bindings] == ["search"]
+        assert result.strict
+
+    def test_include_accepts_any_sequence_normalized_to_tuple(self) -> None:
+        from calfkit.mcp import MCPToolboxRef
+
+        ref = MCPToolboxRef("github", include=["search"])
+        assert ref.include == ("search",)
+
+    def test_frozen_and_hashable(self) -> None:
+        from calfkit.mcp import MCPToolboxRef
+
+        ref = MCPToolboxRef("github", include=("search",))
+        with pytest.raises(Exception):
+            ref.strict = True  # type: ignore[misc]
+        assert len({ref, MCPToolboxRef("github", include=("search",))}) == 1  # value semantics
+
+    def test_satisfies_tool_selector_and_splits_as_selector(self) -> None:
+        from calfkit.mcp import MCPToolboxRef
+
+        ref = MCPToolboxRef("github")
+        assert isinstance(ref, ToolSelector)
+        bindings, selectors = split_tool_declarations([ref])
+        assert bindings == [] and selectors == [ref]
+
+
+class TestMintingAndParity:
+    def test_select_returns_the_public_ref_type(self) -> None:
+        from calfkit.mcp import MCPToolboxRef
+
+        ref = make_toolbox().select(include=["search"], strict=True)
+        assert isinstance(ref, MCPToolboxRef)
+        assert ref.toolbox_id == "github" and ref.include == ("search",) and ref.strict
+
+    def test_toolbox_resolution_delegates_to_its_ref(self) -> None:
+        from calfkit.mcp import MCPToolboxRef
+
+        view: dict[str, Any] = {"github": make_record()}
+        via_toolbox = make_toolbox().resolve_tools(view)
+        via_ref = MCPToolboxRef("github").resolve_tools(view)
+        assert [b.name for b in via_toolbox.bindings] == [b.name for b in via_ref.bindings]
+        assert via_toolbox.toolbox_id == via_ref.toolbox_id
+
+    def test_scoped_selector_is_gone(self) -> None:
+        import calfkit.mcp.mcp_toolbox as mod
+
+        assert not hasattr(mod, "_ScopedSelector")
+
+
+class TestPackageSurface:
+    def test_paired_exports(self) -> None:
+        from calfkit.mcp import MCPToolbox, MCPToolboxRef, StdioServerParameters, StreamableHttpParameters  # noqa: F401
+
+
+class TestDeployingARefFailsLoudAndEarly:
+    def test_add_nodes_rejects_refs_with_teaching_message(self) -> None:
+        from calfkit.client.client import Client
+        from calfkit.mcp import MCPToolboxRef
+        from calfkit.worker.worker import Worker
+
+        worker = Worker(Client.connect("kafka:9092"))
+        with pytest.raises(TypeError, match="MCPToolbox\\(") as excinfo:
+            worker.add_nodes(MCPToolboxRef("github"))  # type: ignore[arg-type]
+        assert "reference" in str(excinfo.value).lower()
+
+    def test_add_nodes_rejects_arbitrary_non_nodes_too(self) -> None:
+        from calfkit.client.client import Client
+        from calfkit.worker.worker import Worker
+
+        worker = Worker(Client.connect("kafka:9092"))
+        with pytest.raises(TypeError):
+            worker.add_nodes("not a node")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Closes #212. Distributed agent hosts can now reference an MCP toolbox with zero deployment knowledge — no connection params, no secrets:

```python
from calfkit.mcp import MCPToolboxRef

agent = Agent(..., tools=[MCPToolboxRef("github", include=("search",), strict=False)])
```

- **`MCPToolboxRef`** — `_ScopedSelector` promoted to a public frozen dataclass: direct ctor, value semantics (list/tuple `include` normalize and hash equal), implements `ToolSelector`. `toolbox.select(...)` now returns it; the toolbox's own resolution delegates through it (one resolution path, parity-pinned). No `ref()` method — `select()` mints; a universal `.ref` verb is deferred to any 1.0 all-node generalization.
- **`calfkit.mcp` package surface** — toolbox + ref + transports exported together (the servant/handle pairing).
- **Eager role-mismatch errors** — `add_nodes` now rejects non-nodes; a deployed ref gets a teaching message pointing at `MCPToolbox(name, connection_params=...)` (previously it would fail late, worst-case registering a competing consumer under the toolbox's identity).
- `resolve_capability` explicitly public (the selector kernel downstreams were already leaning on).
- Docs: by-name section in the how-to (co-located `tools=[toolbox]` stays the lead example), peer-node doc cites its first shipped instance, spec §8.4 records the design adjudication.

## Design note

An ADK-style single-class union ctor (`connection_params` accepting an identity arm) was seriously argued and independently adjudicated. Rejected because ADK's union arms are capability-**invariant** transports while ours would be capability-**variant** (deployable secret-bearing servant vs inert lookup key) — differences that surface in public operations (`add_nodes`, secrets, IDE) warrant a type boundary. Retained from that position: delegation keeps the co-located form primary, one docs page, ADK-shaped host params, and the intuitive error text. Full record in spec §8.4 (+ local ADR).

## Migration (calfcord)

Delete the hand-rolled `McpToolSelector` protocol implementation; `from calfkit.mcp import MCPToolboxRef` is a drop-in (`MCPToolboxRef(server, include=...)`).

## Tests & review

11 new contract tests (TDD, RED-first; plain-dict views, no broker), full suite 2753 passed, 3.10-floor clean, `make fix`/`make check` clean. Independent review converged in one round (zero critical/important findings; hash-normalization, delegation parity, import-cycle, and add_nodes-regression checks all verified).