### PR TITLE
feat: per-delivery reply slot for returns; Envelope.reply + x-calf-kind

### DIFF
--- a/calfkit/_protocol.py
+++ b/calfkit/_protocol.py
@@ -31,10 +31,14 @@ Ingress-only: set by a client invocation or an explicit peer ``Call(route=...)``
 never auto-propagated across control-flow republishes. A node with registered
 ``@handler`` routes dispatches on this header (see ``BaseNodeDef.handler``)."""
 
+HDR_KIND = "x-calf-kind"
+"""Kafka header classifying every calfkit delivery (spec §4.1). Framework-stamped
+on every publish, never user-set. ``call`` = "do work" (Call / fan-out / TailCall /
+client send); ``return`` = "your call resolved" (a ``ReturnCall`` reply). PR-C adds
+``fault``. A missing header reads as ``call`` (raw-producer ingress norm)."""
 
-HDR_EVENT_TYPE = "x-calf-event-type"
-
-EventType = Literal["control-plane", "data-plane"]
+MessageKind = Literal["call", "return"]
+"""Closed value space for :data:`HDR_KIND` in PR-A. PR-C widens it with ``fault``."""
 
 
 def decode_header_str(value: Any) -> str | None:

--- a/calfkit/client/base.py
+++ b/calfkit/client/base.py
@@ -8,7 +8,7 @@ import uuid_utils
 from faststream.kafka import KafkaBroker
 from typing_extensions import Self
 
-from calfkit._protocol import CLIENT_KIND, HDR_EMITTER, HDR_EMITTER_KIND, HDR_ROUTE
+from calfkit._protocol import CLIENT_KIND, HDR_EMITTER, HDR_EMITTER_KIND, HDR_KIND, HDR_ROUTE
 from calfkit._routing import is_concrete_route_key
 from calfkit.client._broker import _PreStartHookBroker
 from calfkit.client.invocation_handle import InvocationHandle
@@ -343,7 +343,7 @@ class BaseClient:
             internal_workflow_state=WorkflowState(call_stack=call_stack),
             context=SessionRunContext(state=state, deps={} if deps is None else deps),
         )
-        headers = {HDR_EMITTER: self._emitter_id, HDR_EMITTER_KIND: CLIENT_KIND}
+        headers = {HDR_EMITTER: self._emitter_id, HDR_EMITTER_KIND: CLIENT_KIND, HDR_KIND: "call"}
         if route is not None:
             headers[HDR_ROUTE] = route
         await self._connection.publish(

--- a/calfkit/client/invocation_handle.py
+++ b/calfkit/client/invocation_handle.py
@@ -39,7 +39,7 @@ class InvocationHandle(Generic[OutputT]):
                 :meth:`Client.send`, which returns a ``correlation_id`` and
                 no handle at all.
             DeserializationError: If the expected output part type is missing
-                from ``final_output_parts``.
+                from the reply parts.
             pydantic.ValidationError: If ``output_type`` is provided and the
                 reply's ``DataPart.data`` doesn't validate against it.
             pydantic.PydanticSchemaGenerationError: If ``output_type`` cannot

--- a/calfkit/client/reply_dispatcher.py
+++ b/calfkit/client/reply_dispatcher.py
@@ -76,6 +76,9 @@ class _ReplyDispatcher:
             emitter_node_id=decode_header_str(headers.get(HDR_EMITTER)),
             emitter_node_kind=decode_header_str(headers.get(HDR_EMITTER_KIND)),
         )
+        # Surface the per-delivery reply so NodeResult.from_envelope (via
+        # from_context) projects the output from reply.parts (spec §4.5).
+        envelope.context._reply = envelope.reply
 
         entry = self._pending.get(correlation_id)
         if entry is None:

--- a/calfkit/models/__init__.py
+++ b/calfkit/models/__init__.py
@@ -11,6 +11,7 @@ from calfkit.models.actions import (  # noqa: I001 — actions first (see commen
 from calfkit.models.consumer_context import ConsumerContext
 from calfkit.models.envelope import Envelope
 from calfkit.models.payload import ContentPart, DataPart, FilePart, TextPart, ToolCallPart
+from calfkit.models.reply import ReturnMessage
 from calfkit.models.session_context import (
     BaseSessionRunContext,
     CallFrame,
@@ -42,6 +43,8 @@ __all__ = [
     "_Call",
     # envelope
     "Envelope",
+    # reply
+    "ReturnMessage",
     # payload
     "ContentPart",
     "DataPart",

--- a/calfkit/models/_coerce.py
+++ b/calfkit/models/_coerce.py
@@ -1,0 +1,32 @@
+from typing import Any, cast
+
+import pydantic_core
+
+from calfkit.models.payload import ContentPart, DataPart, FilePart, TextPart, ToolCallPart
+
+_CONTENT_PART_TYPES = (TextPart, FilePart, DataPart, ToolCallPart)
+
+
+def _coerce_to_parts(value: Any) -> list[ContentPart]:
+    """Coerce a node's output ``value`` into the content-part vocabulary (spec §4.5).
+
+    The single ``value → parts`` conversion, called at the publish chokepoint when a
+    ``ReturnCall(value=…)`` is sent (PR-C adds a second call site, slot materialization):
+
+    * ``None`` → ``[]`` (no output);
+    * ``str`` → one ``TextPart``;
+    * a ``list[ContentPart]`` passes through unchanged (the agent's preamble case —
+      an empty list is vacuously such a list and yields ``[]``);
+    * anything else JSON-serializable → one ``DataPart``, eagerly wire-checked via
+      ``pydantic_core.to_json`` (the ``tool.py`` precedent): a non-serializable value
+      raises here, at the chokepoint, rather than killing serialization mid-publish.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [TextPart(text=value)]
+    if isinstance(value, list) and all(isinstance(p, _CONTENT_PART_TYPES) for p in value):
+        return cast("list[ContentPart]", value)
+    part = DataPart(data=value)
+    pydantic_core.to_json(part)
+    return [part]

--- a/calfkit/models/actions.py
+++ b/calfkit/models/actions.py
@@ -60,9 +60,14 @@ class TailCall(Generic[StateT], _Call[StateT]):
 
 @dataclass
 class ReturnCall(Generic[StateT]):
-    """Finish the node's execution and callback the caller."""
+    """Finish the node's execution and callback the caller.
+
+    ``value`` is the node's output, coerced to ``reply.parts`` at the publish
+    chokepoint (spec §4.5). It replaces the ``State.final_output_parts``
+    side-channel: output is now explicit in the action."""
 
     state: StateT
+    value: Any = None
 
 
 @dataclass

--- a/calfkit/models/consumer_context.py
+++ b/calfkit/models/consumer_context.py
@@ -34,9 +34,9 @@ class ConsumerContext(Generic[OutputT]):
     output: OutputT | None
     """Deserialized final output (typed via ``output_type``).
 
-    ``None`` on intermediate hops — envelopes whose ``state.final_output_parts`` is
-    empty (e.g. tool completions, mid-loop agent hops). Populated only when the
-    upstream node emitted a terminal envelope with final output parts."""
+    ``None`` on intermediate hops — call-kind deliveries with no reply slot (e.g.
+    tool completions, mid-loop agent hops). Populated only when the upstream node
+    emitted a terminal return carrying reply parts."""
 
     state: State
     """Full session state at this hop (message history, in-flight tool
@@ -45,6 +45,10 @@ class ConsumerContext(Generic[OutputT]):
 
     correlation_id: str
     """The correlation id that ties this hop to its invocation."""
+
+    output_parts: list[ContentPart] = field(default_factory=list)
+    """The raw reply parts this observation was projected from (spec §4). ``[]`` on an
+    intermediate hop. Captured from the delivery's reply slot, not ``state``."""
 
     emitter_node_id: str | None = None
     """Node id of the upstream emitter (``x-calf-emitter`` header), or ``None``."""
@@ -76,16 +80,17 @@ class ConsumerContext(Generic[OutputT]):
         """Build from the consumer's stamped ``SessionRunContext``.
 
         Uses ``strict=False`` (consumer semantics): an intermediate hop with no
-        ``final_output_parts`` yields ``output=None`` instead of raising.
-        ``resources`` is sourced from ``ctx.resources`` (stamped by the node's
-        ``prepare_context``), so the consumer needs no separate resources plumbing.
+        reply slot yields ``output=None`` instead of raising. ``resources`` is
+        sourced from ``ctx.resources`` (stamped by the node's ``prepare_context``),
+        so the consumer needs no separate resources plumbing.
 
         Raises:
-            DeserializationError / pydantic.ValidationError: only when
-            ``final_output_parts`` is present but doesn't match ``output_type``.
+            DeserializationError / pydantic.ValidationError: only when the reply
+            parts are present but don't match ``output_type``.
         """
         return cls(
-            output=project_output(ctx.state, output_type, strict=False, type_adapter=type_adapter),
+            output=project_output(ctx._reply, output_type, strict=False, type_adapter=type_adapter),
+            output_parts=ctx._reply.parts if ctx._reply is not None else [],
             state=ctx.state,
             correlation_id=ctx.correlation_id,
             emitter_node_id=ctx.emitter_node_id,
@@ -93,11 +98,6 @@ class ConsumerContext(Generic[OutputT]):
             deps=ctx.deps,
             resources=ctx.resources,
         )
-
-    @property
-    def output_parts(self) -> list[ContentPart]:
-        """Convenience: ``state.final_output_parts``."""
-        return self.state.final_output_parts
 
     @property
     def message_history(self) -> list[ModelMessage]:

--- a/calfkit/models/envelope.py
+++ b/calfkit/models/envelope.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, Field
 
+from calfkit.models.reply import ReturnMessage
 from calfkit.models.session_context import SessionRunContext, WorkflowState
 
 
@@ -9,9 +10,13 @@ from calfkit.models.session_context import SessionRunContext, WorkflowState
 class Envelope(BaseModel):
     """Wire format — framework internal. Carries routing metadata + developer context.
 
-    Uses plain BaseModel (not CompactBaseModel) so all fields are always
-    serialized — no exclude_unset gotchas with reply_stack.
+    Uses plain BaseModel so all fields are always serialized — no exclude_unset
+    gotchas.
     """
 
     context: SessionRunContext
     internal_workflow_state: WorkflowState = Field(description="The internal, framework-level state tracking workflow")
+    reply: ReturnMessage | None = None
+    """Per-delivery response carriage (spec §4). ``None`` on call-kind deliveries;
+    a :class:`~calfkit.models.reply.ReturnMessage` on return-kind deliveries. PR-C
+    widens this to ``ReturnMessage | FaultMessage`` with a ``kind`` discriminator."""

--- a/calfkit/models/node_result.py
+++ b/calfkit/models/node_result.py
@@ -14,6 +14,7 @@ from calfkit.models.state import State
 
 if TYPE_CHECKING:
     from calfkit.models.envelope import Envelope
+    from calfkit.models.reply import ReturnMessage
     from calfkit.models.session_context import SessionRunContext
 
 _UNSET: Any = object()
@@ -56,26 +57,23 @@ class NodeResult(Generic[OutputT]):
 
     Build one with the :meth:`from_envelope` / :meth:`from_context` alternative
     constructors rather than calling the dataclass directly — they project the
-    output from ``state.final_output_parts`` and source identity from the
+    output from the delivery's reply slot and source identity from the
     transport-stamped context.
     """
 
     output: OutputT | None
     """Deserialized final output (typed via ``output_type``).
 
-    ``None`` on intermediate hops — envelopes whose ``state.final_output_parts``
-    is empty (e.g. agent hops mid-tool-call, tool completions). Populated when
-    the upstream node emitted a terminal envelope with final output parts.
-    Client-side strict-mode results (the default) always have ``output``
-    populated; consumer-side results may not.
+    ``None`` on intermediate hops — call-kind deliveries with no reply slot (e.g.
+    agent hops mid-tool-call, tool completions). Populated when the upstream node
+    emitted a terminal return carrying reply parts. Client-side strict-mode results
+    (the default) always have ``output`` populated; consumer-side results may not.
     """
 
     state: State
     """Full session state at this hop. Includes:
 
     * ``message_history`` — cumulative conversation
-    * ``final_output_parts`` — agent's structured/text output (empty on
-      intermediate hops)
     * ``tool_calls`` / ``tool_results`` — in-flight tool batch (keyed by
       ``tool_call_id``)
     * ``metadata`` — application-level metadata
