### PR TITLE
refactor: rename client-facing projection NodeResult -> InvocationResult

### DIFF
--- a/calfkit/__init__.py
+++ b/calfkit/__init__.py
@@ -1,6 +1,6 @@
 from importlib.metadata import version
 
-from calfkit.client import Client, InvocationHandle, NodeResult
+from calfkit.client import Client, InvocationHandle, InvocationResult
 from calfkit.exceptions import DeserializationError, LifecycleConfigError, ToolExecutionError
 from calfkit.models import ToolContext
 from calfkit.nodes import Agent, BaseNodeDef, ConsumerFn, ConsumerNode, GateFunction, NodeDef, ToolNodeDef, agent_tool, consumer
@@ -14,7 +14,7 @@ __all__ = [
     # client
     "Client",
     "InvocationHandle",
-    "NodeResult",
+    "InvocationResult",
     # models
     "ToolContext",
     # nodes

--- a/calfkit/client/__init__.py
+++ b/calfkit/client/__init__.py
@@ -1,6 +1,6 @@
 from calfkit.client.base import BaseClient
 from calfkit.client.client import Client
 from calfkit.client.invocation_handle import InvocationHandle
-from calfkit.models.node_result import NodeResult
+from calfkit.models.node_result import InvocationResult
 
-__all__ = ["BaseClient", "Client", "InvocationHandle", "NodeResult"]
+__all__ = ["BaseClient", "Client", "InvocationHandle", "InvocationResult"]

--- a/calfkit/client/client.py
+++ b/calfkit/client/client.py
@@ -12,7 +12,7 @@ from calfkit._vendor.pydantic_ai.settings import ModelSettings
 from calfkit.client.base import BaseClient
 from calfkit.client.invocation_handle import InvocationHandle
 from calfkit.models import State
-from calfkit.models.node_result import _UNSET, NodeResult
+from calfkit.models.node_result import _UNSET, InvocationResult
 from calfkit.models.state import OverridesState
 from calfkit.models.tool_dispatch import ToolBinding, ToolProvider, normalize_tool_bindings
 
@@ -173,7 +173,7 @@ class Client(BaseClient):
 
         Returns:
             An :class:`InvocationHandle` whose ``result()`` resolves to a
-            :class:`NodeResult`.
+            :class:`InvocationResult`.
         """
         correlation_id, state, overrides = self._build_state_and_overrides(
             user_prompt,
@@ -311,7 +311,7 @@ class Client(BaseClient):
         route: str | None = ...,
         body: Any | None = ...,
         timeout: float | None = ...,
-    ) -> NodeResult[OutputT]: ...
+    ) -> InvocationResult[OutputT]: ...
 
     @overload
     async def execute(
@@ -329,7 +329,7 @@ class Client(BaseClient):
         route: str | None = ...,
         body: Any | None = ...,
         timeout: float | None = ...,
-    ) -> NodeResult[Any]: ...
+    ) -> InvocationResult[Any]: ...
 
     async def execute(
         self,
@@ -347,7 +347,7 @@ class Client(BaseClient):
         route: str | None = None,
         body: Any | None = None,
         timeout: float | None = None,
-    ) -> NodeResult[Any]:
+    ) -> InvocationResult[Any]:
         """Invoke an agent node and await the reply in a single call.
 
         The **execute** pattern (cf. Temporal's ``execute_workflow``):
@@ -382,7 +382,7 @@ class Client(BaseClient):
                 wait indefinitely.
 
         Returns:
-            A :class:`NodeResult` containing the deserialized output and
+            A :class:`InvocationResult` containing the deserialized output and
             session metadata.
 
         Raises:

--- a/calfkit/client/invocation_handle.py
+++ b/calfkit/client/invocation_handle.py
@@ -6,7 +6,7 @@ from typing import Any, Generic
 
 from calfkit._types import OutputT
 from calfkit.models.envelope import Envelope
-from calfkit.models.node_result import _UNSET, NodeResult
+from calfkit.models.node_result import _UNSET, InvocationResult
 
 
 @dataclass
@@ -17,14 +17,14 @@ class InvocationHandle(Generic[OutputT]):
     _future: asyncio.Future[Envelope] = field(repr=False, compare=False)
     _output_type: type[Any] = field(default=_UNSET, repr=False, compare=False)
 
-    async def result(self, timeout: float | None = None) -> NodeResult[OutputT]:
+    async def result(self, timeout: float | None = None) -> InvocationResult[OutputT]:
         """Await the invocation result.
 
         Args:
             timeout: Maximum seconds to wait. ``None`` means wait indefinitely.
 
         Returns:
-            A ``NodeResult`` with the deserialized output and session metadata.
+            A ``InvocationResult`` with the deserialized output and session metadata.
 
         Raises:
             asyncio.TimeoutError: If *timeout* elapses before a reply arrives.
@@ -52,4 +52,4 @@ class InvocationHandle(Generic[OutputT]):
             envelope = await asyncio.wait_for(self._future, timeout=timeout)
         else:
             envelope = await self._future
-        return NodeResult.from_envelope(envelope, self._output_type, correlation_id=self.correlation_id)
+        return InvocationResult.from_envelope(envelope, self._output_type, correlation_id=self.correlation_id)

--- a/calfkit/client/reply_dispatcher.py
+++ b/calfkit/client/reply_dispatcher.py
@@ -70,13 +70,13 @@ class _ReplyDispatcher:
         from the envelope body.
         """
         # Stash the inbound correlation id + emitter so the context surfaces them
-        # (ctx.correlation_id, NodeResult.emitter_node_id / kind).
+        # (ctx.correlation_id, InvocationResult.emitter_node_id / kind).
         envelope.context._stamp_transport(
             correlation_id=correlation_id,
             emitter_node_id=decode_header_str(headers.get(HDR_EMITTER)),
             emitter_node_kind=decode_header_str(headers.get(HDR_EMITTER_KIND)),
         )
-        # Surface the per-delivery reply so NodeResult.from_envelope (via
+        # Surface the per-delivery reply so InvocationResult.from_envelope (via
         # from_context) projects the output from reply.parts (spec §4.5).
         envelope.context._reply = envelope.reply
 

--- a/calfkit/models/consumer_context.py
+++ b/calfkit/models/consumer_context.py
@@ -66,7 +66,7 @@ class ConsumerContext(Generic[OutputT]):
     Empty when the node owns no resources."""
 
     # Holds a mutable Pydantic model (state); declare unhashability explicitly so
-    # static checkers and runtime introspection agree (mirrors NodeResult).
+    # static checkers and runtime introspection agree (mirrors InvocationResult).
     __hash__ = None  # type: ignore[assignment]
 
     @classmethod

--- a/calfkit/models/node_result.py
+++ b/calfkit/models/node_result.py
@@ -21,10 +21,10 @@ _UNSET: Any = object()
 
 
 @dataclass(frozen=True)
-class NodeResult(Generic[OutputT]):
+class InvocationResult(Generic[OutputT]):
     """Client-facing projection of the session state after a node returns.
 
-    A ``NodeResult`` is what callers receive in two places:
+    A ``InvocationResult`` is what callers receive in two places:
 
     * :meth:`Client.execute` / :meth:`InvocationHandle.result` — the
       final reply from an agent invocation.
@@ -35,7 +35,7 @@ class NodeResult(Generic[OutputT]):
     state fields. ``message_history``, ``output_parts``, and ``metadata`` are
     convenience properties that read through ``state``.
 
-    Treat ``NodeResult``, its ``state``, and its ``deps`` as read-only. The
+    Treat ``InvocationResult``, its ``state``, and its ``deps`` as read-only. The
     dataclass is frozen, but ``state`` is a mutable Pydantic model and ``deps``
     is the envelope's dict typed as a read-only ``Mapping`` (both shared with the
     envelope, not copied — the ``Mapping`` annotation makes accidental
@@ -44,13 +44,13 @@ class NodeResult(Generic[OutputT]):
 
     * **Consumer path**: the consumer never republishes (no ``publish_topic``),
       so mutations have no observable downstream effect. They can still
-      surprise other code holding the same ``NodeResult`` instance.
+      surprise other code holding the same ``InvocationResult`` instance.
     * **Client path** (:meth:`Client.execute` / :meth:`InvocationHandle.result`):
       the caller's lifetime owns the instance — mutations are caller-visible
       and may corrupt any other code holding a parallel reference (caches,
       retry layers, etc.).
 
-    ``NodeResult`` is intentionally unhashable (``__hash__ = None``): the
+    ``InvocationResult`` is intentionally unhashable (``__hash__ = None``): the
     underlying ``state`` field is a mutable Pydantic model and cannot be
     placed in a set or used as a dict key safely. Use ``correlation_id`` if
     you need a hashable identifier.
@@ -122,7 +122,7 @@ class NodeResult(Generic[OutputT]):
     ``result.resources[...] = ...`` is a type error at dev time (like ``deps``).
     Empty when the node owns no resources."""
 
-    # NodeResult holds a mutable Pydantic model (state); the dataclass-
+    # InvocationResult holds a mutable Pydantic model (state); the dataclass-
     # synthesized __hash__ would recursively try to hash unhashable fields and
     # raise at use-time. Declare unhashability explicitly so static type
     # checkers and runtime introspection agree.
@@ -138,8 +138,8 @@ class NodeResult(Generic[OutputT]):
         strict: bool = True,
         type_adapter: TypeAdapter[Any] | None = None,
         resources: Mapping[str, Any] | None = None,
-    ) -> NodeResult[Any]:
-        """Project a (transport-stamped) ``SessionRunContext`` into a ``NodeResult``.
+    ) -> InvocationResult[Any]:
+        """Project a (transport-stamped) ``SessionRunContext`` into a ``InvocationResult``.
 
         This is the core constructor; :meth:`from_envelope` delegates here. The
         context must already be stamped (``prepare_context``, the consumer
@@ -158,7 +158,7 @@ class NodeResult(Generic[OutputT]):
                   it through ``TypeAdapter(output_type)`` (or *type_adapter* if
                   provided).
             correlation_id: The transport ``correlation_id`` to surface as
-                ``NodeResult.correlation_id``. Sourced from the transport, never
+                ``InvocationResult.correlation_id``. Sourced from the transport, never
                 from the envelope body. When ``None``, falls back to
                 ``ctx.correlation_id`` (which raises if the context was never
                 stamped).
@@ -174,11 +174,11 @@ class NodeResult(Generic[OutputT]):
                 Consumers pre-build at wiring time so schema-generation errors
                 surface once at construction rather than per envelope.
             resources: The consuming node's lifecycle-managed resources, surfaced
-                as ``NodeResult.resources`` (read-only by type). Defaults to an
+                as ``InvocationResult.resources`` (read-only by type). Defaults to an
                 empty mapping.
 
         Returns:
-            A ``NodeResult`` whose ``.output`` is typed according to *output_type*
+            A ``InvocationResult`` whose ``.output`` is typed according to *output_type*
             (or ``None`` when ``strict=False`` and no parts are present).
 
         Raises:
@@ -214,8 +214,8 @@ class NodeResult(Generic[OutputT]):
         strict: bool = True,
         type_adapter: TypeAdapter[Any] | None = None,
         resources: Mapping[str, Any] | None = None,
-    ) -> NodeResult[Any]:
-        """Project an ``Envelope`` into a ``NodeResult``.
+    ) -> InvocationResult[Any]:
+        """Project an ``Envelope`` into a ``InvocationResult``.
 
         A thin convenience over :meth:`from_context` for callers holding a full
         envelope whose ``context`` was stamped in place (the client reply
@@ -248,7 +248,7 @@ def project_output(
 ) -> Any:
     """Project the deserialized output from the delivery's reply slot (spec §4.5).
 
