### PR TITLE
feat: phase-0 prereqs for in-node fan-out aggregation

### DIFF
--- a/calfkit/_protocol.py
+++ b/calfkit/_protocol.py
@@ -6,6 +6,7 @@ worker, nodes — can depend on it without creating circular import chains.
 Do not add imports from ``calfkit.*`` to this module.
 """
 
+import re
 from typing import Any, Literal
 
 NodeKind = Literal["node", "agent", "tool", "client", "consumer", "toolbox"]
@@ -53,3 +54,20 @@ def decode_header_str(value: Any) -> str | None:
     if isinstance(value, str):
         return value
     return None
+
+
+# Kafka topic-name legality: [a-zA-Z0-9._-], 1-249 chars ("." and ".." additionally
+# reserved). ``node_id`` is embedded raw in framework topic names
+# (``{node_id}.private.return``, ``calf.fanout.{node_id}.*``), and client reply
+# topics/addresses are topics directly. An illegal name only surfaces as a
+# request_timeout stall into an argument-less ``UnknownTopicOrPartitionError`` on a
+# different process, so it is rejected loudly at construction.
+_KAFKA_TOPIC_RE = re.compile(r"[a-zA-Z0-9._-]{1,249}")
+
+
+def is_topic_safe(name: str) -> bool:
+    """Return ``True`` iff *name* is a legal Kafka topic-name component.
+
+    Charset ``[a-zA-Z0-9._-]``, 1-249 chars; ``"."`` and ``".."`` are reserved.
+    """
+    return bool(_KAFKA_TOPIC_RE.fullmatch(name)) and name not in (".", "..")

--- a/calfkit/_protocol.py
+++ b/calfkit/_protocol.py
@@ -56,18 +56,21 @@ def decode_header_str(value: Any) -> str | None:
     return None
 
 
-# Kafka topic-name legality: [a-zA-Z0-9._-], 1-249 chars ("." and ".." additionally
-# reserved). ``node_id`` is embedded raw in framework topic names
-# (``{node_id}.private.return``, ``calf.fanout.{node_id}.*``), and client reply
-# topics/addresses are topics directly. An illegal name only surfaces as a
-# request_timeout stall into an argument-less ``UnknownTopicOrPartitionError`` on a
-# different process, so it is rejected loudly at construction.
+# Kafka topic-name legality: charset [a-zA-Z0-9._-], 1-249 chars, with "." and ".."
+# reserved. Used to validate whole topic names (client reply topics/addresses) and the
+# name components interpolated into framework topics (a node_id in
+# "{node_id}.private.return"). Rejecting at construction turns an otherwise-remote failure
+# — an illegal name surfaces only as an argument-less UnknownTopicOrPartitionError /
+# request-timeout stall on another process — into a loud, local error.
 _KAFKA_TOPIC_RE = re.compile(r"[a-zA-Z0-9._-]{1,249}")
 
 
 def is_topic_safe(name: str) -> bool:
-    """Return ``True`` iff *name* is a legal Kafka topic-name component.
+    """Return ``True`` iff *name* is legal for a Kafka topic name.
 
-    Charset ``[a-zA-Z0-9._-]``, 1-249 chars; ``"."`` and ``".."`` are reserved.
+    Checks the charset (``[a-zA-Z0-9._-]``), the 1-249 length, and the reserved
+    ``"."`` / ``".."``. When *name* is a component interpolated into a longer topic
+    (e.g. a ``node_id`` in ``{node_id}.private.return``) this bounds the *component*,
+    not the assembled topic — a 249-char component can still yield an over-length topic.
     """
     return bool(_KAFKA_TOPIC_RE.fullmatch(name)) and name not in (".", "..")

--- a/calfkit/client/base.py
+++ b/calfkit/client/base.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import re
 from collections.abc import Iterable
 from typing import Any
 
@@ -8,7 +7,7 @@ import uuid_utils
 from faststream.kafka import KafkaBroker
 from typing_extensions import Self
 
-from calfkit._protocol import CLIENT_KIND, HDR_EMITTER, HDR_EMITTER_KIND, HDR_KIND, HDR_ROUTE
+from calfkit._protocol import CLIENT_KIND, HDR_EMITTER, HDR_EMITTER_KIND, HDR_KIND, HDR_ROUTE, is_topic_safe
 from calfkit._routing import is_concrete_route_key
 from calfkit.client._broker import _PreStartHookBroker
 from calfkit.client.invocation_handle import InvocationHandle
@@ -27,13 +26,6 @@ from calfkit.models.state import OverridesState
 from calfkit.provisioning import ProvisioningConfig, StartupTopicEnsurer
 
 logger = logging.getLogger(__name__)
-
-# Kafka's exact topic-name legality: [a-zA-Z0-9._-], 1-249 chars ("." and ".."
-# are additionally reserved). An illegal name would never get metadata at the
-# worker's terminal publish — a request_timeout stall into an argument-less
-# UnknownTopicOrPartitionError on a different process — so it is rejected
-# loudly at the client instead.
-_KAFKA_TOPIC_RE = re.compile(r"[a-zA-Z0-9._-]{1,249}")
 
 
 def _new_client_emitter_id(client_id: str | None = None) -> str:
@@ -149,6 +141,9 @@ class BaseClient:
             **broker_kwargs: Additional keyword arguments forwarded to
                 ``KafkaBroker`` (e.g. ``security``, ``client_id``). Configure
                 broker/admin security with a FastStream ``security=`` object.
+                The shared producer defaults to ``acks="all"`` +
+                ``enable_idempotence=True`` (durable, non-duplicating publishes);
+                pass either here to override.
 
         Returns:
             A new client instance ready for use. Call ``broker.start()`` or use
@@ -182,7 +177,7 @@ class BaseClient:
         client_id = uuid_utils.uuid7().hex
         if reply_topic is None:
             reply_topic = f"calf-client-reply-{client_id}"
-        elif not _KAFKA_TOPIC_RE.fullmatch(reply_topic) or reply_topic in (".", ".."):
+        elif not is_topic_safe(reply_topic):
             # The reply topic is the wire callback on every start()/execute()
             # frame and this client's own subscription — same legality rule,
             # same loud client-side rejection as send(reply_to=...).
@@ -203,11 +198,18 @@ class BaseClient:
         ensurer = StartupTopicEnsurer(config=provisioning)
         ensurer.declare([reply_topic], framework=True)
 
+        # calfkit hardens the shared producer: acks=all + idempotence, so a
+        # broker-acked publish survives leader failover and producer retries
+        # can't duplicate or reorder (fault-rail spec §13 — the fault rail's
+        # escalation hops and the in-node fan-out re-entry self-publish both
+        # depend on it). These are defaults only: a user may override either via
+        # ``Client.connect(**broker_kwargs)`` (document, don't police).
+        producer_posture = {"acks": "all", "enable_idempotence": True}
         broker_connection = _PreStartHookBroker(
             server_list,
             middlewares=[ContextInjectionMiddleware],
             pre_start=ensurer.run,
-            **broker_kwargs,
+            **{**producer_posture, **broker_kwargs},
         )
 
         dispatcher = _ReplyDispatcher(reply_ttl=reply_ttl)
@@ -396,7 +398,7 @@ class BaseClient:
         if reply_to is not None:
             if not reply_to.strip():
                 raise ValueError("reply_to must be a non-empty topic name or None")
-            if not _KAFKA_TOPIC_RE.fullmatch(reply_to) or reply_to in (".", ".."):
+            if not is_topic_safe(reply_to):
                 raise ValueError(
                     f"reply_to {reply_to!r} is not a valid Kafka topic name (allowed: letters, digits, '.', '_', '-'; max 249 chars; not '.' or '..')"
                 )

--- a/calfkit/client/base.py
+++ b/calfkit/client/base.py
@@ -142,8 +142,11 @@ class BaseClient:
                 ``KafkaBroker`` (e.g. ``security``, ``client_id``). Configure
                 broker/admin security with a FastStream ``security=`` object.
                 The shared producer defaults to ``acks="all"`` +
-                ``enable_idempotence=True`` (durable, non-duplicating publishes);
-                pass either here to override.
+                ``enable_idempotence=True`` (durable, non-duplicating publishes). To
+                relax durability, pass ``acks`` AND ``enable_idempotence=False``
+                together — ``acks`` below ``all`` alone is rejected by aiokafka, since
+                idempotence requires ``acks=all``. This hardening is a ``connect()``
+                default only; a hand-built broker passed to the constructor is untouched.
 
         Returns:
             A new client instance ready for use. Call ``broker.start()`` or use
@@ -198,12 +201,11 @@ class BaseClient:
         ensurer = StartupTopicEnsurer(config=provisioning)
         ensurer.declare([reply_topic], framework=True)
 