@@ -88,6 +86,11 @@ class NodeResult(Generic[OutputT]):
 
     correlation_id: str
     """The correlation ID that ties this result to its invocation."""
+
+    output_parts: list[ContentPart] = field(default_factory=list)
+    """The raw reply parts this result was projected from (spec §4). ``[]`` on an
+    intermediate hop. Captured at construction from the delivery's reply slot, not
+    read through ``state`` (the retired ``final_output_parts``)."""
 
     emitter_node_id: str | None = None
     """Node id of the node that emitted this reply (sourced from the
@@ -160,11 +163,11 @@ class NodeResult(Generic[OutputT]):
                 ``ctx.correlation_id`` (which raises if the context was never
                 stamped).
             strict: When ``True`` (default — client semantics), raises
-                :class:`DeserializationError` if ``final_output_parts`` is empty or
-                doesn't contain the expected part type. When ``False`` (consumer
-                semantics), returns ``output=None`` for an empty
-                ``final_output_parts`` (intermediate hop / tool completion);
-                validation errors on *present* parts still propagate.
+                :class:`DeserializationError` if the reply parts are empty or
+                don't contain the expected part type. When ``False`` (consumer
+                semantics), returns ``output=None`` for an empty/absent reply
+                (intermediate hop / tool completion); validation errors on
+                *present* parts still propagate.
             type_adapter: An optional pre-built :class:`pydantic.TypeAdapter` to
                 use for validating ``DataPart.data`` against *output_type*. When
                 ``None`` (default), a new adapter is constructed per call.
@@ -180,7 +183,7 @@ class NodeResult(Generic[OutputT]):
 
         Raises:
             DeserializationError: If the expected content part is not found in
-                ``final_output_parts`` (and either ``strict=True`` or the parts
+                the reply parts (and either ``strict=True`` or the parts
                 list is non-empty but lacks the expected shape).
             pydantic.ValidationError: If ``output_type`` is provided and the
                 matching ``DataPart.data`` doesn't validate against it.
@@ -188,10 +191,11 @@ class NodeResult(Generic[OutputT]):
                 and ``output_type`` cannot be schematized by :class:`TypeAdapter`.
         """
         state = ctx.state
-        output = project_output(state, output_type, strict=strict, type_adapter=type_adapter)
+        output = project_output(ctx._reply, output_type, strict=strict, type_adapter=type_adapter)
 
         return cls(
             output=output,
+            output_parts=ctx._reply.parts if ctx._reply is not None else [],
             state=state,
             correlation_id=correlation_id if correlation_id is not None else ctx.correlation_id,
             emitter_node_id=ctx.emitter_node_id,
@@ -229,11 +233,6 @@ class NodeResult(Generic[OutputT]):
         )
 
     @property
-    def output_parts(self) -> list[ContentPart]:
-        """Convenience: ``state.final_output_parts``."""
-        return self.state.final_output_parts
-
-    @property
     def message_history(self) -> list[ModelMessage]:
         """Convenience: ``state.message_history``."""
         return self.state.message_history
@@ -244,19 +243,21 @@ class NodeResult(Generic[OutputT]):
         return self.state.metadata
 
 
-def project_output(state: State, output_type: type[Any] = _UNSET, *, strict: bool, type_adapter: TypeAdapter[Any] | None = None) -> Any:
-    """Project the deserialized output from ``state.final_output_parts``.
+def project_output(
+    reply: ReturnMessage | None, output_type: type[Any] = _UNSET, *, strict: bool, type_adapter: TypeAdapter[Any] | None = None
+) -> Any:
+    """Project the deserialized output from the delivery's reply slot (spec §4.5).
 
     Shared by :meth:`NodeResult.from_context` (client, ``strict=True``) and
     :meth:`ConsumerContext.from_run_context` (consumer, ``strict=False``). With
-    ``strict=False`` an empty ``final_output_parts`` (an intermediate hop) yields
-    ``None``; otherwise the matching part is extracted/validated per
-    ``output_type`` (raising ``DeserializationError``/``ValidationError`` on a
-    present-but-mismatched part).
+    ``strict=False`` an empty/absent reply (an intermediate hop) yields ``None``;
+    otherwise the matching part is extracted/validated per ``output_type`` (raising
+    ``DeserializationError``/``ValidationError`` on a present-but-mismatched part).
     """
-    if not state.final_output_parts and not strict:
+    parts = reply.parts if reply is not None else []
+    if not parts and not strict:
         return None
-    return _extract_output(state.final_output_parts, output_type, type_adapter=type_adapter)
+    return _extract_output(parts, output_type, type_adapter=type_adapter)
 
 
 def _extract_output(parts: list[Any], output_type: type[Any], type_adapter: TypeAdapter[Any] | None = None) -> Any:
@@ -276,7 +277,7 @@ def _extract_auto(parts: list[Any]) -> Any:
     for part in parts:
         if isinstance(part, TextPart):
             return part.text
-    raise DeserializationError("No DataPart or TextPart found in final_output_parts; cannot auto-detect output.")
+    raise DeserializationError("No DataPart or TextPart found in reply.parts; cannot auto-detect output.")
 
 
 def _extract_text(parts: list[Any]) -> str:
@@ -284,7 +285,7 @@ def _extract_text(parts: list[Any]) -> str:
     for part in parts:
         if isinstance(part, TextPart):
             return part.text
-    raise DeserializationError("No TextPart found in final_output_parts; expected output_type=str.")
+    raise DeserializationError("No TextPart found in reply.parts; expected output_type=str.")
 
 
 def _extract_data(parts: list[Any], output_type: type[Any], type_adapter: TypeAdapter[Any] | None = None) -> Any:
@@ -298,4 +299,4 @@ def _extract_data(parts: list[Any], output_type: type[Any], type_adapter: TypeAd
         if isinstance(part, DataPart):
             adapter = type_adapter if type_adapter is not None else TypeAdapter(output_type)
             return adapter.validate_python(part.data)
-    raise DeserializationError(f"No DataPart found in final_output_parts; expected output_type={getattr(output_type, '__name__', str(output_type))}.")
+    raise DeserializationError(f"No DataPart found in reply.parts; expected output_type={getattr(output_type, '__name__', str(output_type))}.")

--- a/calfkit/models/reply.py
+++ b/calfkit/models/reply.py
@@ -1,0 +1,34 @@
+from typing import Literal
+
+from pydantic import BaseModel
+
+from calfkit.models.payload import ContentPart
+
+
+class _ReplyBase(BaseModel):
+    """Common per-delivery reply correlation (spec §4.2).
+
+    Shipped now so PR-C's ``FaultMessage`` is a pure sibling addition
+    (``class FaultMessage(_ReplyBase)``) rather than a re-parenting of
+    :class:`ReturnMessage`, and the ``Envelope.reply`` union widens to
+    ``ReturnMessage | FaultMessage`` with ``Field(discriminator="kind")``.
+    """
+
+    in_reply_to: str | None
+    """``frame_id`` of the frame this reply answers, echoed by the framework at
+    unwind. ``None`` only on frameless terminals (no caller frame to answer)."""
+
+    tag: str | None
+    """Echo of ``CallFrame.tag`` — the caller's opaque correlation token (the agent
+    sets ``tool_call_id``). Transport metadata, never interpreted as content."""
+
+
+class ReturnMessage(_ReplyBase):
+    """A node's successful output, carried in the per-delivery reply slot.
+
+    The content travels as the existing :data:`~calfkit.models.payload.ContentPart`
+    vocabulary; the reader projects its concrete type (schema-on-read, spec §4.5).
+    """
+
+    kind: Literal["return"] = "return"
+    parts: list[ContentPart]

--- a/calfkit/models/session_context.py
+++ b/calfkit/models/session_context.py
@@ -47,6 +47,11 @@ class CallFrame:
     Read by a routed ``@handler`` (via the ``x-calf-route`` header) or, for a
     routeless body, by the target's inherited ``@handler('*')`` ``run`` (e.g. a tool
     node validating a ``ToolCallRef``). ``None`` when the producer sent no body."""
+    tag: str | None = field(default=None)
+    """Caller-set opaque correlation token, echoed verbatim on the reply
+    (``ReturnMessage.tag``) when this frame unwinds. The agent sets it to
+    ``tool_call_id``. Transport metadata, never content. DORMANT until PR-B wires a
+    producer (``Call.tag`` + the agent); ``None`` on every frame in PR-A."""
 
 
 CallFrameStack = Stack[CallFrame]

--- a/calfkit/models/session_context.py
+++ b/calfkit/models/session_context.py
@@ -8,6 +8,8 @@ from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
 from calfkit._types import DepsT, StackItemT, StateT
 from calfkit.models.actions import _Call
+from calfkit.models.payload import ContentPart
+from calfkit.models.reply import ReturnMessage
 from calfkit.models.state import OverridesState, State
 
 _EMPTY_RESOURCES: Mapping[str, Any] = MappingProxyType({})
@@ -113,6 +115,7 @@ class BaseSessionRunContext(BaseModel, Generic[StateT, DepsT]):
     _emitter_node_kind: str | None = PrivateAttr(default=None)
     _frame_id: str | None = PrivateAttr(default=None)
     _resources: Mapping[str, Any] | None = PrivateAttr(default=None)
+    _reply: ReturnMessage | None = PrivateAttr(default=None)
 
     @property
     def correlation_id(self) -> str:
@@ -195,6 +198,19 @@ class BaseSessionRunContext(BaseModel, Generic[StateT, DepsT]):
         if self._resources is None:
             return _EMPTY_RESOURCES
         return self._resources