-    Shared by :meth:`NodeResult.from_context` (client, ``strict=True``) and
+    Shared by :meth:`InvocationResult.from_context` (client, ``strict=True``) and
     :meth:`ConsumerContext.from_run_context` (consumer, ``strict=False``). With
     ``strict=False`` an empty/absent reply (an intermediate hop) yields ``None``;
     otherwise the matching part is extracted/validated per ``output_type`` (raising

--- a/calfkit/models/tool_context.py
+++ b/calfkit/models/tool_context.py
@@ -37,7 +37,7 @@ class ToolContext(RunContext[dict[str, Any]]):
         Alias of the inherited pydantic-ai ``run_id`` (calfkit always constructs
         a :class:`ToolContext` with ``run_id`` set to the correlation id), exposed
         under calfkit's own vocabulary so tool authors use the same name as the
-        rest of the SDK (``NodeResult.correlation_id``, ``Client.execute``).
+        rest of the SDK (``InvocationResult.correlation_id``, ``Client.execute``).
         """
         if self.run_id is None:
             raise RuntimeError("ToolContext was constructed without a run_id (correlation id).")

--- a/docs/client-features.md
+++ b/docs/client-features.md
@@ -13,7 +13,7 @@ See also: [CLI reference](cli.md) · [Worker lifecycle](worker-lifecycle.md) ·
 
 | Method | Pattern | Returns |
 | --- | --- | --- |
-| `execute(...)` | Request/reply — publish and await the result in one call. | `NodeResult` |
+| `execute(...)` | Request/reply — publish and await the result in one call. | `InvocationResult` |
 | `start(...)` | Publish and get a handle; `await handle.result()` later. | `InvocationHandle` |
 | `send(...)` | One-way — dispatch and return immediately; no reply future. Optional `reply_to` return address. | `correlation_id` (str) |
 

--- a/docs/consumer-nodes.md
+++ b/docs/consumer-nodes.md
@@ -2,7 +2,7 @@
 
 A **consumer node** is a terminal sink — it subscribes to one or more topics and
 runs arbitrary Python logic against every event flowing through. Consumers
-receive the same `NodeResult` that `Client.execute()` returns, including the
+receive the same `InvocationResult` that `Client.execute()` returns, including the
 full session state (`tool_calls`, `tool_results`, `message_history`, `metadata`)
 and the inbound producer `deps` via `result.deps["key"]` — the same data tools
 read as `ctx.deps["key"]`.
@@ -14,12 +14,12 @@ intermediate hops:
 ```python
 # weather_sink.py
 import asyncio
-from calfkit.client import Client, NodeResult
+from calfkit.client import Client, InvocationResult
 from calfkit.nodes import consumer
 from calfkit.worker import Worker
 
 @consumer(subscribe_topics="weather_agent.output")
-async def log_weather(result: NodeResult) -> None:
+async def log_weather(result: InvocationResult) -> None:
     if result.output is None:
         return  # intermediate hop — no final output yet
     print(f"[{result.correlation_id[:8]}] {result.output}")
@@ -49,7 +49,7 @@ only want agent terminals:
     subscribe_topics="weather_agent.output",
     gates=[lambda ctx: bool(ctx.output_parts)],
 )
-async def save_final(result: NodeResult) -> None:
+async def save_final(result: InvocationResult) -> None:
     await db.save(result.output)  # always populated here
 ```
 

--- a/examples/quickstart/weather_sink.py
+++ b/examples/quickstart/weather_sink.py
@@ -2,7 +2,7 @@
 
 Listens on the weather agent's ``publish_topic`` and runs arbitrary Python
 against every envelope that flows through it. The decorated function receives
-the same client-facing ``NodeResult`` returned by ``Client.execute()``.
+the same client-facing ``InvocationResult`` returned by ``Client.execute()``.
 
 Because an agent's ``publish_topic`` carries every state transition (not just
 the final reply), ``result.output`` is ``None`` on intermediate hops — pending
@@ -18,13 +18,13 @@ Run alongside the agent service:
 
 import asyncio
 
-from calfkit.client import Client, NodeResult
+from calfkit.client import Client, InvocationResult
 from calfkit.nodes import consumer
 from calfkit.worker import Worker
 
 
 @consumer(subscribe_topics="weather_agent.output")
-async def log_weather_output(result: NodeResult) -> None:
+async def log_weather_output(result: InvocationResult) -> None:
     if result.output is None:
         # Intermediate hop (e.g. agent about to call a tool). Observe and move on.
         print(f"[{result.correlation_id[:8]}] intermediate hop from {result.emitter_node_id}")

--- a/examples/topic_provisioning.py
+++ b/examples/topic_provisioning.py
@@ -42,7 +42,7 @@ The same one-off provisioning is available from the CLI (no Python)::
 
 import asyncio
 
-from calfkit.client import NodeResult
+from calfkit.client import InvocationResult
 from calfkit.nodes import Agent, agent_tool, consumer
 from calfkit.providers import OpenAIResponsesModelClient
 from calfkit.provisioning import (
@@ -73,7 +73,7 @@ agent = Agent(
 
 
 @consumer(subscribe_topics="weather_agent.output")
-async def log_results(result: NodeResult) -> None:
+async def log_results(result: InvocationResult) -> None:
     print(result.output)
 
 

--- a/tests/integration/test_topic_provisioning.py
+++ b/tests/integration/test_topic_provisioning.py
@@ -273,7 +273,7 @@ async def test_flag_on_provisions_topics_and_round_trips() -> None:
     received: list[str] = []
 
     @consumer(subscribe_topics=inbox)
-    def sink(result: Any) -> None:  # NodeResult
+    def sink(result: Any) -> None:  # InvocationResult
         received.append(result.output)
 
     client = Client.connect(BOOTSTRAP, provisioning=ProvisioningConfig(enabled=True))

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -3,7 +3,7 @@
 The consumer rides the shared ``BaseNodeDef.handler``: ``run`` is the inherited
 ``@handler('*')`` catch-all, and the user function receives a
 :class:`~calfkit.models.consumer_context.ConsumerContext` (not the client-facing
-``NodeResult``). Direct ``handler()`` calls pin contracts that TestKafkaBroker's
+``InvocationResult``). Direct ``handler()`` calls pin contracts that TestKafkaBroker's
 propagation makes ambiguous (error swallowing, projection skips).
 """
 
@@ -27,7 +27,7 @@ from calfkit._vendor.pydantic_ai.messages import (
     TextPart as ModelTextPart,
 )
 from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
-from calfkit.client import Client, NodeResult
+from calfkit.client import Client, InvocationResult
 from calfkit.exceptions import DeserializationError
 from calfkit.models import ConsumerContext, ReturnMessage, SessionRunContext
 from calfkit.models.envelope import Envelope
@@ -698,7 +698,7 @@ async def test_unexpected_projection_exception_is_logged_and_skipped(monkeypatch
 
 
 # ---------------------------------------------------------------------------
-# Client-side NodeResult contract — the consumer no longer uses NodeResult, but
+# Client-side InvocationResult contract — the consumer no longer uses InvocationResult, but
 # Client.execute / InvocationHandle.result still return it. Kept here to
 # preserve the original coverage.
 # ---------------------------------------------------------------------------
@@ -707,9 +707,9 @@ async def test_unexpected_projection_exception_is_logged_and_skipped(monkeypatch
 def test_node_result_is_not_hashable():
     state = State()
     state.message_history = [ModelRequest.user_text_prompt("hi")]
-    result = NodeResult(output="x", state=state, correlation_id="cid-hash")
+    result = InvocationResult(output="x", state=state, correlation_id="cid-hash")
 
-    assert NodeResult.__hash__ is None
+    assert InvocationResult.__hash__ is None
     with pytest.raises(TypeError, match="unhashable"):
         hash(result)
 
@@ -717,12 +717,12 @@ def test_node_result_is_not_hashable():
 def test_strict_mode_raises_on_empty_reply():
     envelope = _envelope()
     with pytest.raises(DeserializationError, match="No DataPart or TextPart"):
-        NodeResult.from_envelope(envelope, correlation_id="cid-strict-empty")  # strict=True default
+        InvocationResult.from_envelope(envelope, correlation_id="cid-strict-empty")  # strict=True default
 
 
 def test_lenient_mode_returns_none_on_empty_reply():
     envelope = _envelope()
-    result = NodeResult.from_envelope(envelope, correlation_id="cid-lenient", strict=False)
+    result = InvocationResult.from_envelope(envelope, correlation_id="cid-lenient", strict=False)
     assert result.output is None
     assert result.state is envelope.context.state  # client path: no copy in from_envelope
 

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -320,7 +320,7 @@ async def test_parallel_fan_out_carries_emitter_per_call(container):
 
 
 # ---------------------------------------------------------------------------
-# Client receives the emitter of the callback reply on NodeResult.
+# Client receives the emitter of the callback reply on InvocationResult.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_lifecycle_e2e.py
+++ b/tests/test_lifecycle_e2e.py
@@ -35,7 +35,7 @@ from faststream.kafka import TestKafkaBroker
 from calfkit._protocol import HDR_EMITTER, HDR_EMITTER_KIND
 from calfkit._vendor.pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart, ToolReturnPart
 from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
-from calfkit.client import Client, NodeResult
+from calfkit.client import Client, InvocationResult
 from calfkit.exceptions import LifecycleConfigError
 from calfkit.models import Silent
 from calfkit.models.envelope import Envelope
@@ -204,11 +204,11 @@ async def test_resources_reach_custom_basenodedef_subclass() -> None:
 
 
 async def test_resources_reach_consumer_result() -> None:
-    received: list[NodeResult] = []
+    received: list[InvocationResult] = []
     worker = _make_worker()
 
     @consumer(subscribe_topics="surface_consumer.in")
-    def sink(result: NodeResult) -> None:
+    def sink(result: InvocationResult) -> None:
         received.append(result)
 
     sentinel = object()
@@ -230,7 +230,7 @@ async def test_consumer_gate_reads_resources() -> None:
     """A consumer's *gate* can read ``ctx.resources`` (parity with regular-node
     gates), so a gate can branch on a lifecycle resource — not just the consumer
     function via ``result.resources``."""
-    received: list[NodeResult] = []
+    received: list[InvocationResult] = []
     gate_saw: list[Any] = []
 
     def gate(ctx: SessionRunContext) -> bool:
@@ -241,7 +241,7 @@ async def test_consumer_gate_reads_resources() -> None:
     worker = _make_worker()
 
     @consumer(subscribe_topics="gate_res.in", gates=[gate])
-    def sink(result: NodeResult) -> None:
+    def sink(result: InvocationResult) -> None:
         received.append(result)
 
     sink.resources["flag"] = "ON"

--- a/tests/test_lifecycle_resource_fields.py
+++ b/tests/test_lifecycle_resource_fields.py
@@ -2,7 +2,7 @@
 
 These cover the read surfaces that lifecycle ``@resource``/callback-owned
 resources reach: ``SessionRunContext`` (agent / ``BaseNodeDef``), ``ToolContext``
-(``agent_tool``), and ``NodeResult`` (consumer) plus the deserialize seam.
+(``agent_tool``), and ``InvocationResult`` (consumer) plus the deserialize seam.
 
 See ``docs/research/node-worker-lifecycle-hooks-plan-v7.md`` §2.5, §3.5.
 """
@@ -62,7 +62,7 @@ def test_tool_context_resources_defaults_empty_and_accepts_kw_only() -> None:
 
 
 def _make_node_result(**overrides: Any) -> Any:
-    from calfkit.models.node_result import NodeResult
+    from calfkit.models.node_result import InvocationResult
     from calfkit.models.state import State
 
     kwargs: dict[str, Any] = {
@@ -71,7 +71,7 @@ def _make_node_result(**overrides: Any) -> Any:
         "correlation_id": "cid",
     }
     kwargs.update(overrides)
-    return NodeResult(**kwargs)
+    return InvocationResult(**kwargs)
 
 
 def test_node_result_resources_defaults_empty_and_accepts_override() -> None:
@@ -100,15 +100,15 @@ def _make_text_envelope(text: str = "hello") -> Any:
 
 
 def test_from_envelope_threads_resources() -> None:
-    from calfkit.models.node_result import NodeResult
+    from calfkit.models.node_result import InvocationResult
 
     envelope = _make_text_envelope()
 
     # Default: empty mapping when resources not supplied.
-    default_result = NodeResult.from_envelope(envelope, str, correlation_id="cid")
+    default_result = InvocationResult.from_envelope(envelope, str, correlation_id="cid")
     assert dict(default_result.resources) == {}
 
-    # Threaded through into the built NodeResult.
+    # Threaded through into the built InvocationResult.
     sentinel = object()
-    result = NodeResult.from_envelope(envelope, str, correlation_id="cid", resources={"db": sentinel})
+    result = InvocationResult.from_envelope(envelope, str, correlation_id="cid", resources={"db": sentinel})
     assert result.resources["db"] is sentinel

--- a/tests/test_lifecycle_review_fixes.py
+++ b/tests/test_lifecycle_review_fixes.py
@@ -125,10 +125,10 @@ def test_tool_context_default_resources_is_a_mapping() -> None:
 def test_node_result_default_resources_is_a_mapping() -> None:
     from collections.abc import Mapping
 
-    from calfkit.models.node_result import NodeResult
+    from calfkit.models.node_result import InvocationResult
     from calfkit.models.state import State
 
-    result = NodeResult(output=None, state=State(), correlation_id="cid")
+    result = InvocationResult(output=None, state=State(), correlation_id="cid")
     assert isinstance(result.resources, Mapping)
     assert dict(result.resources) == {}
 

--- a/tests/test_reply_slot.py
+++ b/tests/test_reply_slot.py
@@ -27,7 +27,7 @@ from calfkit.models import (
     WorkflowState,
 )
 from calfkit.models._coerce import _coerce_to_parts
-from calfkit.models.node_result import NodeResult as InvocationResult
+from calfkit.models.node_result import InvocationResult
 from calfkit.models.reply import ReturnMessage, _ReplyBase
 from calfkit.models.state import State
 


### PR DESCRIPTION
## Summary

Mechanical, no-behavior-change rename that resolves the long-standing **dual meaning of `NodeResult`** (flagged in the PR #223 review and the reply-slot plan §4.9). The name was used for two unrelated types:

- the node `run()` **action union** — `calfkit.models.actions.NodeResult` (`Silent | Call | list[Call] | ReturnCall | TailCall`)
- the client-facing **reply projection** — `calfkit.models.node_result.NodeResult`, re-exported as `calfkit.NodeResult` / `calfkit.client.NodeResult`

This renames **only the projection class** → `InvocationResult`. After this PR:

| Name | Meaning |
|---|---|
| `calfkit.InvocationResult` / `calfkit.client.InvocationResult` | the client-facing reply projection (`Client.execute`/`InvocationHandle.result` return; what `@consumer` sinks receive) |
| `calfkit.models.NodeResult` | the `run()` action union — **unchanged** |

## Scope

- **Hard break, no alias** (pre-1.0 policy): top-level `calfkit.NodeResult` is removed.
- The **action union and every node-side `run()` / `_publish_action` signature are untouched** (`agent.py`, `base.py`, `tool.py`, `mcp_toolbox.py`, `models/actions.py`, `models/__init__.py`).
- Surgical, **file-scoped** rename — verified no file mixes the two meanings, so no action-union reference was touched.
- User-facing docs updated (`docs/client-features.md`, `docs/consumer-nodes.md`); historical `docs/designs/*.md` specs left as records.
- The module file stays `node_result.py` (it also houses `project_output`/`_extract_*`); only the class name changed — the dual-meaning was the class name, now resolved.

## Testing

- Import sanity: `calfkit.InvocationResult` is the projection, `calfkit.models.NodeResult` is the action union, `calfkit.NodeResult` is gone.
- `make check` clean (ruff + format + `mypy --strict`, 55 files); **2785 non-integration tests pass**; 26 integration tests collect clean.

Follow-up to #223 (reply-slot-for-returns). No ADR — mechanical rename, no design decision.
