### PR TITLE
refactor: remove dead action classes Reply/Delegate/Sequential/Emit/Parallel

### DIFF
--- a/calfkit/models/__init__.py
+++ b/calfkit/models/__init__.py
@@ -1,14 +1,9 @@
 # payload must be imported first — state.py imports ContentPart from this package
 from calfkit.models.actions import (  # noqa: I001 — actions first (see comment above)
     Call,
-    Delegate,
-    Emit,
     Next,
     NodeResult,
-    Parallel,
-    Reply,
     ReturnCall,
-    Sequential,
     Silent,
     TailCall,
     _Call,
@@ -39,14 +34,9 @@ from calfkit.models.tool_dispatch import ArgsValidator, ToolBinding, ToolCallRef
 __all__ = [
     # actions
     "Call",
-    "Delegate",
-    "Emit",
     "Next",
     "NodeResult",
-    "Parallel",
-    "Reply",
     "ReturnCall",
-    "Sequential",
     "Silent",
     "TailCall",
     "_Call",

--- a/calfkit/models/actions.py
+++ b/calfkit/models/actions.py
@@ -8,23 +8,6 @@ from calfkit._types import StateT
 
 
 @dataclass
-class Reply(Generic[StateT]):
-    """Terminal: send value back to whoever called this node (pops reply_stack).
-    Does not require a topic address to reply to, it is handled by the framework.
-    Similar mental model to completing an async Promise or Future with a result."""
-
-    value: StateT
-
-
-@dataclass
-class Delegate(Generic[StateT]):
-    """Terminal: forward to another node, expect result back (pushes reply_stack)."""
-
-    topic: str
-    value: StateT | None = None
-
-
-@dataclass
 class _Call(Generic[StateT]):
     """Call another node, providing mutable state.
 
@@ -80,30 +63,6 @@ class ReturnCall(Generic[StateT]):
     """Finish the node's execution and callback the caller."""
 
     state: StateT
-
-
-@dataclass
-class Sequential(Generic[StateT]):
-    """Sequentially forward a shared state from node to node,
-    where the final state is returned to caller."""
-
-    topics: list[str]  # passed to topics in this list in order index 0 -> n
-    value: StateT | None = None
-
-
-@dataclass
-class Emit(Generic[StateT]):
-    """Terminal: fire-and-forget publish to a topic. No reply expected."""
-
-    value: StateT
-    topic: str
-
-
-@dataclass
-class Parallel(Generic[StateT]):
-    """Parallel fan-out of delegates and calls. Developer manages result aggregation via store."""
-
-    delegates: list[Delegate[StateT] | Call[StateT]]
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Removes the five action classes that were **defined and publicly exported but never wired into the framework**:

| Removed | Why it was dead |
|---|---|
| `Reply` | unwired duplicate of `ReturnCall` |
| `Delegate` | unwired duplicate of `Call` |
| `Parallel` | unwired duplicate of `list[Call]` |
| `Emit` | aspirational fire-and-forget action, never built (`Client.emit_to_node` / fire-and-forget frames are the shipped mechanism) |
| `Sequential` | aspirational pipeline action, never built |

None of them have a `_publish_action` branch — returning any of them from a node falls into the *"Return type is unknown or invalid"* error branch and the message is published nowhere. Nothing constructs them; no test, example, or user-facing doc references them (the historical v1 design docs in `docs/designs/` mention `Reply`/`Emit` as part of the original aspirational API and are deliberately left untouched as design records).

## Breaking change

`calfkit.models` no longer exports `Reply`, `Delegate`, `Sequential`, `Emit`, `Parallel`. The live action vocabulary is unchanged: `Call | list[Call] | ReturnCall | TailCall | Silent` (+ `Next` for route handlers) — exactly the `NodeResult` union, which this PR does not touch.

## Motivation

Prerequisite cleanup for the fault-rail & policy-seams design (`docs/designs/fault-rail-and-policy-seams-spec.md`, in review): the error-handling design targets the cleaned action vocabulary rather than documenting around dead code. Agreed during the design discussion to land this as its own PR first.

## Verification

- Word-boundary sweep over `calfkit/`, `tests/`, `examples/`, and non-design docs: zero usages outside the definitions and re-exports
- `make fix` + `make check` (lint, format, mypy): clean
- Full test suite: **2753 passed, 6 skipped**