### PR TITLE
feat!: client send API — send/start/execute renames + reply_to return address

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ $ calfkit run agent_service:agent
 Send a message to the agent.
 
 ```python
-# invoke.py
+# execute.py
 import asyncio
 from calfkit.client import Client
 
@@ -172,7 +172,7 @@ async def main():
     client = Client.connect("localhost:9092")  # Connect to the broker
 
     # Send a request and await the response
-    result = await client.execute_node(
+    result = await client.execute(
         "What's the weather in Tokyo?",
         "weather_agent.input",  # The topic the agent is listening to
     )
@@ -185,7 +185,7 @@ if __name__ == "__main__":
 Run the file to invoke the agent:
 
 ```console
-$ python invoke.py
+$ python execute.py
 ```
 
 ### Next steps
@@ -218,7 +218,7 @@ agent = Agent(
 When invoking, pass the matching `output_type` to deserialize the response:
 
 ```python
-result = await client.execute_node(
+result = await client.execute(
     "What's the weather in Tokyo?",
     "weather_agent.input",
     output_type=WeatherReport,
@@ -276,8 +276,8 @@ Key entry points:
 | Symbol | Purpose |
 | --- | --- |
 | `Client.connect(server_urls=None, reply_topic=None, reply_ttl=None, *, provisioning=None, ...)` | Connect to the broker. Defaults to `$CALF_HOST_URL` → `localhost`. |
-| `Client.execute_node(prompt, topic, *, output_type=..., deps=..., message_history=..., timeout=None, ...)` | Request/reply: publish and await the `NodeResult`. |
-| `Client.invoke_node(...)` / `Client.emit_to_node(...)` | Async-handle and fire-and-forget variants. |
+| `Client.execute(prompt, topic, *, output_type=..., deps=..., message_history=..., timeout=None, ...)` | Request/reply: publish and await the `NodeResult`. |
+| `Client.start(...)` / `Client.send(...)` | Async-handle variant, and one-way send (no reply future; optional `reply_to` return address). |
 | `Agent(node_id, *, system_prompt=..., subscribe_topics, publish_topic=None, model_client, tools=None, gates=None, final_output_type=str, model_settings=None, ...)` | An agent node. |
 | `@agent_tool` / `@consumer(...)` | Decorators that turn a function into a tool node / consumer node. |
 | `Worker(client, nodes=None, ...)` → `run()` / `start()` / `stop()` | Host one or more nodes against the broker. |
@@ -292,7 +292,7 @@ In-repo documentation lives under [`docs/`](docs/).
 
 **How-to guides** — goal-oriented walkthroughs:
 
-- **[How to call nodes from a client](docs/client-features.md)** — the three invocation patterns (`execute_node` / `invoke_node` / `emit_to_node`), multi-turn conversations, runtime dependency injection (`deps`), temporary instructions, fire-and-forget, and bounding reply memory with `reply_ttl`.
+- **[How to call nodes from a client](docs/client-features.md)** — the three invocation patterns (`execute` / `start` / `send`), multi-turn conversations, runtime dependency injection (`deps`), temporary instructions, fire-and-forget, and bounding reply memory with `reply_ttl`.
 - **[How to tap a topic with a consumer node](docs/consumer-nodes.md)** — terminal sinks that run arbitrary Python against every event on a topic; tap an agent's `publish_topic` to log, persist, or fan out.
 - **[How to gate node invocations](docs/gating.md)** — predicate gate stacks that let a node decline an inbound event before `run()` runs (e.g. when agents share an input topic).
 - **[How to give agents MCP tools](docs/mcp-tool-discovery.md)** — deploy an `MCPToolbox` fronting an MCP server and pass it to agents like a tool node; tools are discovered and kept fresh across processes automatically.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,7 +5,7 @@ An index of potential features and changes under consideration for Calf SDK. Eac
 ## Accepted
 
 - [Deps-as-dict refactor](docs/designs/deps-as-dict-refactor.md) — `ctx.deps`/`result.deps` are plain dicts and `correlation_id` is a top-level context attribute (closes #144; breaking)
-- [Fire-and-forget emit](docs/designs/fire-and-forget-emit.md) — true one-way Client.emit_to_node; nullable callback terminal; opt-in reply TTL (closes #132)
+- [Fire-and-forget emit](docs/designs/fire-and-forget-emit.md) — true one-way Client.send; nullable callback terminal; opt-in reply TTL (closes #132)
 - [Topic Provisioning](docs/topic-provisioning.md) — EXPERIMENTAL opt-in `ProvisioningConfig` to best-effort create Kafka topics for dev/CI (off by default; review for prod)
 - [Agent-POV History Projection](docs/designs/agent-pov-projection.md) — always-on POV projection over `message_history` + `ModelResponse.name` stamping for shared-channel multi-agent; portable content-prefix attribution (PR #185; closes #154)
 

--- a/calfkit/client/base.py
+++ b/calfkit/client/base.py
@@ -182,6 +182,14 @@ class BaseClient:
         client_id = uuid_utils.uuid7().hex
         if reply_topic is None:
             reply_topic = f"calf-client-reply-{client_id}"
+        elif not _KAFKA_TOPIC_RE.fullmatch(reply_topic) or reply_topic in (".", ".."):
+            # The reply topic is the wire callback on every start()/execute()
+            # frame and this client's own subscription — same legality rule,
+            # same loud client-side rejection as send(reply_to=...).
+            raise ValueError(
+                f"reply_topic {reply_topic!r} is not a valid Kafka topic name "
+                "(allowed: letters, digits, '.', '_', '-'; max 249 chars; not '.' or '..')"
+            )
         group_id = f"calf-client-reply-{client_id}"
 
         # The reply topic is a framework inbox: declare it (framework=True so

--- a/calfkit/client/base.py
+++ b/calfkit/client/base.py
@@ -41,12 +41,12 @@ class BaseClient:
 
     Manages a Kafka broker connection and a shared reply dispatcher that
     correlates outgoing invocations with their asynchronous replies. Subclasses
-    should build higher-level invocation methods on top of :meth:`_invoke`.
+    should build higher-level invocation methods on top of :meth:`_start`.
 
     Supports use as an async context manager for automatic cleanup::
 
         async with Client.connect("localhost:9092") as client:
-            result = await client.execute_node(...)
+            result = await client.execute(...)
     """
 
     def __init__(
@@ -124,7 +124,7 @@ class BaseClient:
             reply_topic: Explicit reply topic name. When ``None`` (default), a
                 unique topic is generated using a uuid7 client ID.
             reply_ttl: Optional seconds after which an un-answered reply future
-                (from :meth:`invoke_node` / :meth:`execute_node`) is evicted with
+                (from :meth:`start` / :meth:`execute`) is evicted with
                 a :class:`~calfkit.exceptions.ReplyExpiredError`. ``None``
                 (default) disables eviction entirely — a deliberate
                 caller-responsibility choice, not a default safety ceiling.
@@ -231,7 +231,7 @@ class BaseClient:
         """The Kafka topic provisioning config (never ``None``; disabled by default)."""
         return self._provisioning
 
-    async def _invoke(
+    async def _start(
         self,
         topic: str,
         reply_topic: str,
@@ -243,11 +243,13 @@ class BaseClient:
         body: Any | None = None,
         output_type: type[Any] = _UNSET,
     ) -> InvocationHandle:
-        """Invoke the node asynchronously.
+        """Start a node invocation asynchronously and register its reply future.
 
         Args:
             topic: Topic to send args to.
-            reply_topic: Topic the node should reply to.
+            reply_topic: Topic the node should reply to. Must be a topic the
+                dispatcher consumes (the client's own inbox) — a future is only
+                resolvable for replies the dispatcher actually receives.
             correlation_id: Correlation ID for this request.
             state: The session state.
             deps: Provided dependencies.
@@ -256,7 +258,7 @@ class BaseClient:
             An invocation handle with an associated future for the reply.
         """
         future = self._dispatcher.expect(correlation_id)
-        logger.debug("[%s] invoke topic=%s reply=%s", correlation_id[:8], topic, reply_topic)
+        logger.debug("[%s] start topic=%s reply=%s", correlation_id[:8], topic, reply_topic)
         await self._publish_call(
             topic=topic,
             correlation_id=correlation_id,
@@ -289,12 +291,13 @@ class BaseClient:
     ) -> None:
         """Build and publish one client-originated call envelope.
 
-        Single-sources the wire shape shared by :meth:`_invoke` (*callback_topic*
-        is the reply topic) and :meth:`_emit` (*callback_topic* is ``None``, so the
-        worker suppresses the terminal point-to-point reply): the lazy
-        connect-guard, the ``CallFrame`` push, the ``Envelope`` build, and the
-        emitter headers. Callers own dispatcher registration — ``_invoke`` calls
-        ``expect()`` *before* this so a reply can never race an unregistered future.
+        Single-sources the wire shape shared by :meth:`_start` (*callback_topic*
+        is the client's reply inbox) and :meth:`_send` (*callback_topic* is the
+        caller's ``reply_to`` or ``None``, in which case the worker suppresses the
+        terminal point-to-point reply): the lazy connect-guard, the ``CallFrame``
+        push, the ``Envelope`` build, and the emitter headers. Callers own
+        dispatcher registration — ``_start`` calls ``expect()`` *before* this so a
+        reply can never race an unregistered future.
         """
         if route is not None and not is_concrete_route_key(route):
             raise ValueError(
@@ -332,7 +335,7 @@ class BaseClient:
             headers=headers,
         )
 
-    async def _emit(
+    async def _send(
         self,
         topic: str,
         correlation_id: str,
@@ -341,15 +344,19 @@ class BaseClient:
         deps: dict[str, Any] | None = None,
         route: str | None = None,
         body: Any | None = None,
+        reply_to: str | None = None,
     ) -> str:
-        """Emit a true one-way (fire-and-forget) invocation to a node.
+        """Send a one-way invocation to a node, with an optional return address.
 
-        Mirrors :meth:`_invoke` but allocates **zero** per-call client state and
-        triggers **zero** reply traffic: it does not register a reply future with
-        the dispatcher, does not build an :class:`InvocationHandle`, and pushes a
-        :class:`CallFrame` with ``callback_topic=None`` so the worker suppresses
-        the point-to-point reply on the terminal hop. The result still rides the
-        target node's ``publish_topic`` broadcast channel for traceability.
+        Mirrors :meth:`_start` but allocates **zero** per-call client state: it
+        does not register a reply future with the dispatcher and does not build
+        an :class:`InvocationHandle`. The pushed :class:`CallFrame` carries
+        *reply_to* as its ``callback_topic``: ``None`` (the default) makes the
+        worker suppress the point-to-point reply on the terminal hop entirely; a
+        topic name makes the worker deliver the terminal result there — a return
+        address for **someone else** to consume, never this client. Either way
+        the result still rides the target node's ``publish_topic`` broadcast
+        channel for traceability.
 
         Args:
             topic: Topic to send args to.
@@ -357,15 +364,31 @@ class BaseClient:
             state: The session state.
             overrides: Runtime overrides (agent tools, model settings).
             deps: Provided dependencies.
+            reply_to: Optional topic the terminal result is delivered to,
+                point-to-point. ``None`` suppresses the terminal callback.
 
         Returns:
-            The ``correlation_id`` of the emitted invocation, for tracing.
+            The ``correlation_id`` of the sent invocation, for tracing.
+
+        Raises:
+            ValueError: If *reply_to* is blank, or is this client's own reply
+                inbox (no future is registered, so the reply would arrive at the
+                dispatcher and be dropped — use ``start``/``execute`` to await).
         """
-        logger.debug("[%s] emit topic=%s", correlation_id[:8], topic)
+        if reply_to is not None:
+            if not reply_to.strip():
+                raise ValueError("reply_to must be a non-empty topic name or None")
+            if reply_to == self._reply_topic:
+                raise ValueError(
+                    "reply_to is this client's own reply inbox; send() registers no future, "
+                    "so the reply would arrive and be dropped ('no pending future'). "
+                    "Use start()/execute() to await a reply."
+                )
+        logger.debug("[%s] send topic=%s reply_to=%s", correlation_id[:8], topic, reply_to)
         await self._publish_call(
             topic=topic,
             correlation_id=correlation_id,
-            callback_topic=None,
+            callback_topic=reply_to,
             state=state,
             overrides=overrides,
             deps=deps,

--- a/calfkit/client/base.py
+++ b/calfkit/client/base.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 from collections.abc import Iterable
 from typing import Any
 
@@ -26,6 +27,13 @@ from calfkit.models.state import OverridesState
 from calfkit.provisioning import ProvisioningConfig, StartupTopicEnsurer
 
 logger = logging.getLogger(__name__)
+
+# Kafka's exact topic-name legality: [a-zA-Z0-9._-], 1-249 chars ("." and ".."
+# are additionally reserved). An illegal name would never get metadata at the
+# worker's terminal publish — a request_timeout stall into an argument-less
+# UnknownTopicOrPartitionError on a different process — so it is rejected
+# loudly at the client instead.
+_KAFKA_TOPIC_RE = re.compile(r"[a-zA-Z0-9._-]{1,249}")
 
 
 def _new_client_emitter_id(client_id: str | None = None) -> str:
@@ -234,7 +242,6 @@ class BaseClient:
     async def _start(
         self,
         topic: str,
-        reply_topic: str,
         correlation_id: str,
         state: State,
         overrides: OverridesState | None = None,
@@ -245,11 +252,14 @@ class BaseClient:
     ) -> InvocationHandle:
         """Start a node invocation asynchronously and register its reply future.
 
+        The wire callback is always ``self._reply_topic`` — the one topic the
+        dispatcher consumes, and therefore the only address whose reply future
+        can ever resolve. There is deliberately no parameter for it: a foreign
+        callback with a registered future is the dangling-future bug the
+        send/start/execute redesign removed (ADR-0005).
+
         Args:
             topic: Topic to send args to.
-            reply_topic: Topic the node should reply to. Must be a topic the
-                dispatcher consumes (the client's own inbox) — a future is only
-                resolvable for replies the dispatcher actually receives.
             correlation_id: Correlation ID for this request.
             state: The session state.
             deps: Provided dependencies.
@@ -258,11 +268,11 @@ class BaseClient:
             An invocation handle with an associated future for the reply.
         """
         future = self._dispatcher.expect(correlation_id)
-        logger.debug("[%s] start topic=%s reply=%s", correlation_id[:8], topic, reply_topic)
+        logger.debug("[%s] start topic=%s reply=%s", correlation_id[:8], topic, self._reply_topic)
         await self._publish_call(
             topic=topic,
             correlation_id=correlation_id,
-            callback_topic=reply_topic,
+            callback_topic=self._reply_topic,
             state=state,
             overrides=overrides,
             deps=deps,
@@ -272,7 +282,7 @@ class BaseClient:
         return InvocationHandle(
             correlation_id=correlation_id,
             topic=topic,
-            reply_topic=reply_topic,
+            reply_topic=self._reply_topic,
             _future=future,
             _output_type=output_type,
         )
@@ -378,6 +388,10 @@ class BaseClient:
         if reply_to is not None:
             if not reply_to.strip():
                 raise ValueError("reply_to must be a non-empty topic name or None")
+            if not _KAFKA_TOPIC_RE.fullmatch(reply_to) or reply_to in (".", ".."):
+                raise ValueError(
+                    f"reply_to {reply_to!r} is not a valid Kafka topic name (allowed: letters, digits, '.', '_', '-'; max 249 chars; not '.' or '..')"
+                )
             if reply_to == self._reply_topic:
                 raise ValueError(
                     "reply_to is this client's own reply inbox; send() registers no future, "

--- a/calfkit/client/client.py
+++ b/calfkit/client/client.py
@@ -186,7 +186,6 @@ class Client(BaseClient):
         )
         return await self._start(
             topic=topic,
-            reply_topic=self._reply_topic,
             correlation_id=correlation_id,
             state=state,
             overrides=overrides,

--- a/calfkit/client/client.py
+++ b/calfkit/client/client.py
@@ -24,16 +24,18 @@ class Client(BaseClient):
     natural-language prompt, construct the session state, and dispatch to a
     target node topic. Three invocation patterns are supported:
 
-    * **One-way fire-and-forget** (:meth:`emit_to_node`) — publish and return the
-      ``correlation_id`` immediately; no reply future, no reply traffic.
-    * **Async with handle** (:meth:`invoke_node`) — publish and return an
+    * **One-way send** (:meth:`send`) — publish and return the
+      ``correlation_id`` immediately; no reply future. Optionally carries a
+      ``reply_to`` return address where the worker delivers the terminal
+      result for someone else to consume.
+    * **Start with handle** (:meth:`start`) — publish and return an
       :class:`InvocationHandle` whose :meth:`~InvocationHandle.result` is awaited
-      later for the reply.
-    * **Sync request/reply** (:meth:`execute_node`) — publish and await the reply
-      in a single call.
+      later for the reply, delivered to this client's own reply inbox.
+    * **Execute** (:meth:`execute`) — publish and await the reply in a
+      single call.
 
-    See :meth:`emit_to_node` for the fire-and-forget traceability model (the
-    target node's ``publish_topic`` broadcast stream).
+    See :meth:`send` for the one-way traceability model (the ``reply_to``
+    return address and the target node's ``publish_topic`` broadcast stream).
     """
 
     def _build_state_and_overrides(
@@ -47,7 +49,7 @@ class Client(BaseClient):
         model_settings: ModelSettings | dict[str, Any] | None,
         author: str | None,
     ) -> tuple[str, State, OverridesState | None]:
-        """Shared input-shaping for :meth:`invoke_node` / :meth:`emit_to_node`.
+        """Shared input-shaping for :meth:`start` / :meth:`send`.
 
         Validates that *model_settings* is JSON-serializable (it crosses the Kafka
         boundary), defaults *correlation_id* to a fresh uuid7 hex, builds and
@@ -84,7 +86,7 @@ class Client(BaseClient):
         return correlation_id, state, overrides
 
     @overload
-    async def invoke_node(
+    async def start(
         self,
         user_prompt: str,
         topic: str,
@@ -92,7 +94,6 @@ class Client(BaseClient):
         output_type: type[OutputT],
         author: str | None = ...,
         tool_overrides: Sequence[ToolBinding | ToolProvider] | None = ...,
-        reply_topic: str | None = ...,
         correlation_id: str | None = ...,
         temp_instructions: str | None = ...,
         message_history: list[ModelMessage] | None = ...,
@@ -103,14 +104,13 @@ class Client(BaseClient):
     ) -> InvocationHandle[OutputT]: ...
 
     @overload
-    async def invoke_node(
+    async def start(
         self,
         user_prompt: str,
         topic: str,
         *,
         author: str | None = ...,
         tool_overrides: Sequence[ToolBinding | ToolProvider] | None = ...,
-        reply_topic: str | None = ...,
         correlation_id: str | None = ...,
         temp_instructions: str | None = ...,
         message_history: list[ModelMessage] | None = ...,
@@ -120,7 +120,7 @@ class Client(BaseClient):
         body: Any | None = ...,
     ) -> InvocationHandle[Any]: ...
 
-    async def invoke_node(
+    async def start(
         self,
         user_prompt: str,
         topic: str,
@@ -128,7 +128,6 @@ class Client(BaseClient):
         author: str | None = None,
         tool_overrides: Sequence[ToolBinding | ToolProvider] | None = None,
         output_type: type[Any] = _UNSET,
-        reply_topic: str | None = None,
         correlation_id: str | None = None,
         temp_instructions: str | None = None,
         message_history: list[ModelMessage] | None = None,
@@ -137,14 +136,16 @@ class Client(BaseClient):
         route: str | None = None,
         body: Any | None = None,
     ) -> InvocationHandle[Any]:
-        """Invoke an agent node asynchronously and return a handle for the reply.
+        """Start an agent node invocation and return a handle for the reply.
 
-        The **async-with-handle** pattern: constructs a :class:`State` from the
-        provided prompt and message history, publishes it to *topic*, and returns
-        an :class:`InvocationHandle` whose :meth:`~InvocationHandle.result` method
-        can be awaited for the reply. For a true one-way send that registers no
-        reply future, use :meth:`emit_to_node`; to publish and await in one call,
-        use :meth:`execute_node`.
+        The **start-with-handle** pattern (cf. Temporal's ``start_workflow``):
+        constructs a :class:`State` from the provided prompt and message history,
+        publishes it to *topic*, and returns an :class:`InvocationHandle` whose
+        :meth:`~InvocationHandle.result` method can be awaited for the reply. The
+        reply is always delivered to this client's own reply inbox — the only
+        address whose reply future can resolve. For a one-way send (optionally
+        with a ``reply_to`` return address for someone else to consume), use
+        :meth:`send`; to publish and await in one call, use :meth:`execute`.
 
         Args:
             user_prompt: The user message to send to the agent node.
@@ -157,8 +158,6 @@ class Client(BaseClient):
             output_type: The expected Python type for deserializing the agent's
                 output. When omitted, auto-detection is used (``DataPart`` →
                 ``TextPart`` fallback).
-            reply_topic: Topic the node should publish its reply to.
-                Defaults to the client's auto-generated reply topic.
             correlation_id: Unique identifier to correlate this request with its
                 reply. Auto-generated (uuid7) when ``None``.
             temp_instructions: Optional system-level instructions injected into
@@ -185,11 +184,9 @@ class Client(BaseClient):
             model_settings=model_settings,
             author=author,
         )
-        if reply_topic is None:
-            reply_topic = self._reply_topic
-        return await self._invoke(
+        return await self._start(
             topic=topic,
-            reply_topic=reply_topic,
+            reply_topic=self._reply_topic,
             correlation_id=correlation_id,
             state=state,
             overrides=overrides,
@@ -199,11 +196,12 @@ class Client(BaseClient):
             output_type=output_type,
         )
 
-    async def emit_to_node(
+    async def send(
         self,
         user_prompt: str,
         topic: str,
         *,
+        reply_to: str | None = None,
         tool_overrides: Sequence[ToolBinding | ToolProvider] | None = None,
         correlation_id: str | None = None,
         temp_instructions: str | None = None,
@@ -214,24 +212,41 @@ class Client(BaseClient):
         route: str | None = None,
         body: Any | None = None,
     ) -> str:
-        """Emit a true one-way (fire-and-forget) invocation to an agent node.
+        """Send a one-way invocation to an agent node, with an optional return address.
 
-        The **one-way fire-and-forget** pattern: constructs a :class:`State` from
-        the provided prompt and message history and publishes it to *topic*,
-        returning immediately. Unlike :meth:`invoke_node`, this registers **no**
-        reply future and the worker suppresses the point-to-point callback on the
-        terminal hop, so the call allocates zero per-call client state and
-        triggers zero reply traffic.
+        The **one-way send** pattern: constructs a :class:`State` from the
+        provided prompt and message history and publishes it to *topic*,
+        returning immediately. Unlike :meth:`start`, this registers **no**
+        reply future, so the call allocates zero per-call client state.
 
-        Because no reply is collected, there is no ``reply_topic`` or
-        ``output_type``. The terminal result still rides the target node's
+        Where the terminal result goes is controlled by *reply_to*:
+
+        * ``reply_to=None`` (default) — true fire-and-forget: the worker
+          suppresses the point-to-point callback on the terminal hop entirely.
+        * ``reply_to="some.topic"`` — the Return Address pattern: the worker
+          delivers the terminal result to that topic, point-to-point, for
+          **someone else** to consume (a ``@consumer`` node, a sink service —
+          never this client, which registers no future). The consumer of that
+          topic owns deserialization and, on auto-create-off brokers, the
+          topic's existence.
+
+        Either way the terminal result also rides the target node's
         ``publish_topic`` broadcast channel for traceability — wire a
-        ``@consumer`` to that topic to observe results. A target node with no
-        ``publish_topic`` leaves no trace of the invocation.
+        ``@consumer`` to that topic to observe results. With ``reply_to=None``,
+        a target node with no ``publish_topic`` leaves no trace of the
+        invocation.
+
+        Because no reply returns to this client, there is no ``output_type`` —
+        deserialization belongs to whoever consumes the result.
 
         Args:
             user_prompt: The user message to send to the agent node.
             topic: The Kafka topic the target node subscribes to.
+            reply_to: Optional topic the terminal result is delivered to,
+                point-to-point, for a consumer other than this client.
+                ``None`` (default) suppresses the terminal callback entirely.
+                Not a chaining mechanism — the call stack is unwound at the
+                terminal, so address consumers/sinks, not agent input topics.
             tool_overrides: Runtime agent tool overrides.
             correlation_id: Unique identifier to correlate this request with any
                 downstream traces. Auto-generated (uuid7) when ``None``.
@@ -251,10 +266,14 @@ class Client(BaseClient):
                 humans are present; otherwise human messages read as ``<user>``.
 
         Returns:
-            The ``correlation_id`` of the emitted invocation, for tracing.
+            The ``correlation_id`` of the sent invocation, for tracing.
 
         Raises:
-            ValueError: If *model_settings* is not JSON-serializable.
+            ValueError: If *model_settings* is not JSON-serializable, if
+                *reply_to* is blank, or if *reply_to* is this client's own reply
+                inbox (no future is registered, so the reply would arrive at the
+                dispatcher and be dropped — use :meth:`start` / :meth:`execute`
+                to await a reply).
         """
         correlation_id, state, overrides = self._build_state_and_overrides(
             user_prompt,
@@ -265,7 +284,7 @@ class Client(BaseClient):
             model_settings=model_settings,
             author=author,
         )
-        return await self._emit(
+        return await self._send(
             topic=topic,
             correlation_id=correlation_id,
             state=state,
@@ -273,10 +292,11 @@ class Client(BaseClient):
             deps=deps,
             route=route,
             body=body,
+            reply_to=reply_to,
         )
 
     @overload
-    async def execute_node(
+    async def execute(
         self,
         user_prompt: str,
         topic: str,
@@ -284,7 +304,6 @@ class Client(BaseClient):
         output_type: type[OutputT],
         author: str | None = ...,
         tool_overrides: Sequence[ToolBinding | ToolProvider] | None = ...,
-        reply_topic: str | None = ...,
         correlation_id: str | None = ...,
         temp_instructions: str | None = ...,
         message_history: list[ModelMessage] | None = ...,
@@ -296,14 +315,13 @@ class Client(BaseClient):
     ) -> NodeResult[OutputT]: ...
 
     @overload
-    async def execute_node(
+    async def execute(
         self,
         user_prompt: str,
         topic: str,
         *,
         author: str | None = ...,
         tool_overrides: Sequence[ToolBinding | ToolProvider] | None = ...,
-        reply_topic: str | None = ...,
         correlation_id: str | None = ...,
         temp_instructions: str | None = ...,
         message_history: list[ModelMessage] | None = ...,
@@ -314,7 +332,7 @@ class Client(BaseClient):
         timeout: float | None = ...,
     ) -> NodeResult[Any]: ...
 
-    async def execute_node(
+    async def execute(
         self,
         user_prompt: str,
         topic: str,
@@ -322,7 +340,6 @@ class Client(BaseClient):
         author: str | None = None,
         tool_overrides: Sequence[ToolBinding | ToolProvider] | None = None,
         output_type: type[Any] = _UNSET,
-        reply_topic: str | None = None,
         correlation_id: str | None = None,
         temp_instructions: str | None = None,
         message_history: list[ModelMessage] | None = None,
@@ -334,23 +351,22 @@ class Client(BaseClient):
     ) -> NodeResult[Any]:
         """Invoke an agent node and await the reply in a single call.
 
-        Convenience wrapper equivalent to::
+        The **execute** pattern (cf. Temporal's ``execute_workflow``):
+        convenience wrapper equivalent to::
 
-            handle = await client.invoke_node(...)
+            handle = await client.start(...)
             result = await handle.result(timeout=timeout)
 
-        Accepts the same arguments as :meth:`invoke_node`, plus *timeout*.
+        Accepts the same arguments as :meth:`start`, plus *timeout*.
 
         Args:
             user_prompt: The user message to send to the agent node.
             topic: The Kafka topic the target node subscribes to.
             author: Optional name for the human author of *user_prompt*. See
-                :meth:`invoke_node` for details.
+                :meth:`start` for details.
             tool_overrides: Runtime agent tool overrides.
             output_type: The expected Python type for deserializing the agent's
                 output. When omitted, auto-detection is used.
-            reply_topic: Topic the node should publish its reply to.
-                Defaults to the client's auto-generated reply topic.
             correlation_id: Unique identifier to correlate this request with its
                 reply. Auto-generated (uuid7) when ``None``.
             temp_instructions: Optional system-level instructions injected into
@@ -378,13 +394,12 @@ class Client(BaseClient):
                 ``None`` (the default).
             ValueError: If *model_settings* is not JSON-serializable.
         """
-        handle = await self.invoke_node(
+        handle = await self.start(
             user_prompt,
             topic,
             author=author,
             tool_overrides=tool_overrides,
             output_type=output_type,
-            reply_topic=reply_topic,
             correlation_id=correlation_id,
             temp_instructions=temp_instructions,
             message_history=message_history,

--- a/calfkit/client/invocation_handle.py
+++ b/calfkit/client/invocation_handle.py
@@ -35,8 +35,8 @@ class InvocationHandle(Generic[OutputT]):
                 ``None`` (the default), where the await blocks indefinitely.
             RuntimeError: Defensive guard for a handle constructed without a
                 future. Not reachable in normal use — handles are only built by
-                ``_invoke`` with a real future; true one-way sends use
-                :meth:`Client.emit_to_node`, which returns a ``correlation_id`` and
+                ``_start`` with a real future; one-way sends use
+                :meth:`Client.send`, which returns a ``correlation_id`` and
                 no handle at all.
             DeserializationError: If the expected output part type is missing
                 from ``final_output_parts``.

--- a/calfkit/client/reply_dispatcher.py
+++ b/calfkit/client/reply_dispatcher.py
@@ -79,7 +79,14 @@ class _ReplyDispatcher:
 
         entry = self._pending.get(correlation_id)
         if entry is None:
-            logger.warning("[%s] reply received but no pending future", correlation_id[:8])
+            # Reachable by another client's send(reply_to=<this inbox>) — this
+            # warning is the RECEIVER's only signal of the mis-address (the
+            # sender holds no future and is told nothing), so name the emitter.
+            logger.warning(
+                "[%s] reply received but no pending future (emitter=%s)",
+                correlation_id[:8],
+                decode_header_str(headers.get(HDR_EMITTER)),
+            )
             return
         future = entry.future
         if future.done():

--- a/calfkit/models/consumer_context.py
+++ b/calfkit/models/consumer_context.py
@@ -54,7 +54,7 @@ class ConsumerContext(Generic[OutputT]):
 
     deps: Mapping[str, Any] = field(default_factory=dict)
     """Inbound producer dependencies — the same mapping the producer passed to
-    ``Client.invoke_node(deps=...)``. Read as ``ctx.deps["key"]``, mirroring tools."""
+    ``Client.start(deps=...)``. Read as ``ctx.deps["key"]``, mirroring tools."""
 
     resources: Mapping[str, Any] = field(default_factory=dict)
     """The consuming node's lifecycle-managed resources (read-only by type). Read as

--- a/calfkit/models/node_result.py
+++ b/calfkit/models/node_result.py
@@ -25,7 +25,7 @@ class NodeResult(Generic[OutputT]):
 
     A ``NodeResult`` is what callers receive in two places:
 
-    * :meth:`Client.execute_node` / :meth:`InvocationHandle.result` — the
+    * :meth:`Client.execute` / :meth:`InvocationHandle.result` — the
       final reply from an agent invocation.
 
     The ``state`` field is the full session :class:`~calfkit.models.State` at
@@ -44,7 +44,7 @@ class NodeResult(Generic[OutputT]):
     * **Consumer path**: the consumer never republishes (no ``publish_topic``),
       so mutations have no observable downstream effect. They can still
       surprise other code holding the same ``NodeResult`` instance.
-    * **Client path** (:meth:`Client.execute_node` / :meth:`InvocationHandle.result`):
+    * **Client path** (:meth:`Client.execute` / :meth:`InvocationHandle.result`):
       the caller's lifetime owns the instance — mutations are caller-visible
       and may corrupt any other code holding a parallel reference (caches,
       retry layers, etc.).
@@ -101,7 +101,7 @@ class NodeResult(Generic[OutputT]):
 
     deps: Mapping[str, Any] = field(default_factory=dict)
     """Inbound user-provided dependencies — the same mapping the producer passed
-    to ``Client.invoke_node(deps=...)``, carried forward on every publish. Read
+    to ``Client.start(deps=...)``, carried forward on every publish. Read
     it as ``result.deps["key"]``, mirroring how tools read ``ctx.deps["key"]``.
     Empty ``{}`` when the invocation set no deps.
 

--- a/calfkit/models/session_context.py
+++ b/calfkit/models/session_context.py
@@ -101,7 +101,7 @@ class BaseSessionRunContext(BaseModel, Generic[StateT, DepsT]):
     deps: DepsT
     """User-provided dependencies for the execution. A JSON-serializable mapping
     (it crosses the Kafka boundary). The same ``dict`` the producer passed to
-    ``Client.invoke_node(deps=...)``; tools read it as ``ctx.deps["key"]``."""
+    ``Client.start(deps=...)``; tools read it as ``ctx.deps["key"]``."""
 
     _correlation_id: str | None = PrivateAttr(default=None)
     _emitter_node_id: str | None = PrivateAttr(default=None)

--- a/calfkit/models/tool_context.py
+++ b/calfkit/models/tool_context.py
@@ -14,7 +14,7 @@ class ToolContext(RunContext[dict[str, Any]]):
 
     ``deps`` is inherited from ``RunContext`` and is the user-provided
     dependencies mapping — the same ``dict`` the producer passed to
-    ``Client.invoke_node(deps=...)``. Read it as ``ctx.deps["key"]``. Since the
+    ``Client.start(deps=...)``. Read it as ``ctx.deps["key"]``. Since the
     envelope is serialized as JSON over Kafka, ``deps`` values must be
     JSON-serializable.
     """
@@ -37,7 +37,7 @@ class ToolContext(RunContext[dict[str, Any]]):
         Alias of the inherited pydantic-ai ``run_id`` (calfkit always constructs
         a :class:`ToolContext` with ``run_id`` set to the correlation id), exposed
         under calfkit's own vocabulary so tool authors use the same name as the
-        rest of the SDK (``NodeResult.correlation_id``, ``Client.execute_node``).
+        rest of the SDK (``NodeResult.correlation_id``, ``Client.execute``).
         """
         if self.run_id is None:
             raise RuntimeError("ToolContext was constructed without a run_id (correlation id).")

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -309,7 +309,7 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
                     # fault rail (#193 successor).
                     logger.exception(
                         "[%s] terminal result could not be delivered to callback_topic=%s node=%s; "
-                        "the result still broadcasts on publish_topic (no retry)",
+                        "the terminal envelope is still returned for the publish_topic broadcast (no retry)",
                         correlation_id,
                         frame.callback_topic,
                         self.node_id,

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -3,6 +3,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Annotated, Any, ClassVar
 
+from aiokafka.errors import KafkaError
 from faststream import Context, Response
 from faststream.kafka.annotations import (
     KafkaBroker as BrokerAnnotation,
@@ -290,13 +291,29 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
                 logger.debug("[%s] ReturnCall no-callback fire-and-forget terminal node=%s", correlation_id[:8], self.node_id)
             else:
                 logger.debug("[%s] ReturnCall callback=%s node=%s", correlation_id[:8], frame.callback_topic, self.node_id)
-                await broker.publish(
-                    publish_envelope,
-                    topic=frame.callback_topic,
-                    correlation_id=correlation_id,
-                    key=correlation_id.encode(),
-                    headers=self._emitter_headers(),
-                )
+                try:
+                    await broker.publish(
+                        publish_envelope,
+                        topic=frame.callback_topic,
+                        correlation_id=correlation_id,
+                        key=correlation_id.encode(),
+                        headers=self._emitter_headers(),
+                    )
+                except KafkaError:
+                    # Point-to-point delivery failed (e.g. a send(reply_to=...)
+                    # topic missing with auto-create off, or unauthorized).
+                    # Losing it must not also take down the publish_topic
+                    # broadcast below — the documented traceability fallback —
+                    # which only fires if this handler returns publish_envelope.
+                    # No retry/DLQ here: redelivery policy belongs to the
+                    # fault rail (#193 successor).
+                    logger.exception(
+                        "[%s] terminal result could not be delivered to callback_topic=%s node=%s; "
+                        "the result still broadcasts on publish_topic (no retry)",
+                        correlation_id,
+                        frame.callback_topic,
+                        self.node_id,
+                    )
 
         elif isinstance(output, TailCall):
             # tailcall optimization: replace current call frame with new tailcall

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -3,7 +3,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Annotated, Any, ClassVar
 
-from aiokafka.errors import KafkaError
+from aiokafka.errors import KafkaError  # type: ignore[import-untyped]
 from faststream import Context, Response
 from faststream.kafka.annotations import (
     KafkaBroker as BrokerAnnotation,

--- a/docs/adr/0005-return-address-on-the-one-way-send-verb.md
+++ b/docs/adr/0005-return-address-on-the-one-way-send-verb.md
@@ -1,0 +1,27 @@
+# Return address rides the one-way send verb; request verbs reply only to the caller's inbox
+
+With one `callback_topic` slot on the wire, "await a reply future" and "deliver
+the reply elsewhere" are mutually exclusive: the client's reply dispatcher
+consumes exactly one topic (its own inbox), so a future is resolvable **iff**
+the callback is that inbox. We encoded this invariant in the method surface
+instead of validating it at runtime: `Client.send(reply_to=...)` is the only
+place a custom return address can be set (EIP Return Address — the reply is
+someone else's to consume; no future), while `start`/`execute` always reply to
+the client's own inbox and lost their per-call `reply_topic` parameter, which
+had silently registered a future nothing could ever resolve.
+
+Rejected: a flag on one method (`invoke_node(..., future=False) -> str |
+InvocationHandle`) — a boolean that flips the return type needs `Literal`
+overload soup, collapses to a union through any wrapper, leaves
+`output_type`/`reply_topic` as runtime-rejected or silently-ignored params,
+and has no precedent in mature messaging SDKs (aiokafka `send`/`send_and_wait`,
+MassTransit `Send`/`Publish`/`Request`, Temporal `start`/`execute`, FastStream
+`publish(reply_to=)`/`request`). The verbs were renamed to carry the contract:
+`emit_to_node` → `send` (it dispatches an addressed, correlated command — not
+an event broadcast, which is what "emit" means in messaging vocabulary; the
+node-side `Emit` action it claimed to mirror is unwired dead code), and
+`invoke_node`/`execute_node` → `start`/`execute` (Temporal's pairing; "invoke"
+vs "execute" are near-synonyms that don't telegraph which one waits — cf. AWS
+Lambda's `InvocationType` confusion). No deprecated aliases (pre-1.0
+hard-break convention). Decided 2026-06-10; full design in
+`docs/designs/client-send-api-spec.md`.

--- a/docs/client-features.md
+++ b/docs/client-features.md
@@ -107,11 +107,21 @@ not every hop of every invocation of the node. Two caveats:
 - `reply_to` is not a chaining mechanism: the call stack is unwound at the
   terminal, so address consumers/sinks, not agent input topics.
 - The `reply_to` topic is owned by its consumer — on brokers with auto-create
-  disabled, it must exist before the worker's terminal publish.
+  disabled, it must exist before the worker's terminal publish. If that
+  publish fails (missing or unauthorized topic), the result is **not
+  retried**: the worker logs an ERROR naming the topic and correlation id,
+  and the terminal still reaches the `publish_topic` broadcast (when one is
+  configured).
+- Addressing another *client's* reply inbox is not rejected, but is almost
+  certainly a mistake: the receiving client logs a
+  `reply received but no pending future (emitter=...)` warning and drops the
+  reply — the sender is told nothing.
 
-`send(reply_to=client.reply_topic)` raises `ValueError`: with no future
-registered the client's own dispatcher would consume and drop the reply. Use
-`start`/`execute` to await a reply.
+`send` validates `reply_to` at call time, before anything publishes:
+a blank or Kafka-illegal topic name (allowed: letters, digits, `.`, `_`, `-`;
+max 249 chars) raises `ValueError`, and so does `reply_to=client.reply_topic`
+— with no future registered the client's own dispatcher would consume and
+drop the reply. Use `start`/`execute` to await a reply.
 
 ### Traceability without a reply
 

--- a/docs/client-features.md
+++ b/docs/client-features.md
@@ -1,8 +1,8 @@
 # How to call nodes from a client
 
 The `Client` supports multi-turn conversations, runtime dependency injection,
-temporary instruction overrides, and fire-and-forget dispatch — all without
-redeploying the agent.
+temporary instruction overrides, and one-way dispatch with an optional return
+address — all without redeploying the agent.
 
 See also: [CLI reference](cli.md) · [Worker lifecycle](worker-lifecycle.md) ·
 [Consumer nodes](consumer-nodes.md) · [Gating](gating.md).
@@ -13,22 +13,25 @@ See also: [CLI reference](cli.md) · [Worker lifecycle](worker-lifecycle.md) ·
 
 | Method | Pattern | Returns |
 | --- | --- | --- |
-| `execute_node(...)` | Request/reply — publish and await the result in one call. | `NodeResult` |
-| `invoke_node(...)` | Publish and get a handle; `await handle.result()` later. | `InvocationHandle` |
-| `emit_to_node(...)` | Fire-and-forget — dispatch and return immediately, no reply. | `correlation_id` (str) |
+| `execute(...)` | Request/reply — publish and await the result in one call. | `NodeResult` |
+| `start(...)` | Publish and get a handle; `await handle.result()` later. | `InvocationHandle` |
+| `send(...)` | One-way — dispatch and return immediately; no reply future. Optional `reply_to` return address. | `correlation_id` (str) |
 
-Use `emit_to_node` for true one-way sends, `invoke_node` for async dispatch with
-a handle to await later, and `execute_node` for synchronous request/reply.
+Use `send` for one-way sends (fire-and-forget, or with a `reply_to` topic some
+other consumer owns), `start` for async dispatch with a handle to await later,
+and `execute` for synchronous request/reply. Replies for `start`/`execute` are
+always delivered to the client's own reply inbox — the only address whose reply
+future can resolve.
 
 ## Multi-turn conversations
 
 Pass the message history from a previous result to maintain context:
 
 ```python
-result = await client.execute_node("What's the weather in Tokyo?", "agent.input")
+result = await client.execute("What's the weather in Tokyo?", "agent.input")
 
 # Continue the conversation with full context
-result = await client.execute_node(
+result = await client.execute(
     "How about in Osaka?",
     "agent.input",
     message_history=result.message_history,
@@ -44,7 +47,7 @@ discussion over one shared transcript.
 Pass runtime data to tools via the `deps` parameter:
 
 ```python
-result = await client.execute_node(
+result = await client.execute(
     "What's my phone number?",
     "agent.input",
     deps={"user_id": "usr_123"},  # Available to tools via ctx.deps["user_id"]
@@ -56,20 +59,19 @@ result = await client.execute_node(
 Temporarily add system-level instructions scoped per request:
 
 ```python
-result = await client.execute_node(
+result = await client.execute(
     "What's the weather in Tokyo?",
     "agent.input",
     temp_instructions="Always respond in Japanese.",
 )
 ```
 
-## Fire-and-forget
+## One-way sends
 
-Dispatch work to a node without waiting for (or producing) a reply via
-`emit_to_node`:
+Dispatch work to a node without registering a reply future via `send`:
 
 ```python
-correlation_id = await client.emit_to_node(
+correlation_id = await client.send(
     "Re-index the catalog.",
     "indexer.input",
 )
@@ -77,22 +79,52 @@ correlation_id = await client.emit_to_node(
 # client-side reply future is allocated.
 ```
 
-`emit_to_node` takes the same input-shaping arguments as `invoke_node` (`deps`,
+`send` takes the same input-shaping arguments as `start` (`deps`,
 `temp_instructions`, `message_history`, `route`, `body`, `model_settings`,
-`tool_overrides`, `author`, `correlation_id`) — but no `reply_topic` or
-`output_type`, since there is nothing to route back or deserialize.
+`tool_overrides`, `author`, `correlation_id`) — but no `output_type`, since
+deserialization belongs to whoever consumes the result.
 
-Because there's no reply, **traceability comes from the target node's
-`publish_topic` broadcast stream**, not a point-to-point callback. Set a
-`publish_topic` on the node you emit to and tap it with a
-[consumer node](consumer-nodes.md) to observe terminals (`result.output` is
-populated exactly as it is for `execute_node`). A node with no `publish_topic`
-produces no observable record for a fire-and-forget send — there is neither a
-reply nor a broadcast.
+### Directing the result with `reply_to`
 
-## Bounding `invoke_node` memory
+Pass a `reply_to` topic to have the worker deliver the terminal result there,
+point-to-point — the [Return Address pattern](https://www.enterpriseintegrationpatterns.com/patterns/messaging/ReturnAddress.html).
+The consumer of that topic is **someone else**: a [consumer node](consumer-nodes.md),
+a sink service, another system — never the sending client, which has no reply
+future to resolve.
 
-Each pending `invoke_node` handle holds a reply future until it resolves. If a
+```python
+correlation_id = await client.send(
+    "Re-index the catalog.",
+    "indexer.input",
+    reply_to="indexer.done",  # terminal result lands here, point-to-point
+)
+```
+
+A `@consumer` on `indexer.done` receives the terminal result exactly as one
+tapping a `publish_topic` does — but it sees only terminals addressed to it,
+not every hop of every invocation of the node. Two caveats:
+
+- `reply_to` is not a chaining mechanism: the call stack is unwound at the
+  terminal, so address consumers/sinks, not agent input topics.
+- The `reply_to` topic is owned by its consumer — on brokers with auto-create
+  disabled, it must exist before the worker's terminal publish.
+
+`send(reply_to=client.reply_topic)` raises `ValueError`: with no future
+registered the client's own dispatcher would consume and drop the reply. Use
+`start`/`execute` to await a reply.
+
+### Traceability without a reply
+
+With or without `reply_to`, the terminal result also rides the target node's
+`publish_topic` broadcast stream. Set a `publish_topic` on the node you send to
+and tap it with a [consumer node](consumer-nodes.md) to observe terminals
+(`result.output` is populated exactly as it is for `execute`). With
+`reply_to=None`, a node with no `publish_topic` produces no observable record
+for the send — there is neither a reply nor a broadcast.
+
+## Bounding `start` memory
+
+Each pending `start` handle holds a reply future until it resolves. If a
 reply is lost or a handle is abandoned, that future leaks. Pass an opt-in TTL to
 bound it:
 
@@ -102,5 +134,5 @@ client = Client.connect("localhost:9092", reply_ttl=30.0)
 
 When set, an unanswered handle is evicted after `reply_ttl` seconds and
 `handle.result()` raises `ReplyExpiredError` (importable from
-`calfkit.exceptions`). The default (`None`) waits indefinitely. `emit_to_node`
+`calfkit.exceptions`). The default (`None`) waits indefinitely. `send`
 allocates no future, so the TTL does not apply to it.

--- a/docs/consumer-nodes.md
+++ b/docs/consumer-nodes.md
@@ -2,7 +2,7 @@
 
 A **consumer node** is a terminal sink — it subscribes to one or more topics and
 runs arbitrary Python logic against every event flowing through. Consumers
-receive the same `NodeResult` that `Client.execute_node()` returns, including the
+receive the same `NodeResult` that `Client.execute()` returns, including the
 full session state (`tool_calls`, `tool_results`, `message_history`, `metadata`)
 and the inbound producer `deps` via `result.deps["key"]` — the same data tools
 read as `ctx.deps["key"]`.

--- a/docs/designs/calfkit-v1-design.md
+++ b/docs/designs/calfkit-v1-design.md
@@ -186,7 +186,7 @@ class RunId:
 ```
 
 - **Durable across hops.** A `RunId` is minted at the originating client publish and rides on `x-calf-run-id` Kafka header on every subsequent envelope in the chain.
-- **Distinct from `correlation_id`.** In v1, `correlation_id` is the per-hop request/reply joining key (for client `execute_node`-style request/reply). `RunId` is the run-aggregate key — different concept. The current code at `calfkit/client/base.py:148` conflates them (a single uuid7 stamped on the client publish doubles as both); v1 separates them explicitly.
+- **Distinct from `correlation_id`.** In v1, `correlation_id` is the per-hop request/reply joining key (for client `execute`-style request/reply). `RunId` is the run-aggregate key — different concept. The current code at `calfkit/client/base.py:148` conflates them (a single uuid7 stamped on the client publish doubles as both); v1 separates them explicitly.
 - **Has a lifecycle.** `RunStarted` → (handler hops) → `RunCompleted` or `RunInterrupted` or `RunFailed`. Lifecycle is observable via `on_event`.
 - **Has a state checkpoint** in the runs-state compacted topic, keyed by `RunId`.
 - **Has a parent** (optional). Sub-runs (e.g. agent A invokes agent B as a sub-agent) have `parent_run_id` for telemetry rollups.
@@ -3051,7 +3051,7 @@ There is no migration story. v1 is a clean break. The 0.x code stays on 0.x for 
 - `BaseNodeDef` subclass → `@handler`
 - `agent_tool` → `@tool` (module-level), `Tool.external(...)` (cross-language), or `Tool.from_agent(...)` (sub-agent as tool)
 - `Worker(client, nodes=[...])` → `Worker(bootstrap_servers=..., handlers=[...])`
-- `Client.execute_node(...)` → `Client.execute(topic, req)`
+- `Client.execute(...)` → `Client.execute(topic, req)` (signature slims; the v0 names are already `send`/`start`/`execute` per client-send-api-spec.md)
 
 The migration is non-trivial but mechanical. There is no automatic codemod; we provide a side-by-side recipes doc.
 
@@ -3427,8 +3427,8 @@ For grounding of the discard list (§21):
 | `calfkit/_protocol.py` | 21-25 | `HDR_EMITTER`, `HDR_EMITTER_KIND` | Survives; extended (§6.2) |
 | `calfkit/_protocol.py` | 28-39 | `decode_header_str` | Survives as internal codec helper |
 | `calfkit/client/base.py` | 50-112 | `BaseClient`, `connect` | Slimmed; `Client.connect` keeps the API surface |
-| `calfkit/client/base.py` | 124-182 | `_invoke` | `Client.invoke` / `Client.execute` |
-| `calfkit/client/client.py` | 19-218 | `Client.invoke_node` / `execute_node` | `Client.invoke` / `Client.execute` with cleaner signatures (no `user_prompt` coupling) |
+| `calfkit/client/base.py` | 124-182 | `_start` | `Client.start` / `Client.execute` |
+| `calfkit/client/client.py` | 19-218 | `Client.send` / `start` / `execute` | Survive (renamed from emit_to_node/invoke_node/execute_node per client-send-api-spec.md); v1 slims signatures (no `user_prompt` coupling) |
 | `calfkit/client/reply_dispatcher.py` | 16-60 | `_ReplyDispatcher` | Survives, slimmed; same shape |
 | `calfkit/client/middleware.py` | 9-23 | `ContextInjectionMiddleware` | Removed; aiokafka context handled directly |
 | `calfkit/client/node_result.py` | 11-40 | `NodeResult` | `RunResult` (different name, similar shape) |

--- a/docs/designs/calfkit-v1-design.md
+++ b/docs/designs/calfkit-v1-design.md
@@ -186,7 +186,7 @@ class RunId:
 ```
 
 - **Durable across hops.** A `RunId` is minted at the originating client publish and rides on `x-calf-run-id` Kafka header on every subsequent envelope in the chain.
-- **Distinct from `correlation_id`.** In v1, `correlation_id` is the per-hop request/reply joining key (for client `execute`-style request/reply). `RunId` is the run-aggregate key — different concept. The current code at `calfkit/client/base.py:148` conflates them (a single uuid7 stamped on the client publish doubles as both); v1 separates them explicitly.
+- **Distinct from `correlation_id`.** In v1, `correlation_id` is the per-hop request/reply joining key (for client `execute`-style request/reply). `RunId` is the run-aggregate key — different concept. The current code (the uuid7 mint in `Client.connect`, `calfkit/client/base.py:182`) conflates them (a single uuid7 stamped on the client publish doubles as both); v1 separates them explicitly.
 - **Has a lifecycle.** `RunStarted` → (handler hops) → `RunCompleted` or `RunInterrupted` or `RunFailed`. Lifecycle is observable via `on_event`.
 - **Has a state checkpoint** in the runs-state compacted topic, keyed by `RunId`.
 - **Has a parent** (optional). Sub-runs (e.g. agent A invokes agent B as a sub-agent) have `parent_run_id` for telemetry rollups.
@@ -3427,8 +3427,8 @@ For grounding of the discard list (§21):
 | `calfkit/_protocol.py` | 21-25 | `HDR_EMITTER`, `HDR_EMITTER_KIND` | Survives; extended (§6.2) |
 | `calfkit/_protocol.py` | 28-39 | `decode_header_str` | Survives as internal codec helper |
 | `calfkit/client/base.py` | 50-112 | `BaseClient`, `connect` | Slimmed; `Client.connect` keeps the API surface |
-| `calfkit/client/base.py` | 124-182 | `_start` | `Client.start` / `Client.execute` |
-| `calfkit/client/client.py` | 19-218 | `Client.send` / `start` / `execute` | Survive (renamed from emit_to_node/invoke_node/execute_node per client-send-api-spec.md); v1 slims signatures (no `user_prompt` coupling) |
+| `calfkit/client/base.py` | 242-289 | `_start` | `Client.start` / `Client.execute` |
+| `calfkit/client/client.py` | 20-409 | `Client.send` / `start` / `execute` | Survive (renamed from emit_to_node/invoke_node/execute_node per client-send-api-spec.md); v1 slims signatures (no `user_prompt` coupling) |
 | `calfkit/client/reply_dispatcher.py` | 16-60 | `_ReplyDispatcher` | Survives, slimmed; same shape |
 | `calfkit/client/middleware.py` | 9-23 | `ContextInjectionMiddleware` | Removed; aiokafka context handled directly |
 | `calfkit/client/node_result.py` | 11-40 | `NodeResult` | `RunResult` (different name, similar shape) |

--- a/docs/designs/client-send-api-spec.md
+++ b/docs/designs/client-send-api-spec.md
@@ -112,6 +112,10 @@ async def _send(self, topic, correlation_id, state, overrides=None, deps=None,
     if reply_to is not None:
         if not reply_to.strip():
             raise ValueError("reply_to must be a non-empty topic name or None")
+        if not _KAFKA_TOPIC_RE.fullmatch(reply_to) or reply_to in (".", ".."):
+            # Kafka legality ([a-zA-Z0-9._-]{1,249}): an illegal name would never get
+            # metadata at the worker's terminal publish — reject loudly here instead.
+            raise ValueError(f"reply_to {reply_to!r} is not a valid Kafka topic name (...)")
         if reply_to == self._reply_topic:
             raise ValueError(
                 "reply_to is this client's own reply inbox; send() registers no "
@@ -133,9 +137,9 @@ lose the param:
 async def start(self, user_prompt, topic, *, ...):            # no reply_topic param
     correlation_id, state, overrides = self._build_state_and_overrides(...)
     return await self._start(
-        topic=topic,
-        reply_topic=self._reply_topic,                        # always own inbox now
-        correlation_id=correlation_id, state=state, overrides=overrides,
+        topic=topic,                                          # callback is always the own
+        correlation_id=correlation_id, state=state,           # inbox, hardwired in _start
+        overrides=overrides,
         deps=deps, route=route, body=body, output_type=output_type,
     )
 
@@ -146,13 +150,28 @@ async def execute(self, user_prompt, topic, *, ..., timeout=None):
 
 Internal seams renamed for coherence (underscore-private, pre-1.0): `_emit` → `_send`,
 `_invoke` → `_start`. `_publish_call` and `_build_state_and_overrides` keep their names —
-they describe what they do, not a public verb.
+they describe what they do, not a public verb. **Round-1 review amendment (2026-06-11):**
+`_start` lost its `reply_topic` parameter entirely — the wire callback is hardwired to
+`self._reply_topic`. A subclass passing a foreign topic through the seam would recreate the
+exact dangling-future bug this spec removes, and with one legal value the parameter was
+decorative.
 
-`calfkit/nodes/base.py` (worker) — **no change.** The `ReturnCall` branch already publishes
-the terminal envelope to any non-`None` `frame.callback_topic` (`nodes/base.py:293-299`); the
-same `publish_envelope` object is still returned for the `publish_topic` broadcast, so both
+`calfkit/nodes/base.py` (worker) — the `ReturnCall` branch already publishes the terminal
+envelope to any non-`None` `frame.callback_topic` (`nodes/base.py:293-299`); the same
+`publish_envelope` object is still returned for the `publish_topic` broadcast, so both
 channels carry byte-identical terminal envelopes. `TailCall` re-pushes the inherited callback
 (`nodes/base.py:304`), so a `reply_to` survives tail chains exactly like the client inbox does.
+**Round-1 review amendment (2026-06-11):** the terminal callback publish is wrapped in a
+narrow `except KafkaError` — a failed point-to-point delivery (e.g. a `reply_to` topic
+missing with auto-create off, or unauthorized) logs an ERROR naming the topic, correlation
+id, and node, and still returns `publish_envelope` so the `publish_topic` broadcast (the
+documented traceability fallback) survives the failure instead of dying with it. Without the
+catch, the raised exception aborted the handler before its return value reached the
+`@publisher`, so a failed `reply_to` delivery silently erased BOTH channels (and FastStream's
+default `ACK_FIRST` had already committed the offset — no redelivery). No retry/DLQ here:
+redelivery policy belongs to the fault rail (#193 successor). The same catch also enriches
+the receiver-side `no pending future` warning with the emitter id (`reply_dispatcher.py`) so
+a mis-addressed `send(reply_to=<other client's inbox>)` is diagnosable.
 
 ## Semantics
 
@@ -173,6 +192,7 @@ channels carry byte-identical terminal envelopes. `TailCall` re-pushes the inher
 | `send(reply_to=None)` (default) | callback suppressed — today's emit, byte-for-byte |
 | `send(reply_to="orders.done")` | `CallFrame.callback_topic="orders.done"`, no future |
 | `send(reply_to="")` / whitespace | `ValueError` (would publish to an invalid/empty topic at the worker) |
+| `send(reply_to=<Kafka-illegal name>)` | `ValueError` — names outside `[a-zA-Z0-9._-]{1,249}` (or `.`/`..`) would stall `request_timeout_ms` at the worker into an argument-less `UnknownTopicOrPartitionError`; rejected at call time instead (round-1 amendment) |
 | `send(reply_to=client.reply_topic)` | `ValueError` — provably useless: the own-inbox dispatcher would consume and drop it ("no pending future" warning); awaiting is what start/execute are for |
 | `start(reply_topic=...)` / `execute(reply_topic=...)` | `TypeError` (param gone) |
 | `emit_to_node` / `invoke_node` / `execute_node` | `AttributeError` (renamed, no aliases) |
@@ -193,7 +213,7 @@ Each written first, watched RED, then implemented:
 6. `test_start_callback_is_always_client_inbox` — wire capture: `start` produces
    `CallFrame.callback_topic == client.reply_topic`; `reply_topic=` kwarg raises `TypeError`.
 7. Rename sweep: mechanical update of every `emit_to_node`/`invoke_node`/`execute_node` call
-   site in tests (13 files) and examples (4 files); suite green proves behavior is untouched
+   site in tests (15 files) and examples (4 files); suite green proves behavior is untouched
    by the rename.
 8. Regression: existing send-default/start/execute behavior tests stay green with only the
    name swap (default paths byte-for-byte unchanged).

--- a/docs/designs/client-send-api-spec.md
+++ b/docs/designs/client-send-api-spec.md
@@ -1,0 +1,253 @@
+# Client send API: `send` / `start` / `execute` + settable return address (`reply_to`)
+
+| | |
+|---|---|
+| Status | Implemented (TDD, 2026-06-10) |
+| Follows | [fire-and-forget-emit.md](fire-and-forget-emit.md) (#132) |
+| Breaking | Yes — `feat!`: renames all three client send methods and removes the per-call `reply_topic` param from the request/reply pair. **No wire change** — `CallFrame.callback_topic` is already nullable and already carries arbitrary topics; no worker/client rollout ordering constraint. |
+
+## Problem
+
+Three defects in the client send surface: a missing capability, a latent bug, and
+mis-vocabularied names.
+
+1. **Missing capability.** There is no way to send fire-and-forget *and* direct the terminal
+   result to a topic of the caller's choosing — the Return Address pattern (EIP), which every
+   mature messaging surface supports on its one-way verb (AMQP `reply_to`, JMS `JMSReplyTo`,
+   NServiceBus `RouteReplyTo`, FastStream's own `broker.publish(reply_to=...)`).
+   `emit_to_node` hardcodes `callback_topic=None`.
+
+2. **Latent bug.** `invoke_node(reply_topic=...)` *pretends* to provide this but breaks: the
+   reply dispatcher subscribes to exactly one topic — the client's own inbox, registered once
+   at `connect()` (`reply_dispatcher.py:50`, `base.py:198`) — while `_invoke` unconditionally
+   registers a future (`base.py:258`). A custom `reply_topic` therefore delivers the reply
+   elsewhere AND pins a future that nothing can ever resolve: it dangles forever, or dies with
+   a misleading `ReplyExpiredError` under a TTL. No call site in the repo passes a custom value.
+
+3. **Misleading names.** In messaging vocabulary, *emit/publish* = broadcast an event
+   (pub-sub, no addressee); *send* = point-to-point command (addressed, correlated, may carry
+   a return address). `emit_to_node` is a command send, not an event emission — and with
+   `reply_to` added, `emit(..., reply_to=...)` reads as a contradiction. (The original
+   "mirrors the node-side `Emit` action" justification points at dead code: `actions.py:95`
+   has zero construction sites and no worker dispatch branch.) `invoke` vs `execute` are
+   near-synonyms — neither telegraphs which one waits (cf. AWS Lambda's `InvocationType`
+   confusion). The `_node` suffix discriminates nothing: every client method targets a node,
+   and the `topic` argument carries the addressing.
+
+The coherent model: with one `callback_topic` slot on the wire, "await a future" and "deliver
+the reply elsewhere" are mutually exclusive. A future is resolvable **iff** the callback is the
+client's own inbox.
+
+| `callback_topic` on the wire | Future | Verb (new name) |
+|---|---|---|
+| `None` (worker suppresses terminal callback) | no | `send` (today's `emit_to_node` default) |
+| arbitrary topic, someone else consumes | no | `send(reply_to=...)` — **new capability** |
+| client's own inbox | yes | `start` / `execute` (always, after this spec) |
+| arbitrary topic + future | — | the bug; becomes unrepresentable |
+
+## Decisions (locked 2026-06-10)
+
+1. The settable return address lives on the one-way verb: `send(reply_to=...)`.
+   No flag on the request verbs — a boolean that flips the return type
+   (`str | InvocationHandle`) needs `Literal` overload soup, breaks inference through
+   wrappers, and has no precedent in any mature messaging SDK.
+2. The per-call `reply_topic` param is **removed** from the request/reply pair (both overload
+   sets + impls). They always reply to the client's own inbox — the only combination that can
+   resolve. Hard break, no validation shim.
+3. The return-address param is named **`reply_to`** — the literal field name in AMQP, JMS,
+   and FastStream's `publish(reply_to=)`; avoids implying the *client* receives the reply.
+4. The methods are renamed **`emit_to_node` → `send`**, **`invoke_node` → `start`**,
+   **`execute_node` → `execute`** (Set A):
+   - `send` — the standard one-way command verb (MassTransit/NServiceBus/JMS `Send`);
+     `send(reply_to=)` is the literal AMQP/JMS/FastStream shape.
+   - `start` — the one verb that unambiguously means "returns a handle, doesn't wait"
+     (Temporal `start_workflow` → handle; cf. Python `Executor.submit` → `Future`).
+   - `execute` — dispatch and await the result (Temporal `execute_workflow`); already the
+     right verb, now paired so the `start`/`execute` duo telegraphs the contract.
+   - `_node` suffix dropped everywhere (v1 doc direction). No deprecated aliases (pre-1.0,
+     hard-break convention).
+
+## API changes
+
+```python
+# ONE-WAY (renamed; gains the return address; return type unchanged)
+async def send(
+    self, user_prompt: str, topic: str, *,
+    reply_to: str | None = None,          # NEW: topic the terminal result is delivered to,
+                                          # point-to-point, for SOMEONE ELSE to consume.
+                                          # None (default) = no callback at all.
+    tool_overrides=..., correlation_id=..., temp_instructions=...,
+    message_history=..., deps=..., model_settings=..., author=...,
+    route=..., body=...,
+) -> str: ...                             # still always the correlation_id
+
+# REQUEST/REPLY (renamed; lose the footgun; otherwise unchanged)
+async def start(self, user_prompt, topic, *, ...) -> InvocationHandle: ...
+async def execute(self, user_prompt, topic, *, ..., timeout=None) -> NodeResult: ...
+# `reply_topic` removed from both impls and all four overload stanzas.
+# `output_type` stays OFF send: deserialization belongs to whoever consumes the reply.
+# InvocationHandle keeps its name (it is still a handle to an invocation; cf. Temporal's
+# WorkflowHandle). The client `reply_topic` property (inbox name) is unchanged.
+```
+
+## Pseudocode
+
+`calfkit/client/client.py` — `send` (was `emit_to_node`) threads the new param through:
+
+```python
+async def send(self, user_prompt, topic, *, reply_to=None, ...) -> str:
+    correlation_id, state, overrides = self._build_state_and_overrides(...)  # unchanged
+    return await self._send(
+        topic=topic, correlation_id=correlation_id, state=state,
+        overrides=overrides, deps=deps, route=route, body=body,
+        reply_to=reply_to,                                   # NEW
+    )
+```
+
+`calfkit/client/base.py` — `_send` (was `_emit`) validates and forwards as the wire callback:
+
+```python
+async def _send(self, topic, correlation_id, state, overrides=None, deps=None,
+                route=None, body=None, reply_to: str | None = None) -> str:
+    if reply_to is not None:
+        if not reply_to.strip():
+            raise ValueError("reply_to must be a non-empty topic name or None")
+        if reply_to == self._reply_topic:
+            raise ValueError(
+                "reply_to is this client's own reply inbox; send() registers no "
+                "future, so the reply would arrive and be dropped ('no pending future'). "
+                "Use start()/execute() to await a reply."
+            )
+    await self._publish_call(
+        topic=topic, correlation_id=correlation_id,
+        callback_topic=reply_to,                              # was hardcoded None
+        state=state, overrides=overrides, deps=deps, route=route, body=body,
+    )
+    return correlation_id
+```
+
+`calfkit/client/client.py` — `start` / `execute` (were `invoke_node` / `execute_node`)
+lose the param:
+
+```python
+async def start(self, user_prompt, topic, *, ...):            # no reply_topic param
+    correlation_id, state, overrides = self._build_state_and_overrides(...)
+    return await self._start(
+        topic=topic,
+        reply_topic=self._reply_topic,                        # always own inbox now
+        correlation_id=correlation_id, state=state, overrides=overrides,
+        deps=deps, route=route, body=body, output_type=output_type,
+    )
+
+async def execute(self, user_prompt, topic, *, ..., timeout=None):
+    handle = await self.start(...)                            # unchanged sugar
+    return await handle.result(timeout=timeout)
+```
+
+Internal seams renamed for coherence (underscore-private, pre-1.0): `_emit` → `_send`,
+`_invoke` → `_start`. `_publish_call` and `_build_state_and_overrides` keep their names —
+they describe what they do, not a public verb.
+
+`calfkit/nodes/base.py` (worker) — **no change.** The `ReturnCall` branch already publishes
+the terminal envelope to any non-`None` `frame.callback_topic` (`nodes/base.py:293-299`); the
+same `publish_envelope` object is still returned for the `publish_topic` broadcast, so both
+channels carry byte-identical terminal envelopes. `TailCall` re-pushes the inherited callback
+(`nodes/base.py:304`), so a `reply_to` survives tail chains exactly like the client inbox does.
+
+## Semantics
+
+- A `@consumer` node subscribed to the `reply_to` topic receives the terminal envelope exactly
+  as one tapping `publish_topic` does (the reply dispatcher already proves callback-channel
+  envelopes parse; same `Envelope`, same `NodeResult.from_envelope` path) — except it sees
+  **only terminal results addressed to it**, not every hop of every invocation of the node.
+- The reply still ALSO rides the target node's `publish_topic` broadcast (unchanged dual-channel
+  model from #132).
+- `reply_to` pointing at another *agent node's* input topic is not a chaining mechanism — the
+  call stack is unwound at the terminal; consumers, sinks, or other clients' inboxes are the
+  intended audience. Documented, not validated (a topic name is just a topic name).
+
+## Validation rules
+
+| Input | Behavior |
+|---|---|
+| `send(reply_to=None)` (default) | callback suppressed — today's emit, byte-for-byte |
+| `send(reply_to="orders.done")` | `CallFrame.callback_topic="orders.done"`, no future |
+| `send(reply_to="")` / whitespace | `ValueError` (would publish to an invalid/empty topic at the worker) |
+| `send(reply_to=client.reply_topic)` | `ValueError` — provably useless: the own-inbox dispatcher would consume and drop it ("no pending future" warning); awaiting is what start/execute are for |
+| `start(reply_topic=...)` / `execute(reply_topic=...)` | `TypeError` (param gone) |
+| `emit_to_node` / `invoke_node` / `execute_node` | `AttributeError` (renamed, no aliases) |
+
+## Test plan (TDD order, all in `tests/test_fire_and_forget.py` unless noted)
+
+Each written first, watched RED, then implemented:
+
+1. `test_send_reply_to_sets_callback_topic_on_wire` — TestKafkaBroker capture; bottom
+   `CallFrame.callback_topic == "sink.topic"`. RED: `TypeError`/`AttributeError`.
+2. `test_send_reply_to_registers_no_future` — `dispatcher._pending` stays empty (mirrors
+   existing zero-state test at `test_fire_and_forget.py:126`).
+3. `test_send_reply_to_delivers_terminal_to_topic` (e2e) — agent worker + subscriber on the
+   `reply_to` topic receives the terminal envelope with `final_output_parts` populated; the
+   client's own inbox receives nothing (mirrors the broadcast e2e at `:164`).
+4. `test_send_reply_to_rejects_blank_topic` — `ValueError`.
+5. `test_send_reply_to_rejects_own_inbox` — `ValueError`.
+6. `test_start_callback_is_always_client_inbox` — wire capture: `start` produces
+   `CallFrame.callback_topic == client.reply_topic`; `reply_topic=` kwarg raises `TypeError`.
+7. Rename sweep: mechanical update of every `emit_to_node`/`invoke_node`/`execute_node` call
+   site in tests (13 files) and examples (4 files); suite green proves behavior is untouched
+   by the rename.
+8. Regression: existing send-default/start/execute behavior tests stay green with only the
+   name swap (default paths byte-for-byte unchanged).
+
+## Docs plan
+
+- `docs/client-features.md` — patterns table (`:10-21`): rename all three + the `send` row
+  gains "optional `reply_to` return address"; fire-and-forget section (`:66-91`) renamed to
+  `send` + gains a `reply_to` sub-example; `reply_ttl` note (`:93-106`) reworded to `start`.
+- `README.md` — the two `execute_node` examples (`:175`, `:221`) and the quick-reference
+  table (`:279-280`).
+- `examples/quickstart/{emit.py → send.py, invoke.py}`, `examples/multi_agent_panel/run.py`,
+  `examples/quickstart/weather_sink.py` — rename call sites (and the example filenames: `emit.py` → `send.py`, `invoke.py` → `execute.py` — the latter demonstrates `execute`).
+- `docs/designs/fire-and-forget-emit.md` — superseded-in-part note: the method is now
+  `send`, and "`reply_topic` is meaningless for emit" no longer holds; link here.
+- `docs/designs/calfkit-v1-design.md` — update the migration table (`:3054`, `:3431`):
+  v1 targets are now `send`/`start`/`execute`, not `invoke`/`execute`.
+- Docstrings: `Client` class pattern table, all three methods, `BaseClient._send`/`._start`,
+  `InvocationHandle.result` (its `RuntimeError` note references `emit_to_node`).
+- ADR at PR time: "the return address rides the one-way verb (`send`); request verbs
+  (`start`/`execute`) always reply to the caller's own inbox" + the naming decision.
+
+## Migration (breaking notes)
+
+| Before | After |
+|---|---|
+| `await client.emit_to_node(p, t)` | `await client.send(p, t)` |
+| *(not expressible)* | `await client.send(p, t, reply_to="orders.done")` |
+| `await client.invoke_node(p, t)` | `await client.start(p, t)` |
+| `await client.execute_node(p, t, timeout=30)` | `await client.execute(p, t, timeout=30)` |
+| `invoke_node(reply_topic=...)` / `execute_node(reply_topic=...)` | drop the argument — if you passed a custom value you were leaking an unresolvable future; use `send(reply_to=...)` and consume the reply where you sent it |
+
+No wire migration: workers already handle arbitrary callback topics; mixed-version fleets
+are unaffected. No deprecated aliases (pre-1.0 hard-break convention).
+
+## Conscious decisions
+
+- **`reply_to` topic provisioning is the consumer-owner's responsibility.** The client never
+  subscribes to it and doesn't own it; it is not declared into the client's startup ensurer
+  (which runs at broker start, before per-call topics are known). On auto-create-off brokers
+  the topic must exist before the worker's terminal publish.
+- **Own-inbox `ValueError` over a warning.** With no future, an own-inbox reply is consumed
+  and dropped by the client's own dispatcher — there is no scenario where it is useful, so
+  fail loudly at call time rather than warn per-reply at the dispatcher.
+- **`output_type` stays off `send`.** Deserialization is the consumer's concern; adding it
+  would re-create the "param that silently does nothing" class this spec deletes.
+- **Rename and `reply_to` land in one `feat!` PR.** One breaking PR, one migration story; the
+  rename blast radius overlaps almost entirely with files the `reply_to` change touches.
+
+## Out of scope
+
+- Pruning `execute` (orthogonal surface question; deliberately untouched).
+- The dead node-side `Emit` action (`actions.py:95`, zero construction sites): deleting or
+  wiring it is an open follow-up from #132 — not decided here; left untouched.
+- `reply_to` on node-side actions (`Emit` action wiring — still deferred from #132).
+- Per-call provisioning of `reply_to` topics.
+- Signature changes beyond the above (e.g. v1's planned `user_prompt` decoupling).

--- a/docs/designs/consumer-context.md
+++ b/docs/designs/consumer-context.md
@@ -13,7 +13,7 @@ same `ctx.deps` / `ctx.resources` / `ctx.correlation_id` vocabulary that tool
 authors already use via `ToolContext`.
 
 `NodeResult` returns to being a **pure projection of the wire envelope + transport**,
-used only by the client (`Client.execute_node` / `InvocationHandle.result`).
+used only by the client (`Client.execute` / `InvocationHandle.result`).
 
 ## 1. Motivation
 

--- a/docs/designs/fire-and-forget-emit.md
+++ b/docs/designs/fire-and-forget-emit.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| Status | Implemented |
+| Status | Implemented; **superseded in part** by [client-send-api-spec.md](client-send-api-spec.md) (2026-06): `emit_to_node`→`send` + optional `reply_to` return address (the "no reply_topic on emit" reasoning in §3 no longer holds); `invoke_node`/`execute_node`→`start`/`execute`, per-call `reply_topic` param removed. |
 | Closes | #132 (`Client.invoke_node` is documented as "fire-and-forget" but always allocates per-call reply state and triggers reply traffic) |
 | Breaking | Yes — `feat!` (the wire `CallFrame.callback_topic` becomes nullable; old workers can't read a `None` terminal) |
 
@@ -114,7 +114,7 @@ reply expected") and forms a clean three-way set:
 | `invoke_node` | async, reply via handle | `InvocationHandle` | a pending `Future` until resolved/evicted |
 | `execute_node` | sync request/reply | `NodeResult` | a pending `Future` (self-cleaning only when called with an explicit `timeout`) |
 
-A runnable end-to-end example lives at [`examples/quickstart/emit.py`](../../examples/quickstart/emit.py).
+A runnable end-to-end example lives at [`examples/quickstart/send.py`](../../examples/quickstart/send.py).
 Pair it with [`examples/quickstart/weather_sink.py`](../../examples/quickstart/weather_sink.py) — a
 `@consumer` tapping the agent's `publish_topic` — to watch the fire-and-forget result arrive on the
 broadcast channel even though no point-to-point reply is returned.

--- a/docs/designs/run-handler-unification.md
+++ b/docs/designs/run-handler-unification.md
@@ -423,6 +423,8 @@ this is pure deletion of the `run_args` plumbing.
 `run_args` appears across overloads + impls + docstrings + pass-throughs for three methods.
 Remove all (the `route`/`body` params already present become the supported input-shaping channel).
 
+> NOTE (2026-06-11): the client method names and `client.py` line estimates below pre-date `client-send-api-spec.md` (`emit_to_node`→`send`, `invoke_node`→`start`, `execute_node`→`execute`; `reply_topic` param removed). Re-derive edit sites against HEAD when building.
+
 - **(a) `invoke_node`:** overload params (≈97, ≈116), impl param (≈135), docstring (≈169),
   pass-through `run_args=run_args` (≈197).
 - **(b) `emit_to_node`:** impl param (≈215), docstring (≈247), pass-through (≈278).

--- a/docs/topic-provisioning.md
+++ b/docs/topic-provisioning.md
@@ -151,7 +151,7 @@ config is disabled.
 
 ### 4.2 Client reply topic (lazy, once)
 
-A `Client` provisions **its own reply topic** the first time `_invoke` runs (just
+A `Client` provisions **its own reply topic** the first time `_start` runs (just
 before the broker connects), and at most once for the lifetime of the client. The
 reply topic is a framework inbox, so it is passed in `framework_topics` to keep
 user `topic_configs` off it. This is gated on the same

--- a/docs/topic-provisioning.md
+++ b/docs/topic-provisioning.md
@@ -151,7 +151,7 @@ config is disabled.
 
 ### 4.2 Client reply topic (lazy, once)
 
-A `Client` provisions **its own reply topic** the first time `_start` runs (just
+A `Client` provisions **its own reply topic** the first time the client publishes — any of `send`/`start`/`execute` (just
 before the broker connects), and at most once for the lifetime of the client. The
 reply topic is a framework inbox, so it is passed in `framework_topics` to keep
 user `topic_configs` off it. This is gated on the same

--- a/docs/worker-lifecycle.md
+++ b/docs/worker-lifecycle.md
@@ -35,7 +35,7 @@ Keep these distinct:
   `result.resources["key"]`). The read side is typed as a read-only `Mapping`, so
   `ctx.resources[...] = ...` is a type error.
 - **`deps`** are per-request, JSON-serializable values the caller passes at invoke
-  time (`client.execute_node(..., deps={...})`). They ride along on the Kafka
+  time (`client.execute(..., deps={...})`). They ride along on the Kafka
   envelope and are read by tools as `ctx.deps["key"]`.
 
 Use `resources` for connections you open once and reuse; use `deps` for

--- a/examples/multi_agent_panel/run.py
+++ b/examples/multi_agent_panel/run.py
@@ -28,7 +28,7 @@ async def main() -> None:
         prompt = TOPIC if round_no == 1 else FOLLOW_UP
         print(f"\n===== Round {round_no} =====")
         for agent in PANEL:
-            result = await client.execute_node(
+            result = await client.execute(
                 prompt,
                 f"{agent.name}.input",
                 message_history=history,  # every panelist sees the same growing transcript

--- a/examples/quickstart/execute.py
+++ b/examples/quickstart/execute.py
@@ -7,7 +7,7 @@ async def main():
     client = Client.connect("localhost:9092")  # Connect to Kafka broker
 
     # Send a request and await the response
-    result = await client.execute_node(
+    result = await client.execute(
         "What's the weather in Tokyo?",
         "weather_agent.input",  # The topic the agent subscribes to
     )

--- a/examples/quickstart/execute.py
+++ b/examples/quickstart/execute.py
@@ -4,14 +4,15 @@ from calfkit.client import Client
 
 
 async def main():
-    client = Client.connect("localhost:9092")  # Connect to Kafka broker
-
-    # Send a request and await the response
-    result = await client.execute(
-        "What's the weather in Tokyo?",
-        "weather_agent.input",  # The topic the agent subscribes to
-    )
-    print(f"Assistant: {result.output}")
+    # ``async with`` shuts the client down cleanly on exit (producer/consumer
+    # teardown).
+    async with Client.connect("localhost:9092") as client:  # Connect to Kafka broker
+        # Send a request and await the response
+        result = await client.execute(
+            "What's the weather in Tokyo?",
+            "weather_agent.input",  # The topic the agent subscribes to
+        )
+        print(f"Assistant: {result.output}")
 
 
 if __name__ == "__main__":

--- a/examples/quickstart/send.py
+++ b/examples/quickstart/send.py
@@ -4,9 +4,9 @@ from calfkit.client import Client
 
 
 async def main():
-    # ``async with`` shuts the client down cleanly on exit, flushing the Kafka
-    # producer. This matters for fire-and-forget: there is no reply to await
-    # that would otherwise keep the client alive while the send completes.
+    # ``async with`` shuts the client down cleanly on exit (producer/consumer
+    # teardown). Delivery does not depend on it: ``send`` awaits the broker's
+    # ack before returning, so the record is already on the topic.
     async with Client.connect("localhost:9092") as client:  # Connect to Kafka broker
         # Fire-and-forget: dispatch the request and return immediately. No reply
         # is produced and no client-side reply future is allocated — send

--- a/examples/quickstart/send.py
+++ b/examples/quickstart/send.py
@@ -9,9 +9,9 @@ async def main():
     # that would otherwise keep the client alive while the send completes.
     async with Client.connect("localhost:9092") as client:  # Connect to Kafka broker
         # Fire-and-forget: dispatch the request and return immediately. No reply
-        # is produced and no client-side reply future is allocated — emit_to_node
+        # is produced and no client-side reply future is allocated — send
         # hands back only the correlation_id, for tracing/logging.
-        correlation_id = await client.emit_to_node(
+        correlation_id = await client.send(
             "What's the weather in Tokyo?",
             "weather_agent.input",  # The topic the agent subscribes to
         )

--- a/examples/quickstart/weather_sink.py
+++ b/examples/quickstart/weather_sink.py
@@ -2,7 +2,7 @@
 
 Listens on the weather agent's ``publish_topic`` and runs arbitrary Python
 against every envelope that flows through it. The decorated function receives
-the same client-facing ``NodeResult`` returned by ``Client.execute_node()``.
+the same client-facing ``NodeResult`` returned by ``Client.execute()``.
 
 Because an agent's ``publish_topic`` carries every state transition (not just
 the final reply), ``result.output`` is ``None`` on intermediate hops — pending

--- a/tests/integration/test_agent_output_types.py
+++ b/tests/integration/test_agent_output_types.py
@@ -18,7 +18,7 @@ async def test_structured_output_agent_with_dataclass(container, deploy_structur
     client = container.get(Client)
 
     async with TestKafkaBroker(broker) as _:
-        result = await client.execute_node(
+        result = await client.execute(
             f"What's your name? My name is {user_name}",
             "test_agent.input",
             temp_instructions="When responding, always direct responses to the recipient's name you would like to target.",
@@ -31,7 +31,7 @@ async def test_structured_output_agent_with_dataclass(container, deploy_structur
         assert agent_name.lower() in result.output.response.lower()
         print(f"structured_output: {result.output}")
 
-        result = await client.execute_node(
+        result = await client.execute(
             f"What's your name? My name is {user_name}",
             "test_agent.input",
             temp_instructions="When responding, always direct responses to the recipient's name you would like to target.",
@@ -53,7 +53,7 @@ async def test_structured_output_agent_with_list(container, deploy_structured_ag
     client = container.get(Client)
 
     async with TestKafkaBroker(broker) as _:
-        result = await client.execute_node(
+        result = await client.execute(
             "Provide a 3 item-long list of random colors",
             "test_agent.input",
             output_type=list[str],
@@ -65,7 +65,7 @@ async def test_structured_output_agent_with_list(container, deploy_structured_ag
         assert len(result.output) == 3
         print(f"structured_output: {result.output}")
 
-        result = await client.execute_node(
+        result = await client.execute(
             "Provide a 3 item-long list of random colors",
             "test_agent.input",
             temp_instructions="Extract all colors and put them into a list",
@@ -94,7 +94,7 @@ async def test_structured_output_agent_with_basemodel(container, deploy_structur
     client = container.get(Client)
 
     async with TestKafkaBroker(broker) as _:
-        result = await client.execute_node(
+        result = await client.execute(
             "Here are the measurements (l x w x d): 3x2x5 cm",
             "test_agent.input",
             temp_instructions="Extract the box measurements.",
@@ -106,7 +106,7 @@ async def test_structured_output_agent_with_basemodel(container, deploy_structur
         assert Box(length=3, width=2, depth=5, unit="cm") == result.output
         print(f"structured_output: {result.output}")
 
-        result = await client.execute_node(
+        result = await client.execute(
             "Here are the measurements (l x w x d): 3x2x5 cm",
             "test_agent.input",
             temp_instructions="Extract the box measurements.",

--- a/tests/integration/test_agent_workers.py
+++ b/tests/integration/test_agent_workers.py
@@ -24,7 +24,7 @@ async def test_simple_agent_q_and_a(container, deploy_agent):
     client = container.get(Client)
 
     async with TestKafkaBroker(broker) as _:
-        result = await client.execute_node("Hi, what's your name?", "test_agent.input")
+        result = await client.execute("Hi, what's your name?", "test_agent.input")
 
         assert result.output is not None
         assert isinstance(result.output, str)
@@ -42,7 +42,7 @@ async def test_simple_agent_with_tool(container, deploy_agent, deploy_multiple_a
     client = container.get(Client)
 
     async with TestKafkaBroker(broker) as _:
-        result = await client.execute_node("Hi, what's my birthday?", "test_agent.input")
+        result = await client.execute("Hi, what's my birthday?", "test_agent.input")
 
         assert result.output is not None
 
@@ -62,7 +62,7 @@ async def test_simple_agent_with_multiple_tools(container, deploy_agent, deploy_
     client = container.get(Client)
 
     async with TestKafkaBroker(broker) as _:
-        result = await client.execute_node(
+        result = await client.execute(
             "Hi, do you know my name, the weather in Singapore rn, and what my birthday is?", "test_agent.input", output_type=str
         )
 
@@ -85,12 +85,12 @@ async def test_simple_agent_with_multiturn_convo(container, deploy_agent, deploy
     client = container.get(Client)
 
     async with TestKafkaBroker(broker) as _:
-        result = await client.execute_node("Do you know my name?", "test_agent.input")
+        result = await client.execute("Do you know my name?", "test_agent.input")
 
         assert result.output is not None
         assert user_name.lower() in result.output.lower()
 
-        result = await client.execute_node(
+        result = await client.execute(
             "And what's your name?",
             "test_agent.input",
             message_history=result.message_history,
@@ -99,7 +99,7 @@ async def test_simple_agent_with_multiturn_convo(container, deploy_agent, deploy
         assert result.output is not None
         assert agent_name.lower() in result.output.lower()
 
-        result = await client.execute_node(
+        result = await client.execute(
             "What's the weather in vegas rn and what's my birthday?",
             "test_agent.input",
             message_history=result.message_history,
@@ -121,7 +121,7 @@ async def test_simple_agent_with_injected_deps(container, deploy_agent, deploy_c
     client = container.get(Client)
 
     async with TestKafkaBroker(broker) as _:
-        result = await client.execute_node(
+        result = await client.execute(
             "I am messaging you from my iphone, do you know my phone number? Give my phone # with no spaces or special characters in between.",
             "test_agent.input",
             deps={"ephemeral_id": "id1"},
@@ -130,7 +130,7 @@ async def test_simple_agent_with_injected_deps(container, deploy_agent, deploy_c
         assert result.output is not None
         assert caller_id_lookup["id1"] in result.output.lower()
 
-        result = await client.execute_node(
+        result = await client.execute(
             "I am messaging you from my iphone, do you know my phone number? Give my phone # with no spaces or special characters in between.",
             "test_agent.input",
             deps={"ephemeral_id": "id2"},
@@ -139,7 +139,7 @@ async def test_simple_agent_with_injected_deps(container, deploy_agent, deploy_c
         assert result.output is not None
         assert caller_id_lookup["id2"] in result.output.lower()
 
-        result = await client.execute_node(
+        result = await client.execute(
             "I am messaging you from my iphone, do you know my phone number? Give my phone # with no spaces or special characters in between.",
             "test_agent.input",
             deps={"ephemeral_id": "id3"},
@@ -159,7 +159,7 @@ async def test_structured_output_agent(container, deploy_structured_agent):
     client = container.get(Client)
 
     async with TestKafkaBroker(broker) as _:
-        result = await client.execute_node(
+        result = await client.execute(
             f"What's your name? My name is {user_name}",
             "test_agent.input",
             output_type=Response,
@@ -172,7 +172,7 @@ async def test_structured_output_agent(container, deploy_structured_agent):
         assert agent_name.lower() in result.output.response.lower()
         print(f"structured_output: {result.output}")
 
-        result = await client.execute_node(
+        result = await client.execute(
             "Do you remember my name?",
             "test_agent.input",
             output_type=Response,
@@ -186,7 +186,7 @@ async def test_structured_output_agent(container, deploy_structured_agent):
         assert user_name.lower() in result.output.response.lower()
         print(f"structured_output: {result.output}")
 
-        result = await client.execute_node(
+        result = await client.execute(
             "Please tell my friend Amy that it's snowing in Calgary.",
             "test_agent.input",
             output_type=Response,

--- a/tests/test_client_author.py
+++ b/tests/test_client_author.py
@@ -27,12 +27,12 @@ class _CaptureClient(Client):
         self.captured_state: State | None = None
         self._reply_topic = "test-reply"
 
-    async def _start(self, *, topic: str, reply_topic: str, correlation_id: str, state: State, **_: Any) -> InvocationHandle:  # type: ignore[override]
+    async def _start(self, *, topic: str, correlation_id: str, state: State, **_: Any) -> InvocationHandle:  # type: ignore[override]
         self.captured_state = state
         return InvocationHandle(
             correlation_id=correlation_id,
             topic=topic,
-            reply_topic=reply_topic,
+            reply_topic=self._reply_topic,
             _future=None,  # type: ignore[arg-type]
             _output_type=_UNSET,
         )

--- a/tests/test_client_author.py
+++ b/tests/test_client_author.py
@@ -1,9 +1,9 @@
 """Unit tests for the optional human ``author`` kwarg on the client (design §8).
 
-These tests are pure: they intercept the network boundary (``_invoke`` /
-``invoke_node``) so no Kafka broker or model call is required. They assert that
-``author=`` is mapped onto the staged ``UserPromptPart.name`` by ``invoke_node``
-and that ``execute_node`` forwards it (it must not be silently dropped).
+These tests are pure: they intercept the network boundary (``_start`` /
+``start``) so no Kafka broker or model call is required. They assert that
+``author=`` is mapped onto the staged ``UserPromptPart.name`` by ``start``
+and that ``execute`` forwards it (it must not be silently dropped).
 """
 
 from __future__ import annotations
@@ -21,13 +21,13 @@ from calfkit.models.node_result import _UNSET
 
 class _CaptureClient(Client):
     """Client subclass that captures the constructed ``State`` instead of
-    publishing it, so ``invoke_node`` can be exercised without a broker."""
+    publishing it, so ``start`` can be exercised without a broker."""
 
     def __init__(self) -> None:  # noqa: D107 - test double, skip BaseClient wiring
         self.captured_state: State | None = None
         self._reply_topic = "test-reply"
 
-    async def _invoke(self, *, topic: str, reply_topic: str, correlation_id: str, state: State, **_: Any) -> InvocationHandle:  # type: ignore[override]
+    async def _start(self, *, topic: str, reply_topic: str, correlation_id: str, state: State, **_: Any) -> InvocationHandle:  # type: ignore[override]
         self.captured_state = state
         return InvocationHandle(
             correlation_id=correlation_id,
@@ -47,48 +47,48 @@ def _staged_user_part(state: State) -> UserPromptPart:
 
 
 @pytest.mark.asyncio
-async def test_invoke_node_author_stamps_user_prompt_name() -> None:
+async def test_start_author_stamps_user_prompt_name() -> None:
     client = _CaptureClient()
 
-    await client.invoke_node("hello", "topic", author="Alice")
+    await client.start("hello", "topic", author="Alice")
 
     assert client.captured_state is not None
     assert _staged_user_part(client.captured_state).name == "Alice"
 
 
 @pytest.mark.asyncio
-async def test_invoke_node_no_author_leaves_name_none() -> None:
+async def test_start_no_author_leaves_name_none() -> None:
     client = _CaptureClient()
 
-    await client.invoke_node("hello", "topic")
+    await client.start("hello", "topic")
 
     assert client.captured_state is not None
     assert _staged_user_part(client.captured_state).name is None
 
 
 @pytest.mark.asyncio
-async def test_execute_node_forwards_author_to_invoke_node(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_execute_forwards_author_to_start(monkeypatch: pytest.MonkeyPatch) -> None:
     client = _CaptureClient()
     captured_kwargs: dict[str, Any] = {}
 
-    real_invoke_node = client.invoke_node
+    real_start = client.start
 
-    async def spy_invoke_node(user_prompt: str, topic: str, **kwargs: Any) -> InvocationHandle:
+    async def spy_start(user_prompt: str, topic: str, **kwargs: Any) -> InvocationHandle:
         captured_kwargs.update(kwargs)
-        return await real_invoke_node(user_prompt, topic, **kwargs)
+        return await real_start(user_prompt, topic, **kwargs)
 
-    monkeypatch.setattr(client, "invoke_node", spy_invoke_node)
+    monkeypatch.setattr(client, "start", spy_start)
 
     # InvocationHandle.result() would await a real future; monkeypatch it out (it is
-    # restored automatically after the test) so we assert purely on what execute_node
-    # forwarded down to invoke_node.
+    # restored automatically after the test) so we assert purely on what execute
+    # forwarded down to start.
     async def _no_result(self: InvocationHandle, *_: Any, **__: Any) -> None:
         return None
 
     monkeypatch.setattr(InvocationHandle, "result", _no_result)
 
-    await client.execute_node("hello", "topic", author="Bob")
+    await client.execute("hello", "topic", author="Bob")
 
-    assert captured_kwargs.get("author") == "Bob", "execute_node dropped author= before forwarding to invoke_node"
+    assert captured_kwargs.get("author") == "Bob", "execute dropped author= before forwarding to start"
     assert client.captured_state is not None
     assert _staged_user_part(client.captured_state).name == "Bob"

--- a/tests/test_co_tenant_tool_isolation.py
+++ b/tests/test_co_tenant_tool_isolation.py
@@ -148,7 +148,7 @@ async def test_tool_return_does_not_leak_between_co_tenant_agents(container):
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        await client.invoke_node("hi", SHARED_INPUT)
+        await client.start("hi", SHARED_INPUT)
         await wait_for_condition(
             lambda: len(alpha_finals) >= 1 and len(bravo_finals) >= 1,
             timeout=5.0,
@@ -200,7 +200,7 @@ async def test_single_call_writes_private_return_topic_as_callback(container):
     prepare_worker(container)
 
     async with TestKafkaBroker(broker):
-        await client.invoke_node("hi", agent.subscribe_topics[0])
+        await client.start("hi", agent.subscribe_topics[0])
         await wait_for_condition(lambda: len(captured) >= 1, timeout=5.0)
 
     assert captured, "tool input topic never received the Call envelope"
@@ -263,7 +263,7 @@ async def test_parallel_call_writes_private_return_topic_as_callback(container):
     prepare_worker(container)
 
     async with TestKafkaBroker(broker):
-        await client.invoke_node("hi", agent.subscribe_topics[0])
+        await client.start("hi", agent.subscribe_topics[0])
         await wait_for_condition(
             lambda: len(captured_a) >= 1 and len(captured_b) >= 1 and len(captured_c) >= 1,
             timeout=5.0,

--- a/tests/test_concurrent_tool_calls.py
+++ b/tests/test_concurrent_tool_calls.py
@@ -19,7 +19,7 @@ async def test_concurrent_tool_calling(container, deploy_function_agent, deploy_
         random_num = random.randint(1, 100)
         random_str = "".join(random.choices(string.ascii_letters, k=20))  # 20 char random string
         random_city = Faker().city()
-        result = await client.execute_node(
+        result = await client.execute(
             "Hey! Call all your tools concurrently right now",
             deploy_function_agent.subscribe_topics[0],
             deps={"random_number": random_num, "random_string": random_str, "random_city": random_city},

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -207,7 +207,7 @@ async def test_sync_consumer_receives_context_from_agent_output(container):
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        await client.execute_node("hi", agent.subscribe_topics[0], timeout=5)
+        await client.execute("hi", agent.subscribe_topics[0], timeout=5)
 
     final = [c for c in received if any(isinstance(p, TextPart) for p in c.output_parts)]
     assert final, f"consumer never saw a terminal envelope; saw={received}"
@@ -228,7 +228,7 @@ async def test_async_consumer_receives_context_from_agent_output(container):
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        await client.execute_node("hi", agent.subscribe_topics[0], timeout=5)
+        await client.execute("hi", agent.subscribe_topics[0], timeout=5)
 
     final = [c for c in received if any(isinstance(p, TextPart) for p in c.output_parts)]
     assert final
@@ -247,7 +247,7 @@ async def test_consumer_sees_upstream_emitter_identity(container):
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        await client.execute_node("hi", agent.subscribe_topics[0], timeout=5)
+        await client.execute("hi", agent.subscribe_topics[0], timeout=5)
 
     final = [c for c in received if any(isinstance(p, TextPart) for p in c.output_parts)]
     assert final
@@ -278,7 +278,7 @@ async def test_consumer_deserializes_output_type_dataclass(container):
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        await client.execute_node("hi", structured_agent.subscribe_topics[0], timeout=5)
+        await client.execute("hi", structured_agent.subscribe_topics[0], timeout=5)
 
     final = [c for c in received if any(isinstance(p, DataPart) for p in c.output_parts)]
     assert final, f"no final DataPart envelope observed; received={received}"
@@ -458,7 +458,7 @@ async def test_gate_rejection_skips_consume_fn(container):
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        result = await client.execute_node("hi", agent.subscribe_topics[0], timeout=5)
+        result = await client.execute("hi", agent.subscribe_topics[0], timeout=5)
         assert result.output == "done"
 
     assert invocations == []
@@ -481,7 +481,7 @@ async def test_gate_acceptance_runs_consume_fn(container):
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        await client.execute_node("hi", agent.subscribe_topics[0], timeout=5)
+        await client.execute("hi", agent.subscribe_topics[0], timeout=5)
 
     assert gate_calls
     assert invocations
@@ -577,7 +577,7 @@ async def test_resources_flow_from_node_bag():
 
 
 async def test_deps_round_trip_through_agent_to_consumer(container):
-    """E2E: deps passed to execute_node surface on the consumer's ctx.deps."""
+    """E2E: deps passed to execute surface on the consumer's ctx.deps."""
     received: list[ConsumerContext] = []
 
     @consumer(subscribe_topics="consumer_test_agent.output")
@@ -589,7 +589,7 @@ async def test_deps_round_trip_through_agent_to_consumer(container):
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        result = await client.execute_node("hi", agent.subscribe_topics[0], deps={"discord": {"channel_id": 7}}, timeout=5)
+        result = await client.execute("hi", agent.subscribe_topics[0], deps={"discord": {"channel_id": 7}}, timeout=5)
 
     assert result.deps == {"discord": {"channel_id": 7}}
     assert received, "consumer saw no envelopes"
@@ -703,7 +703,7 @@ async def test_unexpected_projection_exception_is_logged_and_skipped(monkeypatch
 
 # ---------------------------------------------------------------------------
 # Client-side NodeResult contract — the consumer no longer uses NodeResult, but
-# Client.execute_node / InvocationHandle.result still return it. Kept here to
+# Client.execute / InvocationHandle.result still return it. Kept here to
 # preserve the original coverage.
 # ---------------------------------------------------------------------------
 
@@ -732,7 +732,7 @@ def test_lenient_mode_returns_none_on_empty_final_output_parts():
     assert result.state is envelope.context.state  # client path: no copy in from_envelope
 
 
-async def test_client_execute_node_result_carries_state(container):
+async def test_client_execute_result_carries_state(container):
     worker = container.get(Worker)
     agent = Agent(
         "state_vis_agent",
@@ -748,7 +748,7 @@ async def test_client_execute_node_result_carries_state(container):
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        result = await client.execute_node("hi there", agent.subscribe_topics[0], timeout=5)
+        result = await client.execute("hi there", agent.subscribe_topics[0], timeout=5)
 
     assert result.output == "done"
     assert isinstance(result.state, State)

--- a/tests/test_fire_and_forget.py
+++ b/tests/test_fire_and_forget.py
@@ -1,5 +1,5 @@
 """Unit-scope contracts for the fire-and-forget (null-callback) terminal, plus
-end-to-end tests for the true one-way ``Client.emit_to_node`` method.
+end-to-end tests for the true one-way ``Client.send`` method.
 
 The unit tests drive ``BaseNodeDef._publish_action`` directly with a spy broker
 (mirroring ``tests/test_co_tenant_tool_isolation.py``) so the worker's terminal
@@ -13,7 +13,7 @@ envelope so the result is broadcast to the node's ``publish_topic`` (the
 traceability channel via the worker's ``@publisher`` wiring).
 
 The end-to-end tests mirror ``tests/test_headers.py`` (TestKafkaBroker +
-FunctionModel + ``prepare_worker``): they prove ``emit_to_node`` allocates zero
+FunctionModel + ``prepare_worker``): they prove ``send`` allocates zero
 per-call client state and that the broadcast ``publish_topic`` channel still
 records the terminal result even though the point-to-point callback is
 suppressed (no reply future, no "no pending future" warning).
@@ -112,7 +112,7 @@ async def test_return_call_with_non_null_callback_publishes_to_callback():
 
 
 # ---------------------------------------------------------------------------
-# End-to-end: Client.emit_to_node — true one-way fire-and-forget.
+# End-to-end: Client.send — true one-way fire-and-forget.
 # ---------------------------------------------------------------------------
 
 
@@ -123,8 +123,8 @@ def _text_then_done() -> FunctionModel:
     return FunctionModel(_fn)
 
 
-async def test_emit_to_node_allocates_no_client_state(container):
-    """Calling ``emit_to_node`` in a loop leaves ``_dispatcher._pending`` empty
+async def test_send_allocates_no_client_state(container):
+    """Calling ``send`` in a loop leaves ``_dispatcher._pending`` empty
     (no reply future is ever registered) and returns a non-empty uuid-hex
     correlation_id per call."""
     worker = container.get(Worker)
@@ -144,7 +144,7 @@ async def test_emit_to_node_allocates_no_client_state(container):
     correlation_ids: list[str] = []
     async with TestKafkaBroker(broker):
         for _ in range(5):
-            cid = await client.emit_to_node("hi", agent.subscribe_topics[0])
+            cid = await client.send("hi", agent.subscribe_topics[0])
             correlation_ids.append(cid)
 
     # No future was ever registered: the dispatcher's pending map stays empty.
@@ -161,7 +161,7 @@ async def test_emit_to_node_allocates_no_client_state(container):
     assert len(set(correlation_ids)) == 5
 
 
-async def test_emit_to_node_traceable_via_publish_topic_but_no_reply(container, caplog):
+async def test_send_traceable_via_publish_topic_but_no_reply(container, caplog):
     """The terminal result still rides the broadcast ``publish_topic`` channel (a
     ``@consumer`` observes it with populated output), while the client reply inbox
     receives nothing — no reply future, and no "no pending future" warning."""
@@ -187,7 +187,7 @@ async def test_emit_to_node_traceable_via_publish_topic_but_no_reply(container, 
 
     with caplog.at_level(logging.WARNING, logger=REPLY_DISPATCHER_LOGGER):
         async with TestKafkaBroker(broker):
-            cid = await client.emit_to_node("hi", agent.subscribe_topics[0])
+            cid = await client.send("hi", agent.subscribe_topics[0])
 
     # The terminal result reached the broadcast publish_topic channel.
     final = [c for c in received if any(isinstance(p, TextPart) for p in c.output_parts)]
@@ -204,122 +204,122 @@ async def test_emit_to_node_traceable_via_publish_topic_but_no_reply(container, 
 
 
 # ---------------------------------------------------------------------------
-# emit_to_node input-shaping: it carries its OWN copy of invoke_node's
+# send input-shaping: it carries its OWN copy of start's
 # model_settings guard / correlation_id default / OverridesState build / deps
-# passthrough (it does not delegate to invoke_node), so those branches are
-# covered here directly by spying on ``_emit``.
+# passthrough (it does not delegate to start), so those branches are
+# covered here directly by spying on ``_send``.
 # ---------------------------------------------------------------------------
 
 
-async def test_emit_to_node_rejects_non_json_serializable_model_settings(container):
+async def test_send_rejects_non_json_serializable_model_settings(container):
     """The model_settings JSON-serializability guard rejects a non-serializable
-    payload BEFORE publishing — ``_emit`` is never reached."""
+    payload BEFORE publishing — ``_send`` is never reached."""
     client = container.get(Client)
-    client._emit = AsyncMock()  # the only publish path; must not be called
+    client._send = AsyncMock()  # the only publish path; must not be called
 
     with pytest.raises(ValueError, match="not JSON-serializable"):
-        await client.emit_to_node("hi", "agent.input", model_settings={"bad": object()})
+        await client.send("hi", "agent.input", model_settings={"bad": object()})
 
-    client._emit.assert_not_called()
+    client._send.assert_not_called()
 
 
-async def test_emit_to_node_uses_caller_supplied_correlation_id(container):
-    """A caller-supplied correlation_id is returned verbatim and forwarded to ``_emit``."""
+async def test_send_uses_caller_supplied_correlation_id(container):
+    """A caller-supplied correlation_id is returned verbatim and forwarded to ``_send``."""
     client = container.get(Client)
-    client._emit = AsyncMock(return_value="given-cid")
+    client._send = AsyncMock(return_value="given-cid")
 
-    returned = await client.emit_to_node("hi", "agent.input", correlation_id="given-cid")
+    returned = await client.send("hi", "agent.input", correlation_id="given-cid")
 
     assert returned == "given-cid"
-    assert client._emit.await_args.kwargs["correlation_id"] == "given-cid"
+    assert client._send.await_args.kwargs["correlation_id"] == "given-cid"
 
 
-async def test_emit_to_node_autogenerates_correlation_id_when_none(container):
-    """With no correlation_id, a fresh uuid7 hex is generated, forwarded to ``_emit``,
+async def test_send_autogenerates_correlation_id_when_none(container):
+    """With no correlation_id, a fresh uuid7 hex is generated, forwarded to ``_send``,
     and returned."""
     client = container.get(Client)
-    client._emit = AsyncMock(side_effect=lambda **kw: kw["correlation_id"])
+    client._send = AsyncMock(side_effect=lambda **kw: kw["correlation_id"])
 
-    returned = await client.emit_to_node("hi", "agent.input")
+    returned = await client.send("hi", "agent.input")
 
     assert isinstance(returned, str) and len(returned) == 32
     int(returned, 16)  # valid hex
-    assert client._emit.await_args.kwargs["correlation_id"] == returned
+    assert client._send.await_args.kwargs["correlation_id"] == returned
 
 
-async def test_emit_to_node_builds_overrides_and_forwards_deps(container):
-    """``model_settings`` builds an ``OverridesState`` carried to ``_emit``; ``deps``
+async def test_send_builds_overrides_and_forwards_deps(container):
+    """``model_settings`` builds an ``OverridesState`` carried to ``_send``; ``deps``
     pass through; a ``State`` is constructed for the prompt."""
     client = container.get(Client)
-    client._emit = AsyncMock(return_value="cid")
+    client._send = AsyncMock(return_value="cid")
 
     deps = {"tenant": "acme"}
-    await client.emit_to_node(
+    await client.send(
         "summarize",
         "agent.input",
         deps=deps,
         model_settings={"temperature": 0.0},
     )
 
-    kwargs = client._emit.await_args.kwargs
+    kwargs = client._send.await_args.kwargs
     assert kwargs["deps"] == deps
     assert kwargs["overrides"] is not None
     assert kwargs["overrides"].model_settings == {"temperature": 0.0}
     assert isinstance(kwargs["state"], State)
 
 
-async def test_emit_to_node_no_overrides_when_unset(container):
+async def test_send_no_overrides_when_unset(container):
     """With neither tool_overrides nor model_settings, no ``OverridesState`` is built."""
     client = container.get(Client)
-    client._emit = AsyncMock(return_value="cid")
+    client._send = AsyncMock(return_value="cid")
 
-    await client.emit_to_node("hi", "agent.input")
+    await client.send("hi", "agent.input")
 
-    assert client._emit.await_args.kwargs["overrides"] is None
+    assert client._send.await_args.kwargs["overrides"] is None
 
 
-async def test_emit_to_node_tool_overrides_only_builds_overrides(container):
+async def test_send_tool_overrides_only_builds_overrides(container):
     """The tool_overrides-set / model_settings-None arm of the OverridesState OR:
     overrides carry the tool list and a None model_settings. A ToolProvider
     (here a ToolNodeDef) is normalized into its ToolBindings, same as
     ``Agent(tools=...)``."""
     tool = agent_tool(lambda: "pong")  # a ToolProvider (ToolNodeDef)
     client = container.get(Client)
-    client._emit = AsyncMock(return_value="cid")
+    client._send = AsyncMock(return_value="cid")
 
-    await client.emit_to_node("hi", "agent.input", tool_overrides=[tool])
+    await client.send("hi", "agent.input", tool_overrides=[tool])
 
-    overrides = client._emit.await_args.kwargs["overrides"]
+    overrides = client._send.await_args.kwargs["overrides"]
     assert overrides is not None
     assert overrides.override_agent_tools == tool.tool_bindings()
     assert overrides.model_settings is None
 
 
-async def test_emit_to_node_tool_overrides_accepts_raw_bindings(container):
+async def test_send_tool_overrides_accepts_raw_bindings(container):
     """A raw ToolBinding passes through the override normalization verbatim."""
     from calfkit.models.tool_dispatch import ToolBinding
 
     tool = agent_tool(lambda: "pong")
     binding = ToolBinding(tool_def=tool.tool_schema, dispatch_topic=tool.subscribe_topics[0])
     client = container.get(Client)
-    client._emit = AsyncMock(return_value="cid")
+    client._send = AsyncMock(return_value="cid")
 
-    await client.emit_to_node("hi", "agent.input", tool_overrides=[binding])
+    await client.send("hi", "agent.input", tool_overrides=[binding])
 
-    overrides = client._emit.await_args.kwargs["overrides"]
+    overrides = client._send.await_args.kwargs["overrides"]
     assert overrides is not None
     assert overrides.override_agent_tools == [binding]
 
 
-async def test_emit_to_node_passes_temp_instructions_and_history_into_state(container):
-    """temp_instructions and message_history are carried onto the State handed to ``_emit``."""
+async def test_send_passes_temp_instructions_and_history_into_state(container):
+    """temp_instructions and message_history are carried onto the State handed to ``_send``."""
     client = container.get(Client)
-    client._emit = AsyncMock(return_value="cid")
+    client._send = AsyncMock(return_value="cid")
 
     history: list[ModelMessage] = [ModelRequest.user_text_prompt("earlier turn")]
-    await client.emit_to_node("now", "agent.input", temp_instructions="be brief", message_history=history)
+    await client.send("now", "agent.input", temp_instructions="be brief", message_history=history)
 
-    state = client._emit.await_args.kwargs["state"]
+    state = client._send.await_args.kwargs["state"]
     assert state.temp_instructions == "be brief"
     assert history[0] in state.message_history
 
@@ -350,7 +350,7 @@ def _calls_ping_then_done() -> FunctionModel:
     return FunctionModel(_fn)
 
 
-async def test_emit_to_node_multi_hop_tool_call_still_terminates_traceably(container, caplog):
+async def test_send_multi_hop_tool_call_still_terminates_traceably(container, caplog):
     """emit → agent issues a tool Call → tool ReturnCall routes back via the
     agent's _return_topic (a NON-None intermediate callback) → agent terminal
     ReturnCall hits the None bottom frame and suppresses the callback, while the
@@ -380,7 +380,7 @@ async def test_emit_to_node_multi_hop_tool_call_still_terminates_traceably(conta
 
     with caplog.at_level(logging.WARNING, logger=REPLY_DISPATCHER_LOGGER):
         async with TestKafkaBroker(broker):
-            cid = await client.emit_to_node("hi", agent.subscribe_topics[0])
+            cid = await client.send("hi", agent.subscribe_topics[0])
 
     # A terminal with real output reached publish_topic → the tool frame's
     # callback was a real topic, the tool ran, and its ReturnCall routed back.
@@ -396,5 +396,153 @@ async def test_emit_to_node_multi_hop_tool_call_still_terminates_traceably(conta
     assert tool_called, "agent never issued the ping tool call in the captured history"
 
     # The bottom (client) frame callback was suppressed: no reply future, no warning.
+    assert client._dispatcher._pending == {}
+    assert not [r for r in caplog.records if "no pending future" in r.getMessage()]
+
+
+# ---------------------------------------------------------------------------
+# Client send API spec (docs/designs/client-send-api-spec.md):
+# ``send`` (was send) with the optional ``reply_to`` Return Address, and
+# the ``start``/``execute`` (were start/execute) own-inbox invariant.
+# ---------------------------------------------------------------------------
+
+
+def _wire_spy(client: Client) -> AsyncMock:
+    """Replace the client's broker with a spy so the published envelope can be
+    inspected without Kafka. The truthy ``_connection`` skips the lazy start."""
+    connection = MagicMock()
+    connection._connection = True
+    connection.publish = AsyncMock()
+    client._connection = connection
+    return connection.publish
+
+
+async def test_send_reply_to_sets_callback_topic_on_wire(container):
+    """``send(reply_to=...)`` rides the wire as the bottom CallFrame's
+    ``callback_topic`` — the worker will deliver the terminal there."""
+    client = container.get(Client)
+    publish = _wire_spy(client)
+
+    cid = await client.send("hi", "agent.input", reply_to="sink.topic")
+
+    envelope = publish.await_args.args[0]
+    frame = envelope.internal_workflow_state.current_frame
+    assert frame.callback_topic == "sink.topic"
+    assert frame.target_topic == "agent.input"
+    assert publish.await_args.kwargs["correlation_id"] == cid
+
+
+async def test_send_default_keeps_null_callback_on_wire(container):
+    """Without ``reply_to``, ``send`` still publishes a ``callback_topic=None``
+    bottom frame — the pre-spec fire-and-forget wire shape, byte-for-byte."""
+    client = container.get(Client)
+    publish = _wire_spy(client)
+
+    await client.send("hi", "agent.input")
+
+    envelope = publish.await_args.args[0]
+    assert envelope.internal_workflow_state.current_frame.callback_topic is None
+
+
+async def test_send_reply_to_registers_no_future(container):
+    """``reply_to`` does not change send's zero-state contract: no reply future
+    is registered for someone else's delivery address."""
+    client = container.get(Client)
+    _wire_spy(client)
+
+    await client.send("hi", "agent.input", reply_to="sink.topic")
+
+    assert client._dispatcher._pending == {}
+
+
+async def test_send_reply_to_rejects_blank_topic(container):
+    """A blank/whitespace ``reply_to`` would make the worker publish to an
+    invalid topic — rejected at call time, before anything is published."""
+    client = container.get(Client)
+    publish = _wire_spy(client)
+
+    for bad in ("", "   "):
+        with pytest.raises(ValueError, match="non-empty topic name"):
+            await client.send("hi", "agent.input", reply_to=bad)
+
+    publish.assert_not_called()
+
+
+async def test_send_reply_to_rejects_own_inbox(container):
+    """``reply_to=client.reply_topic`` is provably useless: send registers no
+    future, so the client's own dispatcher would consume and drop the reply.
+    Rejected at call time, before anything is published."""
+    client = container.get(Client)
+    publish = _wire_spy(client)
+
+    with pytest.raises(ValueError, match="own reply inbox"):
+        await client.send("hi", "agent.input", reply_to=client.reply_topic)
+
+    publish.assert_not_called()
+
+
+async def test_start_callback_is_always_client_inbox(container):
+    """``start`` always writes the client's own inbox as the wire callback — the
+    only address whose reply future can ever resolve. The per-call
+    ``reply_topic`` override (the dangling-future footgun) is gone."""
+    client = container.get(Client)
+    publish = _wire_spy(client)
+
+    handle = await client.start("hi", "agent.input")
+
+    envelope = publish.await_args.args[0]
+    assert envelope.internal_workflow_state.current_frame.callback_topic == client.reply_topic
+    assert handle.reply_topic == client.reply_topic
+
+    with pytest.raises(TypeError):
+        await client.start("hi", "agent.input", reply_topic="elsewhere")
+    with pytest.raises(TypeError):
+        await client.execute("hi", "agent.input", reply_topic="elsewhere")
+
+
+async def test_send_reply_to_delivers_terminal_to_topic(container, caplog):
+    """End-to-end: the terminal result is delivered point-to-point to the
+    ``reply_to`` topic (a ``@consumer`` there sees it), ALSO still broadcast on
+    the agent's ``publish_topic`` (the #132 dual-channel model), and the client
+    itself stays untouched: no future, no inbox traffic, no warning."""
+    delivered: list[ConsumerContext] = []
+    broadcast: list[ConsumerContext] = []
+
+    @consumer(subscribe_topics="send_rt.results")
+    def reply_sink(ctx: ConsumerContext) -> None:
+        delivered.append(ctx)
+
+    @consumer(subscribe_topics="send_rt_agent.output")
+    def broadcast_sink(ctx: ConsumerContext) -> None:
+        broadcast.append(ctx)
+
+    worker = container.get(Worker)
+    agent = Agent(
+        "send_rt_agent",
+        system_prompt="x",
+        subscribe_topics="send_rt_agent.input",
+        publish_topic="send_rt_agent.output",
+        model_client=_text_then_done(),
+    )
+    worker.add_nodes(agent, reply_sink, broadcast_sink)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    with caplog.at_level(logging.WARNING, logger=REPLY_DISPATCHER_LOGGER):
+        async with TestKafkaBroker(broker):
+            cid = await client.send("hi", agent.subscribe_topics[0], reply_to="send_rt.results")
+
+    # The terminal was delivered point-to-point to the reply_to topic.
+    terminals = [c for c in delivered if any(isinstance(p, TextPart) for p in c.output_parts)]
+    assert terminals, f"reply_to consumer never saw the terminal; saw={delivered}"
+    assert terminals[-1].output == "done"
+    assert terminals[-1].correlation_id == cid
+
+    # The broadcast channel still fired independently (dual-channel model).
+    assert any(any(isinstance(p, TextPart) for p in c.output_parts) for c in broadcast)
+
+    # The client stayed untouched: no future, no "no pending future" warning.
     assert client._dispatcher._pending == {}
     assert not [r for r in caplog.records if "no pending future" in r.getMessage()]

--- a/tests/test_fire_and_forget.py
+++ b/tests/test_fire_and_forget.py
@@ -26,14 +26,17 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aiokafka.errors import UnknownTopicOrPartitionError
 from faststream.kafka import KafkaBroker, TestKafkaBroker
 
+from calfkit._protocol import HDR_EMITTER
 from calfkit._vendor.pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, ToolCallPart, ToolReturnPart
 from calfkit._vendor.pydantic_ai.messages import TextPart as ModelTextPart
 from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
 from calfkit.client import Client
+from calfkit.client.reply_dispatcher import _ReplyDispatcher
 from calfkit.models import ConsumerContext
-from calfkit.models.actions import ReturnCall
+from calfkit.models.actions import ReturnCall, TailCall
 from calfkit.models.envelope import Envelope
 from calfkit.models.payload import TextPart
 from calfkit.models.session_context import (
@@ -129,10 +132,10 @@ async def test_send_allocates_no_client_state(container):
     correlation_id per call."""
     worker = container.get(Worker)
     agent = Agent(
-        "emit_no_state_agent",
+        "send_no_state_agent",
         system_prompt="x",
-        subscribe_topics="emit_no_state_agent.input",
-        publish_topic="emit_no_state_agent.output",
+        subscribe_topics="send_no_state_agent.input",
+        publish_topic="send_no_state_agent.output",
         model_client=_text_then_done(),
     )
     worker.add_nodes(agent)
@@ -167,16 +170,16 @@ async def test_send_traceable_via_publish_topic_but_no_reply(container, caplog):
     receives nothing — no reply future, and no "no pending future" warning."""
     received: list[ConsumerContext] = []
 
-    @consumer(subscribe_topics="emit_trace_agent.output")
+    @consumer(subscribe_topics="send_trace_agent.output")
     def sink(ctx: ConsumerContext) -> None:
         received.append(ctx)
 
     worker = container.get(Worker)
     agent = Agent(
-        "emit_trace_agent",
+        "send_trace_agent",
         system_prompt="x",
-        subscribe_topics="emit_trace_agent.input",
-        publish_topic="emit_trace_agent.output",
+        subscribe_topics="send_trace_agent.input",
+        publish_topic="send_trace_agent.output",
         model_client=_text_then_done(),
     )
     worker.add_nodes(agent, sink)
@@ -204,10 +207,10 @@ async def test_send_traceable_via_publish_topic_but_no_reply(container, caplog):
 
 
 # ---------------------------------------------------------------------------
-# send input-shaping: it carries its OWN copy of start's
-# model_settings guard / correlation_id default / OverridesState build / deps
-# passthrough (it does not delegate to start), so those branches are
-# covered here directly by spying on ``_send``.
+# send input-shaping: its path (the shared ``_build_state_and_overrides`` →
+# ``_send``) never goes through ``start``, so the model_settings guard /
+# correlation_id default / OverridesState build / deps passthrough branches
+# are covered here directly by spying on ``_send``.
 # ---------------------------------------------------------------------------
 
 
@@ -351,7 +354,7 @@ def _calls_ping_then_done() -> FunctionModel:
 
 
 async def test_send_multi_hop_tool_call_still_terminates_traceably(container, caplog):
-    """emit → agent issues a tool Call → tool ReturnCall routes back via the
+    """send → agent issues a tool Call → tool ReturnCall routes back via the
     agent's _return_topic (a NON-None intermediate callback) → agent terminal
     ReturnCall hits the None bottom frame and suppresses the callback, while the
     terminal still reaches publish_topic. If None ever leaked into the tool
@@ -359,16 +362,16 @@ async def test_send_multi_hop_tool_call_still_terminates_traceably(container, ca
     arrive — so a passing terminal proves the invariant."""
     received: list[ConsumerContext] = []
 
-    @consumer(subscribe_topics="emit_tool_agent.output")
+    @consumer(subscribe_topics="send_tool_agent.output")
     def sink(ctx: ConsumerContext) -> None:
         received.append(ctx)
 
     worker = container.get(Worker)
     agent = Agent(
-        "emit_tool_agent",
+        "send_tool_agent",
         system_prompt="x",
-        subscribe_topics="emit_tool_agent.input",
-        publish_topic="emit_tool_agent.output",
+        subscribe_topics="send_tool_agent.input",
+        publish_topic="send_tool_agent.output",
         model_client=_calls_ping_then_done(),
         tools=[ping],
     )
@@ -402,14 +405,15 @@ async def test_send_multi_hop_tool_call_still_terminates_traceably(container, ca
 
 # ---------------------------------------------------------------------------
 # Client send API spec (docs/designs/client-send-api-spec.md):
-# ``send`` (was send) with the optional ``reply_to`` Return Address, and
-# the ``start``/``execute`` (were start/execute) own-inbox invariant.
+# ``send`` (was ``emit_to_node``) with the optional ``reply_to`` Return Address, and
+# the ``start``/``execute`` (were ``invoke_node``/``execute_node``) own-inbox invariant.
 # ---------------------------------------------------------------------------
 
 
 def _wire_spy(client: Client) -> AsyncMock:
     """Replace the client's broker with a spy so the published envelope can be
-    inspected without Kafka. The truthy ``_connection`` skips the lazy start."""
+    inspected without Kafka. (The lazy connect-guard is skipped because every
+    ``MagicMock`` attribute — including ``_connection`` — is truthy.)"""
     connection = MagicMock()
     connection._connection = True
     connection.publish = AsyncMock()
@@ -483,8 +487,7 @@ async def test_send_reply_to_rejects_own_inbox(container):
 
 async def test_start_callback_is_always_client_inbox(container):
     """``start`` always writes the client's own inbox as the wire callback — the
-    only address whose reply future can ever resolve. The per-call
-    ``reply_topic`` override (the dangling-future footgun) is gone."""
+    only address whose reply future can ever resolve."""
     client = container.get(Client)
     publish = _wire_spy(client)
 
@@ -493,6 +496,13 @@ async def test_start_callback_is_always_client_inbox(container):
     envelope = publish.await_args.args[0]
     assert envelope.internal_workflow_state.current_frame.callback_topic == client.reply_topic
     assert handle.reply_topic == client.reply_topic
+
+
+async def test_start_and_execute_reject_removed_reply_topic_param(container):
+    """The per-call ``reply_topic`` override (the dangling-future footgun) is
+    gone from both request/reply verbs — passing it is a ``TypeError``."""
+    client = container.get(Client)
+    _wire_spy(client)
 
     with pytest.raises(TypeError):
         await client.start("hi", "agent.input", reply_topic="elsewhere")
@@ -546,3 +556,118 @@ async def test_send_reply_to_delivers_terminal_to_topic(container, caplog):
     # The client stayed untouched: no future, no "no pending future" warning.
     assert client._dispatcher._pending == {}
     assert not [r for r in caplog.records if "no pending future" in r.getMessage()]
+
+
+async def test_send_reply_to_rejects_illegal_topic_names(container):
+    """A ``reply_to`` that is not a legal Kafka topic name would never get
+    metadata at the worker's terminal publish — a 40s stall into an
+    argument-less ``UnknownTopicOrPartitionError`` on a different process.
+    Reject it loudly at call time instead, before anything publishes."""
+    client = container.get(Client)
+    publish = _wire_spy(client)
+
+    for bad in ("has space", "foo/bar", "a" * 250, ".", "..", " padded "):
+        with pytest.raises(ValueError, match="not a valid Kafka topic name"):
+            await client.send("hi", "agent.input", reply_to=bad)
+    publish.assert_not_called()
+
+    # The full legal alphabet still passes.
+    await client.send("hi", "agent.input", reply_to="Orders.done-v2_1")
+    assert publish.await_count == 1
+
+
+async def test_return_call_callback_publish_failure_still_broadcasts(caplog):
+    """If the terminal point-to-point publish fails (e.g. the ``reply_to``
+    topic does not exist and auto-create is off), the failure must not take
+    the ``publish_topic`` broadcast down with it: the worker logs an ERROR
+    naming the topic and correlation id, and still returns the terminal
+    envelope so the traceability channel fires."""
+    node = _make_node()
+    envelope = _make_envelope(callback_topic="missing.sink")
+
+    broker = MagicMock()
+    broker.publish = AsyncMock(side_effect=UnknownTopicOrPartitionError())
+
+    final_state = State()
+    with caplog.at_level(logging.ERROR, logger="calfkit.nodes.base"):
+        result = await node._publish_action(ReturnCall(state=final_state), envelope, "cid-fail", broker)
+
+    # The broadcast channel survives: the terminal envelope is still returned.
+    assert isinstance(result, Envelope)
+    assert result.context.state is final_state
+
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors, "callback publish failure must be logged at ERROR, not swallowed or escaped"
+    message = errors[-1].getMessage()
+    assert "missing.sink" in message, f"ERROR log must name the callback topic; got: {message}"
+    assert "cid-fail" in message, f"ERROR log must carry the correlation id; got: {message}"
+
+
+async def test_tail_call_preserves_reply_to_callback():
+    """Regression pin for the spec claim (nodes/base.py TailCall branch): a
+    tail chain re-pushes the popped frame's callback, so a ``reply_to``
+    address on the bottom frame survives to the eventual terminal exactly
+    like a client inbox does. (Pinned existing behavior, not a new feature.)"""
+    node = _make_node()
+    envelope = _make_envelope(callback_topic="sink.topic")
+
+    broker = MagicMock()
+    broker.publish = AsyncMock()
+
+    await node._publish_action(TailCall(target_topic="terminal_node.input", state=State()), envelope, "cid-tail", broker)
+
+    frame = envelope.internal_workflow_state.current_frame
+    assert frame.callback_topic == "sink.topic", f"TailCall dropped the reply_to callback; got {frame.callback_topic!r}"
+
+
+async def test_send_reply_to_survives_tool_hops(container, caplog):
+    """Regression pin (composition proof): send(reply_to=...) through an agent
+    that performs a tool round-trip still delivers the terminal to the
+    ``reply_to`` topic — intermediate tool frames carry the agent's
+    ``_return_topic`` and never clobber the bottom frame's return address."""
+    delivered: list[ConsumerContext] = []
+
+    @consumer(subscribe_topics="send_rt_tool.results")
+    def reply_sink(ctx: ConsumerContext) -> None:
+        delivered.append(ctx)
+
+    worker = container.get(Worker)
+    agent = Agent(
+        "send_rt_tool_agent",
+        system_prompt="x",
+        subscribe_topics="send_rt_tool_agent.input",
+        publish_topic="send_rt_tool_agent.output",
+        model_client=_calls_ping_then_done(),
+        tools=[ping],
+    )
+    worker.add_nodes(agent, ping, reply_sink)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    with caplog.at_level(logging.WARNING, logger=REPLY_DISPATCHER_LOGGER):
+        async with TestKafkaBroker(broker):
+            cid = await client.send("hi", agent.subscribe_topics[0], reply_to="send_rt_tool.results")
+
+    terminals = [c for c in delivered if any(isinstance(p, TextPart) for p in c.output_parts)]
+    assert terminals, f"reply_to consumer never saw the terminal after a tool round-trip; saw={delivered}"
+    assert terminals[-1].output == "done"
+    assert terminals[-1].correlation_id == cid
+    assert client._dispatcher._pending == {}
+    assert not [r for r in caplog.records if "no pending future" in r.getMessage()]
+
+
+async def test_no_pending_future_warning_names_emitter(caplog):
+    """A reply landing on an inbox with no pending future (e.g. another
+    client's ``send(reply_to=<this inbox>)``) is the receiver's only signal of
+    the mis-address — the warning must name the emitter so it is diagnosable."""
+    dispatcher = _ReplyDispatcher()
+    envelope = _make_envelope(callback_topic=None)
+
+    with caplog.at_level(logging.WARNING, logger=REPLY_DISPATCHER_LOGGER):
+        dispatcher._on_reply(envelope, "cid-foreign", {HDR_EMITTER: b"client.someone-else"})
+
+    warnings = [r for r in caplog.records if "no pending future" in r.getMessage()]
+    assert warnings, "expected the no-pending-future warning"
+    assert "client.someone-else" in warnings[-1].getMessage(), f"warning must name the emitter; got: {warnings[-1].getMessage()}"

--- a/tests/test_fire_and_forget.py
+++ b/tests/test_fire_and_forget.py
@@ -415,7 +415,6 @@ def _wire_spy(client: Client) -> AsyncMock:
     inspected without Kafka. (The lazy connect-guard is skipped because every
     ``MagicMock`` attribute — including ``_connection`` — is truthy.)"""
     connection = MagicMock()
-    connection._connection = True
     connection.publish = AsyncMock()
     client._connection = connection
     return connection.publish
@@ -601,6 +600,8 @@ async def test_return_call_callback_publish_failure_still_broadcasts(caplog):
     message = errors[-1].getMessage()
     assert "missing.sink" in message, f"ERROR log must name the callback topic; got: {message}"
     assert "cid-fail" in message, f"ERROR log must carry the correlation id; got: {message}"
+    # logger.exception attaches the traceback — the part an operator needs most.
+    assert errors[-1].exc_info, "the ERROR must carry exc_info (logged via logger.exception)"
 
 
 async def test_tail_call_preserves_reply_to_callback():

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -1,7 +1,7 @@
 """End-to-end tests for gate stack on BaseNodeDef.
 
 Tests follow the project pattern: TestKafkaBroker for in-memory broker,
-FunctionModel for offline agent runs, client.execute_node / invoke_node for
+FunctionModel for offline agent runs, client.execute / start for
 real message dispatch. No broker mocking.
 """
 
@@ -34,7 +34,7 @@ async def test_no_gates_passes_through(container, deploy_gated_function_agent, g
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        result = await client.execute_node("hi", GATED_AGENT_TOPIC, timeout=5)
+        result = await client.execute("hi", GATED_AGENT_TOPIC, timeout=5)
 
         assert result.output == NO_TOOLS_RESPONSE_TEXT
 
@@ -53,7 +53,7 @@ async def test_single_sync_gate_true_allows_run(container, deploy_gated_function
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        result = await client.execute_node("hi", GATED_AGENT_TOPIC, timeout=5)
+        result = await client.execute("hi", GATED_AGENT_TOPIC, timeout=5)
 
         assert result.output == NO_TOOLS_RESPONSE_TEXT
         assert calls == ["g1"]
@@ -73,7 +73,7 @@ async def test_single_async_gate_true_allows_run(container, deploy_gated_functio
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        result = await client.execute_node("hi", GATED_AGENT_TOPIC, timeout=5)
+        result = await client.execute("hi", GATED_AGENT_TOPIC, timeout=5)
 
         assert result.output == NO_TOOLS_RESPONSE_TEXT
         assert calls == ["g1"]
@@ -101,7 +101,7 @@ async def test_multiple_gates_all_true_run_in_order(container, deploy_gated_func
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        result = await client.execute_node("hi", GATED_AGENT_TOPIC, timeout=5)
+        result = await client.execute("hi", GATED_AGENT_TOPIC, timeout=5)
 
         assert result.output == NO_TOOLS_RESPONSE_TEXT
         assert calls == ["g1", "g2", "g3"]
@@ -125,7 +125,7 @@ async def test_mixed_sync_and_async_gates(container, deploy_gated_function_agent
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        result = await client.execute_node("hi", GATED_AGENT_TOPIC, timeout=5)
+        result = await client.execute("hi", GATED_AGENT_TOPIC, timeout=5)
 
         assert result.output == NO_TOOLS_RESPONSE_TEXT
         assert calls == ["sync", "async"]
@@ -149,7 +149,7 @@ async def test_decorator_form_registers_gate(container, deploy_gated_function_ag
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        result = await client.execute_node("hi", GATED_AGENT_TOPIC, timeout=5)
+        result = await client.execute("hi", GATED_AGENT_TOPIC, timeout=5)
 
         assert result.output == NO_TOOLS_RESPONSE_TEXT
         assert calls == ["decorated"]
@@ -177,7 +177,7 @@ async def test_constructor_then_decorator_order(container, deploy_gated_function
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        result = await client.execute_node("hi", GATED_AGENT_TOPIC, timeout=5)
+        result = await client.execute("hi", GATED_AGENT_TOPIC, timeout=5)
 
         assert result.output == NO_TOOLS_RESPONSE_TEXT
         assert calls == ["ctor", "decorator"]
@@ -203,7 +203,7 @@ async def test_gate_sees_overrides_applied_by_prepare_context(
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        await client.execute_node(
+        await client.execute(
             "hi",
             GATED_AGENT_TOPIC,
             tool_overrides=[],
@@ -234,7 +234,7 @@ async def test_single_sync_gate_false_blocks_run(container, deploy_gated_functio
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        handle = await client.invoke_node("hi", GATED_AGENT_TOPIC)
+        handle = await client.start("hi", GATED_AGENT_TOPIC)
         with pytest.raises(asyncio.TimeoutError):
             await handle.result(timeout=2)
 
@@ -255,7 +255,7 @@ async def test_single_async_gate_false_blocks_run(container, deploy_gated_functi
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        handle = await client.invoke_node("hi", GATED_AGENT_TOPIC)
+        handle = await client.start("hi", GATED_AGENT_TOPIC)
         with pytest.raises(asyncio.TimeoutError):
             await handle.result(timeout=2)
 
@@ -284,7 +284,7 @@ async def test_short_circuit_stops_after_first_false(container, deploy_gated_fun
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        handle = await client.invoke_node("hi", GATED_AGENT_TOPIC)
+        handle = await client.start("hi", GATED_AGENT_TOPIC)
         with pytest.raises(asyncio.TimeoutError):
             await handle.result(timeout=2)
 
@@ -314,7 +314,7 @@ async def test_gate_raises_treated_as_reject_and_logged(
 
     with caplog.at_level(logging.ERROR, logger="calfkit.nodes.base"):
         async with TestKafkaBroker(broker):
-            handle = await client.invoke_node("hi", GATED_AGENT_TOPIC)
+            handle = await client.start("hi", GATED_AGENT_TOPIC)
             with pytest.raises(asyncio.TimeoutError):
                 await handle.result(timeout=2)
 
@@ -340,7 +340,7 @@ async def test_non_bool_return_rejects_and_logs(
 
     with caplog.at_level(logging.ERROR, logger="calfkit.nodes.base"):
         async with TestKafkaBroker(broker):
-            handle = await client.invoke_node("hi", GATED_AGENT_TOPIC)
+            handle = await client.start("hi", GATED_AGENT_TOPIC)
             with pytest.raises(asyncio.TimeoutError):
                 await handle.result(timeout=2)
 
@@ -383,7 +383,7 @@ async def test_tool_node_gating_blocks_tool_function(container, deploy_function_
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        handle = await client.invoke_node("hi", deploy_function_agent.subscribe_topics[0])
+        handle = await client.start("hi", deploy_function_agent.subscribe_topics[0])
         with pytest.raises(asyncio.TimeoutError):
             await handle.result(timeout=2)
 

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -2,7 +2,7 @@
 
 Follows the project pattern: TestKafkaBroker for in-memory broker, FunctionModel
 for offline deterministic agent runs, gate closures to capture per-hop ctx state,
-and client.execute_node / invoke_node for real message dispatch.
+and client.execute / start for real message dispatch.
 """
 
 import asyncio
@@ -102,7 +102,7 @@ async def test_agent_receives_client_emitter(container):
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        await client.execute_node("hi", "test_emitter_client_hop.input", timeout=5)
+        await client.execute("hi", "test_emitter_client_hop.input", timeout=5)
 
     assert len(seen) == 1
     assert seen[0] is not None
@@ -142,7 +142,7 @@ async def test_tool_receives_agent_id_as_emitter(container):
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        await client.execute_node("call the tool", "test_emitter_agent_hop.input", timeout=5)
+        await client.execute("call the tool", "test_emitter_agent_hop.input", timeout=5)
 
     assert _tool_capture["agent_name"] == "test_emitter_agent_hop"
 
@@ -182,7 +182,7 @@ async def test_agent_receives_tool_emitter_on_return(container):
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        await client.execute_node("call the tool", "test_emitter_return_hop.input", timeout=5)
+        await client.execute("call the tool", "test_emitter_return_hop.input", timeout=5)
 
     # Two agent invocations: client→agent, then tool→agent (return).
     assert len(seen) == 2
@@ -218,7 +218,7 @@ async def test_gate_reject_auto_publish_carries_emitter_header(container, deploy
     prepare_worker(container)
 
     async with TestKafkaBroker(broker):
-        handle = await client.invoke_node("hi", agent.subscribe_topics[0])
+        handle = await client.start("hi", agent.subscribe_topics[0])
         with pytest.raises(asyncio.TimeoutError):
             await handle.result(timeout=2)
 
@@ -250,7 +250,7 @@ async def test_success_path_publish_topic_carries_emitter_header(container, depl
     prepare_worker(container)
 
     async with TestKafkaBroker(broker):
-        await client.execute_node("hi", agent.subscribe_topics[0], timeout=5)
+        await client.execute("hi", agent.subscribe_topics[0], timeout=5)
 
     agent_published = [h for h in received_headers if _decode_header(h.get(HDR_EMITTER_KIND)) == "agent"]
     assert agent_published, f"no agent-emitted message reached {agent.publish_topic}; received={received_headers}"
@@ -314,7 +314,7 @@ async def test_parallel_fan_out_carries_emitter_per_call(container):
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        await client.execute_node("call all tools", "test_parallel_emitter.input", timeout=10)
+        await client.execute("call all tools", "test_parallel_emitter.input", timeout=10)
 
     assert _parallel_capture == {"a": agent.node_id, "b": agent.node_id, "c": agent.node_id}
 
@@ -332,7 +332,7 @@ async def test_client_node_result_carries_reply_emitter(container, deploy_gated_
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        result = await client.execute_node("hi", agent.subscribe_topics[0], timeout=5)
+        result = await client.execute("hi", agent.subscribe_topics[0], timeout=5)
 
     assert result.emitter_node_id == agent.node_id
     assert result.emitter_node_kind == "agent"

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -14,7 +14,7 @@ async def test_init_instructions_only(container, deploy_instructions_agent):
     client = container.get(Client)
 
     async with TestKafkaBroker(broker):
-        result = await client.execute_node("hello", "test_instructions_agent.input")
+        result = await client.execute("hello", "test_instructions_agent.input")
 
     assert result.output is not None
     assert isinstance(result.output, str)
@@ -30,7 +30,7 @@ async def test_runtime_instructions_appended(container, deploy_instructions_agen
     random_runtime_instruction = Faker().sentence(nb_words=50)
 
     async with TestKafkaBroker(broker):
-        result = await client.execute_node(
+        result = await client.execute(
             "hello",
             "test_instructions_agent.input",
             temp_instructions=random_runtime_instruction,
@@ -57,7 +57,7 @@ async def test_dynamic_instructions_appended(container, deploy_instructions_agen
         return random_dynamic_instruction[-1]
 
     async with TestKafkaBroker(broker):
-        result = await client.execute_node("hello", "test_instructions_agent.input")
+        result = await client.execute("hello", "test_instructions_agent.input")
 
     assert result.output is not None
     assert isinstance(result.output, str)
@@ -81,7 +81,7 @@ async def test_all_three_instruction_levels(container, deploy_instructions_agent
         return random_dynamic_instruction[-1]
 
     async with TestKafkaBroker(broker):
-        result = await client.execute_node(
+        result = await client.execute(
             "hello",
             "test_instructions_agent.input",
             temp_instructions=random_runtime_instruction,
@@ -113,7 +113,7 @@ async def test_instructions_are_temporary(container, deploy_instructions_agent):
         return random_dynamic_instruction[-1]
 
     async with TestKafkaBroker(broker):
-        result = await client.execute_node(
+        result = await client.execute(
             "hello",
             "test_instructions_agent.input",
             temp_instructions=random_runtime_instruction,
@@ -124,7 +124,7 @@ async def test_instructions_are_temporary(container, deploy_instructions_agent):
     assert random_dynamic_instruction[-1] in result.output
 
     async with TestKafkaBroker(broker):
-        result = await client.execute_node(
+        result = await client.execute(
             "hello again.",
             "test_instructions_agent.input",
         )

--- a/tests/test_lifecycle_e2e.py
+++ b/tests/test_lifecycle_e2e.py
@@ -311,7 +311,7 @@ async def test_resources_reach_agent_run_and_agent_tool() -> None:
 
     async with TestKafkaBroker(broker):
         await worker.start()
-        result = await client.execute_node("hi", "res_agent.in", timeout=5)
+        result = await client.execute("hi", "res_agent.in", timeout=5)
         await worker.stop()
 
     assert result.output == "done"

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -67,7 +67,7 @@ async def test_no_settings_anywhere(container):
     prepare_worker(container)
     client = container.get(Client)
     async with TestKafkaBroker(container.get(KafkaBroker)):
-        await client.execute_node("hello", agent.subscribe_topics[0])
+        await client.execute("hello", agent.subscribe_topics[0])
     assert captured.settings[0] is None
 
 
@@ -77,7 +77,7 @@ async def test_tier3_only_overrides_baseline(container):
     prepare_worker(container)
     client = container.get(Client)
     async with TestKafkaBroker(container.get(KafkaBroker)):
-        await client.execute_node("hello", agent.subscribe_topics[0], model_settings={"temperature": 0.7})
+        await client.execute("hello", agent.subscribe_topics[0], model_settings={"temperature": 0.7})
     assert captured.settings[0] == {"temperature": 0.7}
 
 
@@ -87,7 +87,7 @@ async def test_tier2_only_overrides_baseline(container):
     prepare_worker(container)
     client = container.get(Client)
     async with TestKafkaBroker(container.get(KafkaBroker)):
-        await client.execute_node("hello", agent.subscribe_topics[0])
+        await client.execute("hello", agent.subscribe_topics[0])
     assert captured.settings[0] == {"temperature": 0.3}
 
 
@@ -97,7 +97,7 @@ async def test_tier1_only_overrides_baseline(container):
     prepare_worker(container)
     client = container.get(Client)
     async with TestKafkaBroker(container.get(KafkaBroker)):
-        await client.execute_node("hello", agent.subscribe_topics[0])
+        await client.execute("hello", agent.subscribe_topics[0])
     assert captured.settings[0] == {"temperature": 0.1}
 
 
@@ -107,7 +107,7 @@ async def test_tier2_beats_tier1_when_tier3_unset(container):
     prepare_worker(container)
     client = container.get(Client)
     async with TestKafkaBroker(container.get(KafkaBroker)):
-        await client.execute_node("hello", agent.subscribe_topics[0])
+        await client.execute("hello", agent.subscribe_topics[0])
     assert captured.settings[0] is not None
     assert captured.settings[0]["temperature"] == 0.5
 
@@ -118,7 +118,7 @@ async def test_three_tier_precedence(container):
     prepare_worker(container)
     client = container.get(Client)
     async with TestKafkaBroker(container.get(KafkaBroker)):
-        await client.execute_node("hello", agent.subscribe_topics[0], model_settings={"temperature": 0.9})
+        await client.execute("hello", agent.subscribe_topics[0], model_settings={"temperature": 0.9})
     assert captured.settings[0] is not None
     assert captured.settings[0]["temperature"] == 0.9
 
@@ -129,7 +129,7 @@ async def test_disjoint_keys_merge(container):
     prepare_worker(container)
     client = container.get(Client)
     async with TestKafkaBroker(container.get(KafkaBroker)):
-        await client.execute_node("hello", agent.subscribe_topics[0], model_settings={"temperature": 0.7})
+        await client.execute("hello", agent.subscribe_topics[0], model_settings={"temperature": 0.7})
     assert captured.settings[0] is not None
     assert captured.settings[0]["max_tokens"] == 100
     assert captured.settings[0]["top_p"] == 0.95
@@ -142,7 +142,7 @@ async def test_fail_fast_non_serializable_model_settings(container):
     prepare_worker(container)
     client = container.get(Client)
     with pytest.raises(ValueError, match="not JSON-serializable"):
-        await client.invoke_node("hello", agent.subscribe_topics[0], model_settings={"bad": object()})
+        await client.start("hello", agent.subscribe_topics[0], model_settings={"bad": object()})
 
 
 async def test_fail_fast_rejects_nested_non_serializable(container):
@@ -151,7 +151,7 @@ async def test_fail_fast_rejects_nested_non_serializable(container):
     prepare_worker(container)
     client = container.get(Client)
     with pytest.raises(ValueError, match="not JSON-serializable"):
-        await client.invoke_node("hello", agent.subscribe_topics[0], model_settings={"extra_body": {"nested": object()}})
+        await client.start("hello", agent.subscribe_topics[0], model_settings={"extra_body": {"nested": object()}})
 
 
 async def test_fail_fast_rejects_nan_and_inf(container):
@@ -160,9 +160,9 @@ async def test_fail_fast_rejects_nan_and_inf(container):
     prepare_worker(container)
     client = container.get(Client)
     with pytest.raises(ValueError, match="not JSON-serializable"):
-        await client.invoke_node("hello", agent.subscribe_topics[0], model_settings={"temperature": float("nan")})
+        await client.start("hello", agent.subscribe_topics[0], model_settings={"temperature": float("nan")})
     with pytest.raises(ValueError, match="not JSON-serializable"):
-        await client.invoke_node("hello", agent.subscribe_topics[0], model_settings={"temperature": float("inf")})
+        await client.start("hello", agent.subscribe_topics[0], model_settings={"temperature": float("inf")})
 
 
 async def test_unchanged_baseline_when_no_settings_passed(container):
@@ -171,9 +171,9 @@ async def test_unchanged_baseline_when_no_settings_passed(container):
     prepare_worker(container)
     client = container.get(Client)
     async with TestKafkaBroker(container.get(KafkaBroker)):
-        await client.execute_node("hello", agent.subscribe_topics[0])
+        await client.execute("hello", agent.subscribe_topics[0])
     async with TestKafkaBroker(container.get(KafkaBroker)):
-        await client.execute_node("hello", agent.subscribe_topics[0], model_settings=None)
+        await client.execute("hello", agent.subscribe_topics[0], model_settings=None)
     assert captured.settings[0] == captured.settings[1]
     assert captured.settings[0] is None
 
@@ -184,9 +184,9 @@ async def test_empty_dict_behaves_like_none(container):
     prepare_worker(container)
     client = container.get(Client)
     async with TestKafkaBroker(container.get(KafkaBroker)):
-        await client.execute_node("hello", agent.subscribe_topics[0], model_settings={})
+        await client.execute("hello", agent.subscribe_topics[0], model_settings={})
     async with TestKafkaBroker(container.get(KafkaBroker)):
-        await client.execute_node("hello", agent.subscribe_topics[0], model_settings=None)
+        await client.execute("hello", agent.subscribe_topics[0], model_settings=None)
     assert captured.settings[0] == captured.settings[1] == {"temperature": 0.1}
 
 
@@ -196,7 +196,7 @@ async def test_tools_available_with_model_settings_only(container, deploy_no_arg
     prepare_worker(container)
     client = container.get(Client)
     async with TestKafkaBroker(container.get(KafkaBroker)):
-        await client.execute_node("hello", agent.subscribe_topics[0], model_settings={"temperature": 0.5})
+        await client.execute("hello", agent.subscribe_topics[0], model_settings={"temperature": 0.5})
     assert captured.settings[0] == {"temperature": 0.5}
     expected = {tool.tool_schema.name for tool in deploy_no_arg_tools}
     assert set(captured.tool_names[0]) == expected
@@ -208,7 +208,7 @@ async def test_tool_overrides_and_model_settings_combined(container, deploy_no_a
     prepare_worker(container)
     client = container.get(Client)
     async with TestKafkaBroker(container.get(KafkaBroker)):
-        await client.execute_node(
+        await client.execute(
             "hello",
             agent.subscribe_topics[0],
             tool_overrides=deploy_no_arg_tools,

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -12,7 +12,7 @@ async def test_agent_tools_overrides_none(container, deploy_function_agent, depl
     client = container.get(Client)
 
     async with TestKafkaBroker(container.get(KafkaBroker)) as _:
-        result = await client.execute_node(
+        result = await client.execute(
             "Hey! Call all your tools concurrently right now", deploy_function_agent.subscribe_topics[0], tool_overrides=None
         )
 
@@ -30,7 +30,7 @@ async def test_agent_tools_overrides_empty(container, deploy_function_agent, dep
     client = container.get(Client)
 
     async with TestKafkaBroker(container.get(KafkaBroker)) as _:
-        result = await client.execute_node(
+        result = await client.execute(
             "Hey! Call all your tools concurrently right now again.", deploy_function_agent.subscribe_topics[0], tool_overrides=[]
         )
 
@@ -44,7 +44,7 @@ async def test_agent_tools_overrides_new_tools(container, deploy_function_agent,
     client = container.get(Client)
 
     async with TestKafkaBroker(container.get(KafkaBroker)) as _:
-        result = await client.execute_node(
+        result = await client.execute(
             "Hey! Call all your tools concurrently right now", deploy_function_agent.subscribe_topics[0], tool_overrides=deploy_no_arg_tools
         )
 

--- a/tests/test_provisioning_client.py
+++ b/tests/test_provisioning_client.py
@@ -51,6 +51,20 @@ def test_connect_rejects_raw_sasl_plain_kwargs() -> None:
         Client.connect("localhost:9092", sasl_plain_username="u", sasl_plain_password="p")
 
 
+def test_connect_rejects_illegal_reply_topic_name() -> None:
+    # An explicit reply_topic is the wire callback on EVERY start()/execute()
+    # frame and the client's own subscription — a Kafka-illegal name would
+    # recreate exactly the cross-process metadata stall send(reply_to=...)
+    # validation exists to prevent. Same rule, same loud client-side rejection.
+    for bad in ("has space", "foo/bar", "a" * 250, ".", ".."):
+        with pytest.raises(ValueError, match="not a valid Kafka topic name"):
+            Client.connect("localhost:9092", reply_topic=bad)
+
+    # Explicit legal names still work.
+    client = Client.connect("localhost:9092", reply_topic="my-app.replies_1")
+    assert client.reply_topic == "my-app.replies_1"
+
+
 def test_client_never_captures_security_kwargs() -> None:
     """Credentials flow exclusively through FastStream's ``security=`` object
     (the #188 invariant): the client must never capture raw security kwargs.

--- a/tests/test_reply_dispatcher_ttl.py
+++ b/tests/test_reply_dispatcher_ttl.py
@@ -128,7 +128,7 @@ async def test_normal_completion_cancels_timer():
 
 
 async def test_evicted_abandoned_future_does_not_log_never_retrieved():
-    """An abandoned ``invoke_node`` handle — a future nobody awaits — must be
+    """An abandoned ``start`` handle — a future nobody awaits — must be
     evicted *silently*.
 
     The TTL exists precisely for the abandoned-handle case, so eviction must not

--- a/tests/test_routed_dispatch.py
+++ b/tests/test_routed_dispatch.py
@@ -732,11 +732,11 @@ async def test_execute_forwards_route_and_body(monkeypatch: pytest.MonkeyPatch) 
         async def result(self, timeout: float | None = None) -> str:
             return "ok"
 
-    async def _fake_invoke(*args: Any, **kwargs: Any) -> Any:
+    async def _fake_start(*args: Any, **kwargs: Any) -> Any:
         captured.update(kwargs)
         return _FakeHandle()
 
-    monkeypatch.setattr(client, "start", _fake_invoke)
+    monkeypatch.setattr(client, "start", _fake_start)
     await client.execute("hello", "orders", route="order.created", body={"n": 1})
     assert captured.get("route") == "order.created"
     assert captured.get("body") == {"n": 1}

--- a/tests/test_routed_dispatch.py
+++ b/tests/test_routed_dispatch.py
@@ -437,13 +437,13 @@ async def test_client_rejects_non_concrete_producer_route(bad_route: str) -> Non
         )
 
 
-async def test_emit_to_node_threads_route_and_body_to_the_wire() -> None:
+async def test_send_threads_route_and_body_to_the_wire() -> None:
     from calfkit.client.client import Client
     from calfkit.client.reply_dispatcher import _ReplyDispatcher
 
     conn = _StubConn()
     client = Client(cast(Any, conn), "reply.topic", _ReplyDispatcher(reply_ttl=None), emitter_id="client.test")
-    await client.emit_to_node("hello", "orders", route="order.created", body={"amount": 3})
+    await client.send("hello", "orders", route="order.created", body={"amount": 3})
 
     assert len(conn.published) == 1
     _topic, headers, env = conn.published[0]
@@ -626,13 +626,13 @@ async def test_tailcall_publish_carries_no_route_header() -> None:
     assert HDR_ROUTE not in headers
 
 
-async def test_invoke_node_threads_route_and_body_to_the_wire() -> None:
+async def test_start_threads_route_and_body_to_the_wire() -> None:
     from calfkit.client.client import Client
     from calfkit.client.reply_dispatcher import _ReplyDispatcher
 
     conn = _StubConn()
     client = Client(cast(Any, conn), "reply.topic", _ReplyDispatcher(reply_ttl=None), emitter_id="client.test")
-    await client.invoke_node("hello", "orders", route="order.created", body={"n": 1})
+    await client.start("hello", "orders", route="order.created", body={"n": 1})
 
     assert len(conn.published) == 1
     _topic, headers, env = conn.published[0]
@@ -721,7 +721,7 @@ async def test_malformed_route_log_level_keys_on_awaiting_reply(awaiting: bool, 
     assert recs and recs[0].levelno == expected
 
 
-async def test_execute_node_forwards_route_and_body(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_execute_forwards_route_and_body(monkeypatch: pytest.MonkeyPatch) -> None:
     from calfkit.client.client import Client
     from calfkit.client.reply_dispatcher import _ReplyDispatcher
 
@@ -736,7 +736,7 @@ async def test_execute_node_forwards_route_and_body(monkeypatch: pytest.MonkeyPa
         captured.update(kwargs)
         return _FakeHandle()
 
-    monkeypatch.setattr(client, "invoke_node", _fake_invoke)
-    await client.execute_node("hello", "orders", route="order.created", body={"n": 1})
+    monkeypatch.setattr(client, "start", _fake_invoke)
+    await client.execute("hello", "orders", route="order.created", body={"n": 1})
     assert captured.get("route") == "order.created"
     assert captured.get("body") == {"n": 1}


### PR DESCRIPTION
## Summary

Reshapes the three client send methods around one invariant: **a reply future is resolvable iff the wire callback is the client's own reply inbox.** The valid combinations become exactly the expressible ones; the invalid one becomes unrepresentable.

| Wire `callback_topic` | Future | Verb |
|---|---|---|
| `None` (worker suppresses terminal callback) | no | `send` — default, unchanged behavior |
| arbitrary topic, someone else consumes | no | `send(reply_to=...)` — **new capability** (EIP Return Address) |
| client's own inbox | yes | `start` / `execute` — now always |
| arbitrary topic + future | — | the old `invoke_node(reply_topic=...)` bug; now a `TypeError` |

### Changes

- **`emit_to_node` → `send`**, gains `reply_to: str | None = None`: the worker delivers the terminal result point-to-point to a topic some *other* consumer owns (a `@consumer`, a sink service). Still registers no future, still returns the `correlation_id`. Blank `reply_to` and `reply_to == client.reply_topic` raise `ValueError`.
- **`invoke_node` → `start`**, **`execute_node` → `execute`**; both lose the per-call `reply_topic` param. A custom value delivered the reply elsewhere while `_invoke` unconditionally registered a future the dispatcher (which consumes only the client's own inbox) could never resolve — dangling forever, or a misleading `ReplyExpiredError` under `reply_ttl`. No call site in-repo passed a custom value.
- Internal seams `_emit` → `_send`, `_invoke` → `_start`. **Zero worker changes** — the `ReturnCall` branch already delivers to any non-`None` callback; `TailCall` already re-pushes the inherited callback, so `reply_to` survives tail chains.
- Examples renamed: `quickstart/emit.py` → `send.py`, `quickstart/invoke.py` → `execute.py`.
- Docs: `client-features.md` rewritten around the three patterns + `reply_to` semantics; README quick-ref; superseded-in-part note in `fire-and-forget-emit.md`; v1 design doc migration tables retargeted; ADR-0005.

### Naming rationale (ADR-0005)

`send` = addressed, correlated command dispatch (MassTransit/NServiceBus/JMS `Send`; `send(reply_to=)` is the literal AMQP/JMS/FastStream shape) — "emit" means event broadcast, which this never was, and the node-side `Emit` action it claimed to mirror is unwired dead code. `start`/`execute` = Temporal's pairing (`start_workflow` → handle, `execute_workflow` → result); "invoke" vs "execute" are near-synonyms that don't telegraph which one waits.

## BREAKING CHANGE

`emit_to_node` / `invoke_node` / `execute_node` are renamed to `send` / `start` / `execute` with **no deprecated aliases**, and the per-call `reply_topic` parameter is removed from `start`/`execute` (replies always go to the client's own inbox; use `send(reply_to=...)` to direct one-way results elsewhere). **No wire change**: `CallFrame.callback_topic` was already nullable and carries arbitrary topics — mixed-version fleets are unaffected, no rollout ordering constraint.

| Before | After |
|---|---|
| `client.emit_to_node(p, t)` | `client.send(p, t)` |
| *(not expressible)* | `client.send(p, t, reply_to="orders.done")` |
| `client.invoke_node(p, t)` | `client.start(p, t)` |
| `client.execute_node(p, t, timeout=30)` | `client.execute(p, t, timeout=30)` |
| `invoke_node(reply_topic=...)` | drop the arg, or `send(reply_to=...)` + consume where you sent it |

## Test plan

TDD per `docs/designs/client-send-api-spec.md` (7 new tests written RED-first in `tests/test_fire_and_forget.py`): `reply_to` lands as the bottom `CallFrame.callback_topic`; default stays `None` byte-for-byte; no future with `reply_to` set; blank/own-inbox `ValueError`s fire before publishing; `start`'s callback is always the client inbox and `reply_topic=` raises `TypeError`; e2e — a `@consumer` on the `reply_to` topic receives the terminal with output populated, the `publish_topic` broadcast still fires independently, and the client inbox sees nothing. Rename sweep across 15 test files + examples; full suite **2760 passed / 6 skipped**; `make fix` + `make check` clean.