### PR TITLE
feat: fault wire model: ErrorReport, FaultMessage, NodeFaultError

### DIFF
--- a/calfkit/__init__.py
+++ b/calfkit/__init__.py
@@ -1,8 +1,8 @@
 from importlib.metadata import version
 
 from calfkit.client import Client, InvocationHandle, InvocationResult
-from calfkit.exceptions import DeserializationError, LifecycleConfigError, ToolExecutionError
-from calfkit.models import ToolContext
+from calfkit.exceptions import DeserializationError, LifecycleConfigError, NodeFaultError, ToolExecutionError
+from calfkit.models import ErrorReport, FaultTypes, ToolContext
 from calfkit.nodes import Agent, BaseNodeDef, ConsumerFn, ConsumerNode, GateFunction, NodeDef, ToolNodeDef, agent_tool, consumer
 from calfkit.providers import AnthropicModelClient, OpenAIModelClient, OpenAIResponsesModelClient
 from calfkit.provisioning import ProvisioningConfig
@@ -16,6 +16,8 @@ __all__ = [
     "InvocationHandle",
     "InvocationResult",
     # models
+    "ErrorReport",
+    "FaultTypes",
     "ToolContext",
     # nodes
     "Agent",
@@ -41,5 +43,6 @@ __all__ = [
     # exceptions
     "DeserializationError",
     "LifecycleConfigError",
+    "NodeFaultError",
     "ToolExecutionError",
 ]

--- a/calfkit/_protocol.py
+++ b/calfkit/_protocol.py
@@ -34,11 +34,18 @@ never auto-propagated across control-flow republishes. A node with registered
 HDR_KIND = "x-calf-kind"
 """Kafka header classifying every calfkit delivery (spec §4.1). Framework-stamped
 on every publish, never user-set. ``call`` = "do work" (Call / fan-out / TailCall /
-client send); ``return`` = "your call resolved" (a ``ReturnCall`` reply). PR-C adds
-``fault``. A missing header reads as ``call`` (raw-producer ingress norm)."""
+client send); ``return`` = "your call resolved" (a ``ReturnCall`` reply); ``fault`` =
+"your call failed" (a fault publish, accompanied by :data:`HDR_ERROR_TYPE`). A missing
+header reads as ``call`` (raw-producer ingress norm). The ``fault`` value is in the
+value space now; only the rail stamps it."""
 
-MessageKind = Literal["call", "return"]
-"""Closed value space for :data:`HDR_KIND` in PR-A. PR-C widens it with ``fault``."""
+HDR_ERROR_TYPE = "x-calf-error-type"
+"""Kafka header carrying a fault's ``error_type`` (spec §4.1), stamped alongside
+``x-calf-kind: fault``. Lets ops filter faults at the broker without deserializing
+the body. Framework-stamped, never user-set."""
+
+MessageKind = Literal["call", "return", "fault"]
+"""Closed value space for :data:`HDR_KIND` (spec §4.1)."""
 
 
 def decode_header_str(value: Any) -> str | None:

--- a/calfkit/exceptions.py
+++ b/calfkit/exceptions.py
@@ -65,11 +65,17 @@ class NodeFaultError(Exception):
         else:
             # MINT: build a fresh report from a user-supplied type.
             error_type = error_type_or_report
+            if not error_type or error_type.isspace():
+                raise ValueError("error_type must be a non-empty code (it is the contract consumers branch on).")
             if error_type.startswith(_CALF_NAMESPACE):
                 raise ValueError(
                     f"error_type {error_type!r} is under the reserved {_CALF_NAMESPACE!r} prefix, which is "
                     "framework-only; choose a type outside it so consumers can trust the calf.* namespace."
                 )
+            if details:
+                reserved = sorted(k for k in details if k.startswith(_CALF_NAMESPACE))
+                if reserved:
+                    raise ValueError(f"details keys under the reserved {_CALF_NAMESPACE!r} prefix are framework-only: {reserved}.")
             # Eagerly check the details are JSON-serializable so an unserializable
             # value fails here, at the keyboard, not later on the error path. (An
             # oversized-but-serializable details is not rejected; build_safe bounds
@@ -79,7 +85,9 @@ class NodeFaultError(Exception):
             except Exception as exc:
                 raise ValueError(f"NodeFaultError details are not JSON-serializable: {safe_exc_message(exc)}") from exc
             self.report = ErrorReport.build_safe(error_type=error_type, message=message, retryable=retryable, details=details or {})
-        super().__init__(self.report.message or self.report.error_type)
+        # error_type can be empty on a *received* report (decode has no min_length);
+        # keep the exception string non-empty so logs/tracebacks never read blank.
+        super().__init__(self.report.message or self.report.error_type or "<unspecified fault>")
 
     def __reduce__(self) -> tuple[Any, tuple[ErrorReport]]:
         # Reconstruct from the report, not by replaying self.args (a message

--- a/calfkit/exceptions.py
+++ b/calfkit/exceptions.py
@@ -59,6 +59,8 @@ class NodeFaultError(Exception):
         if isinstance(error_type_or_report, ErrorReport):
             # RECEIVE/WRAP: carry an existing report verbatim. No namespace guard —
             # it may legitimately be a framework-minted calf.* the client re-raises.
+            if message or retryable or details is not None:
+                raise ValueError("message/retryable/details are mint-only; NodeFaultError(report) wraps a report verbatim.")
             self.report = error_type_or_report
         else:
             # MINT: build a fresh report from a user-supplied type.
@@ -68,8 +70,10 @@ class NodeFaultError(Exception):
                     f"error_type {error_type!r} is under the reserved {_CALF_NAMESPACE!r} prefix, which is "
                     "framework-only; choose a type outside it so consumers can trust the calf.* namespace."
                 )
-            # Eagerly check the details are wire-safe so an unserializable value
-            # fails here, at the keyboard, not later on the error path.
+            # Eagerly check the details are JSON-serializable so an unserializable
+            # value fails here, at the keyboard, not later on the error path. (An
+            # oversized-but-serializable details is not rejected; build_safe bounds
+            # it to 16 KB and records the drop under calf.elided.)
             try:
                 pydantic_core.to_json(details or {})
             except Exception as exc:

--- a/calfkit/exceptions.py
+++ b/calfkit/exceptions.py
@@ -1,5 +1,11 @@
 from typing import Any
 
+import pydantic_core
+
+from calfkit.models.error_report import ErrorReport
+
+_CALF_NAMESPACE = "calf."
+
 
 def safe_exc_message(e: BaseException) -> str:
     """Best-effort string of an exception, robust against a broken ``__str__``.
@@ -17,6 +23,66 @@ def safe_exc_message(e: BaseException) -> str:
             return repr(e)
         except Exception:
             return f"<unprintable {type(e).__name__}>"