+
+    @property
+    def output_parts(self) -> list[ContentPart]:
+        """Content parts carried by this delivery's reply slot (spec §4).
+
+        ``[]`` on call-kind deliveries (no reply) and on a context built outside a
+        handler (unstamped) — empty, never raises. The reply-sourced replacement for
+        the retired ``state.final_output_parts`` read: a consumer gate that dropped
+        intermediate hops via ``bool(ctx.state.final_output_parts)`` now uses
+        ``bool(ctx.output_parts)``. Backed by ``_reply`` (stamped by ``prepare_context``
+        / the client reply dispatcher), so it never rides the wire.
+        """
+        return self._reply.parts if self._reply is not None else []
 
     def _stamp_transport(self, *, correlation_id: str | None, emitter_node_id: str | None, emitter_node_kind: str | None) -> None:
         """Stamp transport-sourced identity onto this context.

--- a/calfkit/models/state.py
+++ b/calfkit/models/state.py
@@ -14,7 +14,6 @@ from calfkit._vendor.pydantic_ai.messages import (
     ToolCallPart,
     ToolReturn,
 )
-from calfkit.models.payload import ContentPart
 from calfkit.models.tool_dispatch import ToolBinding
 
 
@@ -36,7 +35,6 @@ class CoreMessageState(BaseAgentActivityState):
     model_config = ConfigDict(extra="ignore")
     uncommitted_message: ModelMessage | None = None
     message_history: list[ModelMessage] = Field(default_factory=list, description="Append-only message history list")
-    final_output_parts: list[ContentPart] = Field(default_factory=list)
 
     temp_instructions: str | None = None
 

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -527,7 +527,7 @@ class BaseAgentNodeDef(
             # stamp author identity onto the agent's own responses (§4, §6.1)
             ctx.state.extend_with_responses(new_messages, self.name)
             if isinstance(result.output, str):
-                ctx.state.final_output_parts = [TextPart(text=result.output)]
+                parts: list[ContentPart] = [TextPart(text=result.output)]
             else:
                 # Surface a text preamble alongside the structured value when present (§7).
                 # ``structured_output_preamble`` reads the run's last ModelResponse and
@@ -535,13 +535,14 @@ class BaseAgentNodeDef(
                 # from the ``final_result`` call); in native/prompted mode the response's
                 # TextPart IS the JSON answer, so it returns "" to avoid duplicating it
                 # alongside the DataPart.
-                parts: list[ContentPart] = []
+                parts = []
                 preamble = structured_output_preamble(new_messages)
                 if preamble:
                     parts.append(TextPart(text=preamble))
                 parts.append(DataPart(data=result.output))
-                ctx.state.final_output_parts = parts
-            return ReturnCall[State](state=ctx.state)
+            # Output rides the reply slot (ReturnCall.value -> reply.parts at the
+            # chokepoint), not the retired State.final_output_parts side-channel (§4.5).
+            return ReturnCall[State](state=ctx.state, value=parts)
 
     def add_tools(self, *tools: ToolProvider | ToolBinding | ToolSelector) -> None:
         """Add tools after construction.

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -25,8 +25,8 @@ from calfkit.models import (
 )
 from calfkit.models._coerce import _coerce_to_parts
 from calfkit.models.envelope import Envelope
-from calfkit.models.reply import ReturnMessage
 from calfkit.models.node_schema import BaseNodeSchema
+from calfkit.models.reply import ReturnMessage
 from calfkit.models.session_context import SessionRunContext
 from calfkit.worker.lifecycle import LifecycleHookMixin
 
@@ -217,6 +217,11 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
         ctx._stamp_transport(correlation_id=correlation_id, emitter_node_id=emitter_node_id, emitter_node_kind=emitter_node_kind)
         ctx._resources = self._effective_resources()
         ctx._frame_id = frame.frame_id if frame is not None else None
+        # Stamp the per-delivery reply AFTER the copy and UNCONDITIONALLY: model_copy
+        # preserves private attrs, and on a fresh deserialize the inbound context's
+        # _reply is None anyway, so source it from the envelope's reply field — setting
+        # None on a call-kind delivery clears any stale value (mirrors _frame_id above).
+        ctx._reply = envelope.reply
         return ctx
 
     def _effective_resources(self) -> dict[str, Any]:

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -10,7 +10,7 @@ from faststream.kafka.annotations import (
 )
 from pydantic import ValidationError
 
-from calfkit._protocol import HDR_EMITTER, HDR_EMITTER_KIND, HDR_ROUTE, NodeKind, decode_header_str
+from calfkit._protocol import HDR_EMITTER, HDR_EMITTER_KIND, HDR_KIND, HDR_ROUTE, MessageKind, NodeKind, decode_header_str
 from calfkit._registry import RegistryMixin, handler
 from calfkit._routing import is_concrete_route_key, match_chain
 from calfkit.exceptions import RegistryConfigError
@@ -23,7 +23,9 @@ from calfkit.models import (
     State,
     TailCall,
 )
+from calfkit.models._coerce import _coerce_to_parts
 from calfkit.models.envelope import Envelope
+from calfkit.models.reply import ReturnMessage
 from calfkit.models.node_schema import BaseNodeSchema
 from calfkit.models.session_context import SessionRunContext
 from calfkit.worker.lifecycle import LifecycleHookMixin
@@ -229,18 +231,23 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
             return dict(self.resources)
         return {**worker.resources, **self.resources}
 
-    def _emitter_headers(self) -> dict[str, str]:
-        return {HDR_EMITTER: self.node_id, HDR_EMITTER_KIND: self._node_kind}
+    def _headers(self, kind: MessageKind, *, route: str | None = None) -> dict[str, str]:
+        """Outbound headers for one publish: emitter id/kind + the ``x-calf-kind``
+        delivery classification (spec §4.1), plus ``x-calf-route`` when a ``Call``
+        addresses a sub-route of a downstream routed node (ingress-only, ``Call`` only)."""
+        h = {HDR_EMITTER: self.node_id, HDR_EMITTER_KIND: self._node_kind, HDR_KIND: kind}
+        if route is not None:
+            h[HDR_ROUTE] = route
+        return h
 
-    def _headers_for_call(self, call: Call[Any]) -> dict[str, str]:
-        """Emitter headers, plus the ``x-calf-route`` header when a ``Call`` addresses
-        a sub-route of a downstream routed node (ingress-only, ``Call`` only)."""
-        if call.route is None:
-            return self._emitter_headers()
-        return {**self._emitter_headers(), HDR_ROUTE: call.route}
-
-    async def _publish_action(self, output: NodeResult[State], envelope: Envelope, correlation_id: str, broker: BrokerAnnotation) -> Envelope:
+    async def _publish_action(
+        self, output: NodeResult[State], envelope: Envelope, correlation_id: str, broker: BrokerAnnotation
+    ) -> tuple[Envelope, MessageKind]:
+        """Publish the node's action point-to-point and return the envelope to mirror
+        on ``publish_topic`` plus its ``x-calf-kind`` (spec §4). The kind is known here
+        per branch but not at the ``handler`` ``Response``, so it is returned upward."""
         publish_envelope: Envelope
+        kind: MessageKind = "call"
 
         if isinstance(output, list) and all(isinstance(item, Call) for item in output):
             # Parallel fan-out: publish each Call with independent workflow_state
@@ -256,9 +263,13 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
                     topic=wf_copy.current_frame.target_topic,
                     correlation_id=correlation_id,
                     key=correlation_id.encode(),
-                    headers=self._headers_for_call(call),
+                    headers=self._headers("call", route=call.route),
                 )
-            return envelope
+            # No-reply hop: the mirror is the inbound envelope — clear any inbound reply
+            # so a return this node was processing is not re-broadcast under its own
+            # emitter to its observers (the I3 leak class).
+            envelope.reply = None
+            return envelope, "call"
 
         elif isinstance(output, Call):
             # push to callstack and call the target topic
@@ -274,20 +285,23 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
                 topic=target_topic,
                 correlation_id=correlation_id,
                 key=correlation_id.encode(),
-                headers=self._headers_for_call(output),
+                headers=self._headers("call", route=output.route),
             )
         elif isinstance(output, ReturnCall):
-            # unwind current frame and return to previous topic
+            # unwind current frame and return to previous topic, carrying the reply slot
             frame = envelope.internal_workflow_state.unwind_frame()
+            reply = ReturnMessage(in_reply_to=frame.frame_id, tag=frame.tag, parts=_coerce_to_parts(output.value))
             publish_envelope = Envelope(
                 context=SessionRunContext(state=output.state, deps=envelope.context.deps),
                 internal_workflow_state=envelope.internal_workflow_state,
+                reply=reply,
             )
+            kind = "return"
             if frame.callback_topic is None:
                 # Fire-and-forget terminal: no requester to return to. Skip the
                 # point-to-point callback publish, but still return
                 # ``publish_envelope`` below so the worker's @publisher broadcasts
-                # the terminal result to ``publish_topic`` (the traceability channel).
+                # the terminal result (with its reply) to ``publish_topic``.
                 logger.debug("[%s] ReturnCall no-callback fire-and-forget terminal node=%s", correlation_id[:8], self.node_id)
             else:
                 logger.debug("[%s] ReturnCall callback=%s node=%s", correlation_id[:8], frame.callback_topic, self.node_id)
@@ -297,7 +311,7 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
                         topic=frame.callback_topic,
                         correlation_id=correlation_id,
                         key=correlation_id.encode(),
-                        headers=self._emitter_headers(),
+                        headers=self._headers("return"),
                     )
                 except KafkaError:
                     # Point-to-point delivery failed (e.g. a send(reply_to=...)
@@ -330,7 +344,7 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
                 topic=target_topic,
                 correlation_id=correlation_id,
                 key=correlation_id.encode(),
-                headers=self._emitter_headers(),
+                headers=self._headers("call"),
             )
 
         elif isinstance(output, Silent):
@@ -338,12 +352,14 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
                 "node (%s) ran and was silent with no explicit publish. This is the end of this event-stream, any state modifications will not be carried downstream.",  # noqa: E501
                 self.name,
             )
+            envelope.reply = None  # no-reply hop: don't re-broadcast an inbound reply (I3)
             publish_envelope = envelope
         else:
             logger.error("Return type is unknown or invalid so the message was not published anywhere.")
+            envelope.reply = None  # no-reply hop: don't re-broadcast an inbound reply (I3)
             publish_envelope = envelope
 
-        return publish_envelope
+        return publish_envelope, kind
 
     async def _dispatch_routed(
         self,
@@ -431,7 +447,9 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
         ctx = await self.prepare_context(envelope, emitter_node_id=emitter, emitter_node_kind=emitter_kind, correlation_id=correlation_id)
 
         if not await self._evaluate_gates(ctx, correlation_id):
+            envelope.reply = None  # no-reply mirror (gate rejected): don't re-broadcast an inbound reply (I3)
             body: Envelope = envelope
+            kind: MessageKind = "call"
         else:
             frame = envelope.internal_workflow_state.current_frame_or_none
             payload = frame.payload if frame is not None else None
@@ -463,11 +481,12 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
                     tuple(type(self)._handlers),
                     body_note,
                 )