-        # calfkit hardens the shared producer: acks=all + idempotence, so a
-        # broker-acked publish survives leader failover and producer retries
-        # can't duplicate or reorder (fault-rail spec §13 — the fault rail's
-        # escalation hops and the in-node fan-out re-entry self-publish both
-        # depend on it). These are defaults only: a user may override either via
-        # ``Client.connect(**broker_kwargs)`` (document, don't police).
+        # calfkit hardens the shared producer: acks=all + idempotence, so a broker-acked
+        # publish survives leader failover and producer retries can't duplicate or reorder.
+        # Defaults only — a user may override via Client.connect(**broker_kwargs) (document,
+        # don't police). These apply to the connect()-built broker; a hand-built KafkaBroker
+        # passed to the constructor keeps aiokafka's defaults.
         producer_posture = {"acks": "all", "enable_idempotence": True}
         broker_connection = _PreStartHookBroker(
             server_list,

--- a/calfkit/models/node_schema.py
+++ b/calfkit/models/node_schema.py
@@ -1,5 +1,7 @@
 from dataclasses import KW_ONLY, dataclass
 
+from calfkit._protocol import is_topic_safe
+
 
 @dataclass
 class BaseNodeSchema:
@@ -22,3 +24,13 @@ class BaseNodeSchema:
         # silent zombie consumer.
         if not self.subscribe_topics:
             raise ValueError(f"node {self.node_id!r} requires at least one subscribe_topic; got empty list")
+        # node_id is interpolated raw into framework topic names
+        # (``{node_id}.private.return``, ``calf.fanout.{node_id}.*``), so it must be a
+        # legal Kafka topic-name component. Like the subscribe_topics guard, this lives
+        # here so it fires for every node kind (the one hook all subclasses run).
+        if not is_topic_safe(self.node_id):
+            raise ValueError(
+                f"node_id {self.node_id!r} is not a valid Kafka topic-name component "
+                "(allowed: letters, digits, '.', '_', '-'; 1-249 chars; not '.' or '..'); "
+                "it is embedded raw in framework topic names."
+            )

--- a/calfkit/models/node_schema.py
+++ b/calfkit/models/node_schema.py
@@ -24,10 +24,11 @@ class BaseNodeSchema:
         # silent zombie consumer.
         if not self.subscribe_topics:
             raise ValueError(f"node {self.node_id!r} requires at least one subscribe_topic; got empty list")
-        # node_id is interpolated raw into framework topic names
-        # (``{node_id}.private.return``, ``calf.fanout.{node_id}.*``), so it must be a
-        # legal Kafka topic-name component. Like the subscribe_topics guard, this lives
-        # here so it fires for every node kind (the one hook all subclasses run).
+        # node_id is interpolated raw into this node's framework topic
+        # ("{node_id}.private.return"), so it must be a legal Kafka topic-name component.
+        # Like the subscribe_topics guard, this lives here so it fires for every node kind
+        # (the one hook all subclasses run). The component's charset/length is bounded
+        # here; the assembled topic's total length is the provisioner's concern.
         if not is_topic_safe(self.node_id):
             raise ValueError(
                 f"node_id {self.node_id!r} is not a valid Kafka topic-name component "

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -74,6 +74,13 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
     :data:`~calfkit._protocol.NodeKind`. The ``"client"`` kind is reserved for the
     :class:`~calfkit.client.base.BaseClient` and is not a valid subclass override.
     """
+    is_caller_capable: ClassVar[bool] = True
+    """Whether this node type makes ``Call``s / runs the seam pipeline and fan-out fold
+    (agent, tool, MCP toolbox, custom ``BaseNodeDef`` subclasses). ``False`` only for
+    observers (``ConsumerNode``). Load-bearing for registration: caller-capable nodes are
+    pinned to ``max_workers=1`` because the seam pipeline and the fan-out fold are
+    await-spanning read-modify-writes that a no-affinity ``max_workers>1`` coroutine pool
+    would race (``concurrency-model.md``)."""
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -75,12 +75,13 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
     :class:`~calfkit.client.base.BaseClient` and is not a valid subclass override.
     """
     is_caller_capable: ClassVar[bool] = True
-    """Whether this node type makes ``Call``s / runs the seam pipeline and fan-out fold
-    (agent, tool, MCP toolbox, custom ``BaseNodeDef`` subclasses). ``False`` only for
-    observers (``ConsumerNode``). Load-bearing for registration: caller-capable nodes are
-    pinned to ``max_workers=1`` because the seam pipeline and the fan-out fold are
-    await-spanning read-modify-writes that a no-affinity ``max_workers>1`` coroutine pool
-    would race (``concurrency-model.md``)."""
+    """Whether this node type handles ``Call``s and their ``ReturnCall`` continuations over
+    its own workflow state (agent, tool, MCP toolbox, custom ``BaseNodeDef`` subclasses);
+    ``False`` only for observers (``ConsumerNode``), which just consume. Subclasses may
+    override it. Load-bearing for registration: such nodes are pinned to ``max_workers=1``
+    because handling a continuation is an await-spanning read-modify-write of workflow state
+    — the agent's tool-call batch aggregation today, the in-node fan-out fold next — that a
+    no-affinity ``max_workers>1`` coroutine pool would race."""
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)

--- a/calfkit/nodes/consumer.py
+++ b/calfkit/nodes/consumer.py
@@ -39,6 +39,7 @@ def _validate_consume_fn(consume_fn: Any) -> None:
 
 class ConsumerNode(Generic[OutputT], BaseNodeDef):
     _node_kind: ClassVar[NodeKind] = "consumer"
+    is_caller_capable: ClassVar[bool] = False  # observer: makes no Calls, runs no seam pipeline → uses the worker's max_workers
 
     def __init__(
         self,

--- a/calfkit/nodes/consumer.py
+++ b/calfkit/nodes/consumer.py
@@ -39,7 +39,7 @@ def _validate_consume_fn(consume_fn: Any) -> None:
 
 class ConsumerNode(Generic[OutputT], BaseNodeDef):
     _node_kind: ClassVar[NodeKind] = "consumer"
-    is_caller_capable: ClassVar[bool] = False  # observer: makes no Calls, runs no seam pipeline → uses the worker's max_workers
+    is_caller_capable: ClassVar[bool] = False  # observer: just consumes (no Calls / continuations) → uses the worker's max_workers
 
     def __init__(
         self,

--- a/calfkit/worker/worker.py
+++ b/calfkit/worker/worker.py
@@ -72,7 +72,11 @@ class Worker(LifecycleHookMixin):
         Args:
             client: The calfkit Client (Kafka connection).
             nodes: List of ``BaseNodeDef`` instances to host.
-            max_workers: FastStream subscriber concurrency cap.
+            max_workers: FastStream subscriber concurrency cap for *observer*
+                (consumer) nodes. Caller-capable nodes (agents/tools/toolboxes)
+                are always registered with ``max_workers=1`` — their seam pipeline
+                and fan-out fold are await-spanning read-modify-writes that a
+                no-affinity concurrent subscriber would race.
             group_id: Optional Kafka consumer group override (defaults to
                 each node's name).
             extra_publish_kwargs: Forwarded to ``broker.publisher(...)``.
@@ -240,11 +244,21 @@ class Worker(LifecycleHookMixin):
                 topics,
                 node.publish_topic,
             )
+            # Caller-capable nodes (seam pipeline / fan-out fold) MUST consume serially:
+            # FastStream's max_workers>1 is a no-affinity coroutine pool that races the
+            # await-spanning read-modify-write. The worker's max_workers knob applies to
+            # observers; caller-capable nodes are framework-pinned to 1, overriding any
+            # worker/extra value (concurrency-model.md). The merge also avoids a duplicate
+            # max_workers kwarg when a user puts one in extra_subscribe_kwargs.
+            subscribe_kwargs = dict(self._extra_subscribe_kwargs)
+            if node.is_caller_capable:
+                subscribe_kwargs["max_workers"] = 1
+            else:
+                subscribe_kwargs.setdefault("max_workers", self._max_workers)
             subscriber = self._client._connection.subscriber(
                 *topics,
                 group_id=group_id,
-                max_workers=self._max_workers,
-                **self._extra_subscribe_kwargs,
+                **subscribe_kwargs,
             )
             handler = subscriber(node.handler)
             if node.publish_topic:

--- a/calfkit/worker/worker.py
+++ b/calfkit/worker/worker.py
@@ -74,9 +74,10 @@ class Worker(LifecycleHookMixin):
             nodes: List of ``BaseNodeDef`` instances to host.
             max_workers: FastStream subscriber concurrency cap for *observer*
                 (consumer) nodes. Caller-capable nodes (agents/tools/toolboxes)
-                are always registered with ``max_workers=1`` — their seam pipeline
-                and fan-out fold are await-spanning read-modify-writes that a
-                no-affinity concurrent subscriber would race.
+                are always registered with ``max_workers=1`` — handling a
+                continuation is an await-spanning read-modify-write of workflow
+                state that a no-affinity concurrent subscriber would race. A
+                request to raise it for a caller-capable node is logged and pinned.
             group_id: Optional Kafka consumer group override (defaults to
                 each node's name).
             extra_publish_kwargs: Forwarded to ``broker.publisher(...)``.
@@ -244,14 +245,23 @@ class Worker(LifecycleHookMixin):
                 topics,
                 node.publish_topic,
             )
-            # Caller-capable nodes (seam pipeline / fan-out fold) MUST consume serially:
-            # FastStream's max_workers>1 is a no-affinity coroutine pool that races the
-            # await-spanning read-modify-write. The worker's max_workers knob applies to
-            # observers; caller-capable nodes are framework-pinned to 1, overriding any
-            # worker/extra value (concurrency-model.md). The merge also avoids a duplicate
-            # max_workers kwarg when a user puts one in extra_subscribe_kwargs.
+            # Caller-capable nodes MUST consume serially: handling a continuation is an
+            # await-spanning read-modify-write of workflow state (the agent's tool-call
+            # batch aggregation today; the in-node fan-out fold next) that FastStream's
+            # no-affinity max_workers>1 coroutine pool would race. The worker's max_workers
+            # knob applies to observers; caller-capable nodes are framework-pinned to 1,
+            # overriding any worker/extra value. The merge into one dict also avoids a
+            # duplicate max_workers kwarg when a user sets one in extra_subscribe_kwargs.
             subscribe_kwargs = dict(self._extra_subscribe_kwargs)
             if node.is_caller_capable:
+                requested = subscribe_kwargs.get("max_workers", self._max_workers)
+                if requested != 1:
+                    # Don't silently discard a value the user passed to the framework.
+                    logger.info(
+                        "node=%s is caller-capable; pinning max_workers=1 (requested %s ignored — continuations must consume serially)",
+                        node.name,
+                        requested,
+                    )
                 subscribe_kwargs["max_workers"] = 1
             else:
                 subscribe_kwargs.setdefault("max_workers", self._max_workers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "typing-extensions>=4.15.0",
     "dishka>=1.9.1",
     "mcp>=1.27.2",
-    "ktables>=0.1.2",
+    "ktables>=0.2.0",
 ]
 
 [project.urls]
@@ -77,13 +77,6 @@ exclude = ["calfkit/_vendor"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP"]
-
-# TODO(ktables>=0.1.2): remove once the py.typed marker ships
-# (https://github.com/ryan-yuuu/ktables/pull/6) — ktables IS typed; the
-# published wheel just lacks the PEP 561 marker.
-[[tool.mypy.overrides]]
-module = "ktables.*"
-ignore_missing_imports = true
 
 [tool.mypy]
 python_version = "3.10"

--- a/tests/test_client_producer_config.py
+++ b/tests/test_client_producer_config.py
@@ -1,0 +1,42 @@
+"""PR-2: ``Client.connect()`` hardens the shared producer.
+
+aiokafka defaults the producer to ``acks=1`` with no idempotence — under which a
+broker-acked publish can vanish on leader failover and retries can duplicate. The
+fault rail's escalation hops and the in-node fan-out re-entry self-publish both need
+durable, non-duplicating publishes, so calfkit defaults the shared producer to
+``acks=all`` + ``enable_idempotence=True`` (fault-rail spec §13). A user may still
+override via ``Client.connect(**broker_kwargs)`` (document-don't-police).
+"""
+
+from calfkit.client import Client
+from calfkit.client._broker import _PreStartHookBroker
+
+
+def _spy_broker_kwargs(monkeypatch) -> dict:  # noqa: ANN001
+    """Capture the kwargs ``Client.connect`` passes to ``_PreStartHookBroker``."""
+    captured: dict = {}
+    orig_init = _PreStartHookBroker.__init__
+
+    def spy_init(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        captured.update(kwargs)
+        orig_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(_PreStartHookBroker, "__init__", spy_init)
+    return captured
+
+
+def test_connect_defaults_to_acks_all_and_idempotence(monkeypatch) -> None:  # noqa: ANN001
+    captured = _spy_broker_kwargs(monkeypatch)
+
+    Client.connect(server_urls="localhost:9092")
+
+    assert captured.get("acks") == "all"
+    assert captured.get("enable_idempotence") is True
+
+
+def test_connect_lets_user_override_producer_posture(monkeypatch) -> None:  # noqa: ANN001
+    captured = _spy_broker_kwargs(monkeypatch)
+
+    Client.connect(server_urls="localhost:9092", enable_idempotence=False)
+
+    assert captured.get("enable_idempotence") is False

--- a/tests/test_client_producer_config.py
+++ b/tests/test_client_producer_config.py
@@ -1,11 +1,10 @@
 """PR-2: ``Client.connect()`` hardens the shared producer.
 
 aiokafka defaults the producer to ``acks=1`` with no idempotence — under which a
-broker-acked publish can vanish on leader failover and retries can duplicate. The
-fault rail's escalation hops and the in-node fan-out re-entry self-publish both need
-durable, non-duplicating publishes, so calfkit defaults the shared producer to
-``acks=all`` + ``enable_idempotence=True`` (fault-rail spec §13). A user may still
-override via ``Client.connect(**broker_kwargs)`` (document-don't-police).
+broker-acked publish can vanish on leader failover and retries can duplicate or reorder.
+calfkit defaults the shared producer to ``acks=all`` + ``enable_idempotence=True`` for
+durable, non-duplicating publishes. A user may still override via
+``Client.connect(**broker_kwargs)`` (document-don't-police).
 """
 
 from calfkit.client import Client
@@ -39,4 +38,15 @@ def test_connect_lets_user_override_producer_posture(monkeypatch) -> None:  # no
 
     Client.connect(server_urls="localhost:9092", enable_idempotence=False)
 
+    assert captured.get("enable_idempotence") is False
+
+
+def test_connect_user_can_relax_acks_with_idempotence_off(monkeypatch) -> None:  # noqa: ANN001
+    # Both posture keys are overridable. Relaxing acks below "all" requires turning
+    # idempotence off too (aiokafka rejects acks<all with idempotence on).
+    captured = _spy_broker_kwargs(monkeypatch)
+
+    Client.connect(server_urls="localhost:9092", acks=1, enable_idempotence=False)
+
+    assert captured.get("acks") == 1
     assert captured.get("enable_idempotence") is False

--- a/tests/test_fire_and_forget.py
+++ b/tests/test_fire_and_forget.py
@@ -286,7 +286,7 @@ async def test_send_tool_overrides_only_builds_overrides(container):
     overrides carry the tool list and a None model_settings. A ToolProvider
     (here a ToolNodeDef) is normalized into its ToolBindings, same as
     ``Agent(tools=...)``."""
-    tool = agent_tool(lambda: "pong")  # a ToolProvider (ToolNodeDef)
+    tool = ping  # a ToolProvider (ToolNodeDef); a named fn yields a topic-safe node_id (a lambda's "tool_<lambda>" is rejected)
     client = container.get(Client)
     client._send = AsyncMock(return_value="cid")
 
@@ -302,7 +302,7 @@ async def test_send_tool_overrides_accepts_raw_bindings(container):
     """A raw ToolBinding passes through the override normalization verbatim."""
     from calfkit.models.tool_dispatch import ToolBinding
 
-    tool = agent_tool(lambda: "pong")
+    tool = ping
     binding = ToolBinding(tool_def=tool.tool_schema, dispatch_topic=tool.subscribe_topics[0])
     client = container.get(Client)
     client._send = AsyncMock(return_value="cid")

--- a/tests/test_ktables_dep.py
+++ b/tests/test_ktables_dep.py
@@ -1,9 +1,9 @@
 """PR-1: the ktables dependency must expose the ``barrier()`` RYOW primitive.
 
-The in-node durable fan-out fold (``in-node-fanout-aggregation-spec.md`` §5.1)
-reads ``state[X]`` with read-your-own-writes freshness via ``KafkaTable.barrier()``,
-which ships in ktables ``>=0.2.0``. This is the dependency-contract gate for the
-bump (and for retiring the ``ktables.*`` mypy override, since 0.2.0 ships ``py.typed``).
+The upcoming in-node durable fan-out fold reads batch state with read-your-own-writes
+freshness via ``KafkaTable.barrier()``, which ships in ktables ``>=0.2.0``. This is the
+dependency-contract gate for the bump (and for retiring the ``ktables.*`` mypy override,
+since 0.2.0 ships ``py.typed``).
 """
 
 import inspect

--- a/tests/test_ktables_dep.py
+++ b/tests/test_ktables_dep.py
@@ -1,0 +1,16 @@
+"""PR-1: the ktables dependency must expose the ``barrier()`` RYOW primitive.
+
+The in-node durable fan-out fold (``in-node-fanout-aggregation-spec.md`` §5.1)
+reads ``state[X]`` with read-your-own-writes freshness via ``KafkaTable.barrier()``,
+which ships in ktables ``>=0.2.0``. This is the dependency-contract gate for the
+bump (and for retiring the ``ktables.*`` mypy override, since 0.2.0 ships ``py.typed``).
+"""
+
+import inspect
+
+from ktables.kafka_table import KafkaTable
+
+
+def test_kafka_table_exposes_async_barrier() -> None:
+    assert hasattr(KafkaTable, "barrier"), "ktables>=0.2.0 must expose KafkaTable.barrier()"
+    assert inspect.iscoroutinefunction(KafkaTable.barrier), "KafkaTable.barrier() must be an async method"

--- a/tests/test_node_id_validation.py
+++ b/tests/test_node_id_validation.py
@@ -1,0 +1,35 @@
+"""PR-3a: ``node_id`` must be a legal Kafka topic-name component.
+
+``node_id`` is interpolated raw into framework topic names — ``{node_id}.private.return``
+(``BaseNodeDef._return_topic``) and (PR-4) ``calf.fanout.{node_id}.{state,basestate}``.
+An illegal id yields an illegal topic, surfacing only as a request-timeout stall into an
+argument-less ``UnknownTopicOrPartitionError`` on another process. Validation lives in
+``BaseNodeSchema.__post_init__`` so it fires for every node kind (the one hook all
+subclasses run — agents/consumers via ``BaseNodeDef.__init__``, ``@dataclass`` tool nodes
+via their generated ``__init__``).
+"""
+
+import pytest
+
+from calfkit.nodes.consumer import ConsumerNode
+from calfkit.nodes.node import NodeDef
+
+ILLEGAL = ["a b", "a/b", "a:b", "a#b", "topic,name", "", ".", ".."]
+LEGAL = ["orchestrator", "my.agent-1_v2", "a", "A.B_C-1"]
+
+
+@pytest.mark.parametrize("node_id", ILLEGAL)
+def test_illegal_node_id_rejected_at_construction(node_id: str) -> None:
+    with pytest.raises(ValueError, match="node_id"):
+        NodeDef(node_id=node_id, subscribe_topics=["t"])
+
+
+@pytest.mark.parametrize("node_id", LEGAL)
+def test_legal_node_id_accepted(node_id: str) -> None:
+    NodeDef(node_id=node_id, subscribe_topics=["t"])  # must not raise
+
+
+def test_consumer_node_id_validated_too() -> None:
+    # Observers run the same __post_init__ — validation is uniform across kinds.
+    with pytest.raises(ValueError, match="node_id"):
+        ConsumerNode(node_id="bad id", consume_fn=lambda ctx: None, subscribe_topics=["t"])

--- a/tests/test_node_id_validation.py
+++ b/tests/test_node_id_validation.py
@@ -1,9 +1,9 @@
 """PR-3a: ``node_id`` must be a legal Kafka topic-name component.
 
-``node_id`` is interpolated raw into framework topic names — ``{node_id}.private.return``
-(``BaseNodeDef._return_topic``) and (PR-4) ``calf.fanout.{node_id}.{state,basestate}``.
-An illegal id yields an illegal topic, surfacing only as a request-timeout stall into an
-argument-less ``UnknownTopicOrPartitionError`` on another process. Validation lives in
+``node_id`` is interpolated raw into this node's framework topic
+(``{node_id}.private.return`` — ``BaseNodeDef._return_topic``). An illegal id yields an
+illegal topic, surfacing only as a request-timeout stall into an argument-less
+``UnknownTopicOrPartitionError`` on another process. Validation lives in
 ``BaseNodeSchema.__post_init__`` so it fires for every node kind (the one hook all
 subclasses run — agents/consumers via ``BaseNodeDef.__init__``, ``@dataclass`` tool nodes
 via their generated ``__init__``).
@@ -33,3 +33,30 @@ def test_consumer_node_id_validated_too() -> None:
     # Observers run the same __post_init__ — validation is uniform across kinds.
     with pytest.raises(ValueError, match="node_id"):
         ConsumerNode(node_id="bad id", consume_fn=lambda ctx: None, subscribe_topics=["t"])
+
+
+def test_max_length_component_node_id_accepted() -> None:
+    # A 249-char node_id is a legal topic-name *component* — the charset/length bound is
+    # on the component (the assembled topic's total length is the provisioner's concern).
+    NodeDef(node_id="a" * 249, subscribe_topics=["t"])  # must not raise
+
+
+def test_over_length_node_id_rejected() -> None:
+    with pytest.raises(ValueError, match="node_id"):
+        NodeDef(node_id="a" * 250, subscribe_topics=["t"])
+
+
+def test_dataclass_node_subclass_validates_node_id_via_post_init() -> None:
+    # @dataclass node types (e.g. tool nodes) get a generated __init__ that bypasses
+    # BaseNodeDef.__init__; the guard must still fire via the shared __post_init__. A
+    # minimal @dataclass(BaseNodeSchema) subclass exercises exactly that bypass path.
+    from dataclasses import dataclass
+
+    from calfkit.models.node_schema import BaseNodeSchema
+
+    @dataclass
+    class _DataclassNode(BaseNodeSchema):
+        pass
+
+    with pytest.raises(ValueError, match="node_id"):
+        _DataclassNode(node_id="bad id", subscribe_topics=["t"], publish_topic=None)

--- a/tests/test_worker_max_workers_pin.py
+++ b/tests/test_worker_max_workers_pin.py
@@ -1,0 +1,72 @@
+"""PR-3b: caller-capable nodes are pinned to ``max_workers=1`` at registration.
+
+FastStream's ``max_workers>1`` is a no-affinity in-process coroutine pool that would
+race the await-spanning seam pipeline / fan-out fold (``concurrency-model.md``). The
+worker's ``max_workers`` knob applies to observers (consumers); caller-capable nodes are
+always serial. The framework chooses the value per node type (not policing a knob), so a
+caller-capable node is pinned to 1 even when the worker / ``extra_subscribe_kwargs`` ask
+for more.
+"""
+
+from calfkit.client import Client
+from calfkit.nodes.consumer import ConsumerNode
+from calfkit.nodes.node import NodeDef
+from calfkit.worker import Worker
+
+
+def _spy_registration(monkeypatch, client) -> list:  # noqa: ANN001
+    """Capture ``(topics, kwargs)`` for every subscriber the worker registers."""
+    calls: list[tuple[tuple, dict]] = []
+
+    def fake_subscriber(*topics, **kwargs):  # noqa: ANN002, ANN003
+        calls.append((topics, kwargs))
+        return lambda fn: fn
+
+    def fake_publisher(*args, **kwargs):  # noqa: ANN002, ANN003
+        return lambda fn: fn
+
+    monkeypatch.setattr(client.broker, "subscriber", fake_subscriber)
+    monkeypatch.setattr(client.broker, "publisher", fake_publisher)
+    return calls
+
+
+def _kwargs_for(calls: list, return_topic: str) -> dict:
+    matches = [kw for topics, kw in calls if return_topic in topics]
+    assert len(matches) == 1, f"expected one subscriber for {return_topic!r}, got {len(matches)}"
+    return matches[0]
+
+
+def test_caller_capable_node_pinned_to_max_workers_1(monkeypatch) -> None:  # noqa: ANN001
+    client = Client.connect()
+    worker = Worker(client, nodes=[NodeDef(node_id="caller", subscribe_topics=["work"])], max_workers=4)
+    calls = _spy_registration(monkeypatch, client)
+
+    worker.register_handlers()
+
+    assert _kwargs_for(calls, "caller.private.return")["max_workers"] == 1
+
+
+def test_observer_uses_worker_max_workers(monkeypatch) -> None:  # noqa: ANN001
+    client = Client.connect()
+    consumer = ConsumerNode(node_id="obs", consume_fn=lambda ctx: None, subscribe_topics=["events"])
+    worker = Worker(client, nodes=[consumer], max_workers=4)
+    calls = _spy_registration(monkeypatch, client)
+
+    worker.register_handlers()
+
+    assert _kwargs_for(calls, "obs.private.return")["max_workers"] == 4
+
+
+def test_caller_capable_pin_overrides_extra_subscribe_kwargs(monkeypatch) -> None:  # noqa: ANN001
+    client = Client.connect()
+    worker = Worker(
+        client,
+        nodes=[NodeDef(node_id="caller", subscribe_topics=["work"])],
+        max_workers=8,
+        extra_subscribe_kwargs={"max_workers": 8},
+    )
+    calls = _spy_registration(monkeypatch, client)
+
+    worker.register_handlers()
+
+    assert _kwargs_for(calls, "caller.private.return")["max_workers"] == 1

--- a/tests/test_worker_max_workers_pin.py
+++ b/tests/test_worker_max_workers_pin.py
@@ -1,12 +1,14 @@
 """PR-3b: caller-capable nodes are pinned to ``max_workers=1`` at registration.
 
-FastStream's ``max_workers>1`` is a no-affinity in-process coroutine pool that would
-race the await-spanning seam pipeline / fan-out fold (``concurrency-model.md``). The
-worker's ``max_workers`` knob applies to observers (consumers); caller-capable nodes are
-always serial. The framework chooses the value per node type (not policing a knob), so a
-caller-capable node is pinned to 1 even when the worker / ``extra_subscribe_kwargs`` ask
-for more.
+FastStream's ``max_workers>1`` is a no-affinity in-process coroutine pool that would race
+the await-spanning read-modify-write of workflow state that handling a continuation
+performs. The worker's ``max_workers`` knob applies to observers (consumers); caller-capable
+nodes are always serial. The framework chooses the value per node type (not policing a
+knob), so a caller-capable node is pinned to 1 even when the worker / ``extra_subscribe_kwargs``
+ask for more.
 """
+
+import logging
 
 from calfkit.client import Client
 from calfkit.nodes.consumer import ConsumerNode
@@ -70,3 +72,54 @@ def test_caller_capable_pin_overrides_extra_subscribe_kwargs(monkeypatch) -> Non
     worker.register_handlers()
 
     assert _kwargs_for(calls, "caller.private.return")["max_workers"] == 1
+
+
+def test_pin_logs_when_overriding_a_requested_max_workers(monkeypatch, caplog) -> None:  # noqa: ANN001
+    # Silently discarding a value the user passed to the framework's own constructor is
+    # poor DX; the override must leave a breadcrumb.
+    client = Client.connect()
+    worker = Worker(client, nodes=[NodeDef(node_id="caller", subscribe_topics=["work"])], max_workers=4)
+    _spy_registration(monkeypatch, client)
+
+    with caplog.at_level(logging.INFO, logger="calfkit.worker.worker"):
+        worker.register_handlers()
+
+    assert any("max_workers" in r.getMessage() and "caller" in r.getMessage() for r in caplog.records), (
+        "expected an INFO log noting the max_workers pin overrode the requested value"
+    )
+
+
+def test_no_pin_log_when_worker_default_is_already_one(monkeypatch, caplog) -> None:  # noqa: ANN001
+    # No breadcrumb when nothing was overridden (the default is already 1) — avoid log noise.
+    client = Client.connect()
+    worker = Worker(client, nodes=[NodeDef(node_id="caller", subscribe_topics=["work"])], max_workers=1)
+    _spy_registration(monkeypatch, client)
+
+    with caplog.at_level(logging.INFO, logger="calfkit.worker.worker"):
+        worker.register_handlers()
+
+    assert not any("pinning max_workers" in r.getMessage() for r in caplog.records)
+
+
+def test_observer_honors_extra_subscribe_kwargs_max_workers(monkeypatch) -> None:  # noqa: ANN001
+    # The observer branch uses setdefault, so an explicit extra value wins over the worker
+    # default (which only fills in when extra didn't set one).
+    client = Client.connect()
+    consumer = ConsumerNode(node_id="obs", consume_fn=lambda ctx: None, subscribe_topics=["events"])
+    worker = Worker(client, nodes=[consumer], max_workers=2, extra_subscribe_kwargs={"max_workers": 5})
+    calls = _spy_registration(monkeypatch, client)
+
+    worker.register_handlers()
+
+    assert _kwargs_for(calls, "obs.private.return")["max_workers"] == 5
+
+
+def test_is_caller_capable_matches_node_kind_taxonomy() -> None:
+    # Pin the invariant: only the observer kind ("consumer") is not caller-capable. Two
+    # independently-set ClassVars (is_caller_capable, _node_kind) must agree, so a new node
+    # kind can't silently drift (and get wrongly pinned to max_workers=1, or left concurrent).
+    from calfkit.nodes import Agent, ToolNodeDef
+    from calfkit.nodes.base import BaseNodeDef
+
+    for cls in (BaseNodeDef, NodeDef, Agent, ToolNodeDef, ConsumerNode):
+        assert cls.is_caller_capable == (cls._node_kind != "consumer"), cls.__name__


### PR DESCRIPTION
## Summary

Three independent prerequisites for the durable **in-node fan-out aggregation** fold (the next feature; design in `notes/in-node-fanout-aggregation-pr-implementation-plan.md`). Each is small and logically separable, landed TDD-first, and combined here into one PR.

### 1. `ktables>=0.2.0` (+ retire the mypy override)
The fold reads batch state with read-your-own-writes freshness via `KafkaTable.barrier()`, new in ktables 0.2.0. 0.2.0 also ships the PEP-561 `py.typed` marker, so the `[[tool.mypy.overrides]]` block for `ktables.*` is removed — `mypy --strict` now type-checks ktables usage directly.

### 2. Producer hardening — `acks=all` + `enable_idempotence=True`
`Client.connect()` now defaults the shared producer to `acks=all` + `enable_idempotence=True` (fault-rail spec §13): a broker-acked publish survives leader failover and producer retries can't duplicate or reorder. Required by the fault rail's escalation hops and the fan-out re-entry self-publish. **Overridable** via `Client.connect(**broker_kwargs)` (document, don't police).
⚠️ Ops-observable latency/throughput trade.

### 3. Caller-capable registration invariants
- **`node_id` validation** at construction (`BaseNodeSchema.__post_init__`) — `node_id` is embedded raw in framework topic names (`{node_id}.private.return`, `calf.fanout.{node_id}.*`), so it must be a legal Kafka topic-name component. `_KAFKA_TOPIC_RE` moved from `client/base.py` into `_protocol.py` as `is_topic_safe()` (one source of truth; client reply-topic/`reply_to` repointed).
- **`max_workers=1` pin** for caller-capable nodes (`is_caller_capable`, new `ClassVar` — `True` on `BaseNodeDef`, `False` on `ConsumerNode`). FastStream's `max_workers>1` is a no-affinity coroutine pool that would race the await-spanning seam pipeline / fan-out fold.
⚠️ The worker's `max_workers` knob now applies to **observers (consumers) only**.

## Notable
`node_id` validation surfaced a latent bug: `agent_tool(lambda …)` produces `node_id="tool_<lambda>"` (illegal `<`/`>`), which would break at the broker if hosted. It is now rejected loudly at construction; two fire-and-forget tests switched from a lambda tool to a named one.

## Test plan
- `make check` clean (ruff lint + format + `mypy --strict`, 55 source files).
- 2804 non-integration tests pass (`pytest tests/ --ignore=tests/integration`).
- New tests: `test_ktables_dep`, `test_client_producer_config`, `test_node_id_validation`, `test_worker_max_workers_pin`.