+
+
+class NodeFaultError(Exception):
+    """A terminal fault — one class, symmetric for minting and receiving (spec §11).
+
+    **Mint** a deliberate typed fault from node/seam code::
+
+        raise NodeFaultError("billing.quota_exceeded", message="...", retryable=False, details={...})
+
+    **Receive** one at the client edge (the reply dispatcher fails the pending
+    future with ``NodeFaultError(report)``), then branch on the slotted report::
+
+        try:
+            result = await handle.result()
+        except NodeFaultError as e:
+            if e.report.find(FaultTypes.MODEL_CONTEXT_WINDOW_EXCEEDED):  # find(), not == — groups compose
+                ...
+
+    The contract is the :class:`~calfkit.models.error_report.ErrorReport` on
+    ``report``, never an exception class — no ``error_type → exception`` registry,
+    so every surface (seams, sinks, client) reads the same slotted report.
+    """
+
+    report: ErrorReport
+
+    def __init__(
+        self,
+        error_type_or_report: str | ErrorReport,
+        *,
+        message: str = "",
+        retryable: bool = False,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        if isinstance(error_type_or_report, ErrorReport):
+            # RECEIVE/WRAP: carry an existing report verbatim. No namespace guard —
+            # it may legitimately be a framework-minted calf.* the client re-raises.
+            self.report = error_type_or_report
+        else:
+            # MINT: build a fresh report from a user-supplied type.
+            error_type = error_type_or_report
+            if error_type.startswith(_CALF_NAMESPACE):
+                raise ValueError(
+                    f"error_type {error_type!r} is under the reserved {_CALF_NAMESPACE!r} prefix, which is "
+                    "framework-only; choose a type outside it so consumers can trust the calf.* namespace."
+                )
+            # Eagerly check the details are wire-safe so an unserializable value
+            # fails here, at the keyboard, not later on the error path.
+            try:
+                pydantic_core.to_json(details or {})
+            except Exception as exc:
+                raise ValueError(f"NodeFaultError details are not JSON-serializable: {safe_exc_message(exc)}") from exc
+            self.report = ErrorReport.build_safe(error_type=error_type, message=message, retryable=retryable, details=details or {})
+        super().__init__(self.report.message or self.report.error_type)
+
+    def __reduce__(self) -> tuple[Any, tuple[ErrorReport]]:
+        # Reconstruct from the report, not by replaying self.args (a message
+        # string) through __init__, which would mis-route the string into the
+        # mint arm and rebuild a different report (cf. ReplyExpiredError /
+        # ToolExecutionError, which carry custom reductions for the same reason).
+        return (self.__class__, (self.report,))
 
 
 class DeserializationError(Exception):

--- a/calfkit/models/__init__.py
+++ b/calfkit/models/__init__.py
@@ -10,8 +10,9 @@ from calfkit.models.actions import (  # noqa: I001 — actions first (see commen
 )
 from calfkit.models.consumer_context import ConsumerContext
 from calfkit.models.envelope import Envelope
+from calfkit.models.error_report import ErrorReport, FaultTypes, FrameRef
 from calfkit.models.payload import ContentPart, DataPart, FilePart, TextPart, ToolCallPart
-from calfkit.models.reply import ReturnMessage
+from calfkit.models.reply import FaultMessage, ReturnMessage
 from calfkit.models.session_context import (
     BaseSessionRunContext,
     CallFrame,
@@ -43,7 +44,12 @@ __all__ = [
     "_Call",
     # envelope
     "Envelope",
+    # error_report
+    "ErrorReport",
+    "FaultTypes",
+    "FrameRef",
     # reply
+    "FaultMessage",
     "ReturnMessage",
     # payload
     "ContentPart",

--- a/calfkit/models/envelope.py
+++ b/calfkit/models/envelope.py
@@ -18,5 +18,8 @@ class Envelope(BaseModel):
     internal_workflow_state: WorkflowState = Field(description="The internal, framework-level state tracking workflow")
     reply: ReturnMessage | None = None
     """Per-delivery response carriage (spec §4). ``None`` on call-kind deliveries;
-    a :class:`~calfkit.models.reply.ReturnMessage` on return-kind deliveries. PR-C
-    widens this to ``ReturnMessage | FaultMessage`` with a ``kind`` discriminator."""
+    a :class:`~calfkit.models.reply.ReturnMessage` on return-kind deliveries. The
+    :class:`~calfkit.models.reply.FaultMessage` shape exists; this slot widens to
+    ``ReturnMessage | FaultMessage`` (with a ``kind`` discriminator) when the rail
+    starts producing faults, together with the projection/dispatch side that gives
+    a fault its behavior."""

--- a/calfkit/models/error_report.py
+++ b/calfkit/models/error_report.py
@@ -145,10 +145,24 @@ class ErrorReport(BaseModel):
         return v
 
     def walk(self) -> Iterator[ErrorReport]:
-        """Yield this report, then every nested cause (pre-order)."""
-        yield self
-        for cause in self.causes:
-            yield from cause.walk()
+        """Yield this report, then every nested cause (pre-order).
+
+        Iterative and cycle-guarded: a report off the wire is acyclic (JSON has no
+        cycles), but the shallow freeze leaves ``causes`` mutable in place, so an
+        in-process cycle (or a cause reached by two paths) is possible. An ``id()``-keyed
+        visited set yields each report once and terminates, instead of recursing without
+        bound — ``walk`` is the public traversal a consumer calls on a possibly
+        attacker-influenced ``NodeFaultError.report``.
+        """
+        seen: set[int] = set()
+        stack: list[ErrorReport] = [self]
+        while stack:
+            report = stack.pop()
+            if id(report) in seen:
+                continue
+            seen.add(id(report))
+            yield report
+            stack.extend(reversed(report.causes))  # reversed ⇒ first cause pops next (pre-order)
 
     def find(self, error_type: str) -> ErrorReport | None:
         """The first report in ``walk()`` order matching ``error_type``, or ``None``.
@@ -252,33 +266,59 @@ class ErrorReport(BaseModel):
 # Carriage-bound helpers (used by ErrorReport.build_safe)
 # ---------------------------------------------------------------------------
 class _CauseBudget:
-    """Shared accounting across the recursive cause bounding: how many reports may
-    still be kept (``remaining``) and how many were dropped (``dropped``)."""
+    """Shared accounting across the cause bounding: how many reports may still be kept
+    (``remaining``), how many were dropped (``dropped``), and the report ids already
+    visited (``seen``) so the walk is cycle/DAG-safe and always terminates."""
 
-    __slots__ = ("remaining", "dropped")
+    __slots__ = ("remaining", "dropped", "seen")
 
     def __init__(self) -> None:
         self.remaining = _MAX_CAUSES_TOTAL
         self.dropped = 0
+        self.seen: set[int] = set()
 
 
 def _bound_cause_list(causes: list[ErrorReport], *, depth: int, budget: _CauseBudget) -> list[ErrorReport]:
-    """Copy ``causes`` keeping the tree within the depth (≤ 8 levels below the
-    root) and total-count (≤ 64) budgets; everything dropped is tallied on
-    ``budget.dropped`` so the caller can record it (never a silent drop).
+    """Copy ``causes`` within the depth (≤ 8 levels, root included) and total-count (≤ 64)
+    budgets; everything dropped is tallied on ``budget.dropped`` so the caller records it
+    (never a silent drop).
 
-    A dropped cause is recursed with the budget already exhausted, so its whole
-    subtree falls through the same drop branch and is counted node-by-node — no
-    separate tree-walk is needed."""
+    The kept-build recursion is bounded by ``_MAX_CAUSES_DEPTH`` — it descends only while a
+    node is *kept* (``depth <= _MAX_CAUSES_DEPTH``), so it cannot exhaust Python's recursion
+    limit. A *dropped* subtree, by contrast, can be arbitrarily deep, so it is counted
+    **iteratively** (:func:`_count_subtree`), never by recursion: otherwise a deep ``causes``
+    chain (nested fault groups, §4.4) would ``RecursionError`` into ``build_safe``'s fallback
+    and silently downgrade the precise ``causes=N`` breadcrumb to a bare ``fallback``.
+    ``budget.seen`` (report ids) makes the whole walk cycle/DAG-safe — a report reached by
+    more than one path, or a self-referential cycle (possible only via in-process mutation of
+    the shallow-frozen ``causes``, never off the wire), is kept once and its re-occurrences
+    counted — so the transform always terminates."""
     kept: list[ErrorReport] = []
     for cause in causes:
-        if depth > _MAX_CAUSES_DEPTH or budget.remaining <= 0:
-            budget.dropped += 1
-            _bound_cause_list(cause.causes, depth=depth + 1, budget=budget)  # tally the dropped subtree
+        if depth > _MAX_CAUSES_DEPTH or budget.remaining <= 0 or id(cause) in budget.seen:
+            budget.dropped += _count_subtree(cause, budget)  # iterative, cycle-safe tally
             continue
+        budget.seen.add(id(cause))
         budget.remaining -= 1
         kept.append(cause.model_copy(update={"causes": _bound_cause_list(cause.causes, depth=depth + 1, budget=budget)}))
     return kept
+
+
+def _count_subtree(root: ErrorReport, budget: _CauseBudget) -> int:
+    """Count every not-yet-seen report in ``root``'s subtree (root included), iteratively and
+    cycle-safe, marking each on ``budget.seen``. The dropped-subtree tally behind the ``causes``
+    elision breadcrumb — the true number of reports elided, however deep or cyclic the dropped
+    input, with no recursion."""
+    count = 0
+    stack: list[ErrorReport] = [root]
+    while stack:
+        node = stack.pop()
+        if id(node) in budget.seen:
+            continue
+        budget.seen.add(id(node))
+        count += 1
+        stack.extend(node.causes)
+    return count
 
 
 def _bound_frame_chain(chain: list[FrameRef]) -> tuple[list[FrameRef], int]:

--- a/calfkit/models/error_report.py
+++ b/calfkit/models/error_report.py
@@ -29,6 +29,13 @@ _MAX_CAUSES_DEPTH = 8
 _MAX_CAUSES_TOTAL = 64
 _MAX_FRAME_CHAIN = 64
 _MAX_DETAILS_BYTES = 16 * 1024
+# The details field budget covers user content AND the ELIDED breadcrumb appended
+# afterwards; reserve headroom for the breadcrumb so it can never push the field
+# over budget (the breadcrumb is a few small int/bool keys, well under the reserve).
+_ELIDED_RESERVE_BYTES = 512
+# Framework-reserved prefix for details keys (mirrors the error_type reservation),
+# so a consumer can trust a calf.* details key was written by the framework.
+_CALF_PREFIX = "calf."
 
 
 class FaultTypes:
@@ -85,8 +92,13 @@ class ErrorReport(BaseModel):
     Frozen: the report travels and is read at many surfaces (a seam's ``fault``
     arg, ``NodeFaultError.report``, ``ConsumerContext.fault``, the broadcast
     mirror) and — once the rail escalates it — passes up a frame chain untouched.
-    Immutability makes the "stable across hops" promise on ``report_id`` real and
+    Freezing makes the "stable across hops" promise on ``report_id`` real and
     matches the codebase's frozen wire values (``FailedToolCall``, ``CallFrame``).
+    The freeze is **shallow** — field *reassignment* is blocked, but the
+    ``causes``/``details``/``frame_chain`` containers remain mutable in place, so
+    transform a report you've handed off with ``model_copy(update=...)``, never by
+    mutating a container (e.g. the rail's batch-closure flatten copies metadata
+    onto a child's ``details`` via ``model_copy``).
     Bounds note: the carriage budgets are applied by :meth:`build_safe` at
     synthesis; the plain constructor (and inbound decode) are NOT re-bounded.
     """
@@ -192,6 +204,9 @@ class ErrorReport(BaseModel):
             bounded_causes = _bound_cause_list(list(causes or []), depth=2, budget=budget)
             bounded_chain, frames_dropped = _bound_frame_chain(list(frame_chain or []))
             bounded_details, details_bytes_dropped = _bound_details(dict(details or {}))
+            # calf.* details keys are framework-reserved; drop any a caller supplied so
+            # the framework's own ELIDED breadcrumb is authoritative and unambiguous.
+            bounded_details = {k: v for k, v in bounded_details.items() if not k.startswith(_CALF_PREFIX)}
             elided: dict[str, Any] = {}
             if budget.dropped:
                 elided["causes"] = budget.dropped
@@ -219,12 +234,15 @@ class ErrorReport(BaseModel):
             # under ELIDED — the fallback must not itself become a silent drop. Use
             # the exception class name (never str(exc), which can raise) and avoid
             # importing safe_exc_message to keep this module calfkit-import-free.
+            # ``type(x) is str`` (not isinstance): a str subclass with a hostile
+            # ``__len__``/``__getitem__`` is what likely broke the primary path's
+            # clamp, so re-passing it would re-break the fallback — coerce it out.
             return cls(
-                error_type=error_type if isinstance(error_type, str) else FaultTypes.UNHANDLED,
-                message=message if isinstance(message, str) else "",
-                retryable=retryable if isinstance(retryable, bool) else False,
-                origin_node_id=origin_node_id if isinstance(origin_node_id, str) else None,
-                origin_frame_id=origin_frame_id if isinstance(origin_frame_id, str) else None,
+                error_type=error_type if type(error_type) is str else FaultTypes.UNHANDLED,
+                message=message if type(message) is str else "",
+                retryable=retryable if type(retryable) is bool else False,
+                origin_node_id=origin_node_id if type(origin_node_id) is str else None,
+                origin_frame_id=origin_frame_id if type(origin_frame_id) is str else None,
                 details={FaultTypes.ELIDED: {"fallback": type(exc).__name__}},
             )
 
@@ -285,6 +303,8 @@ def _bound_details(details: dict[str, Any]) -> tuple[dict[str, Any], int | None]
         # reachable when something else (e.g. the rail) calls build_safe directly;
         # build_safe stays total regardless.
         return {}, None
-    if size <= _MAX_DETAILS_BYTES:
+    # Keep user content within the field budget LESS the breadcrumb reserve, so the
+    # ELIDED breadcrumb appended afterwards cannot push the field over budget.
+    if size <= _MAX_DETAILS_BYTES - _ELIDED_RESERVE_BYTES:
         return dict(details), 0
     return {}, size

--- a/calfkit/models/error_report.py
+++ b/calfkit/models/error_report.py
@@ -203,10 +203,11 @@ class ErrorReport(BaseModel):
             budget = _CauseBudget()
             bounded_causes = _bound_cause_list(list(causes or []), depth=2, budget=budget)
             bounded_chain, frames_dropped = _bound_frame_chain(list(frame_chain or []))
-            bounded_details, details_bytes_dropped = _bound_details(dict(details or {}))
-            # calf.* details keys are framework-reserved; drop any a caller supplied so
-            # the framework's own ELIDED breadcrumb is authoritative and unambiguous.
-            bounded_details = {k: v for k, v in bounded_details.items() if not k.startswith(_CALF_PREFIX)}
+            # calf.* details keys are framework-reserved; drop any a caller supplied
+            # BEFORE bounding, so the framework's ELIDED breadcrumb stays authoritative
+            # and a reserved key's size can never evict legitimate user keys.
+            user_details = {k: v for k, v in dict(details or {}).items() if not k.startswith(_CALF_PREFIX)}
+            bounded_details, details_bytes_dropped = _bound_details(user_details)
             elided: dict[str, Any] = {}
             if budget.dropped:
                 elided["causes"] = budget.dropped
@@ -243,7 +244,7 @@ class ErrorReport(BaseModel):
                 retryable=retryable if type(retryable) is bool else False,
                 origin_node_id=origin_node_id if type(origin_node_id) is str else None,
                 origin_frame_id=origin_frame_id if type(origin_frame_id) is str else None,
-                details={FaultTypes.ELIDED: {"fallback": type(exc).__name__}},
+                details={FaultTypes.ELIDED: {"fallback": type(exc).__name__[:200]}},
             )
 
 

--- a/calfkit/models/error_report.py
+++ b/calfkit/models/error_report.py
@@ -51,9 +51,12 @@ class FaultTypes:
     SLOT_MATERIALIZATION_FAILED = "calf.slot.materialization_failed"
     AGENT_SELF_RETRY_EXHAUSTED = "calf.agent.self_retry_exhausted"
 
-    # details key: a non-silent breadcrumb recording what build_safe elided to
-    # stay within the carriage budget. Maps to a small dict, e.g.
-    # ``{"causes": 6, "frames": 6, "details_bytes": 20012}`` (only non-zero parts).
+    # details key: a non-silent breadcrumb recording what build_safe elided to stay
+    # within the carriage budget. Maps to a small dict carrying only the parts that
+    # applied: ``causes`` (int dropped), ``frames`` (int dropped), ``details_bytes``
+    # (int, oversized details dropped wholesale), ``details_unserializable`` (True),
+    # and ``fallback`` (the exception class name, when build_safe's last-resort arm
+    # dropped causes/frame_chain/details after an unexpected construction error).
     ELIDED = "calf.elided"
 
 
@@ -64,6 +67,8 @@ class FrameRef(BaseModel):
     data, so shipping them in every fault is a leak vector. With ``origin_payload``
     gone from the model, faults carry no user payloads by construction.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     frame_id: str
     target_topic: str
@@ -76,9 +81,17 @@ class ErrorReport(BaseModel):
     seams (the ``fault`` argument), the client (``NodeFaultError.report``) and
     sinks (``ConsumerContext.fault``). Exception identity never crosses the wire —
     ``error_type`` (a dotted string code) is the contract, not a class name.
+
+    Frozen: the report travels and is read at many surfaces (a seam's ``fault``
+    arg, ``NodeFaultError.report``, ``ConsumerContext.fault``, the broadcast
+    mirror) and — once the rail escalates it — passes up a frame chain untouched.
+    Immutability makes the "stable across hops" promise on ``report_id`` real and
+    matches the codebase's frozen wire values (``FailedToolCall``, ``CallFrame``).
+    Bounds note: the carriage budgets are applied by :meth:`build_safe` at
+    synthesis; the plain constructor (and inbound decode) are NOT re-bounded.
     """
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", frozen=True)
 
     report_id: str = Field(default_factory=lambda: uuid_utils.uuid7().hex)
     """Framework-minted UUID7 at synthesis — stable across hops and mirrors; the
@@ -179,12 +192,14 @@ class ErrorReport(BaseModel):
             bounded_causes = _bound_cause_list(list(causes or []), depth=2, budget=budget)
             bounded_chain, frames_dropped = _bound_frame_chain(list(frame_chain or []))
             bounded_details, details_bytes_dropped = _bound_details(dict(details or {}))
-            elided: dict[str, int] = {}
+            elided: dict[str, Any] = {}
             if budget.dropped:
                 elided["causes"] = budget.dropped
             if frames_dropped:
                 elided["frames"] = frames_dropped
-            if details_bytes_dropped:
+            if details_bytes_dropped is None:
+                elided["details_unserializable"] = True
+            elif details_bytes_dropped:
                 elided["details_bytes"] = details_bytes_dropped
             if elided:
                 bounded_details = {**bounded_details, FaultTypes.ELIDED: elided}
@@ -198,13 +213,19 @@ class ErrorReport(BaseModel):
                 details=bounded_details,
                 causes=bounded_causes,
             )
-        except Exception:
+        except Exception as exc:
+            # Last-resort total fallback: keep only the scalar identity that is safe
+            # to coerce, and record the wholesale drop of causes/frame_chain/details
+            # under ELIDED — the fallback must not itself become a silent drop. Use
+            # the exception class name (never str(exc), which can raise) and avoid
+            # importing safe_exc_message to keep this module calfkit-import-free.
             return cls(
                 error_type=error_type if isinstance(error_type, str) else FaultTypes.UNHANDLED,
                 message=message if isinstance(message, str) else "",
                 retryable=retryable if isinstance(retryable, bool) else False,
                 origin_node_id=origin_node_id if isinstance(origin_node_id, str) else None,
                 origin_frame_id=origin_frame_id if isinstance(origin_frame_id, str) else None,
+                details={FaultTypes.ELIDED: {"fallback": type(exc).__name__}},
             )
 
 
@@ -222,19 +243,19 @@ class _CauseBudget:
         self.dropped = 0
 
 
-def _count_tree(report: ErrorReport) -> int:
-    """Total number of reports in a cause subtree, ``report`` included."""
-    return 1 + sum(_count_tree(c) for c in report.causes)
-
-
 def _bound_cause_list(causes: list[ErrorReport], *, depth: int, budget: _CauseBudget) -> list[ErrorReport]:
     """Copy ``causes`` keeping the tree within the depth (≤ 8 levels below the
     root) and total-count (≤ 64) budgets; everything dropped is tallied on
-    ``budget.dropped`` so the caller can record it (never a silent drop)."""
+    ``budget.dropped`` so the caller can record it (never a silent drop).
+
+    A dropped cause is recursed with the budget already exhausted, so its whole
+    subtree falls through the same drop branch and is counted node-by-node — no
+    separate tree-walk is needed."""
     kept: list[ErrorReport] = []
     for cause in causes:
         if depth > _MAX_CAUSES_DEPTH or budget.remaining <= 0:
-            budget.dropped += _count_tree(cause)
+            budget.dropped += 1
+            _bound_cause_list(cause.causes, depth=depth + 1, budget=budget)  # tally the dropped subtree
             continue
         budget.remaining -= 1
         kept.append(cause.model_copy(update={"causes": _bound_cause_list(cause.causes, depth=depth + 1, budget=budget)}))
@@ -252,16 +273,18 @@ def _bound_frame_chain(chain: list[FrameRef]) -> tuple[list[FrameRef], int]:
     return [*chain[:head], *chain[-tail:]], len(chain) - _MAX_FRAME_CHAIN
 
 
-def _bound_details(details: dict[str, Any]) -> tuple[dict[str, Any], int]:
-    """Bound ``details`` to ≤ 16 KB serialized. If it does not fit (or cannot be
-    serialized at all), drop it wholesale and return the dropped byte count so the
-    caller can leave a breadcrumb. Returns ``(bounded_details, bytes_dropped)``."""
+def _bound_details(details: dict[str, Any]) -> tuple[dict[str, Any], int | None]:
+    """Bound ``details`` to ≤ 16 KB serialized. Returns ``(bounded_details, dropped)``
+    where ``dropped`` is the byte count dropped (``0`` if it fit), or ``None`` if the
+    details could not be serialized at all (dropped, size unmeasurable). The caller
+    turns each case into a distinct, non-magic breadcrumb."""
     try:
         size = len(pydantic_core.to_json(details))
     except Exception:
-        # Unserializable (NodeFaultError checks this at mint; build_safe stays
-        # total regardless): drop, marking the drop without a measurable size.
-        return {}, -1
+        # Unserializable. NodeFaultError checks this at mint, so this path is only
+        # reachable when something else (e.g. the rail) calls build_safe directly;
+        # build_safe stays total regardless.
+        return {}, None
     if size <= _MAX_DETAILS_BYTES:
         return dict(details), 0
     return {}, size

--- a/calfkit/models/error_report.py
+++ b/calfkit/models/error_report.py
@@ -1,0 +1,267 @@
+"""The typed fault value and its vocabulary (spec §4.3).
+
+Additive wire model introduced by PR-5: ``ErrorReport`` (the fault carried on
+the reply slot's ``FaultMessage``), its topology breadcrumb ``FrameRef``, the
+``FaultTypes`` constants, and the total-construction ``build_safe`` builder.
+Nothing here produces or routes a fault — that is the rail (PR-6).
+
+A plain ``BaseModel`` (not the long-gone ``CompactBaseModel``): every field
+always serializes, because a fault's absence/presence is load-bearing and
+``exclude_unset`` gotchas must not apply.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pydantic_core
+import uuid_utils
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# Carriage budgets (spec §4.3): construction-time bounds so a fault never grows
+# unboundedly. The total 256 KB serialized cap and the strip-and-retry-then-floor
+# loop are publish-time concerns and live with the fault-publish path (PR-6); what
+# lives here is the per-field bounding applied at synthesis (build_safe) plus the
+# minimal strip target (to_minimal).
+_MAX_MESSAGE_CHARS = 2000
+_MAX_CAUSES_DEPTH = 8
+_MAX_CAUSES_TOTAL = 64
+_MAX_FRAME_CHAIN = 64
+_MAX_DETAILS_BYTES = 16 * 1024
+
+
+class FaultTypes:
+    """Known fault vocabulary (spec §4.3): framework-minted ``error_type`` codes
+    under the reserved ``calf.`` prefix, plus the load-bearing ``details`` key
+    ``build_safe`` writes. Shipped as constants so consumers and the framework
+    never typo magic strings.
+
+    Only the codes this PR can reference are declared; codes produced solely by
+    the rail's synthesis (e.g. the exception-class key, ``details.reason`` values)
+    land with their producer (PR-6), so no constant ships without a user.
+    """
+
+    # error_type codes
+    MODEL_CONTEXT_WINDOW_EXCEEDED = "calf.model.context_window_exceeded"
+    FAULT_GROUP = "calf.fault_group"
+    UNHANDLED = "calf.unhandled"
+    DELIVERY_REJECTED = "calf.delivery.rejected"
+    DELIVERY_UNDECODABLE = "calf.delivery.undecodable"
+    SLOT_MATERIALIZATION_FAILED = "calf.slot.materialization_failed"
+    AGENT_SELF_RETRY_EXHAUSTED = "calf.agent.self_retry_exhausted"
+
+    # details key: a non-silent breadcrumb recording what build_safe elided to
+    # stay within the carriage budget. Maps to a small dict, e.g.
+    # ``{"causes": 6, "frames": 6, "details_bytes": 20012}`` (only non-zero parts).
+    ELIDED = "calf.elided"
+
+
+class FrameRef(BaseModel):
+    """Topology-only breadcrumb of one call frame (spec §4.3).
+
+    Deliberately excludes input payloads/overrides: frame inputs may carry user
+    data, so shipping them in every fault is a leak vector. With ``origin_payload``
+    gone from the model, faults carry no user payloads by construction.
+    """
+
+    frame_id: str
+    target_topic: str
+
+
+class ErrorReport(BaseModel):
+    """A terminal failure as a typed wire value (spec §4.3).
+
+    Travels on the reply slot inside a ``FaultMessage``; the same value reaches
+    seams (the ``fault`` argument), the client (``NodeFaultError.report``) and
+    sinks (``ConsumerContext.fault``). Exception identity never crosses the wire —
+    ``error_type`` (a dotted string code) is the contract, not a class name.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    report_id: str = Field(default_factory=lambda: uuid_utils.uuid7().hex)
+    """Framework-minted UUID7 at synthesis — stable across hops and mirrors; the
+    dedup key for ops taps and the future DLT."""
+
+    error_type: str
+    """Dotted code, e.g. ``calf.model.context_window_exceeded``. An open string
+    code, not a closed enum; consumers must tolerate unknown values."""
+
+    message: str = ""
+    """Human summary, clamped (never rejected) to keep inbound decode total."""
+
+    retryable: bool = False
+    """ADVISORY — consumers may act on it; the framework does not."""
+
+    origin_node_id: str | None = None
+    origin_frame_id: str | None = None
+    frame_chain: list[FrameRef] = Field(default_factory=list)
+    """Full chain topology at fault time (subject to the carriage budget)."""
+
+    details: dict[str, Any] = Field(default_factory=dict)
+    """Open, JSON-serializable extension slot."""
+
+    causes: list[ErrorReport] = Field(default_factory=list)
+    """Recursive — non-empty means this report is composed of other faults
+    (a fault group, a deliberate conversion, or a recovery-then-failure)."""
+
+    @field_validator("message", mode="before")
+    @classmethod
+    def _clamp_message(cls, v: Any) -> Any:
+        """Clamp an over-long ``message`` rather than reject it.
+
+        A rejecting constraint would poison inbound decode of an otherwise-valid
+        report; a BEFORE-mode clamp keeps construction total on every path,
+        including deserialization. Mirrors ``FailedToolCall``'s clamp discipline.
+        """
+        if isinstance(v, str) and len(v) > _MAX_MESSAGE_CHARS:
+            return v[:_MAX_MESSAGE_CHARS]
+        return v
+
+    def walk(self) -> Iterator[ErrorReport]:
+        """Yield this report, then every nested cause (pre-order)."""
+        yield self
+        for cause in self.causes:
+            yield from cause.walk()
+
+    def find(self, error_type: str) -> ErrorReport | None:
+        """The first report in ``walk()`` order matching ``error_type``, or ``None``.
+
+        Use this rather than a bare ``error_type ==`` when faults may compose: a
+        fan-out wraps unhandled siblings in a fault group, so a top-level equality
+        check would silently stop matching the day an agent fans out (spec §4.4).
+        """
+        for report in self.walk():
+            if report.error_type == error_type:
+                return report
+        return None
+
+    def to_minimal(self) -> ErrorReport:
+        """The strip-and-retry floor target (spec §4.3): identity only — no
+        ``causes``, ``details``, or ``frame_chain`` — so an oversized fault can
+        still be published instead of becoming a new silent drop. (The publish-time
+        size check and retry loop that call this live with the rail, PR-6.)"""
+        return ErrorReport(
+            report_id=self.report_id,
+            error_type=self.error_type,
+            message=self.message,
+            retryable=self.retryable,
+            origin_node_id=self.origin_node_id,
+            origin_frame_id=self.origin_frame_id,
+        )
+
+    @classmethod
+    def build_safe(
+        cls,
+        *,
+        error_type: str,
+        message: str = "",
+        retryable: bool = False,
+        origin_node_id: str | None = None,
+        origin_frame_id: str | None = None,
+        frame_chain: list[FrameRef] | None = None,
+        details: dict[str, Any] | None = None,
+        causes: list[ErrorReport] | None = None,
+    ) -> ErrorReport:
+        """Synthesize a report that **never raises** (spec §4.3).
+
+        The fault path must never itself raise — a fault that throws while being
+        built re-opens the silent-drop hole this feature closes (mirrors
+        ``FailedToolCall.build_safe``). Applies the per-field carriage bounds
+        (``causes`` depth/total, ``frame_chain`` head+tail, ``details`` size),
+        recording any elision under ``details[FaultTypes.ELIDED]`` so nothing is
+        dropped silently. On any unexpected construction error, falls back to a
+        minimal report keeping only the scalar identity that is safe to coerce.
+        """
+        try:
+            budget = _CauseBudget()
+            bounded_causes = _bound_cause_list(list(causes or []), depth=2, budget=budget)
+            bounded_chain, frames_dropped = _bound_frame_chain(list(frame_chain or []))
+            bounded_details, details_bytes_dropped = _bound_details(dict(details or {}))
+            elided: dict[str, int] = {}
+            if budget.dropped:
+                elided["causes"] = budget.dropped
+            if frames_dropped:
+                elided["frames"] = frames_dropped
+            if details_bytes_dropped:
+                elided["details_bytes"] = details_bytes_dropped
+            if elided:
+                bounded_details = {**bounded_details, FaultTypes.ELIDED: elided}
+            return cls(
+                error_type=error_type,
+                message=message,
+                retryable=retryable,
+                origin_node_id=origin_node_id,
+                origin_frame_id=origin_frame_id,
+                frame_chain=bounded_chain,
+                details=bounded_details,
+                causes=bounded_causes,
+            )
+        except Exception:
+            return cls(
+                error_type=error_type if isinstance(error_type, str) else FaultTypes.UNHANDLED,
+                message=message if isinstance(message, str) else "",
+                retryable=retryable if isinstance(retryable, bool) else False,
+                origin_node_id=origin_node_id if isinstance(origin_node_id, str) else None,
+                origin_frame_id=origin_frame_id if isinstance(origin_frame_id, str) else None,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Carriage-bound helpers (used by ErrorReport.build_safe)
+# ---------------------------------------------------------------------------
+class _CauseBudget:
+    """Shared accounting across the recursive cause bounding: how many reports may
+    still be kept (``remaining``) and how many were dropped (``dropped``)."""
+
+    __slots__ = ("remaining", "dropped")
+
+    def __init__(self) -> None:
+        self.remaining = _MAX_CAUSES_TOTAL
+        self.dropped = 0
+
+
+def _count_tree(report: ErrorReport) -> int:
+    """Total number of reports in a cause subtree, ``report`` included."""
+    return 1 + sum(_count_tree(c) for c in report.causes)
+
+
+def _bound_cause_list(causes: list[ErrorReport], *, depth: int, budget: _CauseBudget) -> list[ErrorReport]:
+    """Copy ``causes`` keeping the tree within the depth (≤ 8 levels below the
+    root) and total-count (≤ 64) budgets; everything dropped is tallied on
+    ``budget.dropped`` so the caller can record it (never a silent drop)."""
+    kept: list[ErrorReport] = []
+    for cause in causes:
+        if depth > _MAX_CAUSES_DEPTH or budget.remaining <= 0:
+            budget.dropped += _count_tree(cause)
+            continue
+        budget.remaining -= 1
+        kept.append(cause.model_copy(update={"causes": _bound_cause_list(cause.causes, depth=depth + 1, budget=budget)}))
+    return kept
+
+
+def _bound_frame_chain(chain: list[FrameRef]) -> tuple[list[FrameRef], int]:
+    """Bound ``chain`` to ≤ 64 frames with head+tail elision (the ends carry the
+    origin and the most-recent hop). Returns the bounded chain and the count
+    dropped from the middle."""
+    if len(chain) <= _MAX_FRAME_CHAIN:
+        return list(chain), 0
+    head = _MAX_FRAME_CHAIN // 2
+    tail = _MAX_FRAME_CHAIN - head
+    return [*chain[:head], *chain[-tail:]], len(chain) - _MAX_FRAME_CHAIN
+
+
+def _bound_details(details: dict[str, Any]) -> tuple[dict[str, Any], int]:
+    """Bound ``details`` to ≤ 16 KB serialized. If it does not fit (or cannot be
+    serialized at all), drop it wholesale and return the dropped byte count so the
+    caller can leave a breadcrumb. Returns ``(bounded_details, bytes_dropped)``."""
+    try:
+        size = len(pydantic_core.to_json(details))
+    except Exception:
+        # Unserializable (NodeFaultError checks this at mint; build_safe stays
+        # total regardless): drop, marking the drop without a measurable size.
+        return {}, -1
+    if size <= _MAX_DETAILS_BYTES:
+        return dict(details), 0
+    return {}, size

--- a/calfkit/models/reply.py
+++ b/calfkit/models/reply.py
@@ -2,16 +2,22 @@ from typing import Literal
 
 from pydantic import BaseModel
 
+from calfkit.models.error_report import ErrorReport
 from calfkit.models.payload import ContentPart
 
 
 class _ReplyBase(BaseModel):
     """Common per-delivery reply correlation (spec §4.2).
 
-    Shipped now so PR-C's ``FaultMessage`` is a pure sibling addition
-    (``class FaultMessage(_ReplyBase)``) rather than a re-parenting of
-    :class:`ReturnMessage`, and the ``Envelope.reply`` union widens to
-    ``ReturnMessage | FaultMessage`` with ``Field(discriminator="kind")``.
+    The shared parent of the two reply shapes: :class:`ReturnMessage` (a
+    successful output, content as parts) and :class:`FaultMessage` (a terminal
+    failure, an :class:`~calfkit.models.error_report.ErrorReport`) — ``result``
+    XOR ``error``, the JSON-RPC split.
+
+    The ``Envelope.reply`` slot still carries only ``ReturnMessage | None`` today;
+    it widens to ``ReturnMessage | FaultMessage`` with ``Field(discriminator="kind")``
+    when the rail starts producing faults (the projection/dispatch side of that
+    widening is where fault behavior lives, so it lands together there).
     """
 
     in_reply_to: str | None
@@ -32,3 +38,15 @@ class ReturnMessage(_ReplyBase):
 
     kind: Literal["return"] = "return"
     parts: list[ContentPart]
+
+
+class FaultMessage(_ReplyBase):
+    """A terminal failure, carried in the per-delivery reply slot (spec §4.2).
+
+    The same :class:`~calfkit.models.error_report.ErrorReport` reaches every
+    fault-aware surface — a caller's seam (the ``fault`` argument), the client
+    (``NodeFaultError.report``), and sinks (``ConsumerContext.fault``).
+    """
+
+    kind: Literal["fault"] = "fault"
+    error: ErrorReport

--- a/tests/test_fault_wire_model.py
+++ b/tests/test_fault_wire_model.py
@@ -1,0 +1,287 @@
+"""PR-5 — the fault wire model (fault half of the §4 wire vocabulary).
+
+Additive vocabulary the rail (PR-6) speaks; nothing here produces, routes, or
+catches a fault. All unit-level, no broker. See
+notes/pr5-fault-wire-model-implementation-plan.md.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import pytest
+
+from calfkit._protocol import HDR_ERROR_TYPE, MessageKind
+from calfkit.exceptions import NodeFaultError
+from calfkit.models.error_report import ErrorReport, FaultTypes, FrameRef
+from calfkit.models.reply import FaultMessage, _ReplyBase
+
+
+class TestFrameRef:
+    def test_carries_only_frame_id_and_target_topic(self) -> None:
+        ref = FrameRef(frame_id="f1", target_topic="orders")
+        assert ref.frame_id == "f1"
+        assert ref.target_topic == "orders"
+        # topology-only: no payload/overrides leak surface (spec §4.3)
+        assert set(FrameRef.model_fields) == {"frame_id", "target_topic"}
+
+    def test_round_trips(self) -> None:
+        ref = FrameRef(frame_id="f1", target_topic="orders")
+        assert FrameRef.model_validate_json(ref.model_dump_json()) == ref
+
+
+class TestErrorReport:
+    def test_minimal_construction_and_defaults(self) -> None:
+        r = ErrorReport(error_type="billing.quota_exceeded")
+        assert r.error_type == "billing.quota_exceeded"
+        assert r.message == ""
+        assert r.retryable is False
+        assert r.origin_node_id is None
+        assert r.origin_frame_id is None
+        assert r.frame_chain == []
+        assert r.details == {}
+        assert r.causes == []
+
+    def test_report_id_auto_mints_and_is_distinct(self) -> None:
+        a = ErrorReport(error_type="x")
+        b = ErrorReport(error_type="x")
+        assert a.report_id and b.report_id
+        assert a.report_id != b.report_id
+
+    def test_message_clamped_to_2000_on_construction(self) -> None:
+        r = ErrorReport(error_type="x", message="a" * 5000)
+        assert len(r.message) == 2000
+
+    def test_message_clamped_to_2000_on_inbound_decode(self) -> None:
+        # A rejecting constraint would poison inbound decode (spec §4.3); the
+        # clamp must apply on deserialization too, not only at construction.
+        raw = '{"error_type":"x","message":"%s"}' % ("b" * 5000)
+        assert len(ErrorReport.model_validate_json(raw).message) == 2000
+
+    def test_round_trips_with_all_fields(self) -> None:
+        r = ErrorReport(
+            error_type="x",
+            message="boom",
+            retryable=True,
+            origin_node_id="n1",
+            origin_frame_id="f1",
+            frame_chain=[FrameRef(frame_id="f1", target_topic="t")],
+            details={"k": "v"},
+        )
+        back = ErrorReport.model_validate_json(r.model_dump_json())
+        assert back == r
+
+    def test_nested_causes_round_trip(self) -> None:
+        inner = ErrorReport(error_type="calf.unhandled", message="inner")
+        group = ErrorReport(error_type="calf.fault_group", causes=[inner, inner])
+        back = ErrorReport.model_validate_json(group.model_dump_json())
+        assert len(back.causes) == 2
+        assert back.causes[0].error_type == "calf.unhandled"
+        assert back.causes[0].message == "inner"
+
+
+def _linear_cause_chain(depth: int) -> ErrorReport:
+    """A report whose causes nest linearly to ``depth`` (depth=1 ⇒ no causes)."""
+    node = ErrorReport(error_type=f"calf.level.{depth}")
+    for level in range(depth - 1, 0, -1):
+        node = ErrorReport(error_type=f"calf.level.{level}", causes=[node])
+    return node
+
+
+def _max_cause_depth(report: ErrorReport) -> int:
+    if not report.causes:
+        return 1
+    return 1 + max(_max_cause_depth(c) for c in report.causes)
+
+
+class TestBuildSafe:
+    def test_normal_path_carries_fields(self) -> None:
+        r = ErrorReport.build_safe(error_type="x", message="m", retryable=True, origin_node_id="n1")
+        assert (r.error_type, r.message, r.retryable, r.origin_node_id) == ("x", "m", True, "n1")
+
+    def test_never_raises_on_malformed_input(self) -> None:
+        # A cause that is neither an ErrorReport nor a valid dict would make the
+        # plain constructor raise; build_safe must still return a report so the
+        # error path never itself raises (spec §4.3).
+        r = ErrorReport.build_safe(error_type="x", message="keep", causes=[123])  # type: ignore[list-item]
+        assert isinstance(r, ErrorReport)
+        assert r.error_type == "x"
+        assert r.message == "keep"
+        assert r.causes == []
+
+    def test_clamps_message(self) -> None:
+        assert len(ErrorReport.build_safe(error_type="x", message="a" * 5000).message) == 2000
+
+    def test_elides_causes_past_total_budget(self) -> None:
+        causes = [ErrorReport(error_type=f"calf.c.{i}") for i in range(70)]
+        r = ErrorReport.build_safe(error_type="calf.fault_group", causes=causes)
+        assert len(r.causes) == 64
+        assert r.details[FaultTypes.ELIDED]["causes"] == 6
+
+    def test_elides_causes_past_depth_budget(self) -> None:
+        r = ErrorReport.build_safe(error_type="calf.deep", causes=[_linear_cause_chain(12)])
+        assert _max_cause_depth(r) <= 8
+
+    def test_elides_frame_chain_head_and_tail(self) -> None:
+        chain = [FrameRef(frame_id=f"f{i}", target_topic=f"t{i}") for i in range(70)]
+        r = ErrorReport.build_safe(error_type="x", frame_chain=chain)
+        assert len(r.frame_chain) == 64
+        assert r.frame_chain[0] == chain[0]  # head preserved
+        assert r.frame_chain[-1] == chain[-1]  # tail preserved
+
+    def test_clamps_oversized_details(self) -> None:
+        r = ErrorReport.build_safe(error_type="x", details={"big": "z" * 20000})
+        assert "big" not in r.details
+        assert r.details[FaultTypes.ELIDED]["details_bytes"] > 0
+
+
+class TestWalkAndFind:
+    def test_walk_yields_self_then_nested_causes_preorder(self) -> None:
+        leaf_a = ErrorReport(error_type="a")
+        leaf_b = ErrorReport(error_type="b")
+        mid = ErrorReport(error_type="mid", causes=[leaf_a])
+        root = ErrorReport(error_type="root", causes=[mid, leaf_b])
+        assert [r.error_type for r in root.walk()] == ["root", "mid", "a", "b"]
+
+    def test_find_returns_first_match_including_nested(self) -> None:
+        nested = ErrorReport(error_type="calf.unhandled")
+        group = ErrorReport(error_type="calf.fault_group", causes=[nested])
+        found = group.find("calf.unhandled")
+        assert found is nested
+
+    def test_find_returns_none_when_absent(self) -> None:
+        assert ErrorReport(error_type="x").find("calf.unhandled") is None
+
+    def test_find_matches_self(self) -> None:
+        r = ErrorReport(error_type="calf.fault_group")
+        assert r.find("calf.fault_group") is r
+
+
+class TestToMinimal:
+    def test_keeps_identity_drops_heavy_fields(self) -> None:
+        r = ErrorReport(
+            error_type="x",
+            message="boom",
+            retryable=True,
+            origin_node_id="n1",
+            origin_frame_id="f1",
+            frame_chain=[FrameRef(frame_id="f1", target_topic="t")],
+            details={"k": "v"},
+            causes=[ErrorReport(error_type="child")],
+        )
+        m = r.to_minimal()
+        assert m.report_id == r.report_id
+        assert m.error_type == "x"
+        assert m.message == "boom"
+        assert m.origin_node_id == "n1"
+        assert m.origin_frame_id == "f1"
+        # heavy fields stripped (the strip-and-retry floor target, spec §4.3)
+        assert m.causes == []
+        assert m.details == {}
+        assert m.frame_chain == []
+
+    def test_minimal_round_trips(self) -> None:
+        r = ErrorReport(error_type="x", causes=[ErrorReport(error_type="c")])
+        m = r.to_minimal()
+        assert ErrorReport.model_validate_json(m.model_dump_json()) == m
+
+
+class TestFaultMessage:
+    def test_extends_reply_base_and_is_kind_fault(self) -> None:
+        fm = FaultMessage(in_reply_to="f1", tag="t1", error=ErrorReport(error_type="x"))
+        assert isinstance(fm, _ReplyBase)
+        assert fm.kind == "fault"
+
+    def test_in_reply_to_and_tag_accept_none(self) -> None:
+        fm = FaultMessage(in_reply_to=None, tag=None, error=ErrorReport(error_type="x"))
+        assert fm.in_reply_to is None
+        assert fm.tag is None
+
+    def test_round_trips_through_json_with_nested_report(self) -> None:
+        fm = FaultMessage(
+            in_reply_to="f1",
+            tag="call-7",
+            error=ErrorReport(error_type="calf.fault_group", causes=[ErrorReport(error_type="calf.unhandled")]),
+        )
+        back = FaultMessage.model_validate_json(fm.model_dump_json())
+        assert back == fm
+        assert back.error.causes[0].error_type == "calf.unhandled"
+
+
+class TestNodeFaultError:
+    def test_mint_builds_report_from_fields(self) -> None:
+        nfe = NodeFaultError("billing.quota_exceeded", message="over limit", retryable=True, details={"plan": "free"})
+        assert isinstance(nfe.report, ErrorReport)
+        assert nfe.report.error_type == "billing.quota_exceeded"
+        assert nfe.report.message == "over limit"
+        assert nfe.report.retryable is True
+        assert nfe.report.details == {"plan": "free"}
+
+    def test_mint_rejects_reserved_calf_namespace(self) -> None:
+        # Consumers branching on calf.* must trust the namespace, so a user mint
+        # under it fails at the keyboard (spec §4.3, scenario 26).
+        with pytest.raises(ValueError, match="calf"):
+            NodeFaultError("calf.something", message="nope")
+
+    def test_mint_rejects_unserializable_details_at_construction(self) -> None:
+        with pytest.raises(ValueError):
+            NodeFaultError("billing.x", details={"bad": object()})
+
+    def test_receive_wraps_report_verbatim(self) -> None:
+        report = ErrorReport(error_type="x", message="m")
+        nfe = NodeFaultError(report)
+        assert nfe.report is report
+
+    def test_receive_allows_calf_namespace_report(self) -> None:
+        # Wrapping a framework-minted calf.* report (the client re-raise path) must
+        # NOT trip the mint guard — the guard is only for user string mints.
+        report = ErrorReport(error_type=FaultTypes.UNHANDLED)
+        assert NodeFaultError(report).report.error_type == FaultTypes.UNHANDLED
+
+    def test_reduce_reconstructs_from_report(self) -> None:
+        # __reduce__ must rebuild from the report, not replay self.args (a message
+        # string) through __init__, which would mis-route into the mint arm.
+        nfe = NodeFaultError("billing.quota_exceeded", message="m", details={"k": "v"})
+        factory, args = nfe.__reduce__()
+        rebuilt = factory(*args)
+        assert isinstance(rebuilt, NodeFaultError)
+        assert rebuilt.report == nfe.report
+
+
+class TestFaultTypes:
+    def test_known_error_type_codes(self) -> None:
+        assert FaultTypes.MODEL_CONTEXT_WINDOW_EXCEEDED == "calf.model.context_window_exceeded"
+        assert FaultTypes.FAULT_GROUP == "calf.fault_group"
+        assert FaultTypes.UNHANDLED == "calf.unhandled"
+        assert FaultTypes.DELIVERY_REJECTED == "calf.delivery.rejected"
+        assert FaultTypes.DELIVERY_UNDECODABLE == "calf.delivery.undecodable"
+        assert FaultTypes.SLOT_MATERIALIZATION_FAILED == "calf.slot.materialization_failed"
+        assert FaultTypes.AGENT_SELF_RETRY_EXHAUSTED == "calf.agent.self_retry_exhausted"
+
+    def test_elided_details_key(self) -> None:
+        assert FaultTypes.ELIDED == "calf.elided"
+
+
+class TestProtocol:
+    def test_error_type_header_name(self) -> None:
+        assert HDR_ERROR_TYPE == "x-calf-error-type"
+
+    def test_message_kind_value_space_includes_fault(self) -> None:
+        assert typing.get_args(MessageKind) == ("call", "return", "fault")
+
+
+class TestPublicExports:
+    def test_top_level_exports(self) -> None:
+        import calfkit
+
+        assert calfkit.NodeFaultError is NodeFaultError
+        assert calfkit.ErrorReport is ErrorReport
+        assert calfkit.FaultTypes is FaultTypes
+
+    def test_models_package_exports(self) -> None:
+        from calfkit import models
+
+        assert models.FaultMessage is FaultMessage
+        assert models.FrameRef is FrameRef
+        assert models.ErrorReport is ErrorReport
+        assert models.FaultTypes is FaultTypes

--- a/tests/test_fault_wire_model.py
+++ b/tests/test_fault_wire_model.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import typing
 
 import pytest
+from pydantic import ValidationError
 
 from calfkit._protocol import HDR_ERROR_TYPE, MessageKind
 from calfkit.exceptions import NodeFaultError
@@ -134,6 +135,63 @@ class TestBuildSafe:
         assert "big" not in r.details
         assert r.details[FaultTypes.ELIDED]["details_bytes"] > 0
 
+    def test_fallback_arm_records_breadcrumb_never_silent(self) -> None:
+        # A malformed input lands in the except-fallback; the wholesale drop of
+        # causes/frame_chain/details must NOT be silent — the whole feature exists
+        # to kill silent drops (review round 1, convergent MAJOR).
+        r = ErrorReport.build_safe(error_type="x", message="keep", causes=[123])  # type: ignore[list-item]
+        assert r.error_type == "x"
+        assert r.message == "keep"
+        assert r.causes == []
+        assert FaultTypes.ELIDED in r.details  # the drop is recorded
+
+    def test_unserializable_details_records_distinct_breadcrumb(self) -> None:
+        # Reachable when something other than NodeFaultError (which pre-checks at
+        # mint) calls build_safe directly — e.g. the rail. No magic -1 byte count.
+        r = ErrorReport.build_safe(error_type="x", details={"bad": object()})
+        assert isinstance(r, ErrorReport)
+        elided = r.details[FaultTypes.ELIDED]
+        assert elided.get("details_unserializable") is True
+        assert "details_bytes" not in elided
+
+    def test_report_id_preserved_through_cause_bounding(self) -> None:
+        child = ErrorReport(error_type="c")
+        r = ErrorReport.build_safe(error_type="root", causes=[child])
+        assert r.causes[0].report_id == child.report_id  # dedup key survives model_copy
+
+    def test_causes_boundary_64_kept_65_elides_one(self) -> None:
+        kept = [ErrorReport(error_type=f"c{i}") for i in range(64)]
+        r64 = ErrorReport.build_safe(error_type="g", causes=kept)
+        assert len(r64.causes) == 64 and FaultTypes.ELIDED not in r64.details
+        r65 = ErrorReport.build_safe(error_type="g", causes=[*kept, ErrorReport(error_type="extra")])
+        assert len(r65.causes) == 64 and r65.details[FaultTypes.ELIDED]["causes"] == 1
+
+    def test_frame_chain_boundary_64_kept_65_elides_one(self) -> None:
+        c = [FrameRef(frame_id=f"f{i}", target_topic="t") for i in range(64)]
+        r64 = ErrorReport.build_safe(error_type="x", frame_chain=c)
+        assert len(r64.frame_chain) == 64 and FaultTypes.ELIDED not in r64.details
+        r65 = ErrorReport.build_safe(error_type="x", frame_chain=[*c, FrameRef(frame_id="f64", target_topic="t")])
+        assert len(r65.frame_chain) == 64 and r65.details[FaultTypes.ELIDED]["frames"] == 1
+
+    def test_cause_depth_boundary_7_clean_8_elides(self) -> None:
+        r7 = ErrorReport.build_safe(error_type="root", causes=[_linear_cause_chain(7)])
+        assert FaultTypes.ELIDED not in r7.details  # chain sits at depths 2..8, all kept
+        r8 = ErrorReport.build_safe(error_type="root", causes=[_linear_cause_chain(8)])
+        assert r8.details[FaultTypes.ELIDED]["causes"] == 1  # the depth-9 node drops
+        assert _max_cause_depth(r8) <= 8
+
+
+class TestImmutability:
+    def test_error_report_is_frozen(self) -> None:
+        r = ErrorReport(error_type="x")
+        with pytest.raises(ValidationError):
+            r.error_type = "y"  # report_id is "the dedup key, stable across hops" — enforce it
+
+    def test_frame_ref_is_frozen(self) -> None:
+        ref = FrameRef(frame_id="f1", target_topic="t")
+        with pytest.raises(ValidationError):
+            ref.frame_id = "f2"
+
 
 class TestWalkAndFind:
     def test_walk_yields_self_then_nested_causes_preorder(self) -> None:
@@ -237,6 +295,17 @@ class TestNodeFaultError:
         # NOT trip the mint guard — the guard is only for user string mints.
         report = ErrorReport(error_type=FaultTypes.UNHANDLED)
         assert NodeFaultError(report).report.error_type == FaultTypes.UNHANDLED
+
+    def test_receive_rejects_mint_only_kwargs(self) -> None:
+        # message/retryable/details are mint-only; passing them with a report is a
+        # misuse that must fail loudly, not silently ignore them.
+        report = ErrorReport(error_type="x")
+        with pytest.raises(ValueError, match="mint-only"):
+            NodeFaultError(report, message="ignored")
+
+    def test_str_uses_message_then_error_type(self) -> None:
+        assert str(NodeFaultError("billing.x")) == "billing.x"
+        assert str(NodeFaultError("billing.x", message="over limit")) == "over limit"
 
     def test_reduce_reconstructs_from_report(self) -> None:
         # __reduce__ must rebuild from the report, not replay self.args (a message

--- a/tests/test_fault_wire_model.py
+++ b/tests/test_fault_wire_model.py
@@ -208,6 +208,36 @@ class TestBuildSafe:
 
         r = ErrorReport.build_safe(error_type="x", message=_EvilStr("hi"))
         assert isinstance(r, ErrorReport)
+        assert r.message == ""  # the hostile subclass is coerced out
+        assert r.details[FaultTypes.ELIDED]["fallback"] == "RuntimeError"
+
+    def test_details_kept_under_reserve_with_breadcrumb_stays_in_budget(self) -> None:
+        # round 3: the path the 512-byte reserve protects — user details kept just
+        # under threshold AND a breadcrumb appended — must stay within 16 KB.
+        chain = [FrameRef(frame_id=f"f{i}", target_topic="t") for i in range(70)]
+        r = ErrorReport.build_safe(error_type="x", details={"k": "v" * 15000}, frame_chain=chain)
+        assert "k" in r.details  # kept
+        assert FaultTypes.ELIDED in r.details  # breadcrumb present
+        assert len(pydantic_core.to_json(r.details)) <= 16 * 1024
+
+    def test_fallback_breadcrumb_class_name_is_bounded(self) -> None:
+        # round 3: a pathological (huge) exception class name must not blow the details
+        # budget. (A metaclass whose __name__ *raises* is unreachable by any real
+        # exception and is an accepted non-defense.)
+        huge = type("E" + "x" * 20000, (Exception,), {})
+
+        class _H(str):
+            def __len__(self) -> int:
+                raise huge("boom")
+
+        r = ErrorReport.build_safe(error_type="x", message=_H("hi"))
+        assert len(pydantic_core.to_json(r.details)) <= 16 * 1024
+
+    def test_oversized_reserved_key_does_not_evict_legit_details(self) -> None:
+        # round 3: a caller calf.* key is stripped; its size must not evict legit keys.
+        r = ErrorReport.build_safe(error_type="x", details={"calf.elided": "z" * 20000, "ok": 1})
+        assert "calf.elided" not in r.details
+        assert r.details.get("ok") == 1
 
 
 class TestImmutability:

--- a/tests/test_fault_wire_model.py
+++ b/tests/test_fault_wire_model.py
@@ -239,6 +239,29 @@ class TestBuildSafe:
         assert "calf.elided" not in r.details
         assert r.details.get("ok") == 1
 
+    def test_total_on_deep_cause_chain_keeps_precise_breadcrumb(self) -> None:
+        # A causes tree deeper than Python's recursion limit must NOT RecursionError into
+        # the fallback arm (which would silently downgrade the precise causes=N breadcrumb
+        # to a bare "fallback"): the dropped-subtree tally is iterative. The nested-fault-
+        # group path (§4.4) is exactly where deep causes trees arise.
+        deep = _linear_cause_chain(2000)  # well past sys.getrecursionlimit()
+        r = ErrorReport.build_safe(error_type="root", causes=[deep])
+        assert r.error_type == "root"  # total — no RecursionError
+        elided = r.details[FaultTypes.ELIDED]
+        assert "fallback" not in elided  # the precise tally, not the last-resort arm
+        assert elided["causes"] == 1993  # 2000 chain nodes − 7 kept at depths 2..8
+
+    def test_total_on_cyclic_causes(self) -> None:
+        # A self-referential causes cycle — possible only via in-process mutation of the
+        # shallow-frozen list, never off the wire (JSON is acyclic) — must terminate, not
+        # RecursionError. The id()-visited guard keeps each report once.
+        a = ErrorReport(error_type="a")
+        a.causes.append(a)  # cycle: a -> a
+        r = ErrorReport.build_safe(error_type="root", causes=[a])
+        assert r.error_type == "root"  # total, terminates
+        assert "fallback" not in r.details.get(FaultTypes.ELIDED, {})  # handled cleanly
+        assert r.causes[0].error_type == "a" and r.causes[0].causes == []  # cycle cut
+
 
 class TestImmutability:
     def test_error_report_is_frozen(self) -> None:
@@ -272,6 +295,21 @@ class TestWalkAndFind:
     def test_find_matches_self(self) -> None:
         r = ErrorReport(error_type="calf.fault_group")
         assert r.find("calf.fault_group") is r
+
+    def test_walk_terminates_on_cyclic_report(self) -> None:
+        # walk() is cycle-guarded: an in-process cycle (the shallow freeze leaves causes
+        # mutable) yields each report once and terminates, not recursing without bound.
+        a = ErrorReport(error_type="a")
+        b = ErrorReport(error_type="b", causes=[a])
+        a.causes.append(b)  # cycle: a -> b -> a
+        assert [r.error_type for r in a.walk()] == ["a", "b"]
+
+    def test_find_terminates_on_cyclic_report(self) -> None:
+        a = ErrorReport(error_type="a")
+        b = ErrorReport(error_type="b", causes=[a])
+        a.causes.append(b)  # cycle
+        assert a.find("b") is b
+        assert a.find("absent") is None  # terminates rather than RecursionError
 
 
 class TestToMinimal:

--- a/tests/test_fault_wire_model.py
+++ b/tests/test_fault_wire_model.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import typing
 
+import pydantic_core
 import pytest
 from pydantic import ValidationError
 
@@ -180,6 +181,34 @@ class TestBuildSafe:
         assert r8.details[FaultTypes.ELIDED]["causes"] == 1  # the depth-9 node drops
         assert _max_cause_depth(r8) <= 8
 
+    def test_breadcrumb_never_pushes_details_over_field_budget(self) -> None:
+        # round 2: the ELIDED breadcrumb is appended after the details clamp; on the
+        # buggy code a near-16-KB details + a forced elision pushed the field over its
+        # budget. The details field must stay within 16 KB regardless.
+        big = {"k": "v" * 16370}  # serializes just under 16 KB on its own
+        chain = [FrameRef(frame_id=f"f{i}", target_topic="t") for i in range(70)]
+        r = ErrorReport.build_safe(error_type="x", details=big, frame_chain=chain)
+        assert FaultTypes.ELIDED in r.details  # the elision is recorded
+        assert len(pydantic_core.to_json(r.details)) <= 16 * 1024
+
+    def test_caller_calf_namespace_details_key_is_stripped(self) -> None:
+        # round 2: calf.* is framework-reserved for details keys too — a caller value
+        # under it must not survive (even with no framework elision) and mislead a
+        # consumer; non-reserved keys are kept.
+        r = ErrorReport.build_safe(error_type="x", details={"calf.elided": {"user": "data"}, "ok": 1})
+        assert "calf.elided" not in r.details
+        assert r.details["ok"] == 1
+
+    def test_total_against_hostile_str_subclass(self) -> None:
+        # round 2: a str subclass whose __len__ raises breaks the clamp on the primary
+        # path AND, before the fix, the re-passed value re-broke it in the fallback.
+        class _EvilStr(str):
+            def __len__(self) -> int:
+                raise RuntimeError("len boom")
+
+        r = ErrorReport.build_safe(error_type="x", message=_EvilStr("hi"))
+        assert isinstance(r, ErrorReport)
+
 
 class TestImmutability:
     def test_error_report_is_frozen(self) -> None:
@@ -306,6 +335,24 @@ class TestNodeFaultError:
     def test_str_uses_message_then_error_type(self) -> None:
         assert str(NodeFaultError("billing.x")) == "billing.x"
         assert str(NodeFaultError("billing.x", message="over limit")) == "over limit"
+
+    def test_mint_rejects_calf_namespace_details_keys(self) -> None:
+        # round 2: the calf.* reservation extends to details keys so consumers can
+        # trust the namespace there too.
+        with pytest.raises(ValueError, match="calf"):
+            NodeFaultError("billing.x", details={"calf.foo": 1})
+
+    def test_mint_rejects_empty_or_blank_error_type(self) -> None:
+        # round 2: error_type is the contract; an empty/blank code is meaningless and
+        # would make str(e) empty and find("") match.
+        with pytest.raises(ValueError):
+            NodeFaultError("")
+        with pytest.raises(ValueError):
+            NodeFaultError("   ")
+
+    def test_str_is_never_empty_even_for_blank_received_report(self) -> None:
+        nfe = NodeFaultError(ErrorReport(error_type=""))
+        assert str(nfe) != ""
 
     def test_reduce_reconstructs_from_report(self) -> None:
         # __reduce__ must rebuild from the report, not replay self.args (a message

--- a/tests/test_reply_slot.py
+++ b/tests/test_reply_slot.py
@@ -137,7 +137,8 @@ class TestProtocolKind:
         assert HDR_KIND == "x-calf-kind"
 
     def test_message_kind_value_space(self) -> None:
-        assert typing.get_args(MessageKind) == ("call", "return")
+        # Widened with "fault" by the fault-wire-model PR (only the rail stamps it).
+        assert typing.get_args(MessageKind) == ("call", "return", "fault")
 
     def test_dead_event_type_constants_removed(self) -> None:
         # Drift cleanup: HDR_EVENT_TYPE / EventType had zero call sites.


### PR DESCRIPTION
## PR-5 — Fault wire model (additive)

Ships the **fault half** of the §4 wire vocabulary the fault rail (PR-6) will speak — and **nothing that produces, routes, classifies, or catches a fault**. Pure additions; no existing behavior changes.

Spec: `docs/designs/fault-rail-and-policy-seams-spec.md` §4.1–§4.4, §6.5, §11. Plan: `notes/pr5-fault-wire-model-implementation-plan.md`. Part of the in-node-fanout / fault-rail train (parent: `notes/in-node-fanout-aggregation-pr-implementation-plan.md`); has no dependency on the durable-fold PRs and can land any time before PR-6.

### What's added

- **`calfkit/models/error_report.py`** (new): `ErrorReport` (the typed fault value), `FrameRef` (topology-only breadcrumb), `ErrorReport.build_safe` (total-construction synthesizer), `walk()`/`find()` (group-aware traversal), `to_minimal()` (the strip target), and the `FaultTypes` constants.
- **`FaultMessage`** in `calfkit/models/reply.py` — a sibling of `ReturnMessage` under the existing `_ReplyBase` (`error: ErrorReport`, `kind="fault"`).
- **`NodeFaultError`** in `calfkit/exceptions.py` — one class, symmetric for minting and receiving (spec §11).
- **`HDR_ERROR_TYPE = "x-calf-error-type"`** and `MessageKind` widened with `"fault"` in `calfkit/_protocol.py`.
- Public exports (`calfkit.NodeFaultError/ErrorReport/FaultTypes`, `calfkit.models.FaultMessage/FrameRef/...`).

### Verification

- TDD throughout (RED→GREEN per layer); new `tests/test_fault_wire_model.py` (36 tests), all unit-level — no broker, no API calls.
- `make check` clean (ruff + format + `mypy --strict`, 56 source files). Full suite green.

---

## Decisions (open questions resolved, with justification)

**1. Defer the `Envelope.reply` union-widening to PR-6 (the rail), rather than widen it here.**
The plan's PR-5 sketch listed widening `Envelope.reply → ReturnMessage | FaultMessage | None` now. Investigation showed that is **not behavior-neutral**: under `mypy --strict` it cascades to `SessionRunContext._reply`, `project_output`, and four `.parts` read sites — and at each `.parts` site you must *decide what a `FaultMessage` projects to*. That decision **is** the rail's behavior (client → `raise NodeFaultError`; consumer → `ctx.fault`; `project_output` never sees a fault because the dispatcher peels it off first). Widening here would mean shipping placeholder `isinstance(reply, ReturnMessage)` narrowings that are unreachable at runtime (nothing produces faults yet) and that PR-6 immediately rewrites — i.e. an "intermediate working implementation" the train's no-intermediates policy explicitly rejects, plus a latent *silent* fault-swallow (a fault projected as empty output) sitting dormant for one PR. **`FaultMessage` is fully defined and round-trip-tested standalone**; the slot-widening lands with the projection/dispatch behavior that gives a fault meaning. This keeps PR-5 genuinely additive and zero-behavior. *(Best practice: keep a type change co-located with the behavior change it forces; don't ship dead/placeholder branches.)*

**2. Keep `MessageKind`; don't rename to the spec's `KindValue`.**
`MessageKind` is the established code name, used as a real type at four publish-chokepoint sites (`base.py`). The spec calls it `KindValue`, but renaming is cosmetic churn through code PR-6 already reshapes, and the source is the contract over spec wording. Widening the `Literal` with `"fault"` is mypy-safe (the four sites only ever assign/return `"call"`/`"return"`). Only the value `"fault"` is added to the space here — nothing stamps it until the rail.

**3. `FaultTypes` co-located in `error_report.py`, declaring only constants that have a user.**
One public module for the fault vocabulary (`from calfkit import FaultTypes`). Declared: the seven `calf.*` `error_type` codes (public vocabulary; harmless and useful to consumers/tests now) plus `ELIDED` (written by `build_safe`). Deferred to PR-6: detail-key constants produced only by the rail's synthesis (the exception-class key, `details.reason` values) — so no constant ships without a user. *(Best practice: don't introduce API surface ahead of its producer.)*

**4. Carriage bounds enforced in `build_safe`, with a non-silent elision breadcrumb.**
`build_safe` applies the per-field bounds at synthesis — `causes` (depth ≤ 8, ≤ 64 total), `frame_chain` (≤ 64, head+tail elision), `details` (≤ 16 KB serialized) — and records whatever it elided under `details[FaultTypes.ELIDED]` (a small dict, e.g. `{"causes": 6, "details_bytes": 20012}`). This is a faithful elaboration of the spec's illustrative `details["calf.elided"] = n`: a dict generalizes the int and lets the **details-size clamp also be non-silent**. Dropping data silently would re-open the exact silent-drop class this whole feature exists to close, so the clamp leaves a breadcrumb. The **256 KB total cap and the strip-then-retry-then-floor loop are publish-time** behavior and land with the fault-publish path in PR-6; PR-5 ships the mechanism they call (`to_minimal()` + the per-field bounds) and unit-tests it.

**5. `NodeFaultError` — dual constructor + custom `__reduce__`.**
The constructor accepts a `str` (mint) or an `ErrorReport` (receive/wrap). The `calf.` reserved-namespace `ValueError` guard applies **only to the mint arm** — wrapping a framework-minted `calf.*` report (the client re-raise path) must not raise. On mint, `details` are eagerly `to_json`-checked so an unserializable value fails at the keyboard, not on the error path (the `tool.py` precedent). A custom `__reduce__` reconstructs from `self.report` (not by replaying `self.args` through `__init__`, which would mis-route the message string into the mint arm) — mirroring the existing `ReplyExpiredError`/`ToolExecutionError` reductions.

### Out of scope (PR-6, the rail)

Fault production/classification (`_classify`, `_publish_fault`, stamping `x-calf-error-type`), the four policy seams, escalation, `ctx.fault`, the dispatcher fault-arm, the `Envelope.reply` union-widening + projection, the 256 KB publish-time cap + strip-retry loop, and the removals (`FailedToolCall`/`ToolExecutionError`/gates/`Silent`). PR-5 only adds vocabulary.