-                return Response(envelope, headers=self._emitter_headers())
+                envelope.reply = None  # no-reply mirror (no result): don't re-broadcast an inbound reply (I3)
+                return Response(envelope, headers=self._headers("call"))
             logger.debug("[%s] node=%s produced action=%s", correlation_id[:8], self.node_id, type(output).__name__)
-            body = await self._publish_action(output, envelope, correlation_id, broker)
+            body, kind = await self._publish_action(output, envelope, correlation_id, broker)
 
-        return Response(body, headers=self._emitter_headers())
+        return Response(body, headers=self._headers(kind))
 
     @property
     def id(self) -> str:

--- a/docs/consumer-nodes.md
+++ b/docs/consumer-nodes.md
@@ -40,13 +40,14 @@ $ python weather_sink.py
 ```
 
 An agent's `publish_topic` emits on **every** state transition — intermediate
-hops, tool completions, and terminals — so `result.output` is `None` on hops
-without final output parts. Filter via a gate if you only want agent terminals:
+hops, tool completions, and terminals — so `result.output` is `None` on
+intermediate (call-kind) hops that carry no reply slot. Filter via a gate if you
+only want agent terminals:
 
 ```python
 @consumer(
     subscribe_topics="weather_agent.output",
-    gates=[lambda ctx: bool(ctx.state.final_output_parts)],
+    gates=[lambda ctx: bool(ctx.output_parts)],
 )
 async def save_final(result: NodeResult) -> None:
     await db.save(result.output)  # always populated here

--- a/examples/quickstart/weather_sink.py
+++ b/examples/quickstart/weather_sink.py
@@ -9,7 +9,7 @@ the final reply), ``result.output`` is ``None`` on intermediate hops — pending
 tool calls, tool returns, agent retries. Filter via a gate if you only want
 agent terminals:
 
-    gates=[lambda ctx: bool(ctx.state.final_output_parts)]
+    gates=[lambda ctx: bool(ctx.output_parts)]
 
 Run alongside the agent service:
 

--- a/tests/integration/test_topic_provisioning.py
+++ b/tests/integration/test_topic_provisioning.py
@@ -55,6 +55,7 @@ import pytest
 from calfkit.client import Client
 from calfkit.models.envelope import Envelope
 from calfkit.models.payload import TextPart
+from calfkit.models.reply import ReturnMessage
 from calfkit.models.session_context import (
     CallFrameStack,
     SessionRunContext,
@@ -210,13 +211,12 @@ def _text_envelope(text: str, correlation_id: str) -> Envelope:
     Mirrors the framework's on-wire shape (see ``tests/test_consumer`` helpers)
     so a real ``consumer`` node decodes it and exposes ``result.output == text``.
     """
-    state = State()
-    state.final_output_parts = [TextPart(text=text)]
-    ctx = SessionRunContext(state=state, deps={})
+    ctx = SessionRunContext(state=State(), deps={})
     ctx._correlation_id = correlation_id
     return Envelope(
         context=ctx,
         internal_workflow_state=WorkflowState(call_stack=CallFrameStack()),
+        reply=ReturnMessage(in_reply_to=None, tag=None, parts=[TextPart(text=text)]),
     )
 
 

--- a/tests/test_agent_loop_integration.py
+++ b/tests/test_agent_loop_integration.py
@@ -92,9 +92,9 @@ async def test_final_output_parts_tool_mode_structured_surfaces_preamble_and_str
     state = State(message_history=[ModelRequest.user_text_prompt("book flights")])
     ctx = _ctx(state)
 
-    await agent.run(ctx)
+    result = await agent.run(ctx)
 
-    parts = ctx.state.final_output_parts
+    parts = result.value  # output now rides ReturnCall.value -> reply.parts (§4.5)
     # BOTH the preamble and the structured value are surfaced, in order.
     assert len(parts) == 2, parts
     assert isinstance(parts[0], PayloadTextPart)
@@ -123,9 +123,9 @@ async def test_final_output_parts_tool_mode_structured_no_preamble_is_data_only(
     state = State(message_history=[ModelRequest.user_text_prompt("book flights")])
     ctx = _ctx(state)
 
-    await agent.run(ctx)
+    result = await agent.run(ctx)
 
-    parts = ctx.state.final_output_parts
+    parts = result.value  # output now rides ReturnCall.value -> reply.parts (§4.5)
     assert len(parts) == 1, parts
     assert isinstance(parts[0], DataPart)
     assert parts[0].data == FlightPlan(flights=7)
@@ -156,9 +156,9 @@ async def test_final_output_parts_prompted_mode_is_data_only_no_duplication():
     state = State(message_history=[ModelRequest.user_text_prompt("book flights")])
     ctx = _ctx(state)
 
-    await agent.run(ctx)
+    result = await agent.run(ctx)
 
-    parts = ctx.state.final_output_parts
+    parts = result.value  # output now rides ReturnCall.value -> reply.parts (§4.5)
     assert len(parts) == 1, parts  # only the structured value — no duplicated preamble
     assert isinstance(parts[0], DataPart)
     assert parts[0].data == FlightPlan(flights=5)
@@ -181,9 +181,9 @@ async def test_final_output_parts_str_output_unchanged():
     state = State(message_history=[ModelRequest.user_text_prompt("say something")])
     ctx = _ctx(state)
 
-    await agent.run(ctx)
+    result = await agent.run(ctx)
 
-    parts = ctx.state.final_output_parts
+    parts = result.value  # output now rides ReturnCall.value -> reply.parts (§4.5)
     assert len(parts) == 1, parts
     assert isinstance(parts[0], PayloadTextPart)
     assert parts[0].text == "plain string answer"

--- a/tests/test_co_tenant_tool_isolation.py
+++ b/tests/test_co_tenant_tool_isolation.py
@@ -13,7 +13,7 @@ Test layout mirrors the project's established patterns:
   ``tests/test_headers.py``).
 - ``@broker.subscriber`` observers for envelope-level inspection (per
   ``tests/test_headers.py::test_gate_reject_auto_publish_carries_emitter_header``).
-- ``consumer()`` sinks with ``final_output_parts`` gates for counting final
+- ``consumer()`` sinks with reply-slot gates for counting final
   hops (per ``tests/test_consumer.py``).
 - ``wait_for_condition`` from ``tests/utils.py`` for deterministic settling.
 """
@@ -122,7 +122,7 @@ async def test_tool_return_does_not_leak_between_co_tenant_agents(container):
 
     @consumer(
         subscribe_topics="alpha_agent.out",
-        gates=[lambda ctx: bool(ctx.state.final_output_parts)],
+        gates=[lambda ctx: bool(ctx.output_parts)],
         node_id="alpha_final_sink",
     )
     def alpha_sink(ctx: ConsumerContext) -> None:
@@ -130,7 +130,7 @@ async def test_tool_return_does_not_leak_between_co_tenant_agents(container):
 
     @consumer(
         subscribe_topics="bravo_agent.out",
-        gates=[lambda ctx: bool(ctx.state.final_output_parts)],
+        gates=[lambda ctx: bool(ctx.output_parts)],
         node_id="bravo_final_sink",
     )
     def bravo_sink(ctx: ConsumerContext) -> None:

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -29,7 +29,7 @@ from calfkit._vendor.pydantic_ai.messages import (
 from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
 from calfkit.client import Client, NodeResult
 from calfkit.exceptions import DeserializationError
-from calfkit.models import ConsumerContext, SessionRunContext
+from calfkit.models import ConsumerContext, ReturnMessage, SessionRunContext
 from calfkit.models.envelope import Envelope
 from calfkit.models.payload import DataPart, TextPart
 from calfkit.models.session_context import CallFrameStack, WorkflowState
@@ -82,23 +82,21 @@ def _wire_agent_with_consumer(container, consumer_node: ConsumerNode) -> Agent:
     return agent
 
 
-def _text_state(text: str) -> State:
-    s = State()
-    s.final_output_parts = [TextPart(text=text)]
-    return s
+def _text_reply(text: str) -> ReturnMessage:
+    return ReturnMessage(in_reply_to=None, tag=None, parts=[TextPart(text=text)])
 
 
-def _data_state(data: dict) -> State:
-    s = State()
-    s.final_output_parts = [DataPart(data=data)]
-    return s
+def _data_reply(data: dict) -> ReturnMessage:
+    return ReturnMessage(in_reply_to=None, tag=None, parts=[DataPart(data=data)])
 
 
-def _envelope(state: State, *, deps: dict | None = None) -> Envelope:
-    """A frameless envelope — the shape a sink sees tapping a publish_topic."""
+def _envelope(reply: ReturnMessage | None = None, *, state: State | None = None, deps: dict | None = None) -> Envelope:
+    """A frameless envelope carrying a reply — the shape a sink sees tapping a
+    publish_topic. No ``reply`` = an intermediate (call-kind) hop."""
     return Envelope(
-        context=SessionRunContext(state=state, deps=deps or {}),
+        context=SessionRunContext(state=state if state is not None else State(), deps=deps or {}),
         internal_workflow_state=WorkflowState(call_stack=CallFrameStack()),
+        reply=reply,
     )
 
 
@@ -168,8 +166,9 @@ def test_async_generator_function_rejected_at_construction():
 
 
 def test_from_run_context_projects_fields_and_resources():
-    ctx = SessionRunContext(state=_text_state("done"), deps={"k": "v"})
+    ctx = SessionRunContext(state=State(), deps={"k": "v"})
     ctx._stamp_transport(correlation_id="cid-fc", emitter_node_id="up", emitter_node_kind="agent")
+    ctx._reply = _text_reply("done")
     sentinel = object()
     ctx._resources = {"db": sentinel}
 
@@ -304,8 +303,8 @@ async def test_consumer_fans_in_across_multiple_topics(container):
     headers_a = {HDR_EMITTER: "src_a", HDR_EMITTER_KIND: "client"}
     headers_b = {HDR_EMITTER: "src_b", HDR_EMITTER_KIND: "client"}
     async with TestKafkaBroker(broker):
-        await broker.publish(_envelope(_text_state("from_a")), topic="fanin.a", correlation_id="cid-a", headers=headers_a)
-        await broker.publish(_envelope(_text_state("from_b")), topic="fanin.b", correlation_id="cid-b", headers=headers_b)
+        await broker.publish(_envelope(_text_reply("from_a")), topic="fanin.a", correlation_id="cid-a", headers=headers_a)
+        await broker.publish(_envelope(_text_reply("from_b")), topic="fanin.b", correlation_id="cid-b", headers=headers_b)
 
     assert {c.output for c in received} == {"from_a", "from_b"}
 
@@ -321,7 +320,7 @@ async def test_intermediate_hop_passes_to_fn_with_output_none(caplog):
     node = ConsumerNode(node_id="int_sink", subscribe_topics="t", consume_fn=received.append)
 
     with caplog.at_level(logging.ERROR, logger=CONSUMER_LOGGER):
-        await _handle(node, _envelope(State()))
+        await _handle(node, _envelope())
 
     assert len(received) == 1
     assert received[0].output is None
@@ -335,7 +334,7 @@ async def test_validation_error_on_present_parts_logs_and_skips(caplog):
     node = ConsumerNode(node_id="val_sink", subscribe_topics="t", consume_fn=lambda ctx: invocations.append("ran"), agent_output_type=Report)
 
     with caplog.at_level(logging.ERROR, logger=CONSUMER_LOGGER):
-        await _handle(node, _envelope(_data_state({"unexpected": "shape"})))
+        await _handle(node, _envelope(_data_reply({"unexpected": "shape"})))
 
     assert invocations == []
     rec = [r for r in caplog.records if "projection failed" in r.getMessage()]
@@ -351,7 +350,7 @@ async def test_missing_emitter_header_warns_and_still_invokes_fn(caplog):
     node = ConsumerNode(node_id="noemit_sink", subscribe_topics="t", consume_fn=received.append)
 
     with caplog.at_level(logging.WARNING, logger=BASE_LOGGER):
-        await _handle(node, _envelope(_text_state("hello")), headers={})
+        await _handle(node, _envelope(_text_reply("hello")), headers={})
 
     assert len(received) == 1
     assert received[0].output == "hello"
@@ -373,7 +372,7 @@ async def test_consume_fn_exception_swallowed_and_logged(caplog):
     node = ConsumerNode(node_id="boom_sink", subscribe_topics="t", consume_fn=boom)
 
     with caplog.at_level(logging.ERROR, logger=CONSUMER_LOGGER):
-        resp = await _handle(node, _envelope(_text_state("hi")))
+        resp = await _handle(node, _envelope(_text_reply("hi")))
 
     assert resp is not None
     err = [r for r in caplog.records if "consume_fn raised" in r.getMessage()]
@@ -390,7 +389,7 @@ async def test_cancelled_error_always_propagates():
 
     node = ConsumerNode(node_id="cancel_sink", subscribe_topics="t", consume_fn=cancels)
     with pytest.raises(asyncio.CancelledError):
-        await _handle(node, _envelope(_text_state("hi")))
+        await _handle(node, _envelope(_text_reply("hi")))
 
 
 async def test_callable_class_generator_detected_at_call_site(caplog):
@@ -403,7 +402,7 @@ async def test_callable_class_generator_detected_at_call_site(caplog):
 
     node = ConsumerNode(node_id="gen_sink", subscribe_topics="t", consume_fn=GenSink())
     with caplog.at_level(logging.ERROR, logger=CONSUMER_LOGGER):
-        await _handle(node, _envelope(_text_state("hi")))
+        await _handle(node, _envelope(_text_reply("hi")))
 
     rec = [r for r in caplog.records if "consume_fn raised" in r.getMessage()]
     assert rec and isinstance(rec[0].exc_info[1], TypeError)
@@ -418,7 +417,7 @@ async def test_function_returning_generator_object_detected(caplog):
 
     node = ConsumerNode(node_id="gen_ret", subscribe_topics="t", consume_fn=sink)
     with caplog.at_level(logging.ERROR, logger=CONSUMER_LOGGER):
-        await _handle(node, _envelope(_text_state("hi")))
+        await _handle(node, _envelope(_text_reply("hi")))
 
     rec = [r for r in caplog.records if "consume_fn raised" in r.getMessage()]
     assert rec and isinstance(rec[0].exc_info[1], TypeError)
@@ -434,7 +433,7 @@ async def test_function_returning_async_generator_object_detected(caplog):
 
     node = ConsumerNode(node_id="agen_ret", subscribe_topics="t", consume_fn=sink)
     with caplog.at_level(logging.ERROR, logger=CONSUMER_LOGGER):
-        await _handle(node, _envelope(_text_state("hi")))
+        await _handle(node, _envelope(_text_reply("hi")))
 
     rec = [r for r in caplog.records if "consume_fn raised" in r.getMessage()]
     assert rec and isinstance(rec[0].exc_info[1], TypeError)
@@ -488,16 +487,16 @@ async def test_gate_acceptance_runs_consume_fn(container):
 
 
 async def test_final_only_gate_idiom_filters_intermediate():
-    """Documented idiom: a gate keyed off final_output_parts drops intermediate hops."""
+    """Documented idiom: a gate keyed off the reply slot drops intermediate hops."""
     received: list[ConsumerContext] = []
 
     def has_final_output(ctx: SessionRunContext) -> bool:
-        return bool(ctx.state.final_output_parts)
+        return bool(ctx.output_parts)
 
     node = ConsumerNode(node_id="filtered", subscribe_topics="t", consume_fn=received.append, gates=[has_final_output])
 
-    await _handle(node, _envelope(State()), correlation_id="cid-int")  # intermediate → rejected
-    await _handle(node, _envelope(_text_state("final!")), correlation_id="cid-final")  # terminal → accepted
+    await _handle(node, _envelope(), correlation_id="cid-int")  # intermediate → rejected
+    await _handle(node, _envelope(_text_reply("final!")), correlation_id="cid-final")  # terminal → accepted
 
     assert len(received) == 1
     assert received[0].output == "final!"
@@ -519,11 +518,11 @@ async def test_consumer_sees_tool_results_via_state():
     state.add_tool_call(tool_call)
     state.add_tool_result(tool_call.tool_call_id, "sunny in Tokyo")
 
-    await _handle(node, _envelope(state), headers={HDR_EMITTER: "tool_get_weather", HDR_EMITTER_KIND: "tool"})
+    await _handle(node, _envelope(state=state), headers={HDR_EMITTER: "tool_get_weather", HDR_EMITTER_KIND: "tool"})
 
     assert len(captured) == 1
     c = captured[0]
-    assert c.output is None  # tool hop — no final_output_parts
+    assert c.output is None  # tool hop — no reply slot
     assert c.emitter_node_kind == "tool"
     assert c.state.tool_results[tool_call.tool_call_id] == "sunny in Tokyo"
     assert c.state.tool_calls[tool_call.tool_call_id].tool_name == "get_weather"
@@ -533,7 +532,7 @@ async def test_consumer_reads_inbound_deps():
     captured: list[ConsumerContext] = []
     node = ConsumerNode(node_id="deps_sink", subscribe_topics="t", consume_fn=captured.append)
 
-    await _handle(node, _envelope(_text_state("hi"), deps={"discord": {"channel_id": 42}}), correlation_id="cid-deps")
+    await _handle(node, _envelope(_text_reply("hi"), deps={"discord": {"channel_id": 42}}), correlation_id="cid-deps")
 
     assert captured[0].deps == {"discord": {"channel_id": 42}}
     assert captured[0].correlation_id == "cid-deps"
@@ -543,7 +542,7 @@ async def test_consumer_deps_defaults_to_empty_dict():
     captured: list[ConsumerContext] = []
     node = ConsumerNode(node_id="deps_empty", subscribe_topics="t", consume_fn=captured.append)
 
-    await _handle(node, _envelope(_text_state("hi")))
+    await _handle(node, _envelope(_text_reply("hi")))
 
     assert captured[0].deps == {}
 
@@ -553,14 +552,13 @@ async def test_consumer_convenience_properties_read_through_state():
     node = ConsumerNode(node_id="props", subscribe_topics="t", consume_fn=captured.append)
 
     state = State()
-    state.final_output_parts = [TextPart(text="hello")]
     state.message_history = [ModelRequest.user_text_prompt("hi")]
     state.metadata = {"app": "demo"}
 
-    await _handle(node, _envelope(state))
+    await _handle(node, _envelope(_text_reply("hello"), state=state))
 
     c = captured[0]
-    assert c.output_parts is c.state.final_output_parts
+    assert c.output_parts == [TextPart(text="hello")]  # reply-sourced field (not a state read-through)
     assert c.message_history is c.state.message_history
     assert c.metadata is c.state.metadata
 
@@ -571,7 +569,7 @@ async def test_resources_flow_from_node_bag():
     sentinel = object()
     node.resources["db"] = sentinel
 
-    await _handle(node, _envelope(_text_state("hi")))
+    await _handle(node, _envelope(_text_reply("hi")))
 
     assert captured[0].resources["db"] is sentinel
 
@@ -602,9 +600,7 @@ async def test_deps_round_trip_through_agent_to_consumer(container):
 
 
 def test_consumer_context_is_not_hashable():
-    state = State()
-    state.final_output_parts = [TextPart(text="x")]
-    cctx = ConsumerContext(output="x", state=state, correlation_id="cid")
+    cctx = ConsumerContext(output="x", state=State(), correlation_id="cid")
 
     assert ConsumerContext.__hash__ is None
     with pytest.raises(TypeError, match="unhashable"):
@@ -649,7 +645,7 @@ def test_consumer_reuses_prebuilt_type_adapter(monkeypatch):
     constructions_after_decoration = construct_count["n"]
     assert constructions_after_decoration == 1  # built once at __init__
 
-    env = _envelope(_data_state({"location": "Tokyo", "summary": "sunny"}))
+    env = _envelope(_data_reply({"location": "Tokyo", "summary": "sunny"}))
     for _ in range(3):
         asyncio.run(sink.handler(env, correlation_id="cid-reuse", headers=_HEADERS, broker=MagicMock()))
 
@@ -692,7 +688,7 @@ async def test_unexpected_projection_exception_is_logged_and_skipped(monkeypatch
     monkeypatch.setattr(consumer_mod, "ConsumerContext", _BoomContext)
 
     with caplog.at_level(logging.ERROR, logger=CONSUMER_LOGGER):
-        resp = await _handle(node, _envelope(_text_state("hi")), correlation_id="cid-safety")
+        resp = await _handle(node, _envelope(_text_reply("hi")), correlation_id="cid-safety")
 
     assert invocations == []
     assert resp is not None
@@ -710,7 +706,6 @@ async def test_unexpected_projection_exception_is_logged_and_skipped(monkeypatch
 
 def test_node_result_is_not_hashable():
     state = State()
-    state.final_output_parts = [TextPart(text="x")]
     state.message_history = [ModelRequest.user_text_prompt("hi")]
     result = NodeResult(output="x", state=state, correlation_id="cid-hash")
 
@@ -719,14 +714,14 @@ def test_node_result_is_not_hashable():
         hash(result)
 
 
-def test_strict_mode_raises_on_empty_final_output_parts():
-    envelope = _envelope(State())
+def test_strict_mode_raises_on_empty_reply():
+    envelope = _envelope()
     with pytest.raises(DeserializationError, match="No DataPart or TextPart"):
         NodeResult.from_envelope(envelope, correlation_id="cid-strict-empty")  # strict=True default
 
 
-def test_lenient_mode_returns_none_on_empty_final_output_parts():
-    envelope = _envelope(State())
+def test_lenient_mode_returns_none_on_empty_reply():
+    envelope = _envelope()
     result = NodeResult.from_envelope(envelope, correlation_id="cid-lenient", strict=False)
     assert result.output is None
     assert result.state is envelope.context.state  # client path: no copy in from_envelope

--- a/tests/test_fire_and_forget.py
+++ b/tests/test_fire_and_forget.py
@@ -89,7 +89,7 @@ async def test_return_call_with_null_callback_publishes_no_callback():
     broker.publish = AsyncMock()
 
     final_state = State()
-    result = await node._publish_action(ReturnCall(state=final_state), envelope, "cid-ff", broker)
+    result, _kind = await node._publish_action(ReturnCall(state=final_state), envelope, "cid-ff", broker)
 
     assert broker.publish.call_count == 0, f"expected no callback publish for null-callback terminal; got {broker.publish.call_count}"
     # The terminal envelope must still be returned so the worker's @publisher
@@ -107,7 +107,7 @@ async def test_return_call_with_non_null_callback_publishes_to_callback():
     broker = MagicMock()
     broker.publish = AsyncMock()
 
-    result = await node._publish_action(ReturnCall(state=State()), envelope, "cid-cb", broker)
+    result, _kind = await node._publish_action(ReturnCall(state=State()), envelope, "cid-cb", broker)
 
     assert broker.publish.call_count == 1, f"expected exactly one callback publish for non-null callback; got {broker.publish.call_count}"
     assert broker.publish.call_args.kwargs["topic"] == "client.reply.inbox"
@@ -589,7 +589,7 @@ async def test_return_call_callback_publish_failure_still_broadcasts(caplog):
 
     final_state = State()
     with caplog.at_level(logging.ERROR, logger="calfkit.nodes.base"):
-        result = await node._publish_action(ReturnCall(state=final_state), envelope, "cid-fail", broker)
+        result, _kind = await node._publish_action(ReturnCall(state=final_state), envelope, "cid-fail", broker)
 
     # The broadcast channel survives: the terminal envelope is still returned.
     assert isinstance(result, Envelope)

--- a/tests/test_fire_and_forget.py
+++ b/tests/test_fire_and_forget.py
@@ -29,7 +29,7 @@ import pytest
 from aiokafka.errors import UnknownTopicOrPartitionError
 from faststream.kafka import KafkaBroker, TestKafkaBroker
 
-from calfkit._protocol import HDR_EMITTER
+from calfkit._protocol import HDR_EMITTER, HDR_KIND
 from calfkit._vendor.pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, ToolCallPart, ToolReturnPart
 from calfkit._vendor.pydantic_ai.messages import TextPart as ModelTextPart
 from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
@@ -433,6 +433,17 @@ async def test_send_reply_to_sets_callback_topic_on_wire(container):
     assert frame.callback_topic == "sink.topic"
     assert frame.target_topic == "agent.input"
     assert publish.await_args.kwargs["correlation_id"] == cid
+
+
+async def test_send_stamps_x_calf_kind_call_on_wire(container):
+    """Every client publish is a call-kind ingress: it carries ``x-calf-kind: call``
+    so a node/consumer classifies it correctly (the wire stamp PR-C's fault arm relies on)."""
+    client = container.get(Client)
+    publish = _wire_spy(client)
+
+    await client.send("hi", "agent.input")
+
+    assert publish.await_args.kwargs["headers"][HDR_KIND] == "call"
 
 
 async def test_send_default_keeps_null_callback_on_wire(container):

--- a/tests/test_lifecycle_e2e.py
+++ b/tests/test_lifecycle_e2e.py
@@ -40,6 +40,7 @@ from calfkit.exceptions import LifecycleConfigError
 from calfkit.models import Silent
 from calfkit.models.envelope import Envelope
 from calfkit.models.payload import TextPart as PayloadTextPart
+from calfkit.models.reply import ReturnMessage
 from calfkit.models.session_context import (
     CallFrame,
     CallFrameStack,
@@ -76,11 +77,11 @@ def _frame_envelope(target_topic: str) -> Envelope:
 
 
 def _text_envelope(text: str) -> Envelope:
-    """A terminal envelope carrying a final TextPart (for consumer output)."""
-    state = State(final_output_parts=[PayloadTextPart(text=text)])
+    """A terminal envelope carrying a final TextPart in its reply slot (for consumer output)."""
     return Envelope(
-        context=SessionRunContext(state=state, deps={}),
+        context=SessionRunContext(state=State(), deps={}),
         internal_workflow_state=WorkflowState(call_stack=CallFrameStack()),
+        reply=ReturnMessage(in_reply_to=None, tag=None, parts=[PayloadTextPart(text=text)]),
     )
 
 

--- a/tests/test_lifecycle_resource_fields.py
+++ b/tests/test_lifecycle_resource_fields.py
@@ -86,15 +86,17 @@ def test_node_result_resources_defaults_empty_and_accepts_override() -> None:
 
 
 def _make_text_envelope(text: str = "hello") -> Any:
-    from calfkit.models import State, TextPart
+    from calfkit.models import ReturnMessage, State, TextPart
     from calfkit.models.envelope import Envelope
     from calfkit.models.session_context import CallFrameStack, SessionRunContext, WorkflowState
 
-    state = State(final_output_parts=[TextPart(text=text)])
-    return Envelope(
-        context=SessionRunContext(state=state, deps={}),
+    env = Envelope(
+        context=SessionRunContext(state=State(), deps={}),
         internal_workflow_state=WorkflowState(call_stack=CallFrameStack()),
+        reply=ReturnMessage(in_reply_to=None, tag=None, parts=[TextPart(text=text)]),
     )
+    env.context._reply = env.reply  # as _on_reply stamps it before from_envelope projects
+    return env
 
 
 def test_from_envelope_threads_resources() -> None:

--- a/tests/test_lifecycle_resource_injection.py
+++ b/tests/test_lifecycle_resource_injection.py
@@ -148,7 +148,7 @@ async def test_tool_run_injects_node_resources_into_tool_context() -> None:
 
 
 async def test_consumer_handler_injects_node_resources_into_context() -> None:
-    from calfkit.models import ConsumerContext, TextPart
+    from calfkit.models import ConsumerContext
     from calfkit.nodes import ConsumerNode
 
     seen: dict[str, Any] = {}
@@ -165,7 +165,7 @@ async def test_consumer_handler_injects_node_resources_into_context() -> None:
     sentinel = object()
     node.resources["db"] = sentinel
 
-    state = State(final_output_parts=[TextPart(text="hi")])
+    state = State()
     envelope = Envelope(
         context=SessionRunContext(state=state, deps={}),
         internal_workflow_state=WorkflowState(call_stack=CallFrameStack()),
@@ -189,7 +189,7 @@ async def test_consumer_handler_injects_node_resources_into_context() -> None:
 async def test_consumer_context_resources_is_shallow_copy_of_node_bag() -> None:
     """The consumer's ``ctx.resources`` is a distinct dict from the node's
     bag, so a consumer mutating it cannot corrupt the shared resources."""
-    from calfkit.models import ConsumerContext, TextPart
+    from calfkit.models import ConsumerContext
     from calfkit.nodes import ConsumerNode
 
     seen: dict[str, Any] = {}
@@ -207,7 +207,7 @@ async def test_consumer_context_resources_is_shallow_copy_of_node_bag() -> None:
     )
     node.resources["db"] = object()
 
-    state = State(final_output_parts=[TextPart(text="hi")])
+    state = State()
     envelope = Envelope(
         context=SessionRunContext(state=state, deps={}),
         internal_workflow_state=WorkflowState(call_stack=CallFrameStack()),

--- a/tests/test_reply_slot.py
+++ b/tests/test_reply_slot.py
@@ -14,10 +14,11 @@ from pydantic import BaseModel
 
 import calfkit._protocol as protocol
 from calfkit._protocol import HDR_KIND, MessageKind
-
+from calfkit.exceptions import DeserializationError
 from calfkit.models import (
     CallFrame,
     CallFrameStack,
+    ConsumerContext,
     DataPart,
     Envelope,
     ReturnCall,
@@ -26,6 +27,7 @@ from calfkit.models import (
     WorkflowState,
 )
 from calfkit.models._coerce import _coerce_to_parts
+from calfkit.models.node_result import NodeResult as InvocationResult
 from calfkit.models.reply import ReturnMessage, _ReplyBase
 from calfkit.models.state import State
 
@@ -141,3 +143,39 @@ class TestProtocolKind:
         # Drift cleanup: HDR_EVENT_TYPE / EventType had zero call sites.
         assert not hasattr(protocol, "HDR_EVENT_TYPE")
         assert not hasattr(protocol, "EventType")
+
+
+def _reply_env(parts: list) -> Envelope:
+    """A frameless envelope carrying a reply, with _reply stamped as a handler/
+    dispatcher would (prepare_context / _on_reply)."""
+    env = Envelope(
+        context=SessionRunContext(state=State(), deps={}),
+        internal_workflow_state=WorkflowState(call_stack=CallFrameStack()),
+        reply=ReturnMessage(in_reply_to=None, tag=None, parts=parts),
+    )
+    env.context._stamp_transport(correlation_id="cid", emitter_node_id=None, emitter_node_kind=None)
+    env.context._reply = env.reply
+    return env
+
+
+class TestProjectionFromReply:
+    """Output projects from the reply slot, not State.final_output_parts (spec §4.5)."""
+
+    def test_node_result_projects_output_from_reply_parts(self) -> None:
+        result = InvocationResult.from_envelope(_reply_env([TextPart(text="from-reply")]), correlation_id="cid")
+        assert result.output == "from-reply"
+        assert result.output_parts == [TextPart(text="from-reply")]
+
+    def test_consumer_context_projects_from_ctx_reply(self) -> None:
+        cc = ConsumerContext.from_run_context(_reply_env([DataPart(data={"k": 1})]).context)
+        assert cc.output == {"k": 1}
+        assert cc.output_parts == [DataPart(data={"k": 1})]
+
+    def test_strict_empty_reply_raises(self) -> None:
+        with pytest.raises(DeserializationError):
+            InvocationResult.from_envelope(_reply_env([]), correlation_id="cid")
+
+    def test_lenient_empty_reply_returns_none(self) -> None:
+        cc = ConsumerContext.from_run_context(_reply_env([]).context)  # strict=False
+        assert cc.output is None
+        assert cc.output_parts == []

--- a/tests/test_reply_slot.py
+++ b/tests/test_reply_slot.py
@@ -1,0 +1,143 @@
+"""PR-A — the per-delivery reply slot (return half of the §4 wire model).
+
+Layer-1: the new wire models round-trip and the new fields default correctly.
+See notes/reply-slot-for-returns-pr-implementation-plan.md.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import pydantic_core
+import pytest
+from pydantic import BaseModel
+
+import calfkit._protocol as protocol
+from calfkit._protocol import HDR_KIND, MessageKind
+
+from calfkit.models import (
+    CallFrame,
+    CallFrameStack,
+    DataPart,
+    Envelope,
+    ReturnCall,
+    SessionRunContext,
+    TextPart,
+    WorkflowState,
+)
+from calfkit.models._coerce import _coerce_to_parts
+from calfkit.models.reply import ReturnMessage, _ReplyBase
+from calfkit.models.state import State
+
+
+def _envelope(*, reply: ReturnMessage | None = None) -> Envelope:
+    stack = CallFrameStack()
+    stack.push(CallFrame(target_topic="t", callback_topic="reply.topic"))
+    return Envelope(
+        internal_workflow_state=WorkflowState(call_stack=stack),
+        context=SessionRunContext(state=State(), deps={}),
+        reply=reply,
+    )
+
+
+class TestReturnMessage:
+    def test_extends_reply_base_and_is_kind_return(self) -> None:
+        rm = ReturnMessage(in_reply_to="f1", tag="t1", parts=[TextPart(text="hi")])
+        assert isinstance(rm, _ReplyBase)
+        assert rm.kind == "return"
+
+    def test_in_reply_to_and_tag_accept_none(self) -> None:
+        rm = ReturnMessage(in_reply_to=None, tag=None, parts=[])
+        assert rm.in_reply_to is None
+        assert rm.tag is None
+
+    def test_round_trips_through_json(self) -> None:
+        rm = ReturnMessage(in_reply_to="f1", tag="call-7", parts=[TextPart(text="hi")])
+        back = ReturnMessage.model_validate_json(rm.model_dump_json())
+        assert back == rm
+        assert back.parts[0].text == "hi"
+
+
+class TestEnvelopeReply:
+    def test_reply_defaults_none(self) -> None:
+        assert _envelope().reply is None
+
+    def test_carries_reply_and_round_trips(self) -> None:
+        env = _envelope(reply=ReturnMessage(in_reply_to="f1", tag="t1", parts=[TextPart(text="out")]))
+        back = Envelope.model_validate_json(env.model_dump_json())
+        assert back.reply is not None
+        assert back.reply.kind == "return"
+        assert back.reply.in_reply_to == "f1"
+        assert back.reply.parts[0].text == "out"
+
+    def test_none_reply_round_trips(self) -> None:
+        back = Envelope.model_validate_json(_envelope().model_dump_json())
+        assert back.reply is None
+
+
+class TestCallFrameTag:
+    def test_tag_defaults_none(self) -> None:
+        assert CallFrame(target_topic="t", callback_topic=None).tag is None
+
+    def test_tag_is_set_and_survives_envelope_round_trip(self) -> None:
+        stack = CallFrameStack()
+        stack.push(CallFrame(target_topic="t", callback_topic="cb", tag="call-9"))
+        env = Envelope(
+            internal_workflow_state=WorkflowState(call_stack=stack),
+            context=SessionRunContext(state=State(), deps={}),
+        )
+        back = Envelope.model_validate_json(env.model_dump_json())
+        assert back.internal_workflow_state.current_frame.tag == "call-9"
+
+
+class TestReturnCallValue:
+    def test_value_defaults_none(self) -> None:
+        assert ReturnCall(state=State()).value is None
+
+    def test_value_is_carried_and_in_eq(self) -> None:
+        parts = [TextPart(text="hi")]
+        rc = ReturnCall(state=State(), value=parts)
+        assert rc.value == parts
+        assert rc == ReturnCall(state=rc.state, value=parts)
+
+
+class _Struct(BaseModel):
+    n: int
+
+
+class TestCoerceToParts:
+    def test_str_becomes_one_textpart(self) -> None:
+        assert _coerce_to_parts("hi") == [TextPart(text="hi")]
+
+    def test_none_becomes_empty_list(self) -> None:
+        assert _coerce_to_parts(None) == []
+
+    def test_list_of_content_parts_passes_through(self) -> None:
+        parts = [TextPart(text="a"), DataPart(data={"k": "v"})]
+        assert _coerce_to_parts(parts) == parts
+
+    def test_dict_becomes_one_datapart(self) -> None:
+        assert _coerce_to_parts({"k": "v"}) == [DataPart(data={"k": "v"})]
+
+    def test_basemodel_becomes_datapart_and_is_wire_safe(self) -> None:
+        out = _coerce_to_parts(_Struct(n=7))
+        assert out == [DataPart(data=_Struct(n=7))]
+        # the coerced part must serialize (eager wire-safety, tool.py precedent)
+        pydantic_core.to_json(out[0])
+
+    def test_non_serializable_value_raises(self) -> None:
+        with pytest.raises(pydantic_core.PydanticSerializationError):
+            _coerce_to_parts(object())
+
+
+class TestProtocolKind:
+    def test_hdr_kind_header_name(self) -> None:
+        assert HDR_KIND == "x-calf-kind"
+
+    def test_message_kind_value_space(self) -> None:
+        assert typing.get_args(MessageKind) == ("call", "return")
+
+    def test_dead_event_type_constants_removed(self) -> None:
+        # Drift cleanup: HDR_EVENT_TYPE / EventType had zero call sites.
+        assert not hasattr(protocol, "HDR_EVENT_TYPE")
+        assert not hasattr(protocol, "EventType")

--- a/tests/test_reply_slot_publish.py
+++ b/tests/test_reply_slot_publish.py
@@ -15,6 +15,7 @@ from calfkit.models import (
     CallFrame,
     CallFrameStack,
     Envelope,
+    Next,
     ReturnCall,
     SessionRunContext,
     Silent,
@@ -175,6 +176,30 @@ class TestNoReplyMirrorClearsInboundReply:
         resp = await _run(_SilentNode(node_id="n", subscribe_topics=["t"]), _envelope(reply=leak), broker)
         assert resp.body.reply is None
 
+    async def test_gate_reject_mirror_clears_inbound_reply(self) -> None:
+        # The handler-level gate-reject path mirrors kind=call with reply cleared.
+        class _GatedNode(NodeDef[Any]):
+            async def run(self, ctx: SessionRunContext) -> Any:
+                return Silent()
+
+        node = _GatedNode(node_id="n", subscribe_topics=["t"], gates=[lambda ctx: False])
+        leak = ReturnMessage(in_reply_to="prev", tag="t", parts=[TextPart(text="LEAK")])
+        resp = await _run(node, _envelope(reply=leak), _CaptureBroker())
+        assert resp.body.reply is None
+        assert resp.headers[HDR_KIND] == "call"
+
+    async def test_no_result_mirror_clears_inbound_reply(self) -> None:
+        # The handler-level no-result/all-declined path mirrors kind=call, reply cleared.
+        class _DeclineNode(NodeDef[Any]):
+            async def run(self, ctx: SessionRunContext) -> Any:
+                return Next()  # decline → no handler produced a result
+
+        node = _DeclineNode(node_id="n", subscribe_topics=["t"])
+        leak = ReturnMessage(in_reply_to="prev", tag="t", parts=[TextPart(text="LEAK")])
+        resp = await _run(node, _envelope(reply=leak), _CaptureBroker())
+        assert resp.body.reply is None
+        assert resp.headers[HDR_KIND] == "call"
+
 
 class TestReplyStamping:
     """prepare_context stamps ctx._reply from envelope.reply (after the deep-copy,
@@ -191,6 +216,17 @@ class TestReplyStamping:
         # Unconditional stamp: a call-kind delivery (reply=None) clears any stale value.
         node = _CallNode(node_id="n", subscribe_topics=["t"])
         ctx = await node.prepare_context(_envelope(reply=None), correlation_id=_CORR)
+        assert ctx._reply is None
+        assert ctx.output_parts == []
+
+    async def test_stamp_clears_stale_inbound_reply_on_call_kind(self) -> None:
+        # THE pin for the unconditional stamp: a stale _reply on the inbound context
+        # (in-process reuse) survives model_copy(deep=True), so prepare_context MUST
+        # overwrite it with envelope.reply (None here) — the guarded form would leak it.
+        node = _CallNode(node_id="n", subscribe_topics=["t"])
+        env = _envelope(reply=None)  # call-kind delivery
+        env.context._reply = ReturnMessage(in_reply_to="stale", tag=None, parts=[TextPart(text="STALE")])
+        ctx = await node.prepare_context(env, correlation_id=_CORR)
         assert ctx._reply is None
         assert ctx.output_parts == []
 

--- a/tests/test_reply_slot_publish.py
+++ b/tests/test_reply_slot_publish.py
@@ -174,3 +174,27 @@ class TestNoReplyMirrorClearsInboundReply:
         leak = ReturnMessage(in_reply_to="prev", tag="t", parts=[TextPart(text="LEAK")])
         resp = await _run(_SilentNode(node_id="n", subscribe_topics=["t"]), _envelope(reply=leak), broker)
         assert resp.body.reply is None
+
+
+class TestReplyStamping:
+    """prepare_context stamps ctx._reply from envelope.reply (after the deep-copy,
+    unconditionally), and ctx.output_parts is the permanent reply-sourced accessor."""
+
+    async def test_stamps_reply_and_exposes_output_parts(self) -> None:
+        node = _CallNode(node_id="n", subscribe_topics=["t"])
+        reply = ReturnMessage(in_reply_to="F1", tag=None, parts=[TextPart(text="out")])
+        ctx = await node.prepare_context(_envelope(reply=reply), correlation_id=_CORR)
+        assert ctx._reply == reply
+        assert ctx.output_parts == [TextPart(text="out")]
+
+    async def test_call_kind_reply_none_yields_empty_output_parts(self) -> None:
+        # Unconditional stamp: a call-kind delivery (reply=None) clears any stale value.
+        node = _CallNode(node_id="n", subscribe_topics=["t"])
+        ctx = await node.prepare_context(_envelope(reply=None), correlation_id=_CORR)
+        assert ctx._reply is None
+        assert ctx.output_parts == []
+
+    def test_unstamped_context_output_parts_empty_not_error(self) -> None:
+        # A context built outside a handler must yield [] (loud-by-emptiness), never raise.
+        ctx = SessionRunContext(state=State(), deps={})
+        assert ctx.output_parts == []

--- a/tests/test_reply_slot_publish.py
+++ b/tests/test_reply_slot_publish.py
@@ -1,0 +1,176 @@
+"""PR-A Layer-4 — the publish chokepoint stamps ``x-calf-kind`` + the reply slot per
+branch, and the broadcast mirror (the handler's ``Response``) carries the hop's kind.
+No-reply hops clear ``reply`` so a stale inbound reply can't ride out (the I3
+production-side guard).
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from calfkit._protocol import HDR_KIND, HDR_ROUTE
+from calfkit._registry import handler
+from calfkit.models import (
+    Call,
+    CallFrame,
+    CallFrameStack,
+    Envelope,
+    ReturnCall,
+    SessionRunContext,
+    Silent,
+    State,
+    TailCall,
+    TextPart,
+    WorkflowState,
+)
+from calfkit.models.reply import ReturnMessage
+from calfkit.nodes.node import NodeDef
+
+_CORR = "corr-1234"
+
+
+class _CaptureBroker:
+    """Node-side broker stub: records (topic, headers, envelope) per publish."""
+
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict[str, str], Any]] = []
+
+    async def publish(self, envelope: Any, *, topic: str, correlation_id: str, key: bytes, headers: dict[str, str]) -> None:
+        self.published.append((topic, headers, envelope))
+
+
+def _envelope(
+    *,
+    callback_topic: str | None = "reply.topic",
+    frame_id: str = "F1",
+    tag: str | None = None,
+    reply: ReturnMessage | None = None,
+) -> Envelope:
+    stack = CallFrameStack()
+    stack.push(CallFrame(target_topic="t", callback_topic=callback_topic, frame_id=frame_id, tag=tag))
+    return Envelope(
+        internal_workflow_state=WorkflowState(call_stack=stack),
+        context=SessionRunContext(state=State(), deps={}),
+        reply=reply,
+    )
+
+
+class _RetNode(NodeDef[Any]):
+    @handler("go")
+    async def go(self, ctx: SessionRunContext) -> Any:
+        return ReturnCall(state=ctx.state, value="hello")
+
+    async def run(self, ctx: SessionRunContext) -> Any:
+        return Silent()
+
+
+class _CallNode(NodeDef[Any]):
+    @handler("go")
+    async def go(self, ctx: SessionRunContext) -> Any:
+        return Call("downstream", ctx.state)
+
+    async def run(self, ctx: SessionRunContext) -> Any:
+        return Silent()
+
+
+class _FanNode(NodeDef[Any]):
+    @handler("go")
+    async def go(self, ctx: SessionRunContext) -> Any:
+        return [Call("a", ctx.state), Call("b", ctx.state)]
+
+    async def run(self, ctx: SessionRunContext) -> Any:
+        return Silent()
+
+
+class _TailNode(NodeDef[Any]):
+    @handler("go")
+    async def go(self, ctx: SessionRunContext) -> Any:
+        return TailCall("downstream", ctx.state)
+
+    async def run(self, ctx: SessionRunContext) -> Any:
+        return Silent()
+
+
+async def _run(node: NodeDef[Any], env: Envelope, broker: _CaptureBroker) -> Any:
+    return await node.handler(env, correlation_id=_CORR, headers={HDR_ROUTE: "go"}, broker=cast(Any, broker))
+
+
+class TestReturnCallStamping:
+    async def test_callback_publish_is_kind_return_with_reply_slot(self) -> None:
+        broker = _CaptureBroker()
+        node = _RetNode(node_id="n", subscribe_topics=["t"])
+        await _run(node, _envelope(frame_id="F1", tag="call-7"), broker)
+
+        assert len(broker.published) == 1
+        topic, headers, env = broker.published[0]
+        assert topic == "reply.topic"
+        assert headers[HDR_KIND] == "return"
+        assert isinstance(env.reply, ReturnMessage)
+        assert env.reply.in_reply_to == "F1"  # echoes the popped frame_id
+        assert env.reply.tag == "call-7"  # echoes the popped frame tag
+        assert env.reply.parts == [TextPart(text="hello")]  # value coerced to parts
+
+    async def test_mirror_response_carries_kind_return_and_reply(self) -> None:
+        broker = _CaptureBroker()
+        node = _RetNode(node_id="n", subscribe_topics=["t"])
+        resp = await _run(node, _envelope(), broker)
+        assert resp.headers[HDR_KIND] == "return"
+        assert isinstance(resp.body.reply, ReturnMessage)
+
+
+class TestCallStamping:
+    async def test_call_publish_is_kind_call_with_no_reply(self) -> None:
+        broker = _CaptureBroker()
+        await _run(_CallNode(node_id="n", subscribe_topics=["t"]), _envelope(), broker)
+        _topic, headers, env = broker.published[0]
+        assert headers[HDR_KIND] == "call"
+        assert env.reply is None
+
+    async def test_mirror_response_is_kind_call(self) -> None:
+        broker = _CaptureBroker()
+        resp = await _run(_CallNode(node_id="n", subscribe_topics=["t"]), _envelope(), broker)
+        assert resp.headers[HDR_KIND] == "call"
+
+
+class TestFanOutStamping:
+    async def test_each_sibling_is_kind_call_with_no_reply(self) -> None:
+        broker = _CaptureBroker()
+        await _run(_FanNode(node_id="n", subscribe_topics=["t"]), _envelope(), broker)
+        assert {t for t, _, _ in broker.published} == {"a", "b"}
+        for _topic, headers, env in broker.published:
+            assert headers[HDR_KIND] == "call"
+            assert env.reply is None
+
+
+class TestTailCallStamping:
+    async def test_tailcall_publish_is_kind_call_with_no_reply(self) -> None:
+        broker = _CaptureBroker()
+        await _run(_TailNode(node_id="n", subscribe_topics=["t"]), _envelope(), broker)
+        _topic, headers, env = broker.published[0]
+        assert headers[HDR_KIND] == "call"
+        assert env.reply is None
+
+
+class TestNoReplyMirrorClearsInboundReply:
+    """I3 production-side guard: a node processing an inbound *return* that then
+    fans out / goes silent must NOT re-broadcast the inbound reply on its mirror."""
+
+    async def test_fanout_mirror_clears_inbound_reply(self) -> None:
+        broker = _CaptureBroker()
+        leak = ReturnMessage(in_reply_to="prev", tag="t", parts=[TextPart(text="LEAK")])
+        resp = await _run(_FanNode(node_id="n", subscribe_topics=["t"]), _envelope(reply=leak), broker)
+        assert resp.body.reply is None
+
+    async def test_silent_mirror_clears_inbound_reply(self) -> None:
+        class _SilentNode(NodeDef[Any]):
+            @handler("go")
+            async def go(self, ctx: SessionRunContext) -> Any:
+                return Silent()
+
+            async def run(self, ctx: SessionRunContext) -> Any:
+                return Silent()
+
+        broker = _CaptureBroker()
+        leak = ReturnMessage(in_reply_to="prev", tag="t", parts=[TextPart(text="LEAK")])
+        resp = await _run(_SilentNode(node_id="n", subscribe_topics=["t"]), _envelope(reply=leak), broker)
+        assert resp.body.reply is None


### PR DESCRIPTION
## Summary

Introduces the **per-delivery reply slot** — the *return* half of the fault-rail §4 wire model — and migrates a node's output off the `State.final_output_parts` side-channel onto it. This is **PR-A** of the fault-rail train (reply-slot → durable aggregator → fault rail + seams); it ships the wire-model groundwork the later PRs bolt onto, with no fault vocabulary yet.

## What changed

**Wire model**
- `Envelope.reply: ReturnMessage | None` — per-delivery response carriage. `ReturnMessage(_ReplyBase)` carries `in_reply_to` + `tag` (correlation) + `parts: list[ContentPart]` (the output). `_ReplyBase` ships now so PR-C's `FaultMessage` is a pure sibling addition.
- `x-calf-kind: call | return` header (`HDR_KIND`/`MessageKind`), framework-stamped on every publish. Deleted the dead, unused `HDR_EVENT_TYPE`/`EventType`.
- `CallFrame.tag` (caller correlation token, dormant until PR-B wires a producer) and `ReturnCall.value` (output explicit in the action).

**Carriage + projection**
- `_publish_action` stamps `reply` + `x-calf-kind` per branch and returns the kind so `handler` stamps the broadcast mirror; no-reply hops clear `reply` so a node processing a return that then fans out / goes silent can't re-broadcast a foreign reply to its observers (the I3 leak guard).
- `_coerce_to_parts` (value → `list[ContentPart]`, with an eager `pydantic_core.to_json` wire-safety check).
- `prepare_context` / the client `_on_reply` stamp `ctx._reply`; `project_output` sources from the reply; `NodeResult`/`ConsumerContext` gain an `output_parts` field captured at construction; `SessionRunContext` gains a permanent `ctx.output_parts` accessor.
- Agent terminal returns `ReturnCall(value=parts)` instead of writing `final_output_parts`; client `send`/`start` stamp `x-calf-kind=call`.

## Behavior

**Preserved** for the two consumers of output (client `execute`/`result`, `@consumer` sinks): a terminal reply projects to the identical typed output, because `final_output_parts`-nonempty ⟺ `reply.parts`-nonempty.

**One intended, observable change (the I3 fix):** at mid-loop hops in agent-calls-agent / agent-as-tool chains, the never-cleared `final_output_parts` used to leak an inner agent's terminal output to a consumer tapping the outer mid-loop hop; the reply slot correctly projects `None` there. Strict improvement; no test asserted the old leaky behavior.

## Breaking changes (pre-1.0, no shims)

- **`State.final_output_parts` deleted outright.** Output rides `reply.parts`.
- The documented gate idiom `bool(ctx.state.final_output_parts)` → `bool(ctx.output_parts)` (migrated in tests + the quickstart `weather_sink.py`).
- `ReturnCall` gains `value`; the wire format (`Envelope`) and `State` shape change. Mixed-version rolling deploys unsupported (hard-break policy).

## Scope boundary (deferred — NOT in this PR)

- **PR-B (durable aggregator):** the `fanout_id` marker, frame_id-keyed batch, durable batch state. In-process `_pending_batches` and the `tool_results`-scan matching are untouched here; `in_reply_to`/`tag` ride the wire but the batch still matches as today.
- **PR-C (fault rail + seams):** `FaultMessage`, `ErrorReport`, `kind=fault`, the policy seams, the `_classify` classifier, `Silent` removal. The handler does not yet *read*/branch on `x-calf-kind` (only stamps it) — reading is PR-C's sealed `_classify`.
- The `NodeResult` → `InvocationResult` rename is a separate follow-up PR.

## Two implementation notes for reviewers

1. **Commit grouping:** the read-side repoint (projection) + agent-terminal + client-stamp are in one commit — they're interlocked (the e2e flow only goes green when all three land), so there's no green intermediate to split between.
2. **No no-op `_on_reply` kind read:** `x-calf-kind` is stamped on send (wire correctly classified) and `_on_reply` stamps `_reply` for projection, but I did not add a kind *read* that branches on nothing — that's dead code in PR-A; reading/classifying is PR-C's `_classify`.

## Testing

- TDD throughout (RED→GREEN per step). New: `tests/test_reply_slot.py`, `tests/test_reply_slot_publish.py`.
- **2781 non-integration tests pass**; 26 integration tests collect clean (not run here — real-API cost; the `FunctionModel`-based e2e tests exercise the full agent→reply→consumer/client flow).
- `make check` clean: ruff + format + `mypy --strict` (55 files).

## References

Implements the return half of ADR-0006 (reply rides a per-delivery envelope slot). Spec: `docs/designs/fault-rail-and-policy-seams-spec.md` §4/§4.5/§6.9/§11/§15.
