### PR TITLE
feat: durable in-node fan-out, return-only — staged pipeline + ktables store

### DIFF
--- a/calfkit/models/__init__.py
+++ b/calfkit/models/__init__.py
@@ -26,7 +26,6 @@ from calfkit.models.state import (
     InFlightToolsState,
     NodeConsumeState,
     PartialState,
-    PendingToolBatch,
     State,
 )
 from calfkit.models.tool_context import ToolContext
@@ -65,7 +64,6 @@ __all__ = [
     "NodeConsumeState",
     "PartialState",
     "State",
-    "PendingToolBatch",
     # tool_context
     "ToolContext",
     # tool_dispatch

--- a/calfkit/models/actions.py
+++ b/calfkit/models/actions.py
@@ -31,15 +31,19 @@ class Call(Generic[StateT], _Call[StateT]):
 
     Optionally carries header-route-dispatch metadata: ``route`` (a concrete route
     key, stamped as the ``x-calf-route`` header on the publish) and ``body`` (an
-    optional payload validated against the target handler's ``schema``). These live
-    on ``Call`` only — ``TailCall``/``ReturnCall`` never carry a route. ``init=False``
-    keeps the custom keyword-only ``route``/``body`` constructor while letting them
-    participate in ``__eq__``/``__repr__``."""
+    optional payload validated against the target handler's ``schema``). ``tag`` is the
+    caller's opaque correlation token (the agent sets it to ``tool_call_id``); the
+    framework carries it on the call frame and echoes it on the reply slot, so a fan-out
+    sibling's reply is self-describing (``reply.in_reply_to`` = slot id, ``reply.tag`` =
+    tool_call_id). These live on ``Call`` only — ``TailCall``/``ReturnCall`` never carry a
+    route. ``init=False`` keeps the custom keyword-only ``route``/``body``/``tag``
+    constructor while letting them participate in ``__eq__``/``__repr__``."""
 
     route: str | None = None
     body: Any | None = None
+    tag: str | None = None
 
-    def __init__(self, target_topic: str, state: StateT, *, route: str | None = None, body: Any | None = None) -> None:
+    def __init__(self, target_topic: str, state: StateT, *, route: str | None = None, body: Any | None = None, tag: str | None = None) -> None:
         if route is not None and not is_concrete_route_key(route):
             raise ValueError(
                 f"Call route {route!r} must be a concrete key — non-empty, '.'-delimited words, no empty "
@@ -51,6 +55,7 @@ class Call(Generic[StateT], _Call[StateT]):
         super().__init__(target_topic, state)
         self.route = route
         self.body = body
+        self.tag = tag
 
 
 class TailCall(Generic[StateT], _Call[StateT]):

--- a/calfkit/models/fanout.py
+++ b/calfkit/models/fanout.py
@@ -9,9 +9,9 @@ Fan-out batch state lives in two node-scoped compacted ktables, both keyed by
   write-once closure snapshot, read back at the re-entry to rebuild context.
 
 All values are plain pydantic models so ``KafkaTable.json(model=...)`` /
-``KafkaTableWriter.json(model=...)`` decode/encode them as JSON, and each carries a
-``version`` for forward-compatible schema evolution (drain-before-deploy is the
-cross-version contract; ktables' decoder swallows undecodable records).
+``KafkaTableWriter.json(model=...)`` decode/encode them as JSON. The cross-version
+contract is drain-before-deploy (the batch state never spans a schema change), and
+ktables' decoder swallows any record it cannot decode.
 """
 
 from typing import Any
@@ -38,13 +38,15 @@ class FanoutOpen(BaseModel):
     because it is embedded in :class:`FanoutState` and re-written on every fold.
     """
 
-    version: int = 1
     fanout_id: str
     """= the fan-out node's own inbound ``frame_id``; the batch key."""
     node_id: str
-    expected: list[SlotRef]
+    """Diagnostic/self-describing record field, not read at runtime: the batch is
+    namespaced by topic (``calf.fanout.{node_id}.*``) and keyed by ``fanout_id``."""
+    expected: list[SlotRef] = Field(..., min_length=2)
     """The full slot set, fixed at OPEN. Only a true fan-out (N >= 2) registers; a
-    single ``Call`` / batch-of-one is never registered (it is a stateless continuation)."""
+    single ``Call`` / batch-of-one is never registered (it is a stateless continuation).
+    ``min_length=2`` makes an empty/singleton batch unrepresentable at the type."""
 
 
 class FanoutOutcome(BaseModel):
@@ -57,7 +59,6 @@ class FanoutOutcome(BaseModel):
     of resolved returns.
     """
 
-    version: int = 1
     slot: str
     """The resolved slot's frame id (== :attr:`SlotRef.frame_id`); the idempotent fold key."""
     tag: str | None
@@ -72,7 +73,6 @@ class FanoutState(BaseModel):
     writes); completion is ``outcomes.keys() == {s.frame_id for s in open.expected}``.
     """
 
-    version: int = 1
     open: FanoutOpen
     outcomes: dict[str, FanoutOutcome] = Field(default_factory=dict)
     """Resolved slots by frame id. Folding a slot already present is an idempotent no-op
@@ -88,7 +88,6 @@ class EnvelopeSnapshot(BaseModel):
     re-stamped from the node's bag, so they are deliberately NOT snapshotted.
     """
 
-    version: int = 1
     state: State
     """Conversation State as of fan-out (pre tool-results)."""
     stack: WorkflowState
@@ -99,6 +98,5 @@ class EnvelopeSnapshot(BaseModel):
 class FanoutBaseState(BaseModel):
     """``calf.fanout.{node_id}.basestate`` value — written ONCE at OPEN, read at close."""
 
-    version: int = 1
     fanout_id: str
     snapshot: EnvelopeSnapshot

--- a/calfkit/models/fanout.py
+++ b/calfkit/models/fanout.py
@@ -1,0 +1,104 @@
+"""Durable fan-out batch records (PR-4).
+
+Fan-out batch state lives in two node-scoped compacted ktables, both keyed by
+``fanout_id`` (the fan-out node's own inbound ``frame_id``):
+
+- ``calf.fanout.{node_id}.state`` holds a :class:`FanoutState` — the registration
+  plus accumulating per-slot outcomes, re-written once per fold (LWW).
+- ``calf.fanout.{node_id}.basestate`` holds a :class:`FanoutBaseState` — the
+  write-once closure snapshot, read back at the re-entry to rebuild context.
+
+All values are plain pydantic models so ``KafkaTable.json(model=...)`` /
+``KafkaTableWriter.json(model=...)`` decode/encode them as JSON, and each carries a
+``version`` for forward-compatible schema evolution (drain-before-deploy is the
+cross-version contract; ktables' decoder swallows undecodable records).
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from calfkit.models.session_context import WorkflowState
+from calfkit.models.state import CalfToolResult, State
+
+
+class SlotRef(BaseModel):
+    """One expected sibling slot, fixed at OPEN."""
+
+    frame_id: str
+    """The callee frame id the framework minted for this sibling Call."""
+    tag: str | None
+    """The caller's correlation token echoed on the reply (the agent's tool_call_id)."""
+
+
+class FanoutOpen(BaseModel):
+    """Small registration metadata written once at fan-out OPEN.
+
+    The full snapshot lives in :class:`FanoutBaseState`, not here — this stays small
+    because it is embedded in :class:`FanoutState` and re-written on every fold.
+    """
+
+    version: int = 1
+    fanout_id: str
+    """= the fan-out node's own inbound ``frame_id``; the batch key."""
+    node_id: str
+    expected: list[SlotRef]
+    """The full slot set, fixed at OPEN. Only a true fan-out (N >= 2) registers; a
+    single ``Call`` / batch-of-one is never registered (it is a stateless continuation)."""
+
+
+class FanoutOutcome(BaseModel):
+    """One resolved slot — a sub-value of :attr:`FanoutState.outcomes`.
+
+    ``result`` mirrors ``State.tool_results``' value type so a ``CalfToolResult``
+    (including a ``FailedToolCall`` marker) round-trips through JSON as a TYPED
+    instance via the same discriminator, not as a bare ``dict``. Return-only for now;
+    the fault rail widens this field (a ``fault`` arm) without touching the carriage
+    of resolved returns.
+    """
+
+    version: int = 1
+    slot: str
+    """The resolved slot's frame id (== :attr:`SlotRef.frame_id`); the idempotent fold key."""
+    tag: str | None
+    result: CalfToolResult | Any
+    """The captured ``state.tool_results[tag]`` entry for this sibling."""
+
+
+class FanoutState(BaseModel):
+    """``calf.fanout.{node_id}.state`` value — re-written once per fold (LWW).
+
+    Mutable across folds, so reads require a ktables ``barrier()`` first (read-your-own-
+    writes); completion is ``outcomes.keys() == {s.frame_id for s in open.expected}``.
+    """
+
+    version: int = 1
+    open: FanoutOpen
+    outcomes: dict[str, FanoutOutcome] = Field(default_factory=dict)
+    """Resolved slots by frame id. Folding a slot already present is an idempotent no-op
+    (LWW on the same slot key absorbs a producer-retry duplicate)."""
+
+
+class EnvelopeSnapshot(BaseModel):
+    """The closure's correctness contract, captured pre-marker-stamp at OPEN.
+
+    ``deps`` is wire data (it crosses the Kafka boundary on every hop), captured here
+    because the re-entry envelope clears ``context.state`` and ``context.deps`` — this
+    snapshot is the sole restore source at close. ``resources`` are node-local and
+    re-stamped from the node's bag, so they are deliberately NOT snapshotted.
+    """
+
+    version: int = 1
+    state: State
+    """Conversation State as of fan-out (pre tool-results)."""
+    stack: WorkflowState
+    """The call stack with the node's own fan-out frame on top, no sibling frames pushed."""
+    deps: dict[str, Any] = Field(default_factory=dict)
+
+
+class FanoutBaseState(BaseModel):
+    """``calf.fanout.{node_id}.basestate`` value — written ONCE at OPEN, read at close."""
+
+    version: int = 1
+    fanout_id: str
+    snapshot: EnvelopeSnapshot

--- a/calfkit/models/session_context.py
+++ b/calfkit/models/session_context.py
@@ -54,6 +54,14 @@ class CallFrame:
     (``ReturnMessage.tag``) when this frame unwinds. The agent sets it to
     ``tool_call_id``. Transport metadata, never content. DORMANT until PR-B wires a
     producer (``Call.tag`` + the agent); ``None`` on every frame in PR-A."""
+    fanout_id: str | None = field(default=None)
+    """Fan-out batch marker: the fan-out node's OWN inbound ``frame_id``, stamped on
+    each sibling ``Call``'s frame copy at fan-out dispatch (and ONLY there). It routes a
+    marked sibling reply into the durable fold rather than the stateless-continuation
+    path, and its equality with the current frame id identifies the batch's closure
+    re-entry. ``None`` on every non-sibling frame (single calls, escalation hops); the
+    closure re-entry is built from the pre-stamp snapshot, so the continuation is
+    unmarked by construction."""
 
 
 CallFrameStack = Stack[CallFrame]
@@ -88,13 +96,14 @@ class WorkflowState(BaseModel):
     def unwind_frame(self) -> CallFrame:
         return self.call_stack.pop()
 
-    def invoke_frame(self, call: _Call, callback_topic: str | None, payload: Any = None) -> None:
+    def invoke_frame(self, call: _Call, callback_topic: str | None, payload: Any = None, *, fanout_id: str | None = None) -> None:
         if call.target_topic is None:
             raise Exception("")
         frame = CallFrame(
             target_topic=call.target_topic,
             callback_topic=callback_topic,
             payload=payload,
+            fanout_id=fanout_id,
         )
         return self.call_stack.push(frame)
 

--- a/calfkit/models/session_context.py
+++ b/calfkit/models/session_context.py
@@ -51,9 +51,10 @@ class CallFrame:
     node validating a ``ToolCallRef``). ``None`` when the producer sent no body."""
     tag: str | None = field(default=None)
     """Caller-set opaque correlation token, echoed verbatim on the reply
-    (``ReturnMessage.tag``) when this frame unwinds. The agent sets it to
-    ``tool_call_id``. Transport metadata, never content. DORMANT until PR-B wires a
-    producer (``Call.tag`` + the agent); ``None`` on every frame in PR-A."""
+    (``ReturnMessage.tag``) when this frame unwinds. The agent sets it to ``tool_call_id`` on
+    fan-out tool ``Call``s so a sibling reply is self-describing — the durable fold reads that
+    sibling's result from ``state.tool_results[reply.tag]``. Transport metadata, never content.
+    ``None`` on frames whose producer set no ``Call.tag`` (single/sequential calls, escalation hops)."""
     fanout_id: str | None = field(default=None)
     """Fan-out batch marker (= the fan-out node's OWN inbound ``frame_id``, which is
     also the batch key for the durable tables). At fan-out dispatch it is stamped on the

--- a/calfkit/models/session_context.py
+++ b/calfkit/models/session_context.py
@@ -189,15 +189,15 @@ class BaseSessionRunContext(BaseModel, Generic[StateT, DepsT]):
     def frame_id(self) -> str | None:
         """Per-invocation identifier of the current call frame on the workflow stack.
 
-        Set by ``BaseNodeDef.prepare_context`` from
-        ``envelope.internal_workflow_state.current_frame.frame_id``. Every
-        ``Call`` published by the framework pushes a fresh ``CallFrame`` with a
-        UUID7-generated ``frame_id``, so parallel invocations of the same node
-        (which share a single ``correlation_id``) are still uniquely
-        identifiable per invocation. Used by the agent to key its in-memory
-        parallel tool-batch aggregation dict so concurrent fan-outs do not
-        collide. Backed by a ``PrivateAttr`` so it never rides on the wire and
-        cannot be spoofed via the model constructor.
+        Set by ``BaseNodeDef.prepare_context`` from the inbound frame
+        (``envelope.internal_workflow_state.current_frame.frame_id``), so it is the id
+        of the frame this delivery is running under. Every ``Call`` published by the
+        framework pushes a fresh ``CallFrame`` with a UUID7-generated ``frame_id``, so
+        parallel invocations of the same node (which share a single ``correlation_id``)
+        are still uniquely identifiable per invocation. No longer tied to any in-process
+        aggregation (durable fan-out is keyed by ``fanout_id`` in the store, not by this
+        field). Backed by a ``PrivateAttr`` so it never rides on the wire and cannot be
+        spoofed via the model constructor.
         """
         return self._frame_id
 

--- a/calfkit/models/session_context.py
+++ b/calfkit/models/session_context.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from types import MappingProxyType
 from typing import Any, Generic
 
@@ -111,6 +111,15 @@ class WorkflowState(BaseModel):
         else:
             frame = CallFrame(target_topic=call.target_topic, callback_topic=callback_topic, payload=payload, frame_id=frame_id)
         return self.call_stack.push(frame)
+
+    def mark_fanout(self) -> None:
+        """Stamp the current (top) frame as the fan-out origin: set ``fanout_id`` to the
+        frame's OWN ``frame_id`` (the batch key). ``CallFrame`` is frozen, so this replaces
+        the top frame with a marked copy. The marker rides the node's own frame — *not* the
+        pushed callee frames — so it survives the callee's return-pop and is the top frame
+        when a sibling reply re-enters this node, routing it into the durable fold."""
+        frame = self.call_stack.pop()
+        self.call_stack.push(replace(frame, fanout_id=frame.frame_id))
 
 
 class BaseSessionRunContext(BaseModel, Generic[StateT, DepsT]):

--- a/calfkit/models/session_context.py
+++ b/calfkit/models/session_context.py
@@ -55,13 +55,15 @@ class CallFrame:
     ``tool_call_id``. Transport metadata, never content. DORMANT until PR-B wires a
     producer (``Call.tag`` + the agent); ``None`` on every frame in PR-A."""
     fanout_id: str | None = field(default=None)
-    """Fan-out batch marker: the fan-out node's OWN inbound ``frame_id``, stamped on
-    each sibling ``Call``'s frame copy at fan-out dispatch (and ONLY there). It routes a
-    marked sibling reply into the durable fold rather than the stateless-continuation
-    path, and its equality with the current frame id identifies the batch's closure
-    re-entry. ``None`` on every non-sibling frame (single calls, escalation hops); the
-    closure re-entry is built from the pre-stamp snapshot, so the continuation is
-    unmarked by construction."""
+    """Fan-out batch marker (= the fan-out node's OWN inbound ``frame_id``, which is
+    also the batch key for the durable tables). At fan-out dispatch it is stamped on the
+    node's **own** frame within each sibling's stack copy — *not* on the pushed callee
+    frame — so it survives the callee's return-pop and is the top frame when the sibling
+    reply re-enters this node, routing that reply into the durable fold rather than the
+    stateless-continuation path. A marked frame therefore has ``fanout_id == frame_id``.
+    ``None`` on every non-sibling frame (single calls, escalation hops); the closure
+    re-entry is built from the pre-stamp snapshot, so the continuation is unmarked by
+    construction."""
 
 
 CallFrameStack = Stack[CallFrame]
@@ -96,15 +98,18 @@ class WorkflowState(BaseModel):
     def unwind_frame(self) -> CallFrame:
         return self.call_stack.pop()
 
-    def invoke_frame(self, call: _Call, callback_topic: str | None, payload: Any = None, *, fanout_id: str | None = None) -> None:
+    def invoke_frame(self, call: _Call, callback_topic: str | None, payload: Any = None, *, frame_id: str | None = None) -> None:
         if call.target_topic is None:
             raise Exception("")
-        frame = CallFrame(
-            target_topic=call.target_topic,
-            callback_topic=callback_topic,
-            payload=payload,
-            fanout_id=fanout_id,
-        )
+        # ``frame_id`` lets the fan-out OPEN pre-mint each callee slot id, so the
+        # published callee frame *is* that id and a reply's ``in_reply_to`` matches
+        # the registered slot directly; ``None`` keeps the default fresh-uuid7 mint.
+        # ``invoke_frame`` never sets the ``fanout_id`` marker — that rides the node's
+        # OWN frame, not the pushed callee frame.
+        if frame_id is None:
+            frame = CallFrame(target_topic=call.target_topic, callback_topic=callback_topic, payload=payload)
+        else:
+            frame = CallFrame(target_topic=call.target_topic, callback_topic=callback_topic, payload=payload, frame_id=frame_id)
         return self.call_stack.push(frame)
 
 

--- a/calfkit/models/session_context.py
+++ b/calfkit/models/session_context.py
@@ -98,18 +98,21 @@ class WorkflowState(BaseModel):
     def unwind_frame(self) -> CallFrame:
         return self.call_stack.pop()
 
-    def invoke_frame(self, call: _Call, callback_topic: str | None, payload: Any = None, *, frame_id: str | None = None) -> None:
+    def invoke_frame(
+        self, call: _Call, callback_topic: str | None, payload: Any = None, *, frame_id: str | None = None, tag: str | None = None
+    ) -> None:
         if call.target_topic is None:
             raise Exception("")
         # ``frame_id`` lets the fan-out OPEN pre-mint each callee slot id, so the
-        # published callee frame *is* that id and a reply's ``in_reply_to`` matches
-        # the registered slot directly; ``None`` keeps the default fresh-uuid7 mint.
-        # ``invoke_frame`` never sets the ``fanout_id`` marker — that rides the node's
-        # OWN frame, not the pushed callee frame.
+        # published callee frame *is* that id and a reply's ``in_reply_to`` matches the
+        # registered slot directly; ``None`` keeps the default fresh-uuid7 mint. ``tag``
+        # (the caller's tool_call_id) rides the callee frame and is echoed on its reply,
+        # making a sibling reply self-describing. ``invoke_frame`` never sets the
+        # ``fanout_id`` marker — that rides the node's OWN frame, not the pushed callee.
         if frame_id is None:
-            frame = CallFrame(target_topic=call.target_topic, callback_topic=callback_topic, payload=payload)
+            frame = CallFrame(target_topic=call.target_topic, callback_topic=callback_topic, payload=payload, tag=tag)
         else:
-            frame = CallFrame(target_topic=call.target_topic, callback_topic=callback_topic, payload=payload, frame_id=frame_id)
+            frame = CallFrame(target_topic=call.target_topic, callback_topic=callback_topic, payload=payload, frame_id=frame_id, tag=tag)
         return self.call_stack.push(frame)
 
     def mark_fanout(self) -> None:

--- a/calfkit/models/state.py
+++ b/calfkit/models/state.py
@@ -1,5 +1,4 @@
 import logging
-from dataclasses import dataclass, field
 from typing import Annotated, Any, ClassVar, Generic, Literal
 
 from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag, field_validator
@@ -219,20 +218,3 @@ class NodeConsumeState(BaseModel, Generic[AgentStateSubsetT]):
 
     model_config = ConfigDict(extra="ignore")
     run_state: AgentStateSubsetT
-
-
-@dataclass
-class PendingToolBatch:
-    """Tracks an in-flight parallel tool call batch for one correlation chain."""
-
-    expected_tool_call_ids: frozenset[str]
-
-    # State snapshot at fan-out time, with tool_calls registered
-    base_state: State
-
-    # map of tool call IDs to tool call results
-    collected_results: dict[str, CalfToolResult | Any] = field(default_factory=dict)
-
-    @property
-    def is_complete(self) -> bool:
-        return self.expected_tool_call_ids == frozenset(self.collected_results.keys())

--- a/calfkit/nodes/_fanout_store.py
+++ b/calfkit/nodes/_fanout_store.py
@@ -1,26 +1,35 @@
-"""The durable fan-out batch store seam (PR-4).
+"""The durable fan-out batch store seam + fold/close state machine (PR-4).
 
 Fan-out batch state lives in two node-scoped compacted ktables. To keep the fold/
 close logic a pure function over an injected store — unit-testable without a broker,
 since ktables can't run under the synchronous ``TestKafkaBroker`` — the two tables
 (``state`` + ``basestate``, each a reader/writer pair) sit behind one
-:class:`FanoutBatchStore` Protocol. ``KtablesFanoutBatchStore`` implements it over
-real ktables (the kafka lane); ``tests._fanout_fakes.FakeFanoutBatchStore`` backs the
-offline lane.
+:class:`FanoutBatchStore` Protocol. ``KtablesFanoutBatchStore`` implements it over real
+ktables (the kafka lane); ``tests._fanout_fakes.FakeFanoutBatchStore`` backs the offline
+lane.
+
+:func:`fold_sibling`, :func:`close_batch`, and :func:`abort_batch` are the durable
+analog of the agent's in-process ``_parallel_state_aggregation`` — store- and
+caller-agnostic (no broker, no envelope), so the staged handler (the §6.8 ``_aggregate``
+stage) wires them in with no re-home.
 """
 
+import logging
+from dataclasses import dataclass
 from typing import Protocol
 
 from calfkit.models.fanout import EnvelopeSnapshot, FanoutBaseState, FanoutOpen, FanoutOutcome, FanoutState
+
+logger = logging.getLogger(__name__)
 
 
 class FanoutStoreUnavailableError(Exception):
     """The durable store is terminally unavailable, so freshness cannot be confirmed.
 
-    Raised by a :class:`FanoutBatchStore` when the underlying reader has died (the
-    real impl: ``barrier()`` returns ``False`` with ``status == "failed"``). The fold
-    maps this to **abort** (spec §4.4: tombstone both tables + ERROR-log + strand) — it
-    is NOT transient degradation (``loading``/``timeout``), which the store absorbs by
+    Raised by a :class:`FanoutBatchStore` when the underlying reader has died (the real
+    impl: ``barrier()`` returns ``False`` with ``status == "failed"``). The fold maps
+    this to **abort** (spec §4.4: tombstone both tables + ERROR-log + strand) — it is NOT
+    transient degradation (``loading``/``timeout``), which the store absorbs by
     blocking-and-retrying internally rather than raising.
     """
 
@@ -61,3 +70,136 @@ class FanoutBatchStore(Protocol):
         """Delete both the state and basestate records (awaiting acks). Idempotent —
         safe on an already-absent batch."""
         ...
+
+
+# ── fold/close decision vocabulary (return-only; the rail adds a fault arm) ──────
+
+
+@dataclass(frozen=True)
+class FoldParked:
+    """The slot was folded; the batch is still incomplete — park (no-reply mirror)."""
+
+
+@dataclass(frozen=True)
+class FoldComplete:
+    """The slot was folded and the batch is now complete — publish the closure re-entry."""
+
+
+@dataclass(frozen=True)
+class FoldStray:
+    """The reply did not fold a live pending slot — floor (foreign / post_closure) or
+    idempotent-ignore (duplicate). ``reason`` drives the handler's log level."""
+
+    reason: str
+
+
+@dataclass(frozen=True)
+class FoldAbort:
+    """The store died mid-fold — abort (tombstone attempted; the caller strands)."""
+
+    reason: str
+
+
+FoldResult = FoldParked | FoldComplete | FoldStray | FoldAbort
+
+
+@dataclass(frozen=True)
+class CloseResume:
+    """The batch closed cleanly — resume the body on this materialized snapshot."""
+
+    snapshot: EnvelopeSnapshot
+
+
+@dataclass(frozen=True)
+class CloseAbandon:
+    """No open batch under this key (already closed) — abandon the re-entry."""
+
+
+@dataclass(frozen=True)
+class CloseSpurious:
+    """An open-but-incomplete batch saw a re-entry — spurious; WARN and ignore."""
+
+
+@dataclass(frozen=True)
+class CloseAbort:
+    """The close cannot complete — tombstone (where possible) and strand. ``reason`` is
+    ``basestate_missing`` | ``materialization_failed`` | ``store_unavailable``."""
+
+    reason: str
+
+
+CloseResult = CloseResume | CloseAbandon | CloseSpurious | CloseAbort
+
+
+async def fold_sibling(store: FanoutBatchStore, fanout_id: str, outcome: FanoutOutcome) -> FoldResult:
+    """Fold one marked sibling reply into the durable batch state.
+
+    Reads the confirmed-fresh state, runs the stray check (§4.2) against it, and on a live
+    pending slot persists the outcome and reports completion. Idempotent per slot frame id
+    (a duplicate never re-folds or re-completes). A terminally-unavailable store aborts
+    (best-effort tombstone + strand).
+    """
+    try:
+        state = await store.read_state(fanout_id)
+        if state is None:
+            return FoldStray("post_closure")  # batch already closed/tombstoned
+        expected = {s.frame_id for s in state.open.expected}
+        if outcome.slot not in expected:
+            return FoldStray("foreign")
+        if outcome.slot in state.outcomes:
+            return FoldStray("duplicate")
+        updated = await store.fold(fanout_id, outcome)
+        if set(updated.outcomes) == expected:
+            return FoldComplete()
+        return FoldParked()
+    except FanoutStoreUnavailableError:
+        await abort_batch(store, fanout_id)
+        return FoldAbort("store_unavailable")
+
+
+async def close_batch(store: FanoutBatchStore, fanout_id: str) -> CloseResult:
+    """Close a fan-out batch on its re-entry: rebuild + materialize, then tombstone.
+
+    Reads the basestate snapshot and state. ``state`` is the abandon gate (absent ⇒
+    already closed); an incomplete state is spurious. On a complete batch it materializes
+    every outcome into a fresh copy of the snapshot's ``State`` and **tombstones both
+    records before returning** (tombstone-first, §4.3) so the resumed body runs on a closed
+    batch. A missing basestate, a wire-unsafe materialization (no tag), or a dead store
+    aborts deterministically — the close never hangs.
+    """
+    try:
+        base = await store.read_basestate(fanout_id)
+        state = await store.read_state(fanout_id)
+        if state is None:
+            return CloseAbandon()
+        if base is None:
+            return CloseAbort("basestate_missing")
+        expected = {s.frame_id for s in state.open.expected}
+        if set(state.outcomes) != expected:
+            return CloseSpurious()
+        snapshot = base.snapshot.model_copy(deep=True)
+        for outcome in state.outcomes.values():
+            if outcome.tag is None:
+                await abort_batch(store, fanout_id)
+                return CloseAbort("materialization_failed")
+            snapshot.state.add_tool_result(outcome.tag, outcome.result)
+        await store.tombstone(fanout_id)  # tombstone-first, before the body resumes
+        return CloseResume(snapshot)
+    except FanoutStoreUnavailableError:
+        await abort_batch(store, fanout_id)
+        return CloseAbort("store_unavailable")
+
+
+async def abort_batch(store: FanoutBatchStore, fanout_id: str) -> None:
+    """Best-effort tombstone of both records (the §4.4 abort cleanup).
+
+    A dead store can't be tombstoned — the corpse is left for the aged-reclaim issue
+    (#220) rather than raising, so an abort never masks itself behind a second failure.
+    """
+    try:
+        await store.tombstone(fanout_id)
+    except FanoutStoreUnavailableError:
+        logger.error(
+            "fan-out batch %s could not be tombstoned (store unavailable); the record strands until reclaimed",
+            fanout_id,
+        )

--- a/calfkit/nodes/_fanout_store.py
+++ b/calfkit/nodes/_fanout_store.py
@@ -176,10 +176,10 @@ async def close_batch(store: FanoutBatchStore, fanout_id: str) -> CloseResult:
     aborts deterministically — the close never hangs.
     """
     try:
-        base = await store.read_basestate(fanout_id)
         state = await store.read_state(fanout_id)
         if state is None:
-            return CloseAbandon()
+            return CloseAbandon()  # abandon gate first — short-circuit the already-closed path
+        base = await store.read_basestate(fanout_id)
         if base is None:
             return CloseAbort("basestate_missing")
         expected = {s.frame_id for s in state.open.expected}

--- a/calfkit/nodes/_fanout_store.py
+++ b/calfkit/nodes/_fanout_store.py
@@ -1,0 +1,63 @@
+"""The durable fan-out batch store seam (PR-4).
+
+Fan-out batch state lives in two node-scoped compacted ktables. To keep the fold/
+close logic a pure function over an injected store — unit-testable without a broker,
+since ktables can't run under the synchronous ``TestKafkaBroker`` — the two tables
+(``state`` + ``basestate``, each a reader/writer pair) sit behind one
+:class:`FanoutBatchStore` Protocol. ``KtablesFanoutBatchStore`` implements it over
+real ktables (the kafka lane); ``tests._fanout_fakes.FakeFanoutBatchStore`` backs the
+offline lane.
+"""
+
+from typing import Protocol
+
+from calfkit.models.fanout import EnvelopeSnapshot, FanoutBaseState, FanoutOpen, FanoutOutcome, FanoutState
+
+
+class FanoutStoreUnavailableError(Exception):
+    """The durable store is terminally unavailable, so freshness cannot be confirmed.
+
+    Raised by a :class:`FanoutBatchStore` when the underlying reader has died (the
+    real impl: ``barrier()`` returns ``False`` with ``status == "failed"``). The fold
+    maps this to **abort** (spec §4.4: tombstone both tables + ERROR-log + strand) — it
+    is NOT transient degradation (``loading``/``timeout``), which the store absorbs by
+    blocking-and-retrying internally rather than raising.
+    """
+
+
+class FanoutBatchStore(Protocol):
+    """Two node-scoped compacted ktables (``state`` + ``basestate``) behind one interface.
+
+    Freshness contract: :meth:`read_state` / :meth:`read_basestate` return only
+    confirmed-fresh data (the real impl barriers before reading; transient degradation
+    blocks-and-retries internally). On terminal store death they raise
+    :class:`FanoutStoreUnavailableError`, which the fold maps to abort. Writes await their
+    broker acks.
+    """
+
+    async def open(self, fanout_id: str, reg: FanoutOpen, snapshot: EnvelopeSnapshot) -> None:
+        """Register a batch: write the basestate snapshot THEN the state, awaiting both
+        acks before returning — so *registration present ⟹ basestate present* (the spec
+        §4.1 causality precondition the close relies on)."""
+        ...
+
+    async def read_state(self, fanout_id: str) -> FanoutState | None:
+        """The accumulating :class:`FanoutState`, confirmed fresh (read-your-own-writes).
+        ``None`` if the batch is absent or tombstoned."""
+        ...
+
+    async def fold(self, fanout_id: str, outcome: FanoutOutcome) -> FanoutState:
+        """Merge one resolved-slot ``outcome`` into the batch's state and persist it
+        (awaiting the ack); **idempotent per slot frame id** (LWW absorbs a re-fold).
+        Returns the updated state."""
+        ...
+
+    async def read_basestate(self, fanout_id: str) -> FanoutBaseState | None:
+        """The write-once open-time snapshot, confirmed fresh. ``None`` if absent or
+        tombstoned."""
+        ...
+
+    async def tombstone(self, fanout_id: str) -> None:
+        """Delete both the state and basestate records (awaiting acks). Idempotent —
+        safe on an already-absent batch."""
+        ...

--- a/calfkit/nodes/_fanout_store.py
+++ b/calfkit/nodes/_fanout_store.py
@@ -22,6 +22,11 @@ from calfkit.models.fanout import EnvelopeSnapshot, FanoutBaseState, FanoutOpen,
 
 logger = logging.getLogger(__name__)
 
+FANOUT_STORE_KEY = "calfkit.fanout.store"
+"""Resource-bag key under which a fan-out agent's :class:`FanoutBatchStore` lives — a
+node-owned ``@resource`` (ktables) in production, an injected fake in offline tests
+(``agent.resources[FANOUT_STORE_KEY] = fake``)."""
+
 
 class FanoutStoreUnavailableError(Exception):
     """The durable store is terminally unavailable, so freshness cannot be confirmed.

--- a/calfkit/nodes/_fanout_store.py
+++ b/calfkit/nodes/_fanout_store.py
@@ -16,9 +16,12 @@ stage) wires them in with no re-home.
 
 import logging
 from dataclasses import dataclass
-from typing import Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from calfkit.models.fanout import EnvelopeSnapshot, FanoutBaseState, FanoutOpen, FanoutOutcome, FanoutState
+
+if TYPE_CHECKING:
+    from ktables import KafkaTable, KafkaTableWriter
 
 logger = logging.getLogger(__name__)
 
@@ -208,3 +211,99 @@ async def abort_batch(store: FanoutBatchStore, fanout_id: str) -> None:
             "fan-out batch %s could not be tombstoned (store unavailable); the record strands until reclaimed",
             fanout_id,
         )
+
+
+# ── the real ktables-backed store (the kafka lane) ───────────────────────────────
+
+
+class KtablesFanoutBatchStore:
+    """:class:`FanoutBatchStore` over two node-scoped compacted ktables — ``state`` (mutable,
+    re-written per fold) and ``basestate`` (write-once) — each a reader (:class:`KafkaTable`)
+    + writer (:class:`KafkaTableWriter`) pair.
+
+    Freshness (spec §5): the mutable ``state`` barriers before every read (read-your-own-writes —
+    an owner must see its own prior folds); the write-once ``basestate`` barriers only on a miss
+    (present ⇒ correct, only absence is potentially stale). ``barrier()`` returns ``bool``; a
+    ``False`` with reader ``status == "failed"`` is terminal → :class:`FanoutStoreUnavailableError`
+    (the fold maps it to abort), while transient degradation (loading/timeout/stop-race) blocks and
+    retries (spec §5.1/§4.2 as reconciled to the shipped ``bool`` API). Writers are idempotent
+    (``acks=all``); ``delete`` is a null tombstone. The tables self-provision compacted via ktables'
+    ``ensure_topic`` (spec §9) — no calfkit provisioner involvement.
+    """
+
+    _BARRIER_TIMEOUT_S = 30.0
+
+    def __init__(self, *, bootstrap_servers: str, node_id: str, catchup_timeout: float | None = None) -> None:
+        import ktables  # lazy: keep ktables off the offline import path (only a real store touches it)
+
+        state_topic = f"calf.fanout.{node_id}.state"
+        basestate_topic = f"calf.fanout.{node_id}.basestate"
+        reader_kwargs: dict[str, Any] = {"ensure_topic": True}
+        if catchup_timeout is not None:
+            reader_kwargs["catchup_timeout"] = catchup_timeout
+        self._state_reader: KafkaTable[FanoutState] = ktables.KafkaTable.json(
+            bootstrap_servers=bootstrap_servers, topic=state_topic, model=FanoutState, **reader_kwargs
+        )
+        self._state_writer: KafkaTableWriter[FanoutState] = ktables.KafkaTableWriter.json(
+            bootstrap_servers=bootstrap_servers, topic=state_topic, model=FanoutState, ensure_topic=True, enable_idempotence=True
+        )
+        self._base_reader: KafkaTable[FanoutBaseState] = ktables.KafkaTable.json(
+            bootstrap_servers=bootstrap_servers, topic=basestate_topic, model=FanoutBaseState, **reader_kwargs
+        )
+        self._base_writer: KafkaTableWriter[FanoutBaseState] = ktables.KafkaTableWriter.json(
+            bootstrap_servers=bootstrap_servers, topic=basestate_topic, model=FanoutBaseState, ensure_topic=True, enable_idempotence=True
+        )
+
+    async def start(self) -> None:
+        """Open all four tables. Each reader's ``start()`` replays its compacted topic to the
+        start-time end offsets (the catch-up gate) so the store serves a current view; writers
+        connect their idempotent producers. Self-provisions the compacted topics if absent."""
+        await self._state_reader.start()
+        await self._base_reader.start()
+        await self._state_writer.start()
+        await self._base_writer.start()
+
+    async def stop(self) -> None:
+        for component in (self._state_writer, self._base_writer, self._state_reader, self._base_reader):
+            await component.stop()
+
+    async def _await_fresh(self, reader: "KafkaTable[Any]") -> None:
+        """Block until ``reader`` is confirmed fresh (barrier returns ``True``). A ``False`` with
+        ``status == "failed"`` is terminal (raise); any other ``False`` (timeout / stop-race /
+        snapshot-error / loading / degraded) is transient and retried — a persistently degraded
+        table is an operational failure (spec §7), not a floor."""
+        while not await reader.barrier(timeout=self._BARRIER_TIMEOUT_S):
+            if reader.status == "failed":
+                raise FanoutStoreUnavailableError(f"fan-out table {reader.topic!r} reader died ({reader.failure!r})") from reader.failure
+            logger.warning("fan-out table %r barrier not yet fresh (status=%s); retrying", reader.topic, reader.status)
+
+    async def open(self, fanout_id: str, reg: FanoutOpen, snapshot: EnvelopeSnapshot) -> None:
+        # basestate THEN state, each awaiting its ack — so *registration present ⟹ basestate present*.
+        await self._base_writer.set(fanout_id, FanoutBaseState(fanout_id=fanout_id, snapshot=snapshot))
+        await self._state_writer.set(fanout_id, FanoutState(open=reg, outcomes={}))
+
+    async def read_state(self, fanout_id: str) -> FanoutState | None:
+        await self._await_fresh(self._state_reader)  # mutable ⇒ barrier-before-read (RYOW)
+        return self._state_reader.get(fanout_id)
+
+    async def fold(self, fanout_id: str, outcome: FanoutOutcome) -> FanoutState:
+        await self._await_fresh(self._state_reader)
+        current = self._state_reader.get(fanout_id)
+        if current is None:
+            # Single-writer + the caller's preceding read_state make this unreachable; guard
+            # loudly rather than silently re-creating a tombstoned batch.
+            raise ValueError(f"fold on an unregistered fan-out batch {fanout_id!r}")
+        updated = current.model_copy(update={"outcomes": {**current.outcomes, outcome.slot: outcome}})
+        await self._state_writer.set(fanout_id, updated)
+        return updated
+
+    async def read_basestate(self, fanout_id: str) -> FanoutBaseState | None:
+        value = self._base_reader.get(fanout_id)
+        if value is None:  # write-once ⇒ barrier only on a miss (absence may be stale, presence is correct)
+            await self._await_fresh(self._base_reader)
+            value = self._base_reader.get(fanout_id)
+        return value
+
+    async def tombstone(self, fanout_id: str) -> None:
+        await self._state_writer.delete(fanout_id)
+        await self._base_writer.delete(fanout_id)

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -68,6 +68,12 @@ class BaseAgentNodeDef(
             model_settings=cast(ModelSettings | None, model_settings),
         )
 
+    @property
+    def _is_fanout_capable(self) -> bool:
+        """A non-sequential agent folds durable fan-out batches in-node; a
+        ``sequential_only_mode`` agent issues only single calls and never fans out."""
+        return not self.sequential_only_mode
+
     @staticmethod
     def _require_frame_id_for_write(ctx: SessionRunContext) -> str:
         """Resolve the per-invocation frame_id when WRITING a new parallel batch.

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from typing import Any, ClassVar, Generic, cast
 
 from pydantic import ValidationError
@@ -15,15 +15,16 @@ from calfkit._vendor.pydantic_ai.tools import DeferredToolResults
 from calfkit._vendor.pydantic_ai.toolsets.external import ExternalToolset
 from calfkit.exceptions import MCPToolResolutionError, ToolExecutionError, safe_exc_message
 from calfkit.models import Call, DataPart, NodeResult, ReturnCall, State, TailCall, TextPart
-from calfkit.models.actions import Silent
 from calfkit.models.capability import CAPABILITY_VIEW_RESOURCE_KEY, SelectorResult
 from calfkit.models.payload import ContentPart
 from calfkit.models.session_context import SessionRunContext
-from calfkit.models.state import FailedToolCall, PendingToolBatch
+from calfkit.models.state import FailedToolCall
 from calfkit.models.tool_dispatch import ToolBinding, ToolCallRef, ToolProvider, ToolSelector, split_tool_declarations
+from calfkit.nodes._fanout_store import FANOUT_STORE_KEY, FanoutBatchStore, KtablesFanoutBatchStore
 from calfkit.nodes._projection import project, structured_output_preamble
 from calfkit.nodes.base import BaseNodeDef, GateFunction
 from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
+from calfkit.worker.lifecycle import ResourceSetupContext
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +53,6 @@ class BaseAgentNodeDef(
         self.system_prompt = system_prompt
         self.tools, self._tool_selectors = split_tool_declarations(tools)
         self.sequential_only_mode = sequential_only_mode
-        self._pending_batches: dict[str, PendingToolBatch] = dict()
 
         if not isinstance(subscribe_topics, (list, tuple)):
             subscribe_topics = [subscribe_topics]
@@ -68,104 +68,41 @@ class BaseAgentNodeDef(
             model_settings=cast(ModelSettings | None, model_settings),
         )
 
+        if not self.sequential_only_mode:
+            # A true fan-out agent owns its durable batch store as a node @resource (opened by the
+            # worker lifecycle before serving; mirrors the worker's Capability View resource). The
+            # @resource never runs under the synchronous TestKafkaBroker — offline, the test harness
+            # injects a fake into the bag instead (tests/providers.py::prepare_worker).
+            self.resource(name=FANOUT_STORE_KEY)(self._fanout_store_resource)
+
+    async def _fanout_store_resource(self, ctx: ResourceSetupContext["BaseAgentNodeDef[AgentOutputT]"]) -> AsyncIterator[FanoutBatchStore]:
+        """Open this fan-out agent's durable batch store for the worker's lifetime.
+
+        Mirrors the worker's Capability View resource: each ktables reader's ``start()`` is the
+        catch-up gate (replays the compacted state/basestate topics to their start-time offsets),
+        and the topics self-provision compacted via ktables' ``ensure_topic``. The resulting store
+        lands in this node's own ``ctx.resources`` under :data:`FANOUT_STORE_KEY`.
+        """
+        worker = self._worker
+        if worker is None:
+            raise RuntimeError(f"fan-out agent {self.node_id!r} has no hosting worker; cannot open its durable store")
+        bootstrap = worker._derive_bootstrap_servers()
+        if not bootstrap:
+            raise RuntimeError(
+                f"cannot derive Kafka bootstrap servers for fan-out agent {self.node_id!r}'s durable store (client built without connect()?)."
+            )
+        store = KtablesFanoutBatchStore(bootstrap_servers=bootstrap, node_id=self.node_id)
+        await store.start()
+        try:
+            yield store
+        finally:
+            await store.stop()
+
     @property
     def _is_fanout_capable(self) -> bool:
         """A non-sequential agent folds durable fan-out batches in-node; a
         ``sequential_only_mode`` agent issues only single calls and never fans out."""
         return not self.sequential_only_mode
-
-    @staticmethod
-    def _require_frame_id_for_write(ctx: SessionRunContext) -> str:
-        """Resolve the per-invocation frame_id when WRITING a new parallel batch.
-
-        ``ctx.frame_id`` is populated by ``BaseNodeDef.prepare_context`` from
-        ``envelope.internal_workflow_state.current_frame.frame_id``. It is the
-        only correct key for ``_pending_batches`` because parallel invocations
-        of the same agent share a single ``correlation_id`` — see
-        :meth:`_parallel_state_aggregation` for the collision scenario this
-        defends against. A ``None`` value at write time means the agent was
-        invoked outside the framework's prepare-context path (e.g. a test
-        driving ``run()`` directly without seeding ``_frame_id``); raising is
-        the right call because silently bucketing every batch under ``None``
-        would re-introduce the exact bug this keying is designed to prevent.
-
-        Read-side lookups tolerate ``None`` (treated as "no batch present")
-        because the only way a read can find a ``None``-keyed entry is if a
-        write was previously allowed to use ``None`` — which this guard
-        prevents at the source.
-        """
-        frame_id = ctx.frame_id
-        if frame_id is None:
-            raise RuntimeError(
-                "ctx.frame_id is None — parallel tool-batch dispatch requires a "
-                "frame_id, normally populated by BaseNodeDef.prepare_context from "
-                "the inbound envelope's current_frame. If you are driving run() "
-                "directly in a test that fans out a parallel batch, set "
-                "ctx._frame_id before invoking."
-            )
-        return frame_id
-
-    def _parallel_state_aggregation(self, ctx: SessionRunContext) -> None:
-        # Keyed on ``ctx.frame_id`` (per-invocation), NOT ``ctx.correlation_id``:
-        # a supervisor that fans out two ``Call``s to the same agent topic shares one
-        # ``correlation_id`` across both invocations. Each invocation publishes onto
-        # its own fresh ``CallFrame`` (UUID7 ``frame_id``), so the per-invocation
-        # frame is the only key that keeps concurrent batches from clobbering each
-        # other in this dict.
-        frame_id = ctx.frame_id
-        if frame_id is None:
-            # ``BaseNodeDef.prepare_context`` unconditionally mirrors
-            # ``current_frame.frame_id`` (which has a ``default_factory``) onto
-            # ``ctx._frame_id``, so a None here means ``run()`` was driven outside
-            # the framework handler — either a unit test or a subclass that
-            # bypasses ``prepare_context``. Warn loudly so a future regression in
-            # the handler path surfaces immediately instead of silently skipping
-            # aggregation and potentially advancing past a real batch.
-            logger.warning(
-                "[%s] _parallel_state_aggregation: ctx.frame_id is None on node=%s; "
-                "skipping aggregation. prepare_context is the only legitimate "
-                "population path for _frame_id — a None value here indicates run() "
-                "was driven outside the framework handler.",
-                ctx.correlation_id[:8],
-                self.name,
-            )
-            return
-        batch = self._pending_batches.get(frame_id)
-        if batch is not None:
-            for tool_call_id in batch.expected_tool_call_ids:
-                if tool_call_id not in batch.collected_results and tool_call_id in ctx.state.tool_results:
-                    batch.collected_results[tool_call_id] = ctx.state.tool_results[tool_call_id]
-
-            if batch.is_complete:
-                for tool_call_id, tool_call_result in batch.collected_results.items():
-                    batch.base_state.add_tool_result(tool_call_id, tool_call_result)
-                ctx.state = batch.base_state
-                del self._pending_batches[frame_id]
-        else:
-            # Stray-reply / lost-batch detection: more than one tool_result for the
-            # current ``latest_tool_calls`` is present, but no batch is registered
-            # for this frame_id. The agent would have written a batch on dispatch
-            # (single-tool dispatch in parallel mode is the one legitimate
-            # no-batch path, hence the ``> 1`` floor to suppress that false
-            # positive). Likely causes: lost batch from partition rebalance or
-            # process restart, stray/duplicate delivery, or a routing error.
-            # Replies will not be aggregated; if any tool_call_ids remain
-            # incomplete the existing guard at the bottom of ``run()`` raises
-            # ``RuntimeError`` — this warning fires in the all-arrived-together
-            # race that would otherwise silently advance.
-            completed_latest = [tc for tc in ctx.state.latest_tool_calls() if tc.tool_call_id in ctx.state.tool_results]
-            if len(completed_latest) > 1:
-                logger.warning(
-                    "[%s] no PendingToolBatch for frame_id=%s on node=%s but %d completed "
-                    "tool replies present (tool_call_ids=%s); replies will NOT be "
-                    "aggregated. Likely a lost batch (partition rebalance or process "
-                    "restart), stray/duplicate delivery, or a routing error.",
-                    ctx.correlation_id[:8],
-                    frame_id,
-                    self.name,
-                    len(completed_latest),
-                    [tc.tool_call_id for tc in completed_latest],
-                )
 
     def _maybe_resolve_selectors(self, ctx: SessionRunContext, tools_registry: dict[str, ToolBinding]) -> None:
         """Selector resolution gate: per-run overrides pin the EXACT tool
@@ -260,24 +197,10 @@ class BaseAgentNodeDef(
             len(ctx.state.message_history),
         )
 
-        if not self.sequential_only_mode:
-            self._parallel_state_aggregation(ctx)
-            # Defense-in-depth: ``_parallel_state_aggregation`` already warns
-            # and returns early on a None ``frame_id``, but a future refactor
-            # that calls this branch independently must not silently mask the
-            # missing key. See ``_require_frame_id_for_write`` for why write-side
-            # rejects None.
-            if ctx.frame_id is None:
-                logger.warning(
-                    "[%s] run(): ctx.frame_id is None on node=%s; cannot look up parallel batch — treating as no batch.",
-                    ctx.correlation_id[:8],
-                    self.name,
-                )
-                batch = None
-            else:
-                batch = self._pending_batches.get(ctx.frame_id)
-            if batch and not batch.is_complete:
-                return Silent()
+        # Parallel fan-out aggregation lives in the durable in-node fold (BaseNodeDef._aggregate):
+        # sibling replies are folded in the handler and never reach run(); run() is re-entered
+        # (with all tool results materialized) only at the batch's durable close. There is no
+        # in-process park here — incomplete batches park in the handler, not run().
 
         # Collect all FailedToolCall results in this turn so operators see every
         # failure in a parallel batch; raise on the first after logging all.
@@ -355,9 +278,10 @@ class BaseAgentNodeDef(
                 else:
                     remaining = [tc for tc in latest_tool_calls if tc.tool_call_id not in ctx.state.tool_results]
                     raise RuntimeError(
-                        f"[{ctx.correlation_id[:8]}] Parallel mode reached incomplete tool calls outside aggregation gate. "
+                        f"[{ctx.correlation_id[:8]}] Parallel mode reached incomplete tool calls in run(). "
                         f"node={self.name} frame_id={ctx.frame_id} remaining_ids={[tc.tool_call_id for tc in remaining]}. "
-                        f"This indicates lost PendingToolBatch state (e.g. partition rebalance or process restart)."
+                        f"The durable in-node fold should re-enter run() only on a complete batch — this indicates "
+                        f"the fan-out did not fully fold before re-entry (e.g. a lost batch from rebalance/restart)."
                     )
 
             tool_results = DeferredToolResults(calls={tc.tool_call_id: ctx.state.get_tool_result(tc.tool_call_id) for tc in latest_tool_calls})
@@ -510,21 +434,19 @@ class BaseAgentNodeDef(
                     body=ToolCallRef.from_tool_call_part(target_tool_call),
                 )
             else:
-                launch_tool_call_ids = [tc.tool_call_id for tc in pending_tool_calls]
+                # Parallel fan-out: each sibling Call carries its tool_call_id as ``tag`` so the
+                # callee echoes it on its reply, letting the durable fold read the result from
+                # ``state.tool_results[tag]``. The handler's _handle_fanout_open opens the durable
+                # batch from this list — replacing the old in-process _pending_batches registration.
                 parallel_tool_calls = [
                     Call[State](
                         tools_registry[tc.tool_name].dispatch_topic,
                         ctx.state.model_copy(deep=True),
                         body=ToolCallRef.from_tool_call_part(tc),
+                        tag=tc.tool_call_id,
                     )
                     for tc in pending_tool_calls
                 ]
-
-                self._pending_batches[self._require_frame_id_for_write(ctx)] = PendingToolBatch(
-                    expected_tool_call_ids=frozenset(launch_tool_call_ids),
-                    base_state=ctx.state.model_copy(deep=True),
-                )
-
                 return parallel_tool_calls
 
         else:

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -1,7 +1,7 @@
 import inspect
 import logging
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Annotated, Any, ClassVar
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, cast
 
 from aiokafka.errors import KafkaError  # type: ignore[import-untyped]
 from faststream import Context, Response
@@ -28,6 +28,7 @@ from calfkit.models.envelope import Envelope
 from calfkit.models.node_schema import BaseNodeSchema
 from calfkit.models.reply import ReturnMessage
 from calfkit.models.session_context import SessionRunContext
+from calfkit.nodes._fanout_store import FANOUT_STORE_KEY, FanoutBatchStore
 from calfkit.worker.lifecycle import LifecycleHookMixin
 
 if TYPE_CHECKING:
@@ -398,6 +399,45 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
             key=correlation_id.encode(),
             headers=self._headers("return"),
         )
+
+    @property
+    def _is_fanout_capable(self) -> bool:
+        """Whether this node folds durable fan-out batches in-node. ``False`` for every
+        node type except a non-sequential agent (which overrides this) — it gates the
+        staged handler's fan-out recognition and the OPEN dispatch path."""
+        return False
+
+    def _resolve_fanout_store(self, ctx: SessionRunContext) -> FanoutBatchStore:
+        """The node's durable fan-out store, from the resource bag.
+
+        Production: a node-owned ``@resource`` (ktables). Offline tests inject a fake
+        (``agent.resources[FANOUT_STORE_KEY] = fake``). Fan-out cannot proceed without it,
+        so a missing store is a misconfiguration (raise), never a silent skip."""
+        store = ctx.resources.get(FANOUT_STORE_KEY)
+        if store is None:
+            raise RuntimeError(
+                f"node={self.node_id} fanned out but no FanoutBatchStore is registered under "
+                f"{FANOUT_STORE_KEY!r}; a fan-out-capable agent needs its durable store resource."
+            )
+        return cast(FanoutBatchStore, store)
+
+    def _classify_fanout(self, envelope: Envelope) -> Literal["sibling", "reentry"] | None:
+        """Recognize a fan-out continuation on a fan-out-capable node.
+
+        ``"sibling"`` (a marked sibling reply → fold), ``"reentry"`` (the self-published
+        closure → close), or ``None`` (normal ingress / single-call continuation). The
+        marker rides the node's OWN frame (``fanout_id`` set), so it is the top frame when
+        a fan-out continuation re-enters; the reply slot's ``in_reply_to`` then tells a
+        sibling callee (≠ the frame id) from the re-entry (== it)."""
+        if not self._is_fanout_capable:
+            return None
+        frame = envelope.internal_workflow_state.current_frame_or_none
+        if frame is None or frame.fanout_id is None:
+            return None
+        reply = envelope.reply
+        if reply is None:
+            return None  # a marked frame with no reply slot is not a fold/close continuation
+        return "reentry" if reply.in_reply_to == frame.frame_id else "sibling"
 
     async def _dispatch_routed(
         self,

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -1,7 +1,9 @@
 import inspect
 import logging
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, cast
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Final, Literal, cast
 
 import uuid_utils
 from aiokafka.errors import KafkaError  # type: ignore[import-untyped]
@@ -32,11 +34,16 @@ from calfkit.models.reply import ReturnMessage
 from calfkit.models.session_context import SessionRunContext
 from calfkit.nodes._fanout_store import (
     FANOUT_STORE_KEY,
+    CloseAbandon,
+    CloseAbort,
+    CloseResume,
+    CloseSpurious,
     FanoutBatchStore,
     FoldAbort,
     FoldComplete,
     FoldParked,
     FoldStray,
+    close_batch,
     fold_sibling,
 )
 from calfkit.worker.lifecycle import LifecycleHookMixin
@@ -66,6 +73,44 @@ Returning ``False`` (or raising, or returning a non-bool) skips ``run()`` and re
 envelope unchanged. Gates stack with AND semantics in registration order and short-circuit
 on the first rejection.
 """
+
+
+# ---------------------------------------------------------------------------
+# Staged-pipeline outcome vocabulary (fault-rail spec §6.8) — return-only subset
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _BatchClosed:
+    """The aggregation stage resolved — proceed to the body. Either a completed fan-out
+    closure (the durable snapshot's state/stack/deps restored onto ``ctx``+``envelope``, its
+    outcomes materialized) or a stateless single-call continuation (no batch registered)."""
+
+
+@dataclass(frozen=True)
+class _BatchOpen:
+    """The fan-out batch is still open — park via the no-reply mirror (``_CONSUMED``). Either
+    an incomplete sibling fold, or a no-op close (a spurious/abandoned/aborted re-entry)."""
+
+
+# TODO(fault rail PR-6): add ``_BatchFaulted(report: ErrorReport)`` to this union — an unhandled
+# callee fault closes the batch through the fault arm. Needs the fault wire model (PR-5).
+
+
+class _PipelineSentinel(Enum):
+    """Non-action outcomes of the staged pipeline (§6.8) — narrowable singletons, distinct from
+    the publishable :data:`NodeResult` actions the handler routes to ``_publish_action``."""
+
+    CONSUMED = auto()
+    """A parked fan-out fold or a self-published re-entry: no publishable action this hop (the
+    output is still owed by pending siblings). The handler emits the no-reply broadcast mirror."""
+
+    DECLINED = auto()
+    """Every handler in the body's route Chain-of-Responsibility declined (all-declined terminal)."""
+
+
+_CONSUMED: Final = _PipelineSentinel.CONSUMED
+_DECLINED: Final = _PipelineSentinel.DECLINED
 
 
 # ---------------------------------------------------------------------------
@@ -431,6 +476,20 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
             )
         return cast(FanoutBatchStore, store)
 
+    def _classify(self, headers: dict[str, Any]) -> MessageKind:
+        """Classify the inbound delivery kind from the ``x-calf-kind`` header (§6.8 stage-0).
+
+        Missing ⇒ ``"call"`` (a producer that didn't stamp it / a fresh ingress). Return-only:
+        only ``call`` and ``return`` exist; an unrecognized value falls back to ``"call"``
+        (the pre-rail body path). The kind selects stage routing in :meth:`_execute`
+        (``return`` ⇒ the aggregation stage; ``call`` ⇒ straight to the body).
+
+        TODO(fault rail PR-6): widen to ``"fault"`` (``MessageKind`` gains the arm) and add the
+        unknown-value→ERROR-and-ignore + the kind↔reply-slot disagreement→stray checks
+        (fault-rail spec §6.8 stage-0). Both need the fault wire model, not yet in tree.
+        """
+        return "return" if decode_header_str(headers.get(HDR_KIND)) == "return" else "call"
+
     def _classify_fanout(self, envelope: Envelope) -> Literal["sibling", "reentry"] | None:
         """Recognize a fan-out continuation on a fan-out-capable node.
 
@@ -487,32 +546,126 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
         envelope.reply = None  # no-reply mirror (I3): the output is owed by the pending siblings
         return Response(envelope, headers=self._headers("call"))
 
-    async def _handle_sibling_fold(self, ctx: SessionRunContext, envelope: Envelope, correlation_id: str, broker: BrokerAnnotation) -> Response:
-        """Fold one marked sibling reply into the durable batch (§4.2).
+    async def _aggregate(
+        self, ctx: SessionRunContext, envelope: Envelope, correlation_id: str, broker: BrokerAnnotation
+    ) -> _BatchOpen | _BatchClosed:
+        """The durable fan-out fold/close stage (fault-rail §6.8 stage-2 made durable; in-node
+        spec §4.2/§4.3). Runs on ``kind == "return"`` deliveries.
 
-        The reply is self-describing — ``in_reply_to`` is the slot id, ``tag`` the
-        tool_call_id, and the tool's result sits in ``ctx.state.tool_results[tag]``. Park
-        (no-reply mirror) until the batch completes; on completion self-publish the closure
-        re-entry. A stray is logged-and-ignored; a store abort strands the caller (pre-rail)."""
-        store = self._resolve_fanout_store(ctx)
-        frame = envelope.internal_workflow_state.current_frame
-        fanout_id = frame.frame_id  # == frame.fanout_id, the batch key
-        reply = envelope.reply
-        assert reply is not None  # guaranteed by _classify_fanout == "sibling"
-        tag = reply.tag
-        result = ctx.state.tool_results.get(tag) if tag is not None else None
-        outcome = FanoutOutcome(slot=reply.in_reply_to or "", tag=tag, result=result)
-        match await fold_sibling(store, fanout_id, outcome):
-            case FoldComplete():
-                await self._publish_reentry(envelope, correlation_id, broker)
-            case FoldStray(reason=reason):
-                logger.warning("[%s] fan-out stray (%s) slot=%s node=%s", correlation_id[:8], reason, reply.in_reply_to, self.node_id)
-            case FoldAbort(reason=reason):
-                logger.error("[%s] fan-out fold abort (%s) batch=%s node=%s; caller strands", correlation_id[:8], reason, fanout_id, self.node_id)
-            case FoldParked():
-                pass
-        envelope.reply = None  # no-reply mirror (_CONSUMED): the output is still owed
-        return Response(envelope, headers=self._headers("call"))
+        - A non-fan-out return is a **stateless continuation** → ``_BatchClosed`` (run the body).
+        - A **marked sibling reply** folds into the durable batch → ``_BatchOpen`` (park); on the
+          completing fold it self-publishes the closure re-entry (a fresh delivery), still parked.
+        - The self-published **re-entry** closes the batch: the durable snapshot's state/stack/deps
+          are restored onto ``ctx``+``envelope`` and the materialized outcomes resume the body →
+          ``_BatchClosed``. A spurious/abandoned/aborted close is a no-op park → ``_BatchOpen``.
+
+        TODO(fault rail PR-6): add the ``_BatchFaulted`` arm (an unhandled callee fault closes the
+        batch through the fault group), the per-sibling stage-1 ``on_callee_error`` on fault
+        deliveries, and the ``seam_budgets`` tally — all need the fault wire model.
+        """
+        match self._classify_fanout(envelope):
+            case None:
+                return _BatchClosed()  # stateless single-call continuation → body
+            case "sibling":
+                store = self._resolve_fanout_store(ctx)
+                frame = envelope.internal_workflow_state.current_frame
+                fanout_id = frame.frame_id  # == frame.fanout_id, the batch key
+                reply = envelope.reply
+                assert reply is not None  # guaranteed by _classify_fanout == "sibling"
+                tag = reply.tag
+                result = ctx.state.tool_results.get(tag) if tag is not None else None
+                outcome = FanoutOutcome(slot=reply.in_reply_to or "", tag=tag, result=result)
+                match await fold_sibling(store, fanout_id, outcome):
+                    case FoldComplete():
+                        await self._publish_reentry(envelope, correlation_id, broker)
+                    case FoldStray(reason=reason):
+                        logger.warning("[%s] fan-out stray (%s) slot=%s node=%s", correlation_id[:8], reason, reply.in_reply_to, self.node_id)
+                    case FoldAbort(reason=reason):
+                        logger.error(
+                            "[%s] fan-out fold abort (%s) batch=%s node=%s; caller strands",
+                            correlation_id[:8],
+                            reason,
+                            fanout_id,
+                            self.node_id,
+                        )
+                    case FoldParked():
+                        pass
+                return _BatchOpen()  # park (no-reply mirror) — the output is still owed by siblings
+            case "reentry":
+                store = self._resolve_fanout_store(ctx)
+                fanout_id = envelope.internal_workflow_state.current_frame.frame_id
+                match await close_batch(store, fanout_id):
+                    case CloseResume(snapshot=snapshot):
+                        self._restore_from_snapshot(ctx, envelope, snapshot)
+                        return _BatchClosed()  # resume the body on the restored context
+                    case CloseSpurious():
+                        logger.warning("[%s] fan-out spurious re-entry (incomplete) batch=%s node=%s", correlation_id[:8], fanout_id, self.node_id)
+                    case CloseAbandon():
+                        logger.debug("[%s] fan-out re-entry on a closed batch=%s node=%s; abandoning", correlation_id[:8], fanout_id, self.node_id)
+                    case CloseAbort(reason=reason):
+                        logger.error(
+                            "[%s] fan-out close abort (%s) batch=%s node=%s; caller strands",
+                            correlation_id[:8],
+                            reason,
+                            fanout_id,
+                            self.node_id,
+                        )
+                return _BatchOpen()  # no-op park for a spurious/abandoned/aborted re-entry
+
+    def _restore_from_snapshot(self, ctx: SessionRunContext, envelope: Envelope, snapshot: EnvelopeSnapshot) -> None:
+        """Restore the closure context from the durable snapshot (in-node spec §4.3 stage-0).
+
+        ``_publish_reentry`` cleared the re-entry envelope's context, so the basestate snapshot
+        (its outcomes already materialized into ``snapshot.state`` by ``close_batch``) is the sole
+        restore source. Overwrites ``ctx``'s state/deps and the envelope's stack so the resumed
+        body runs on the conversation as of fan-out and its ``ReturnCall`` unwinds the original
+        (unmarked) fan-out frame back to its caller. ``resources`` are node-local — re-stamped
+        from the bag, never snapshotted.
+        """
+        frame = snapshot.stack.current_frame_or_none
+        ctx.state = snapshot.state
+        ctx.deps = snapshot.deps
+        ctx._frame_id = frame.frame_id if frame is not None else None
+        ctx._resources = self._effective_resources()
+        ctx._reply = None
+        envelope.internal_workflow_state = snapshot.stack
+        envelope.context = SessionRunContext(state=snapshot.state, deps=snapshot.deps)
+
+    async def _execute(
+        self,
+        ctx: SessionRunContext,
+        kind: MessageKind,
+        envelope: Envelope,
+        route: str | None,
+        payload: Any,
+        *,
+        awaiting_reply: bool,
+        correlation_id: str,
+        broker: BrokerAnnotation,
+    ) -> NodeResult[State] | _PipelineSentinel:
+        """The staged inner pipeline (fault-rail §6.8 ``_execute``) — return-only subset.
+
+        Stage 2 (:meth:`_aggregate`) runs on ``return`` deliveries: an open batch parks
+        (``_CONSUMED``); a closed batch or a stateless continuation falls through to the body.
+        Stage 4 is the body — today's route Chain-of-Responsibility (:meth:`_dispatch_routed`),
+        untouched; an all-declined body is ``_DECLINED``.
+
+        TODO(fault rail PR-6): stage 1 ``on_callee_error`` (before stage 2, on ``fault`` kind),
+        stage 3 ``before_node`` (after ``_aggregate``, before the body), stage 6 ``after_node``
+        (wrapping the output), and the ``_BatchFaulted`` arm — all need the seam machinery + the
+        fault wire model. Gates currently occupy the stage-3 slot from the handler; the rail
+        deletes gates and adds ``before_node`` here.
+        """
+        if kind == "return":
+            match await self._aggregate(ctx, envelope, correlation_id, broker):
+                case _BatchOpen():
+                    return _CONSUMED
+                case _BatchClosed():
+                    pass  # fan-out close resume OR stateless continuation → run the body
+        result = await self._dispatch_routed(ctx, route, payload, awaiting_reply=awaiting_reply, correlation_id=correlation_id)
+        if result is None:
+            return _DECLINED
+        return result
 
     async def _dispatch_routed(
         self,
@@ -585,6 +738,19 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
         headers: Annotated[dict[str, Any], Context("message.headers")],
         broker: BrokerAnnotation,
     ) -> Response:
+        """The closed per-delivery pipeline (fault-rail §6.8) — return-only subset.
+
+        stage-0 (emitter decode → :meth:`_classify` → :meth:`prepare_context`) → gates →
+        :meth:`_execute` (stage-2 :meth:`_aggregate` + stage-4 the body) → output disposition.
+        Returns a broadcast-mirror :class:`Response` whose ``x-calf-kind`` is the hop's kind.
+
+        TODO(fault rail PR-6): stage-0 ``_stray_check``/``_floor_stray`` (return-only has no
+        stage-0 strays — fan-out strays floor inside :meth:`_aggregate`, closure-recognition is in
+        :meth:`_classify_fanout`); the fault boundary wrapping ``_execute`` (try/except →
+        ``on_node_error``/``_publish_fault``) — pre-rail, body exceptions propagate (dropped under
+        ACK_FIRST → the caller strands, preserving today's at-most-once behavior); ``before_node``
+        replaces the gate block below. All need the seam machinery + the fault wire model.
+        """
         raw_emitter = headers.get(HDR_EMITTER)
         emitter = decode_header_str(raw_emitter)
         if emitter is None:
@@ -596,50 +762,64 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
                 "None" if raw_emitter is None else type(raw_emitter).__name__,
             )
         emitter_kind = decode_header_str(headers.get(HDR_EMITTER_KIND))
-        logger.debug("[%s] handler entered node=%s emitter=%s kind=%s", correlation_id[:8], self.node_id, emitter, emitter_kind)
+        kind = self._classify(headers)
+        logger.debug("[%s] handler entered node=%s emitter=%s kind=%s", correlation_id[:8], self.node_id, emitter, kind)
         ctx = await self.prepare_context(envelope, emitter_node_id=emitter, emitter_node_kind=emitter_kind, correlation_id=correlation_id)
 
         if not await self._evaluate_gates(ctx, correlation_id):
             envelope.reply = None  # no-reply mirror (gate rejected): don't re-broadcast an inbound reply (I3)
-            body: Envelope = envelope
-            kind: MessageKind = "call"
-        else:
-            frame = envelope.internal_workflow_state.current_frame_or_none
-            payload = frame.payload if frame is not None else None
-            awaiting_reply = frame.callback_topic is not None if frame is not None else False
-            route = decode_header_str(headers.get(HDR_ROUTE))
-            output = await self._dispatch_routed(
-                ctx,
-                route,
-                payload,
-                awaiting_reply=awaiting_reply,
-                correlation_id=correlation_id,
-            )
-            if output is None:
-                # No matched handler produced a terminal result: every match declined
-                # (returned Next/None). The '*' handler (run) is always in the chain — the
-                # base run() always declines; an overridden run() may also decline, or a
-                # schema'd '*' run may have REJECTED the body (logged above). Stuck workflow
-                # if a caller awaits a return, else a fire-and-forget no-op. The body_note
-                # surfaces a present-but-unconsumed payload (e.g. a malformed tool ToolCallRef)
-                # so a dropped body is observable, not silent — callback-aware via `level`.
-                level = _stuck_level(awaiting_reply)
-                body_note = " — a body was not consumed (rejected by a schema handler, or unmatched)" if payload is not None else ""
-                logger.log(
-                    level,
-                    "[%s] no handler produced a result for route=%s on node=%s; registered=%s%s",
-                    correlation_id[:8],
-                    route,
-                    self.node_id,
-                    tuple(type(self)._handlers),
-                    body_note,
-                )
-                envelope.reply = None  # no-reply mirror (no result): don't re-broadcast an inbound reply (I3)
-                return Response(envelope, headers=self._headers("call"))
-            logger.debug("[%s] node=%s produced action=%s", correlation_id[:8], self.node_id, type(output).__name__)
-            body, kind = await self._publish_action(output, envelope, correlation_id, broker)
+            return Response(envelope, headers=self._headers("call"))
 
-        return Response(body, headers=self._headers(kind))
+        frame = envelope.internal_workflow_state.current_frame_or_none
+        payload = frame.payload if frame is not None else None
+        awaiting_reply = frame.callback_topic is not None if frame is not None else False
+        route = decode_header_str(headers.get(HDR_ROUTE))
+        output = await self._execute(
+            ctx,
+            kind,
+            envelope,
+            route,
+            payload,
+            awaiting_reply=awaiting_reply,
+            correlation_id=correlation_id,
+            broker=broker,
+        )
+
+        if output is _CONSUMED:
+            # A parked fan-out fold or a self-published re-entry: no publishable action this hop,
+            # the output is still owed by the pending siblings.
+            envelope.reply = None  # no-reply mirror (I3)
+            return Response(envelope, headers=self._headers("call"))
+        if output is _DECLINED:
+            # No matched handler produced a terminal result: every match declined (returned
+            # Next/None). The '*' handler (run) is always in the chain — the base run() always
+            # declines; an overridden run() may also decline, or a schema'd '*' run may have
+            # REJECTED the body (logged above). Stuck workflow if a caller awaits a return, else a
+            # fire-and-forget no-op. The body_note surfaces a present-but-unconsumed payload (e.g. a
+            # malformed tool ToolCallRef) so a dropped body is observable, not silent.
+            level = _stuck_level(awaiting_reply)
+            body_note = " — a body was not consumed (rejected by a schema handler, or unmatched)" if payload is not None else ""
+            logger.log(
+                level,
+                "[%s] no handler produced a result for route=%s on node=%s; registered=%s%s",
+                correlation_id[:8],
+                route,
+                self.node_id,
+                tuple(type(self)._handlers),
+                body_note,
+            )
+            envelope.reply = None  # no-reply mirror (no result): don't re-broadcast an inbound reply (I3)
+            return Response(envelope, headers=self._headers("call"))
+
+        # Fan-out OPEN: a fan-out-capable node whose body returned a parallel batch registers the
+        # durable batch + publishes the marked siblings. A non-capable node's list[Call] stays the
+        # plain parallel publish in _publish_action.
+        if self._is_fanout_capable and isinstance(output, list) and output and all(isinstance(c, Call) for c in output):
+            return await self._handle_fanout_open(ctx, output, envelope, correlation_id, broker)
+
+        logger.debug("[%s] node=%s produced action=%s", correlation_id[:8], self.node_id, type(output).__name__)
+        body, pubkind = await self._publish_action(output, envelope, correlation_id, broker)
+        return Response(body, headers=self._headers(pubkind))
 
     @property
     def id(self) -> str:

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -3,6 +3,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, cast
 
+import uuid_utils
 from aiokafka.errors import KafkaError  # type: ignore[import-untyped]
 from faststream import Context, Response
 from faststream.kafka.annotations import (
@@ -25,10 +26,19 @@ from calfkit.models import (
 )
 from calfkit.models._coerce import _coerce_to_parts
 from calfkit.models.envelope import Envelope
+from calfkit.models.fanout import EnvelopeSnapshot, FanoutOpen, FanoutOutcome, SlotRef
 from calfkit.models.node_schema import BaseNodeSchema
 from calfkit.models.reply import ReturnMessage
 from calfkit.models.session_context import SessionRunContext
-from calfkit.nodes._fanout_store import FANOUT_STORE_KEY, FanoutBatchStore
+from calfkit.nodes._fanout_store import (
+    FANOUT_STORE_KEY,
+    FanoutBatchStore,
+    FoldAbort,
+    FoldComplete,
+    FoldParked,
+    FoldStray,
+    fold_sibling,
+)
 from calfkit.worker.lifecycle import LifecycleHookMixin
 
 if TYPE_CHECKING:
@@ -438,6 +448,71 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
         if reply is None:
             return None  # a marked frame with no reply slot is not a fold/close continuation
         return "reentry" if reply.in_reply_to == frame.frame_id else "sibling"
+
+    async def _handle_fanout_open(
+        self, ctx: SessionRunContext, calls: list[Call[State]], envelope: Envelope, correlation_id: str, broker: BrokerAnnotation
+    ) -> Response:
+        """OPEN a durable fan-out batch, then publish the marked siblings (§4.1).
+
+        Pre-mint a callee slot id per ``Call``; register the batch (basestate snapshot THEN
+        state, awaiting acks before any sibling publishes — so *registration ⟹ basestate*);
+        then publish each sibling on its pre-minted id, with the node's OWN frame marked so
+        the marker survives the callee's return-pop. Returns the no-reply mirror — the
+        output is owed by the pending siblings."""
+        store = self._resolve_fanout_store(ctx)
+        fanout_id = envelope.internal_workflow_state.current_frame.frame_id
+        slot_ids = [uuid_utils.uuid7().hex for _ in calls]
+        reg = FanoutOpen(
+            fanout_id=fanout_id,
+            node_id=self.node_id,
+            expected=[SlotRef(frame_id=fid, tag=call.tag) for fid, call in zip(slot_ids, calls)],
+        )
+        snapshot = EnvelopeSnapshot(state=ctx.state, stack=envelope.internal_workflow_state, deps=dict(ctx.deps))
+        await store.open(fanout_id, reg, snapshot)
+        for call, slot_id in zip(calls, slot_ids):
+            wf_copy = envelope.internal_workflow_state.model_copy(deep=True)
+            wf_copy.mark_fanout()  # mark the node's OWN (current top) frame, before the callee push
+            wf_copy.invoke_frame(call, self._return_topic, payload=call.body, frame_id=slot_id, tag=call.tag)
+            sibling = Envelope(
+                context=SessionRunContext(state=call.state, deps=envelope.context.deps),
+                internal_workflow_state=wf_copy,
+            )
+            await broker.publish(
+                sibling,
+                topic=wf_copy.current_frame.target_topic,
+                correlation_id=correlation_id,
+                key=correlation_id.encode(),
+                headers=self._headers("call", route=call.route),
+            )
+        envelope.reply = None  # no-reply mirror (I3): the output is owed by the pending siblings
+        return Response(envelope, headers=self._headers("call"))
+
+    async def _handle_sibling_fold(self, ctx: SessionRunContext, envelope: Envelope, correlation_id: str, broker: BrokerAnnotation) -> Response:
+        """Fold one marked sibling reply into the durable batch (§4.2).
+
+        The reply is self-describing — ``in_reply_to`` is the slot id, ``tag`` the
+        tool_call_id, and the tool's result sits in ``ctx.state.tool_results[tag]``. Park
+        (no-reply mirror) until the batch completes; on completion self-publish the closure
+        re-entry. A stray is logged-and-ignored; a store abort strands the caller (pre-rail)."""
+        store = self._resolve_fanout_store(ctx)
+        frame = envelope.internal_workflow_state.current_frame
+        fanout_id = frame.frame_id  # == frame.fanout_id, the batch key
+        reply = envelope.reply
+        assert reply is not None  # guaranteed by _classify_fanout == "sibling"
+        tag = reply.tag
+        result = ctx.state.tool_results.get(tag) if tag is not None else None
+        outcome = FanoutOutcome(slot=reply.in_reply_to or "", tag=tag, result=result)
+        match await fold_sibling(store, fanout_id, outcome):
+            case FoldComplete():
+                await self._publish_reentry(envelope, correlation_id, broker)
+            case FoldStray(reason=reason):
+                logger.warning("[%s] fan-out stray (%s) slot=%s node=%s", correlation_id[:8], reason, reply.in_reply_to, self.node_id)
+            case FoldAbort(reason=reason):
+                logger.error("[%s] fan-out fold abort (%s) batch=%s node=%s; caller strands", correlation_id[:8], reason, fanout_id, self.node_id)
+            case FoldParked():
+                pass
+        envelope.reply = None  # no-reply mirror (_CONSUMED): the output is still owed
+        return Response(envelope, headers=self._headers("call"))
 
     async def _dispatch_routed(
         self,

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -374,6 +374,31 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
 
         return publish_envelope, kind
 
+    async def _publish_reentry(self, envelope: Envelope, correlation_id: str, broker: BrokerAnnotation) -> None:
+        """Self-publish the fan-out closure re-entry to this node's own return inbox.
+
+        A bespoke, frame-preserving self-return (NOT a ``ReturnCall``, which pops): the
+        node addresses ITSELF so its fan-out frame stays current, and the close (§4.3)
+        rebuilds context from the durable basestate. Deltas from a normal ``ReturnCall``:
+        no pop; ``in_reply_to`` = the fan-out frame's own id; ``parts=[]``; target = own
+        ``_return_topic``; ``key=correlation_id`` (same partition, single-writer); context
+        ``state``/``deps`` cleared (rebuilt at close); **not** broadcast-mirrored — a direct
+        point-to-point publish, never returned for the ``@publisher`` mirror.
+        """
+        frame = envelope.internal_workflow_state.current_frame  # the fan-out frame — NOT popped
+        reentry = Envelope(
+            context=SessionRunContext(state=State(), deps={}),  # cleared — rebuilt from basestate at close
+            internal_workflow_state=envelope.internal_workflow_state,
+            reply=ReturnMessage(in_reply_to=frame.frame_id, tag=frame.tag, parts=[]),
+        )
+        await broker.publish(
+            reentry,
+            topic=self._return_topic,
+            correlation_id=correlation_id,
+            key=correlation_id.encode(),
+            headers=self._headers("return"),
+        )
+
     async def _dispatch_routed(
         self,
         ctx: SessionRunContext,

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -43,6 +43,7 @@ from calfkit.nodes._fanout_store import (
     FoldComplete,
     FoldParked,
     FoldStray,
+    abort_batch,
     close_batch,
     fold_sibling,
 )
@@ -80,6 +81,8 @@ on the first rejection.
 # ---------------------------------------------------------------------------
 
 
+# These are dataclasses (not ``_PipelineSentinel`` enum members) so the fault rail can add the
+# payload-carrying ``_BatchFaulted(report)`` arm additively, without an enum→union migration.
 @dataclass(frozen=True)
 class _BatchClosed:
     """The aggregation stage resolved — proceed to the body. Either a completed fan-out
@@ -572,12 +575,30 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
                 fanout_id = frame.frame_id  # == frame.fanout_id, the batch key
                 reply = envelope.reply
                 assert reply is not None  # guaranteed by _classify_fanout == "sibling"
+                if reply.in_reply_to is None:
+                    logger.error(
+                        "[%s] malformed sibling reply (no in_reply_to) on fan-out node=%s; not folding",
+                        correlation_id[:8],
+                        self.node_id,
+                    )
+                    return _BatchOpen()
                 tag = reply.tag
                 result = ctx.state.tool_results.get(tag) if tag is not None else None
-                outcome = FanoutOutcome(slot=reply.in_reply_to or "", tag=tag, result=result)
+                outcome = FanoutOutcome(slot=reply.in_reply_to, tag=tag, result=result)
                 match await fold_sibling(store, fanout_id, outcome):
                     case FoldComplete():
-                        await self._publish_reentry(envelope, correlation_id, broker)
+                        try:
+                            await self._publish_reentry(envelope, correlation_id, broker)
+                        except KafkaError:
+                            logger.error(
+                                "[%s] fan-out re-entry publish failed batch=%s node=%s; aborting + caller strands",
+                                correlation_id[:8],
+                                fanout_id,
+                                self.node_id,
+                            )
+                            await abort_batch(store, fanout_id)
+                            # TODO(fault rail PR-6): on a permanent re-entry-publish failure, escalate a typed fault to the
+                            # caller (spec §4.4) instead of stranding — the abort+tombstone here is the return-only precursor.
                     case FoldStray(reason=reason):
                         logger.warning("[%s] fan-out stray (%s) slot=%s node=%s", correlation_id[:8], reason, reply.in_reply_to, self.node_id)
                     case FoldAbort(reason=reason):
@@ -623,6 +644,8 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
         from the bag, never snapshotted.
         """
         frame = snapshot.stack.current_frame_or_none
+        # The snapshot's overrides are authoritative-by-capture (baked into snapshot.state.overrides
+        # at OPEN); do NOT re-stamp them from the restored frame here — the capture is the source of truth.
         ctx.state = snapshot.state
         ctx.deps = snapshot.deps
         ctx._frame_id = frame.frame_id if frame is not None else None
@@ -811,10 +834,11 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
             envelope.reply = None  # no-reply mirror (no result): don't re-broadcast an inbound reply (I3)
             return Response(envelope, headers=self._headers("call"))
 
-        # Fan-out OPEN: a fan-out-capable node whose body returned a parallel batch registers the
-        # durable batch + publishes the marked siblings. A non-capable node's list[Call] stays the
-        # plain parallel publish in _publish_action.
-        if self._is_fanout_capable and isinstance(output, list) and output and all(isinstance(c, Call) for c in output):
+        # Fan-out OPEN: a fan-out-capable node whose body returned a parallel batch (N >= 2 Calls)
+        # registers the durable batch + publishes the marked siblings. A non-capable node's
+        # list[Call] stays the plain parallel publish in _publish_action; a 1-element list is a
+        # single stateless continuation (not a durable batch) and reroutes there too.
+        if self._is_fanout_capable and isinstance(output, list) and len(output) >= 2 and all(isinstance(c, Call) for c in output):
             return await self._handle_fanout_open(ctx, output, envelope, correlation_id, broker)
 
         logger.debug("[%s] node=%s produced action=%s", correlation_id[:8], self.node_id, type(output).__name__)

--- a/calfkit/worker/worker.py
+++ b/calfkit/worker/worker.py
@@ -188,11 +188,7 @@ class Worker(LifecycleHookMixin):
         from ktables import KafkaTable  # the one ktables import outside calfkit.mcp
 
         cfg = self._mcp_discovery
-        bootstrap = cfg.bootstrap_servers or self._client.server_urls
-        if not bootstrap:
-            kwargs = getattr(self._client.broker, "_connection_kwargs", None) or {}
-            servers = kwargs.get("bootstrap_servers")
-            bootstrap = servers if isinstance(servers, str) else ",".join(servers) if servers else None
+        bootstrap = cfg.bootstrap_servers or self._derive_bootstrap_servers()
         if not bootstrap:
             raise RuntimeError(
                 "cannot derive Kafka bootstrap servers for the MCP Capability View "
@@ -210,6 +206,21 @@ class Worker(LifecycleHookMixin):
         await table.start()
         yield table
         await table.stop()
+
+    def _derive_bootstrap_servers(self) -> str | None:
+        """The Kafka bootstrap address for this worker's client, or ``None`` if underivable.
+
+        Prefers the client's explicit ``server_urls`` (set by ``Client.connect``), falling back
+        to the broker's connection kwargs. A client built directly via ``__init__`` (no
+        ``connect()``) may have neither — callers raise their own contextual error on ``None``.
+        Shared by the MCP Capability View resource and each fan-out agent's durable store resource.
+        """
+        bootstrap = self._client.server_urls
+        if not bootstrap:
+            kwargs = getattr(self._client.broker, "_connection_kwargs", None) or {}
+            servers = kwargs.get("bootstrap_servers")
+            bootstrap = servers if isinstance(servers, str) else ",".join(servers) if servers else None
+        return bootstrap
 
     def register_handlers(self) -> None:
         """Register FastStream subscribers + publishers for every node.

--- a/docs/adr/0008-durable-in-node-fanout-store-and-self-published-re-entry.md
+++ b/docs/adr/0008-durable-in-node-fanout-store-and-self-published-re-entry.md
@@ -1,0 +1,40 @@
+# Durable in-node fan-out: node-scoped compacted tables + a self-published re-entry close
+
+A fan-out agent issues N parallel tool calls and must aggregate the N returns before resuming its
+turn. The original implementation held that batch in-process (`agent._pending_batches`, a dict
+keyed by the invocation's `frame_id`): correct on one steady process, but the batch is **lost on a
+graceful rebalance or restart and unsafe under multiple replicas** — a partition moving mid-batch
+strands the workflow with no record of what was owed.
+
+We make the batch **durable in two node-scoped compacted ktables**: `calf.fanout.{node_id}.state`
+(a `FanoutState` — the registration plus the accumulating per-slot outcomes, re-written once per
+fold, last-write-wins) and `calf.fanout.{node_id}.basestate` (a write-once `EnvelopeSnapshot` — the
+conversation state, call stack, and deps as of fan-out, the sole restore source at close). The fold
+is **framework-final in the node** (`BaseNodeDef._aggregate`), not a separate worker-level
+aggregator loop over a `calf.fanout.events` topic (the rejected v1 design) — the aggregator added a
+topic, a process, and a hop for machinery that belongs in the one place that already holds the
+batch's context.
+
+The close is a **self-published re-entry** (`x-calf-kind: return`, `in_reply_to == fanout_id`), not
+an in-process resume: on the completing fold the owner publishes a frame-preserving return
+addressed to its own inbox, and on consuming it rebuilds context from the durable basestate and
+resumes the body. This keeps the resume on the normal delivery path (the durable analog of a tool
+return), so it survives a rebalance between completion and resume rather than living in volatile
+call-stack state.
+
+The design is **single-writer-safe from transport, not from the tables**: compacted topics are LWW
+with no compare-and-swap, so correctness rests on exactly one folder per batch — every sibling
+reply is correlation-keyed (one partition), all replicas share `group_id = node.name`, and
+caller-capable nodes are pinned to `max_workers=1`. The tables provide *availability* (a new owner
+reads the durable state and continues); transport provides *serialization*. Reads of the mutable
+`state` barrier first for read-your-own-writes (ktables `barrier()`); the write-once `basestate`
+barriers only on a miss.
+
+Consequences: +1 Kafka hop per fan-out closure (the re-entry); two compacted topics per fan-out
+node, **self-provisioned by ktables' `ensure_topic`** because calfkit's provisioner cannot set
+`cleanup.policy=compact`; each fan-out agent owns the store as a node `@resource` (offline tests,
+where the `@resource` never runs under `TestKafkaBroker`, inject a fake into the bag instead). This
+PR is **return-only**: a failed sibling folds as a `FailedToolCall` and still strands the caller at
+close — today's at-most-once behavior, minus the lost batch. Typed-fault escalation is the
+fault-rail PR's job, which re-homes this fold's `FanoutOutcome.result` field to the parts/fault
+carriage and adds the seam arms onto the staged pipeline this PR builds. Decided 2026-06-15.

--- a/tests/_fanout_fakes.py
+++ b/tests/_fanout_fakes.py
@@ -58,3 +58,29 @@ class FakeFanoutBatchStore:
         self._guard()
         self._state.pop(fanout_id, None)
         self._basestate.pop(fanout_id, None)
+
+
+class OfflineFanoutBatchStore(FakeFanoutBatchStore):
+    """Constructor-compatible offline stand-in for :class:`KtablesFanoutBatchStore`.
+
+    A fan-out agent opens its durable store as a node ``@resource`` that runs on every
+    ``worker.start()``; offline (no broker) that bracket must not dial a real cluster. The
+    autouse ``_offline_fanout_store`` fixture (``tests/conftest.py``) swaps this class in for
+    ``calfkit.nodes.agent.KtablesFanoutBatchStore``, so any Worker hosting a fan-out agent boots
+    broker-free by default — no per-test injection.
+
+    It mirrors the real store's constructor signature exactly (so a future signature change
+    surfaces as a loud failure rather than silent skew) and adds the no-op ``start``/``stop`` the
+    bracket awaits — neither is on the :class:`FanoutBatchStore` Protocol, so the inherited
+    in-memory fold alone is not a drop-in. The transport kwargs are accepted and ignored: an
+    in-memory store has no cluster to reach.
+    """
+
+    def __init__(self, *, bootstrap_servers: str, node_id: str, catchup_timeout: float | None = None) -> None:
+        super().__init__()
+
+    async def start(self) -> None:
+        """No-op: there is no cluster to connect to or catch up against."""
+
+    async def stop(self) -> None:
+        """No-op: nothing to close."""

--- a/tests/_fanout_fakes.py
+++ b/tests/_fanout_fakes.py
@@ -1,0 +1,58 @@
+"""In-memory FanoutBatchStore double for the offline test lane (PR-4).
+
+Mirrors ``tests._provisioning_fakes``: a broker-free fake so the pure fold/close logic
+(step 4) and the staged handler (step 6) are testable without Kafka. The real
+read-your-own-writes / lag behavior is proven against ktables in the kafka lane
+(step 7), so this fake is always fresh and never simulates lag — it only simulates
+terminal unavailability (:meth:`make_unavailable`), keeping the fold-abort path (spec
+§4.4) testable offline.
+"""
+
+from calfkit.models.fanout import EnvelopeSnapshot, FanoutBaseState, FanoutOpen, FanoutOutcome, FanoutState
+from calfkit.nodes._fanout_store import FanoutStoreUnavailableError
+
+
+class FakeFanoutBatchStore:
+    """An in-memory :class:`~calfkit.nodes._fanout_store.FanoutBatchStore`."""
+
+    def __init__(self) -> None:
+        self._state: dict[str, FanoutState] = {}
+        self._basestate: dict[str, FanoutBaseState] = {}
+        self._unavailable = False
+
+    def make_unavailable(self) -> None:
+        """Simulate terminal store death — every subsequent call raises
+        :class:`FanoutStoreUnavailableError` (exercises the fold-abort path, spec §4.4)."""
+        self._unavailable = True
+
+    def _guard(self) -> None:
+        if self._unavailable:
+            raise FanoutStoreUnavailableError("fake fan-out store marked unavailable")
+
+    async def open(self, fanout_id: str, reg: FanoutOpen, snapshot: EnvelopeSnapshot) -> None:
+        self._guard()
+        # basestate THEN state (registration present ⟹ basestate present).
+        self._basestate[fanout_id] = FanoutBaseState(fanout_id=fanout_id, snapshot=snapshot)
+        self._state[fanout_id] = FanoutState(open=reg, outcomes={})
+
+    async def read_state(self, fanout_id: str) -> FanoutState | None:
+        self._guard()
+        return self._state.get(fanout_id)
+
+    async def fold(self, fanout_id: str, outcome: FanoutOutcome) -> FanoutState:
+        self._guard()
+        current = self._state.get(fanout_id)
+        if current is None:
+            raise ValueError(f"fold on an unregistered fan-out batch {fanout_id!r}")
+        updated = current.model_copy(update={"outcomes": {**current.outcomes, outcome.slot: outcome}})
+        self._state[fanout_id] = updated
+        return updated
+
+    async def read_basestate(self, fanout_id: str) -> FanoutBaseState | None:
+        self._guard()
+        return self._basestate.get(fanout_id)
+
+    async def tombstone(self, fanout_id: str) -> None:
+        self._guard()
+        self._state.pop(fanout_id, None)
+        self._basestate.pop(fanout_id, None)

--- a/tests/_fanout_fakes.py
+++ b/tests/_fanout_fakes.py
@@ -31,9 +31,11 @@ class FakeFanoutBatchStore:
 
     async def open(self, fanout_id: str, reg: FanoutOpen, snapshot: EnvelopeSnapshot) -> None:
         self._guard()
-        # basestate THEN state (registration present ⟹ basestate present).
-        self._basestate[fanout_id] = FanoutBaseState(fanout_id=fanout_id, snapshot=snapshot)
-        self._state[fanout_id] = FanoutState(open=reg, outcomes={})
+        # basestate THEN state (registration present ⟹ basestate present). Store deep copies so the
+        # fake matches the real KtablesFanoutBatchStore's freeze-on-write (it serializes on ``set``):
+        # a later mutation of the caller's ``snapshot``/``reg`` must not bleed into the stored record.
+        self._basestate[fanout_id] = FanoutBaseState(fanout_id=fanout_id, snapshot=snapshot.model_copy(deep=True))
+        self._state[fanout_id] = FanoutState(open=reg.model_copy(deep=True), outcomes={})
 
     async def read_state(self, fanout_id: str) -> FanoutState | None:
         self._guard()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ from calfkit.models.tool_dispatch import ToolBinding
 from calfkit.nodes import Agent, ToolNodeDef
 from calfkit.providers.pydantic_ai.openai import OpenAIModelClient, OpenAIResponsesModelClient
 from calfkit.worker import Worker
+from tests._fanout_fakes import OfflineFanoutBatchStore
 from tests.providers import (
     INSTRUCTIONS_TEST_SYSTEM_PROMPT,
     AgentProvider,
@@ -38,6 +39,25 @@ from tests.providers import (
 load_dotenv()
 
 fake = Faker()
+
+
+@pytest.fixture(autouse=True)
+def _offline_fanout_store(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the offline lane broker-free for fan-out agents.
+
+    A fan-out agent opens its durable batch store as a node ``@resource`` that runs on every
+    ``worker.start()`` and, in production, dials a live cluster via ktables. Offline there is no
+    broker, so the store the bracket constructs is swapped for an in-memory drop-in
+    (:class:`OfflineFanoutBatchStore`). Every Worker hosting a fan-out agent then boots broker-free
+    by default — there is no per-test injection to remember, and a test can no longer silently
+    re-acquire a hidden live-broker dependency at ``worker.start()``.
+
+    The ``kafka`` lane is exempt: those tests assert the *real* ``KtablesFanoutBatchStore`` opens
+    its tables over the wire (see ``tests/integration/test_durable_fanout_agent_kafka.py``).
+    """
+    if request.node.get_closest_marker("kafka") is not None:
+        return
+    monkeypatch.setattr("calfkit.nodes.agent.KtablesFanoutBatchStore", OfflineFanoutBatchStore)
 
 
 @pytest.fixture

--- a/tests/integration/test_durable_fanout_agent_kafka.py
+++ b/tests/integration/test_durable_fanout_agent_kafka.py
@@ -1,0 +1,315 @@
+"""Real-broker (``kafka`` lane) agent-level test for PR-4's durable in-node fan-out.
+
+This is the over-the-wire counterpart to the offline arc test
+(``tests/test_durable_fanout_e2e.py``). The offline test drives the full
+OPEN -> fold -> re-entry -> close -> resume arc through the synchronous
+``TestKafkaBroker`` with a **fake** store stuffed into the agent's resource bag,
+because the node-owned ``@resource`` never runs under ``TestKafkaBroker``.
+
+What that offline test CANNOT prove — and what this one does — is the one piece
+that only exists under a real lifecycle against a live broker:
+
+* the fan-out agent's node-owned ``@resource`` actually OPENS the real
+  :class:`~calfkit.nodes._fanout_store.KtablesFanoutBatchStore` (its four
+  compacted ktables) when a real :class:`~calfkit.worker.Worker` boots, and
+* the durable fold + the self-published re-entry close the batch over the wire,
+  so the agent resumes to a final result.
+
+Crucially this test injects **no** store: the agent is a plain non-sequential
+:class:`~calfkit.nodes.Agent`, which auto-registers its ``@resource`` in
+``__init__``; the worker's resource phase opens the real ktables-backed store
+before serving. An offline ``FunctionModel`` removes any LLM dependency — only
+the broker is real.
+
+Opt-in (``-m kafka`` / ``make test-kafka``); skips cleanly without Docker. Run
+with ``uv run --group integration pytest ... -m kafka``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from aiokafka.admin import AIOKafkaAdminClient
+
+from calfkit._vendor.pydantic_ai import models
+from calfkit._vendor.pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+)
+from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
+from calfkit.client import Client
+from calfkit.nodes import Agent, agent_tool
+from calfkit.nodes._fanout_store import FANOUT_STORE_KEY
+from calfkit.worker import Worker
+
+# Every test here needs a real broker. FunctionModel is an offline model, but
+# pydantic-ai still gates "model requests" behind this flag in some paths; set
+# it so the agent loop runs without an allow-list error (matches
+# tests/integration/test_agent_workers.py).
+pytestmark = pytest.mark.kafka
+models.ALLOW_MODEL_REQUESTS = True
+
+
+# ── the fan-out agent's two tools (mirror tests/test_durable_fanout_e2e.py) ──────
+
+
+@agent_tool
+def fanout_tool_a() -> str:
+    return "a_result"
+
+
+@agent_tool
+def fanout_tool_b() -> str:
+    return "b_result"
+
+
+def _calls_two_then_done(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+    """Fan out both tools on the first turn; once their returns are in history, finish.
+
+    The marker that the durable arc actually ran is the second turn: it only
+    happens after BOTH sibling tool returns have been folded into the durable
+    batch, the re-entry has closed it, and the snapshot's materialized outcomes
+    have been replayed into ``message_history`` — i.e. the model sees the tool
+    returns it never would on a single-call (non-fan-out) path.
+    """
+    last = messages[-1]
+    if isinstance(last, ModelRequest) and any(isinstance(p, ToolReturnPart) for p in last.parts):
+        return ModelResponse(parts=[TextPart("done")])
+    return ModelResponse(parts=[ToolCallPart("fanout_tool_a"), ToolCallPart("fanout_tool_b")])
+
+
+def _tool_returns(history: list[ModelMessage]) -> dict[str, object]:
+    """Map ``tool_name -> return_value`` over every ToolReturnPart in the history."""
+    returns: dict[str, object] = {}
+    for msg in history:
+        if isinstance(msg, ModelRequest):
+            for part in msg.parts:
+                if isinstance(part, ToolReturnPart):
+                    returns[part.tool_name] = part.content
+    return returns
+
+
+async def _topics(bootstrap: str) -> set[str]:
+    admin = AIOKafkaAdminClient(bootstrap_servers=bootstrap)
+    await admin.start()
+    try:
+        return set(await admin.list_topics())
+    finally:
+        await admin.close()
+
+
+async def test_fanout_agent_opens_real_store_and_resumes_over_the_wire(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """A real Worker hosts a fan-out agent against live Redpanda; the node-owned
+    ``@resource`` opens the REAL ktables store; the agent fans out two tools and
+    the durable fold + self-published re-entry close the batch so the agent
+    resumes to a final result — no fake store injected anywhere.
+    """
+    agent_id = f"{topic_namespace}-fanout-agent"
+    agent_in = f"{topic_namespace}.fanout-agent.input"
+
+    agent = Agent(
+        agent_id,
+        system_prompt="x",
+        subscribe_topics=agent_in,
+        model_client=FunctionModel(_calls_two_then_done),
+        tools=[fanout_tool_a, fanout_tool_b],
+    )
+
+    # A non-sequential agent auto-registers its durable-store @resource in
+    # __init__; the worker lifecycle opens the REAL KtablesFanoutBatchStore.
+    # Guard the premise of this test: nothing pre-seeds the bag (the offline
+    # fake-injection pattern must NOT be in play here).
+    assert agent._is_fanout_capable
+    assert FANOUT_STORE_KEY not in agent.resources
+
+    client = Client.connect(kafka_bootstrap)
+    worker = Worker(
+        client,
+        nodes=[agent, fanout_tool_a, fanout_tool_b],
+        # Read from earliest so a node's consumer-group join never races (and
+        # drops) the publish that addresses it — the agent's input call, the
+        # fanned-out sibling calls, the tool returns, and the self-published
+        # re-entry all flow before their consumers may have positioned
+        # themselves on a freshly-auto-created partition.
+        extra_subscribe_kwargs={"auto_offset_reset": "earliest"},
+    )
+
+    # ``async with worker`` runs the full lifecycle on the shared broker: the
+    # resource phase opens the agent's ktables store (the thing under test),
+    # then the broker serves both the hosted nodes and the client's reply
+    # consumer (registered on the same connection by Client.connect).
+    async with worker:
+        # The agent's @resource opening the store created its compacted tables;
+        # this is the over-the-wire proof the real KtablesFanoutBatchStore
+        # opened (the offline fake-store test cannot make this assertion).
+        topics = await _topics(kafka_bootstrap)
+        assert f"calf.fanout.{agent_id}.state" in topics
+        assert f"calf.fanout.{agent_id}.basestate" in topics
+
+        result = await client.execute("call both tools", agent_in, timeout=120)
+
+    # The agent resumed past the durable close to its final result.
+    assert result.output is not None and "done" in result.output
+
+    # Both sibling returns were folded durably and materialized back into the
+    # resumed body's history — the marker that the OPEN -> fold -> re-entry ->
+    # close -> resume arc ran over the wire (not a single-call shortcut).
+    returns = _tool_returns(result.message_history)
+    assert returns.get("fanout_tool_a") == "a_result"
+    assert returns.get("fanout_tool_b") == "b_result"
+
+    # The batch closed exactly once: the model was asked exactly twice (turn 1
+    # fans out; turn 2 sees both returns and finishes). A double-close or a
+    # re-fanned batch would show extra turns.
+    model_turns = [m for m in result.message_history if isinstance(m, ModelResponse)]
+    assert len(model_turns) == 2
+    fanned = [p for p in model_turns[0].parts if isinstance(p, ToolCallPart)]
+    assert {p.tool_name for p in fanned} == {"fanout_tool_a", "fanout_tool_b"}
+
+    await client.close()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Secondary goal: graceful-rebalance continuation across two workers.
+#
+# ADR-0008 claims the durable design's core availability property: "a new owner
+# reads the durable state and continues", and the self-published re-entry "keeps
+# the resume on the normal delivery path ... so it survives a rebalance between
+# completion and resume". This test proves it directly: the original owner opens
+# the durable batch and then leaves the group BEFORE any sibling reply is folded;
+# a fresh owner (same consumer group, same node id) takes over, folds both
+# replies from the durable tables, and closes the batch exactly once.
+#
+# Determinism (no timing races): the two tools BLOCK on a shared gate, so their
+# replies cannot land until the test releases them — strictly after the first
+# owner has stopped. The first owner is fully torn down before the gate opens, so
+# only the second owner can possibly fold/close. A separate, always-up driver
+# client owns the reply future; each worker has its own broker connection, so
+# stopping the first owner never disturbs the driver or the second owner. The
+# first owner's graceful stop commits its input offset (verified behavior), so
+# the second owner — reading ``earliest`` to catch the replies produced while it
+# was down — never re-reads the input and never re-OPENs the batch.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+_GATE = asyncio.Event()
+_TOOL_ENTRIES = 0
+
+
+@agent_tool
+async def gated_tool_a() -> str:
+    """A fan-out sibling that records its entry, then blocks until the test
+    releases the gate — keeping the batch OPEN across the rebalance."""
+    global _TOOL_ENTRIES
+    _TOOL_ENTRIES += 1
+    await _GATE.wait()
+    return "a_result"
+
+
+@agent_tool
+async def gated_tool_b() -> str:
+    global _TOOL_ENTRIES
+    _TOOL_ENTRIES += 1
+    await _GATE.wait()
+    return "b_result"
+
+
+def _calls_two_gated_then_done(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+    last = messages[-1]
+    if isinstance(last, ModelRequest) and any(isinstance(p, ToolReturnPart) for p in last.parts):
+        return ModelResponse(parts=[TextPart("done")])
+    return ModelResponse(parts=[ToolCallPart("gated_tool_a"), ToolCallPart("gated_tool_b")])
+
+
+def _make_fanout_agent(node_id: str, agent_in: str) -> Agent:
+    """A fresh fan-out agent instance bound to a shared ``node_id`` (so two
+    instances in two workers share one consumer group + one durable store)."""
+    return Agent(
+        node_id,
+        system_prompt="x",
+        subscribe_topics=agent_in,
+        model_client=FunctionModel(_calls_two_gated_then_done),
+        tools=[gated_tool_a, gated_tool_b],
+    )
+
+
+async def _wait(predicate, *, timeout: float, what: str) -> None:
+    """Poll ``predicate`` until true or fail loudly — no bare sleeps."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.1)
+    raise AssertionError(f"timed out after {timeout}s waiting for: {what}")
+
+
+async def test_graceful_rebalance_continues_batch_on_new_owner(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """Owner-1 OPENs a durable fan-out batch then leaves the group with the batch
+    still open; owner-2 (same group + node id) folds both replies from the
+    durable tables and closes the batch exactly once, resuming to a final result.
+    """
+    global _TOOL_ENTRIES
+    _GATE.clear()
+    _TOOL_ENTRIES = 0
+
+    agent_id = f"{topic_namespace}-rebal-agent"
+    agent_in = f"{topic_namespace}.rebal-agent.input"
+    earliest = {"auto_offset_reset": "earliest"}
+
+    # Independent broker connections (all -> same Redpanda):
+    #  - driver: owns the reply future; stays up the whole test.
+    #  - tools worker: hosts the two gated tools; stays up.
+    #  - owner-1 / owner-2: each hosts a fan-out agent on the SHARED node id.
+    driver = Client.connect(kafka_bootstrap)
+    tools_worker = Worker(
+        Client.connect(kafka_bootstrap),
+        nodes=[gated_tool_a, gated_tool_b],
+        extra_subscribe_kwargs=earliest,
+    )
+    owner1 = Worker(Client.connect(kafka_bootstrap), nodes=[_make_fanout_agent(agent_id, agent_in)], extra_subscribe_kwargs=earliest)
+    owner2 = Worker(Client.connect(kafka_bootstrap), nodes=[_make_fanout_agent(agent_id, agent_in)], extra_subscribe_kwargs=earliest)
+
+    # The tools worker stays up across BOTH owners — the blocked siblings must
+    # survive owner-1's departure so their replies can be released to owner-2.
+    async with tools_worker:
+        async with owner1:
+            # Kick off the invocation; owner-1 OPENs the durable batch and fans
+            # out the two (now-blocked) siblings. Don't await the reply yet.
+            handle = await driver.start("call both tools", agent_in)
+
+            # Both siblings reached the tools => owner-1's OPEN ran, the durable
+            # batch is written, and the siblings are published and parked on the
+            # gate. The batch CANNOT close on owner-1: no reply has folded.
+            await _wait(lambda: _TOOL_ENTRIES == 2, timeout=60, what="both fan-out siblings to reach the tools")
+
+            topics = await _topics(kafka_bootstrap)
+            assert f"calf.fanout.{agent_id}.state" in topics and f"calf.fanout.{agent_id}.basestate" in topics
+
+        # Owner-1 has gracefully left the group (committing its input offset).
+        # The batch is durably OPEN with zero folds; only a new owner finishes it.
+        async with owner2:
+            # Release the siblings AFTER owner-1 is gone: their replies land on
+            # the agent's return inbox while owner-2 owns it. Owner-2 reads them
+            # from earliest, folds both from the durable state, completes,
+            # self-publishes the re-entry, and closes from the durable
+            # basestate — the rebalance continuation.
+            _GATE.set()
+            result = await handle.result(timeout=120)
+
+    assert result.output is not None and "done" in result.output
+    returns = _tool_returns(result.message_history)
+    assert returns.get("gated_tool_a") == "a_result"
+    assert returns.get("gated_tool_b") == "b_result"
+    # Exactly-once close: the batch fanned out once and finished once.
+    model_turns = [m for m in result.message_history if isinstance(m, ModelResponse)]
+    assert len(model_turns) == 2
+
+    await driver.close()
+    await tools_worker._client.close()
+    await owner1._client.close()
+    await owner2._client.close()

--- a/tests/integration/test_fanout_store_kafka.py
+++ b/tests/integration/test_fanout_store_kafka.py
@@ -1,0 +1,75 @@
+"""Real-broker (``kafka`` lane) tests for the durable fan-out store (PR-4 step 7).
+
+These exercise :class:`KtablesFanoutBatchStore` against a REAL Redpanda broker — the
+durability properties the offline ``FakeFanoutBatchStore`` cannot reproduce: the
+read-your-own-writes barrier across folds, tombstone visibility, and the pure
+fold/close state machine running over the wire. Opt-in (``-m kafka`` / ``make
+test-kafka``); skips cleanly without Docker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from calfkit._vendor.pydantic_ai.messages import ToolReturn
+from calfkit.models.fanout import EnvelopeSnapshot, FanoutOpen, FanoutOutcome, SlotRef
+from calfkit.models.session_context import CallFrame, Stack, WorkflowState
+from calfkit.models.state import State
+from calfkit.nodes._fanout_store import (
+    CloseResume,
+    FoldComplete,
+    FoldParked,
+    KtablesFanoutBatchStore,
+    close_batch,
+    fold_sibling,
+)
+
+pytestmark = pytest.mark.kafka
+
+
+def _snapshot() -> EnvelopeSnapshot:
+    own = CallFrame(target_topic="a", callback_topic="caller", frame_id="A")
+    return EnvelopeSnapshot(state=State(), stack=WorkflowState(call_stack=Stack([own])), deps={"k": "v"})
+
+
+def _reg() -> FanoutOpen:
+    return FanoutOpen(fanout_id="A", node_id="n", expected=[SlotRef(frame_id="f1", tag="tc1"), SlotRef(frame_id="f2", tag="tc2")])
+
+
+async def test_open_then_read_is_read_your_own_writes(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """After OPEN, a barriered read sees the just-written state + basestate (RYOW)."""
+    store = KtablesFanoutBatchStore(bootstrap_servers=kafka_bootstrap, node_id=f"{topic_namespace}-n")
+    await store.start()
+    try:
+        await store.open("A", _reg(), _snapshot())
+        state = await store.read_state("A")
+        assert state is not None
+        assert {s.frame_id for s in state.open.expected} == {"f1", "f2"}
+        assert state.outcomes == {}
+        base = await store.read_basestate("A")
+        assert base is not None and base.snapshot.deps == {"k": "v"}
+    finally:
+        await store.stop()
+
+
+async def test_fold_across_folds_then_close_and_tombstone(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """The pure fold/close machine runs over the wire: each fold's barrier sees the prior
+    fold (RYOW), completion closes + materializes, and the tombstone is visible on re-read."""
+    store = KtablesFanoutBatchStore(bootstrap_servers=kafka_bootstrap, node_id=f"{topic_namespace}-n")
+    await store.start()
+    try:
+        await store.open("A", _reg(), _snapshot())
+        first = await fold_sibling(store, "A", FanoutOutcome(slot="f1", tag="tc1", result=ToolReturn(return_value="r1")))
+        assert isinstance(first, FoldParked)  # 1 of 2 — barrier saw the OPEN
+        second = await fold_sibling(store, "A", FanoutOutcome(slot="f2", tag="tc2", result=ToolReturn(return_value="r2")))
+        assert isinstance(second, FoldComplete)  # 2 of 2 — barrier saw fold #1 (RYOW)
+
+        closed = await close_batch(store, "A")
+        assert isinstance(closed, CloseResume)
+        assert closed.snapshot.state.get_tool_result("tc1") == ToolReturn(return_value="r1")
+        assert closed.snapshot.state.get_tool_result("tc2") == ToolReturn(return_value="r2")
+        # Tombstoned at close — a barriered re-read sees the delete (RYOW on the null tombstone).
+        assert await store.read_state("A") is None
+        assert await store.read_basestate("A") is None
+    finally:
+        await store.stop()

--- a/tests/providers.py
+++ b/tests/providers.py
@@ -10,7 +10,9 @@ from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
 from calfkit.client import Client
 from calfkit.models.tool_context import ToolContext
 from calfkit.nodes import Agent, BaseToolNodeDef, ToolNodeDef, agent_tool
+from calfkit.nodes._fanout_store import FANOUT_STORE_KEY
 from calfkit.worker import Worker
+from tests._fanout_fakes import FakeFanoutBatchStore
 
 load_dotenv()
 
@@ -170,3 +172,9 @@ class WorkerProvider(Provider):
 def prepare_worker(container):
     worker: Worker = container.get(Worker)
     worker.register_handlers()
+    # Offline analog of the production node-owned fan-out @resource (which never runs under the
+    # synchronous TestKafkaBroker): give each fan-out-capable node a fake durable store, unless a
+    # test already injected its own (e.g. the spy store in tests/test_durable_fanout_e2e.py).
+    for node in worker._nodes:
+        if node._is_fanout_capable and FANOUT_STORE_KEY not in node.resources:
+            node.resources[FANOUT_STORE_KEY] = FakeFanoutBatchStore()

--- a/tests/test_callframe_fanout_id.py
+++ b/tests/test_callframe_fanout_id.py
@@ -3,8 +3,8 @@
 ``CallFrame`` carries ``fanout_id`` — the fan-out node's own inbound ``frame_id``.
 At fan-out dispatch it is stamped on the node's OWN frame within each sibling's stack
 copy (so it survives the callee's return-pop and is the top frame when the sibling
-reply re-enters this node), *not* on the pushed callee frame — the stamping op itself
-lands with the dispatch wiring. It defaults to ``None`` (unmarked) on every
+reply re-enters this node), *not* on the pushed callee frame — ``WorkflowState.mark_fanout``
+stamps it by replacing the frozen top frame. It defaults to ``None`` (unmarked) on every
 non-sibling frame and must survive the JSON hop.
 
 ``WorkflowState.invoke_frame`` takes a keyword-only ``frame_id`` so the fan-out OPEN
@@ -53,3 +53,23 @@ def test_workflowstate_roundtrips_fanout_id() -> None:
     ws = WorkflowState(call_stack=Stack([CallFrame(target_topic="t", callback_topic="cb", fanout_id="X")]))
     rt = WorkflowState.model_validate_json(ws.model_dump_json())
     assert rt.current_frame.fanout_id == "X"
+
+
+def test_mark_fanout_stamps_own_frame_id_on_top_frame() -> None:
+    # The marker value IS the frame's own id (the batch key); mark_fanout sets it on the
+    # node's own (top) frame without changing the frame_id.
+    ws = WorkflowState(call_stack=Stack())
+    ws.invoke_frame(Call(target_topic="t", state=State()), callback_topic="cb", frame_id="agent-frame")
+    ws.mark_fanout()
+    assert ws.current_frame.fanout_id == "agent-frame"
+    assert ws.current_frame.frame_id == "agent-frame"
+
+
+def test_mark_fanout_only_marks_the_top_frame() -> None:
+    ws = WorkflowState(call_stack=Stack())
+    ws.invoke_frame(Call(target_topic="caller", state=State()), callback_topic=None, frame_id="bottom")
+    ws.invoke_frame(Call(target_topic="agent", state=State()), callback_topic="cb", frame_id="agent-frame")
+    ws.mark_fanout()
+    top = ws.unwind_frame()
+    assert top.fanout_id == "agent-frame"
+    assert ws.current_frame.fanout_id is None  # the lower frame is untouched

--- a/tests/test_callframe_fanout_id.py
+++ b/tests/test_callframe_fanout_id.py
@@ -1,0 +1,38 @@
+"""PR-4 step 2: the fan-out marker carrier.
+
+``CallFrame`` carries ``fanout_id`` — the fan-out node's own inbound ``frame_id``,
+stamped on each sibling ``Call``'s frame copy at fan-out dispatch (the stamping
+itself lands in step 5/6). It defaults to ``None`` (unmarked) on every non-sibling
+frame, and ``WorkflowState.invoke_frame`` accepts it as a keyword-only arg so the
+existing positional call sites are untouched. The marker must survive the JSON hop.
+"""
+
+from calfkit.models.actions import Call
+from calfkit.models.session_context import CallFrame, Stack, WorkflowState
+from calfkit.models.state import State
+
+
+def test_callframe_fanout_id_defaults_none() -> None:
+    assert CallFrame(target_topic="t", callback_topic="cb").fanout_id is None
+
+
+def test_callframe_carries_fanout_id() -> None:
+    assert CallFrame(target_topic="t", callback_topic="cb", fanout_id="X").fanout_id == "X"
+
+
+def test_invoke_frame_unmarked_by_default() -> None:
+    ws = WorkflowState(call_stack=Stack())
+    ws.invoke_frame(Call(target_topic="t", state=State()), callback_topic="cb")
+    assert ws.current_frame.fanout_id is None
+
+
+def test_invoke_frame_stamps_fanout_id() -> None:
+    ws = WorkflowState(call_stack=Stack())
+    ws.invoke_frame(Call(target_topic="t", state=State()), callback_topic="cb", fanout_id="X")
+    assert ws.current_frame.fanout_id == "X"
+
+
+def test_workflowstate_roundtrips_fanout_id() -> None:
+    ws = WorkflowState(call_stack=Stack([CallFrame(target_topic="t", callback_topic="cb", fanout_id="X")]))
+    rt = WorkflowState.model_validate_json(ws.model_dump_json())
+    assert rt.current_frame.fanout_id == "X"

--- a/tests/test_callframe_fanout_id.py
+++ b/tests/test_callframe_fanout_id.py
@@ -1,10 +1,16 @@
-"""PR-4 step 2: the fan-out marker carrier.
+"""PR-4: the fan-out marker carrier + caller-chosen slot frame ids.
 
-``CallFrame`` carries ``fanout_id`` — the fan-out node's own inbound ``frame_id``,
-stamped on each sibling ``Call``'s frame copy at fan-out dispatch (the stamping
-itself lands in step 5/6). It defaults to ``None`` (unmarked) on every non-sibling
-frame, and ``WorkflowState.invoke_frame`` accepts it as a keyword-only arg so the
-existing positional call sites are untouched. The marker must survive the JSON hop.
+``CallFrame`` carries ``fanout_id`` — the fan-out node's own inbound ``frame_id``.
+At fan-out dispatch it is stamped on the node's OWN frame within each sibling's stack
+copy (so it survives the callee's return-pop and is the top frame when the sibling
+reply re-enters this node), *not* on the pushed callee frame — the stamping op itself
+lands with the dispatch wiring. It defaults to ``None`` (unmarked) on every
+non-sibling frame and must survive the JSON hop.
+
+``WorkflowState.invoke_frame`` takes a keyword-only ``frame_id`` so the fan-out OPEN
+can pre-mint each callee slot's frame id: the published callee frame *is* that id, so
+a reply's ``in_reply_to`` matches the registered slot directly. Existing positional
+call sites are untouched, and ``invoke_frame`` never stamps the marker.
 """
 
 from calfkit.models.actions import Call
@@ -20,16 +26,27 @@ def test_callframe_carries_fanout_id() -> None:
     assert CallFrame(target_topic="t", callback_topic="cb", fanout_id="X").fanout_id == "X"
 
 
-def test_invoke_frame_unmarked_by_default() -> None:
+def test_invoke_frame_does_not_mark_pushed_frame() -> None:
+    # invoke_frame pushes the CALLEE frame; the fan-out marker belongs on the node's
+    # OWN frame, so the pushed callee frame is always unmarked.
     ws = WorkflowState(call_stack=Stack())
     ws.invoke_frame(Call(target_topic="t", state=State()), callback_topic="cb")
     assert ws.current_frame.fanout_id is None
 
 
-def test_invoke_frame_stamps_fanout_id() -> None:
+def test_invoke_frame_uses_caller_chosen_frame_id() -> None:
+    # The fan-out OPEN pre-mints each callee slot id and publishes the sibling on it,
+    # so a reply's in_reply_to matches the registered SlotRef.frame_id directly.
     ws = WorkflowState(call_stack=Stack())
-    ws.invoke_frame(Call(target_topic="t", state=State()), callback_topic="cb", fanout_id="X")
-    assert ws.current_frame.fanout_id == "X"
+    ws.invoke_frame(Call(target_topic="t", state=State()), callback_topic="cb", frame_id="slot-1")
+    assert ws.current_frame.frame_id == "slot-1"
+
+
+def test_invoke_frame_mints_frame_id_when_unspecified() -> None:
+    # Without a caller-chosen id, invoke_frame keeps minting a fresh uuid7 hex.
+    ws = WorkflowState(call_stack=Stack())
+    ws.invoke_frame(Call(target_topic="t", state=State()), callback_topic="cb")
+    assert len(ws.current_frame.frame_id) == 32  # uuid7().hex
 
 
 def test_workflowstate_roundtrips_fanout_id() -> None:

--- a/tests/test_callframe_fanout_id.py
+++ b/tests/test_callframe_fanout_id.py
@@ -73,3 +73,15 @@ def test_mark_fanout_only_marks_the_top_frame() -> None:
     top = ws.unwind_frame()
     assert top.fanout_id == "agent-frame"
     assert ws.current_frame.fanout_id is None  # the lower frame is untouched
+
+
+def test_call_carries_tag() -> None:
+    assert Call(target_topic="t", state=State(), tag="tc1").tag == "tc1"
+
+
+def test_invoke_frame_sets_caller_tag_on_frame() -> None:
+    # The fan-out OPEN passes each sibling's tool_call_id as the callee frame's tag, so
+    # the tool's reply echoes it (reply.tag) — a self-describing sibling reply.
+    ws = WorkflowState(call_stack=Stack())
+    ws.invoke_frame(Call(target_topic="t", state=State()), callback_topic="cb", tag="tc1")
+    assert ws.current_frame.tag == "tc1"

--- a/tests/test_durable_fanout_e2e.py
+++ b/tests/test_durable_fanout_e2e.py
@@ -1,0 +1,98 @@
+"""End-to-end durable fan-out (PR-4 6b-B): a real 2-tool fan-out driven through
+``TestKafkaBroker`` with a fan-out store injected into the agent's resource bag.
+
+This is the north-star for the staged-handler cutover. It proves the full durable arc:
+OPEN (write the batch + publish marked siblings) → fold each sibling reply into the store →
+self-publish the closure re-entry on completion → close (restore context from the snapshot,
+materialize the outcomes) → resume the agent body to a final result.
+
+Before the cutover the agent aggregates in-process (``_pending_batches``) and the injected
+store is never touched — so the store-usage assertions are RED. After the cutover the fold is
+durable and they pass.
+"""
+
+from __future__ import annotations
+
+from faststream.kafka import KafkaBroker, TestKafkaBroker
+
+from calfkit._vendor.pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, TextPart, ToolCallPart, ToolReturnPart
+from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
+from calfkit.client import Client
+from calfkit.models.fanout import EnvelopeSnapshot, FanoutOpen, FanoutOutcome
+from calfkit.models.tool_context import ToolContext
+from calfkit.nodes import Agent, agent_tool
+from calfkit.nodes._fanout_store import FANOUT_STORE_KEY
+from calfkit.worker import Worker
+from tests._fanout_fakes import FakeFanoutBatchStore
+from tests.providers import prepare_worker
+
+
+@agent_tool
+def e2e_tool_a(ctx: ToolContext) -> str:
+    return "a_result"
+
+
+@agent_tool
+def e2e_tool_b(ctx: ToolContext) -> str:
+    return "b_result"
+
+
+def _calls_two_then_done(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+    """Fan out both tools on the first turn; once their returns are in history, finish."""
+    last = messages[-1]
+    if isinstance(last, ModelRequest) and any(isinstance(p, ToolReturnPart) for p in last.parts):
+        return ModelResponse(parts=[TextPart("done")])
+    return ModelResponse(parts=[ToolCallPart("e2e_tool_a"), ToolCallPart("e2e_tool_b")])
+
+
+class _SpyStore(FakeFanoutBatchStore):
+    """A FakeFanoutBatchStore that counts the durable operations, to prove the fold went
+    through the store (not the in-process ``_pending_batches``)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.opens = 0
+        self.folds = 0
+        self.tombstones = 0
+
+    async def open(self, fanout_id: str, reg: FanoutOpen, snapshot: EnvelopeSnapshot) -> None:
+        self.opens += 1
+        await super().open(fanout_id, reg, snapshot)
+
+    async def fold(self, fanout_id: str, outcome: FanoutOutcome):  # type: ignore[no-untyped-def]
+        self.folds += 1
+        return await super().fold(fanout_id, outcome)
+
+    async def tombstone(self, fanout_id: str) -> None:
+        self.tombstones += 1
+        await super().tombstone(fanout_id)
+
+
+async def test_durable_fanout_folds_in_store_and_closes_via_reentry(container) -> None:
+    worker = container.get(Worker)
+    agent = Agent(
+        "durable_fanout_agent",
+        system_prompt="x",
+        subscribe_topics="durable_fanout_agent.input",
+        model_client=FunctionModel(_calls_two_then_done),
+        tools=[e2e_tool_a, e2e_tool_b],
+    )
+    spy = _SpyStore()
+    # Offline injection: the node-owned @resource never runs under TestKafkaBroker, so the
+    # fan-out agent just gets its store stuffed into the bag (the established pattern).
+    agent.resources[FANOUT_STORE_KEY] = spy
+    worker.add_nodes(agent, e2e_tool_a, e2e_tool_b)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        result = await client.execute("call both tools", "durable_fanout_agent.input", timeout=10)
+
+    # The batch was folded DURABLY in the store (not the in-process _pending_batches)...
+    assert spy.opens == 1  # one OPEN for the 2-call batch
+    assert spy.folds == 2  # both sibling replies folded through the store
+    assert spy.tombstones >= 1  # closed (tombstone-first at the re-entry)
+    # ...and the agent resumed past the durable close to its final result.
+    assert result.output is not None and "done" in result.output

--- a/tests/test_durable_fanout_e2e.py
+++ b/tests/test_durable_fanout_e2e.py
@@ -13,11 +13,13 @@ durable and they pass.
 
 from __future__ import annotations
 
+import pytest
 from faststream.kafka import KafkaBroker, TestKafkaBroker
 
 from calfkit._vendor.pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, TextPart, ToolCallPart, ToolReturnPart
 from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
 from calfkit.client import Client
+from calfkit.exceptions import ToolExecutionError
 from calfkit.models.fanout import EnvelopeSnapshot, FanoutOpen, FanoutOutcome
 from calfkit.models.tool_context import ToolContext
 from calfkit.nodes import Agent, agent_tool
@@ -35,6 +37,11 @@ def e2e_tool_a(ctx: ToolContext) -> str:
 @agent_tool
 def e2e_tool_b(ctx: ToolContext) -> str:
     return "b_result"
+
+
+@agent_tool
+def e2e_tool_boom(ctx: ToolContext) -> str:
+    raise ValueError("e2e boom")
 
 
 def _calls_two_then_done(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
@@ -96,3 +103,46 @@ async def test_durable_fanout_folds_in_store_and_closes_via_reentry(container) -
     assert spy.tombstones >= 1  # closed (tombstone-first at the re-entry)
     # ...and the agent resumed past the durable close to its final result.
     assert result.output is not None and "done" in result.output
+
+
+def _calls_ok_and_boom(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+    """Fan out a succeeding + a failing tool on the first turn."""
+    last = messages[-1]
+    if isinstance(last, ModelRequest) and any(isinstance(p, ToolReturnPart) for p in last.parts):
+        return ModelResponse(parts=[TextPart("done")])
+    return ModelResponse(parts=[ToolCallPart("e2e_tool_a"), ToolCallPart("e2e_tool_boom")])
+
+
+async def test_durable_fanout_with_failing_tool_strands_via_tool_execution_error(container) -> None:
+    # (coverage b) The return-only strand, end-to-end: a 2-tool fan-out where ONE tool raises. The
+    # failure folds durably as a FailedToolCall, the batch completes + closes, and the resumed agent
+    # body raises ToolExecutionError (the documented strand — the fault-rail PR will escalate a typed
+    # fault instead). Under TestKafkaBroker the raise escapes the handler and propagates out of
+    # client.execute, so pytest.raises is the cleanest end-to-end assertion.
+    worker = container.get(Worker)
+    agent = Agent(
+        "durable_fanout_fail_agent",
+        system_prompt="x",
+        subscribe_topics="durable_fanout_fail_agent.input",
+        model_client=FunctionModel(_calls_ok_and_boom),
+        tools=[e2e_tool_a, e2e_tool_boom],
+    )
+    spy = _SpyStore()
+    agent.resources[FANOUT_STORE_KEY] = spy
+    worker.add_nodes(agent, e2e_tool_a, e2e_tool_boom)
+    prepare_worker(container)
+
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    with pytest.raises(ToolExecutionError) as exc_info:
+        async with TestKafkaBroker(broker):
+            await client.execute("call both tools", "durable_fanout_fail_agent.input", timeout=10)
+
+    # The strand carries the failing tool's identity (sourced from the durably-folded marker).
+    assert exc_info.value.tool_name == "e2e_tool_boom"
+    assert exc_info.value.exc_type == "ValueError"
+    # And the failure travelled the DURABLE path: both siblings folded through the store before close.
+    assert spy.opens == 1
+    assert spy.folds == 2
+    assert spy.tombstones >= 1

--- a/tests/test_fanout_fold.py
+++ b/tests/test_fanout_fold.py
@@ -14,7 +14,7 @@ import pytest
 from calfkit._vendor.pydantic_ai.messages import ToolReturn
 from calfkit.models.fanout import EnvelopeSnapshot, FanoutOpen, FanoutOutcome, SlotRef
 from calfkit.models.session_context import CallFrame, Stack, WorkflowState
-from calfkit.models.state import State
+from calfkit.models.state import FailedToolCall, State
 from calfkit.nodes._fanout_store import (
     CloseAbandon,
     CloseAbort,
@@ -130,6 +130,22 @@ async def test_close_complete_batch_resumes_materialized_and_tombstones(store: F
     assert await store.read_basestate("X") is None
 
 
+async def test_close_materializes_failed_tool_call_as_typed_marker(store: FakeFanoutBatchStore) -> None:
+    # (coverage a) A return-only tool failure folds as a FailedToolCall outcome; on close it must
+    # materialize into the snapshot's State as a TYPED FailedToolCall (via the discriminator), not a
+    # bare dict or None — so the resumed agent body sees the marker and strands the caller.
+    marker = FailedToolCall.build_safe(tool_name="t", tool_call_id="tc1", exc_type="ValueError", exc_message="boom")
+    await store.open("X", _open(), _snapshot())
+    await fold_sibling(store, "X", FanoutOutcome(slot="f1", tag="tc1", result=marker))
+    await fold_sibling(store, "X", _outcome("f2", "tc2", value="ok"))  # completes
+    result = await close_batch(store, "X")
+    assert isinstance(result, CloseResume)
+    materialized = result.snapshot.state.get_tool_result("tc1")
+    assert isinstance(materialized, FailedToolCall)
+    assert materialized.exc_type == "ValueError"
+    assert materialized.tool_call_id == "tc1"
+
+
 async def test_close_incomplete_batch_is_spurious_and_keeps_state(store: FakeFanoutBatchStore) -> None:
     await store.open("X", _open(), _snapshot())
     await fold_sibling(store, "X", _outcome("f1", "tc1"))  # only 1 of 2
@@ -164,8 +180,9 @@ async def test_close_unavailable_store_aborts(store: FakeFanoutBatchStore) -> No
 
 
 async def test_close_materialization_failure_on_missing_tag_aborts(store: FakeFanoutBatchStore) -> None:
-    await store.open("X", _open(slots=(("f1", "tc1"),)), _snapshot())
-    await fold_sibling(store, "X", _outcome("f1", tag=None))  # no tag → can't materialize
+    await store.open("X", _open(), _snapshot())  # 2-slot batch (the N>=2 invariant)
+    await fold_sibling(store, "X", _outcome("f1", "tc1"))
+    await fold_sibling(store, "X", _outcome("f2", tag=None))  # no tag → can't materialize → completes the batch
     result = await close_batch(store, "X")
     assert isinstance(result, CloseAbort)
     assert result.reason == "materialization_failed"

--- a/tests/test_fanout_fold.py
+++ b/tests/test_fanout_fold.py
@@ -1,0 +1,199 @@
+"""PR-4 step 4: the pure fold/close/abort state machine over a FanoutBatchStore.
+
+These are the durable analog of the agent's in-process _parallel_state_aggregation —
+store- and caller-agnostic pure fns (no broker, no envelope), exercised exhaustively
+over the in-memory fake so wiring them into the staged handler (step 6) is no re-home:
+
+- fold_sibling  : one marked sibling reply → park / complete / stray / abort
+- close_batch   : the re-entry → resume (materialized) / abandon / spurious / abort
+- abort_batch   : best-effort tombstone of both records (the §4.4 abort cleanup)
+"""
+
+import pytest
+
+from calfkit._vendor.pydantic_ai.messages import ToolReturn
+from calfkit.models.fanout import EnvelopeSnapshot, FanoutOpen, FanoutOutcome, SlotRef
+from calfkit.models.session_context import CallFrame, Stack, WorkflowState
+from calfkit.models.state import State
+from calfkit.nodes._fanout_store import (
+    CloseAbandon,
+    CloseAbort,
+    CloseResume,
+    CloseSpurious,
+    FoldAbort,
+    FoldComplete,
+    FoldParked,
+    FoldStray,
+    abort_batch,
+    close_batch,
+    fold_sibling,
+)
+from tests._fanout_fakes import FakeFanoutBatchStore
+
+
+def _open(fanout_id: str = "X", slots: tuple[tuple[str, str | None], ...] = (("f1", "tc1"), ("f2", "tc2"))) -> FanoutOpen:
+    return FanoutOpen(fanout_id=fanout_id, node_id="agent", expected=[SlotRef(frame_id=f, tag=t) for f, t in slots])
+
+
+def _snapshot() -> EnvelopeSnapshot:
+    stack = WorkflowState(call_stack=Stack([CallFrame(target_topic="t", callback_topic="cb")]))
+    return EnvelopeSnapshot(state=State(), stack=stack, deps={})
+
+
+def _outcome(slot: str = "f1", tag: str | None = "tc1", value: str = "ok") -> FanoutOutcome:
+    return FanoutOutcome(slot=slot, tag=tag, result=ToolReturn(return_value=value))
+
+
+@pytest.fixture
+def store() -> FakeFanoutBatchStore:
+    return FakeFanoutBatchStore()
+
+
+# ── fold_sibling ─────────────────────────────────────────────────────────────
+
+
+async def test_fold_first_sibling_parks(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    result = await fold_sibling(store, "X", _outcome("f1", "tc1"))
+    assert isinstance(result, FoldParked)
+    state = await store.read_state("X")
+    assert state is not None
+    assert set(state.outcomes) == {"f1"}
+
+
+async def test_fold_last_sibling_completes(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    await fold_sibling(store, "X", _outcome("f1", "tc1"))
+    result = await fold_sibling(store, "X", _outcome("f2", "tc2"))
+    assert isinstance(result, FoldComplete)
+
+
+async def test_fold_foreign_slot_is_stray_and_leaves_state_untouched(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    result = await fold_sibling(store, "X", _outcome("f99", "tcX"))
+    assert isinstance(result, FoldStray)
+    assert result.reason == "foreign"
+    state = await store.read_state("X")
+    assert state is not None
+    assert state.outcomes == {}
+
+
+async def test_fold_after_tombstone_is_post_closure_stray(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    await store.tombstone("X")
+    result = await fold_sibling(store, "X", _outcome("f1", "tc1"))
+    assert isinstance(result, FoldStray)
+    assert result.reason == "post_closure"
+
+
+async def test_fold_duplicate_slot_is_idempotent_stray(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    await fold_sibling(store, "X", _outcome("f1", "tc1"))
+    result = await fold_sibling(store, "X", _outcome("f1", "tc1"))
+    assert isinstance(result, FoldStray)
+    assert result.reason == "duplicate"
+    state = await store.read_state("X")
+    assert state is not None
+    assert set(state.outcomes) == {"f1"}
+
+
+async def test_fold_duplicate_after_complete_does_not_recomplete(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    await fold_sibling(store, "X", _outcome("f1", "tc1"))
+    await fold_sibling(store, "X", _outcome("f2", "tc2"))  # completes
+    result = await fold_sibling(store, "X", _outcome("f1", "tc1"))  # dup after complete
+    assert isinstance(result, FoldStray)
+    assert result.reason == "duplicate"
+
+
+async def test_fold_unavailable_store_aborts(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    store.make_unavailable()
+    result = await fold_sibling(store, "X", _outcome("f1", "tc1"))
+    assert isinstance(result, FoldAbort)
+    assert result.reason == "store_unavailable"
+
+
+# ── close_batch ──────────────────────────────────────────────────────────────
+
+
+async def test_close_complete_batch_resumes_materialized_and_tombstones(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    await fold_sibling(store, "X", _outcome("f1", "tc1", value="r1"))
+    await fold_sibling(store, "X", _outcome("f2", "tc2", value="r2"))
+    result = await close_batch(store, "X")
+    assert isinstance(result, CloseResume)
+    assert result.snapshot.state.get_tool_result("tc1") is not None
+    assert result.snapshot.state.get_tool_result("tc2") is not None
+    # tombstone-first: both records gone
+    assert await store.read_state("X") is None
+    assert await store.read_basestate("X") is None
+
+
+async def test_close_incomplete_batch_is_spurious_and_keeps_state(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    await fold_sibling(store, "X", _outcome("f1", "tc1"))  # only 1 of 2
+    result = await close_batch(store, "X")
+    assert isinstance(result, CloseSpurious)
+    assert await store.read_state("X") is not None  # NOT tombstoned
+
+
+async def test_close_absent_batch_abandons(store: FakeFanoutBatchStore) -> None:
+    result = await close_batch(store, "X")  # never opened
+    assert isinstance(result, CloseAbandon)
+
+
+async def test_close_basestate_missing_aborts(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    await fold_sibling(store, "X", _outcome("f1", "tc1"))
+    await fold_sibling(store, "X", _outcome("f2", "tc2"))  # completes
+    store._basestate.pop("X")  # white-box: simulate the impossible-by-ordering miss
+    result = await close_batch(store, "X")
+    assert isinstance(result, CloseAbort)
+    assert result.reason == "basestate_missing"
+
+
+async def test_close_unavailable_store_aborts(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    await fold_sibling(store, "X", _outcome("f1", "tc1"))
+    await fold_sibling(store, "X", _outcome("f2", "tc2"))
+    store.make_unavailable()
+    result = await close_batch(store, "X")
+    assert isinstance(result, CloseAbort)
+    assert result.reason == "store_unavailable"
+
+
+async def test_close_materialization_failure_on_missing_tag_aborts(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(slots=(("f1", "tc1"),)), _snapshot())
+    await fold_sibling(store, "X", _outcome("f1", tag=None))  # no tag → can't materialize
+    result = await close_batch(store, "X")
+    assert isinstance(result, CloseAbort)
+    assert result.reason == "materialization_failed"
+    assert await store.read_state("X") is None  # the un-closable batch is tombstoned
+
+
+# ── abort_batch + sequential re-fan-out ──────────────────────────────────────
+
+
+async def test_abort_batch_tombstones_both(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    await abort_batch(store, "X")
+    assert await store.read_state("X") is None
+    assert await store.read_basestate("X") is None
+
+
+async def test_abort_batch_on_unavailable_store_is_best_effort(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    store.make_unavailable()
+    await abort_batch(store, "X")  # must not raise
+
+
+async def test_reopen_after_close_starts_fresh_batch(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    await fold_sibling(store, "X", _outcome("f1", "tc1"))
+    await fold_sibling(store, "X", _outcome("f2", "tc2"))
+    await close_batch(store, "X")  # tombstones
+    await store.open("X", _open(), _snapshot())  # sequential re-fan-out, same key
+    state = await store.read_state("X")
+    assert state is not None
+    assert state.outcomes == {}  # fresh registration, never the stale tombstone

--- a/tests/test_fanout_handler.py
+++ b/tests/test_fanout_handler.py
@@ -9,22 +9,28 @@ fake`). These pin the pieces the staged handler wires together in 6b-B:
 - _classify_fanout: marker + reply slot => SIBLING fold / RE-ENTRY close / NORMAL
 """
 
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 import pytest
 from faststream import Context
 from faststream.kafka import KafkaBroker, TestKafkaBroker
+from pydantic import ValidationError
 
-from calfkit._vendor.pydantic_ai.messages import ModelResponse, TextPart
+from calfkit._protocol import HDR_KIND
+from calfkit._vendor.pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart, ToolReturn
 from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
+from calfkit._vendor.pydantic_ai.models.test import TestModel
 from calfkit.models import Call
 from calfkit.models.envelope import Envelope
+from calfkit.models.fanout import FanoutOpen, SlotRef
 from calfkit.models.reply import ReturnMessage
 from calfkit.models.session_context import CallFrame, SessionRunContext, Stack, WorkflowState
 from calfkit.models.state import State
 from calfkit.nodes import Agent
 from calfkit.nodes._fanout_store import FANOUT_STORE_KEY
 from calfkit.nodes.base import BaseNodeDef
+from calfkit.nodes.node import NodeDef
+from calfkit.worker.lifecycle import ResourceSetupContext
 from tests._fanout_fakes import FakeFanoutBatchStore
 
 
@@ -136,6 +142,13 @@ def test_classify_non_capable_node_is_normal() -> None:
     assert node._classify_fanout(env) is None
 
 
+def test_classify_marked_frame_without_reply_is_normal() -> None:
+    # (coverage d) a marked frame with NO reply slot is not a fold/close continuation → None
+    env = _envelope(frame_id="A", fanout_id="A", reply_in_reply_to=None)  # reply_in_reply_to=None ⇒ reply=None
+    assert env.reply is None
+    assert _agent()._classify_fanout(env) is None
+
+
 # ── OPEN dispatch path ───────────────────────────────────────────────────────
 
 
@@ -191,3 +204,125 @@ async def test_handle_fanout_open_writes_open_and_publishes_marked_siblings() ->
 # helper was subsumed by BaseNodeDef._aggregate. The sibling-fold + re-entry-close behavior is
 # covered by tests/test_staged_pipeline.py::TestAggregate (fold→park, complete→publish re-entry,
 # re-entry→close+restore) and end-to-end by tests/test_durable_fanout_e2e.py.
+
+
+# ── the N>=2 OPEN gate (#2) ──────────────────────────────────────────────────
+
+
+def test_fanout_open_rejects_singleton_expected() -> None:
+    # The N>=2 fan-out invariant is enforced at the record type: a single-slot batch is
+    # unrepresentable, so a batch-of-one can never be registered.
+    with pytest.raises(ValidationError):
+        FanoutOpen(fanout_id="x", node_id="a", expected=[SlotRef(frame_id="f1", tag="tc1")])
+
+
+class _CaptureBroker:
+    """Node-side broker stub: records (topic, headers, envelope) per publish."""
+
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict[str, str], Envelope]] = []
+
+    async def publish(self, envelope: Envelope, *, topic: str, correlation_id: str, key: bytes, headers: dict[str, str]) -> None:
+        self.published.append((topic, headers, envelope))
+
+
+class _SingleCallFanoutNode(NodeDef[Any]):
+    """A fan-out-capable node whose body returns a ONE-element list[Call]."""
+
+    @property
+    def _is_fanout_capable(self) -> bool:
+        return True
+
+    async def run(self, ctx: SessionRunContext) -> Any:
+        return [Call("only.tool", ctx.state, tag="tc1")]
+
+
+async def test_single_call_list_does_not_open_durable_batch() -> None:
+    # (#2) A fan-out-capable node whose body returns a 1-element list[Call] is a single stateless
+    # continuation, NOT a durable batch: the OPEN dispatch's len(output) >= 2 gate reroutes it
+    # through _publish_action (the plain parallel publish), so the store is never opened and the
+    # node's own frame is never marked.
+    node = _SingleCallFanoutNode(node_id="fan", subscribe_topics=["fan.in"])
+    fake = FakeFanoutBatchStore()
+    node.resources[FANOUT_STORE_KEY] = fake
+    own = CallFrame(target_topic="fan.in", callback_topic="caller", frame_id="A")
+    env = Envelope(
+        context=SessionRunContext(state=State(), deps={}),
+        internal_workflow_state=WorkflowState(call_stack=Stack([own])),
+    )
+    broker = _CaptureBroker()
+
+    await node.handler(env, correlation_id="corr-1", headers={HDR_KIND: "call"}, broker=cast(Any, broker))
+
+    # The durable store was never opened — no batch registered for the single call.
+    assert await fake.read_state("A") is None
+    assert await fake.read_basestate("A") is None
+    # The single call was published via the normal parallel path (callee frame NOT fan-out-marked).
+    assert [t for t, _, _ in broker.published] == ["only.tool"]
+    callee = broker.published[0][2].internal_workflow_state.current_frame
+    assert callee.target_topic == "only.tool"
+    assert callee.fanout_id is None  # not marked: this is not a durable fan-out
+
+
+# ── @resource preconditions (coverage d) ─────────────────────────────────────
+
+
+class _NoBootstrapWorker:
+    """Minimal worker stub whose bootstrap address is underivable (client built without connect())."""
+
+    def _derive_bootstrap_servers(self) -> str | None:
+        return None
+
+
+async def test_fanout_store_resource_raises_without_worker() -> None:
+    # (coverage d) The fan-out store @resource cannot open without a hosting worker.
+    agent = _agent()
+    agent._worker = None
+    ctx = ResourceSetupContext(owner=agent, resources={})
+    gen = agent._fanout_store_resource(ctx)
+    with pytest.raises(RuntimeError, match="no hosting worker"):
+        await gen.__anext__()
+
+
+async def test_fanout_store_resource_raises_without_bootstrap() -> None:
+    # (coverage d) A worker present but with no derivable bootstrap address also raises (rather than
+    # opening a store against nothing).
+    agent = _agent()
+    agent._worker = cast(Any, _NoBootstrapWorker())
+    ctx = ResourceSetupContext(owner=agent, resources={})
+    gen = agent._fanout_store_resource(ctx)
+    with pytest.raises(RuntimeError, match="bootstrap servers"):
+        await gen.__anext__()
+
+
+# ── parallel-mode incomplete-batch guard in run() (coverage d) ────────────────
+
+
+async def test_parallel_run_on_incomplete_batch_raises_runtime_error() -> None:
+    # (coverage d) run() must only be re-entered on a COMPLETE batch (the durable close materializes
+    # every outcome first). A parallel-mode ctx whose latest tool-call set is incomplete (one call
+    # has no result) is the lost-batch/rebalance signal — run() raises a diagnostic RuntimeError
+    # rather than silently proceeding.
+    agent = Agent(
+        "agent_incomplete_batch",
+        system_prompt="x",
+        subscribe_topics="agent_incomplete_batch.input",
+        publish_topic="agent_incomplete_batch.output",
+        model_client=TestModel(),
+    )
+
+    state = State()
+    done_id, pending_id = "tc-done", "tc-pending"
+    for tool_name, tcid in (("tool_done", done_id), ("tool_pending", pending_id)):
+        part = ToolCallPart(tool_name=tool_name, args={}, tool_call_id=tcid)
+        state.add_tool_call(part)
+        state.message_history.append(ModelResponse(parts=[part]))
+    state.add_tool_result(done_id, ToolReturn(return_value="ok"))
+    # pending_id deliberately has NO result → the batch is incomplete.
+
+    ctx = SessionRunContext(state=state, deps={})
+    ctx._correlation_id = "cid-incomplete-batch"
+    ctx._frame_id = "frame-incomplete-batch"
+
+    with pytest.raises(RuntimeError, match="incomplete tool calls in run"):
+        await agent.run(ctx)

--- a/tests/test_fanout_handler.py
+++ b/tests/test_fanout_handler.py
@@ -9,11 +9,17 @@ fake`). These pin the pieces the staged handler wires together in 6b-B:
 - _classify_fanout: marker + reply slot => SIBLING fold / RE-ENTRY close / NORMAL
 """
 
-import pytest
+from typing import Annotated, Any
 
-from calfkit._vendor.pydantic_ai.messages import ModelResponse, TextPart
+import pytest
+from faststream import Context
+from faststream.kafka import KafkaBroker, TestKafkaBroker
+
+from calfkit._vendor.pydantic_ai.messages import ModelResponse, TextPart, ToolReturn
 from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
+from calfkit.models import Call
 from calfkit.models.envelope import Envelope
+from calfkit.models.fanout import EnvelopeSnapshot, FanoutOpen, SlotRef
 from calfkit.models.reply import ReturnMessage
 from calfkit.models.session_context import CallFrame, SessionRunContext, Stack, WorkflowState
 from calfkit.models.state import State
@@ -21,6 +27,13 @@ from calfkit.nodes import Agent
 from calfkit.nodes._fanout_store import FANOUT_STORE_KEY
 from calfkit.nodes.base import BaseNodeDef
 from tests._fanout_fakes import FakeFanoutBatchStore
+
+
+def _ctx_with_store(store: FakeFanoutBatchStore, *, deps: dict[str, Any] | None = None) -> SessionRunContext:
+    ctx = SessionRunContext(state=State(), deps=deps or {})
+    ctx._resources = {FANOUT_STORE_KEY: store}
+    ctx._correlation_id = "corr-1"
+    return ctx
 
 
 def _model(_messages: object, _info: AgentInfo) -> ModelResponse:
@@ -106,3 +119,112 @@ def test_classify_non_capable_node_is_normal() -> None:
     node = BaseNodeDef(node_id="n", subscribe_topics=["n.in"])
     env = _envelope(frame_id="A", fanout_id="A", reply_in_reply_to="B")
     assert node._classify_fanout(env) is None
+
+
+# ── OPEN dispatch path ───────────────────────────────────────────────────────
+
+
+async def test_handle_fanout_open_writes_open_and_publishes_marked_siblings() -> None:
+    broker = KafkaBroker("localhost")
+    captured: dict[str, Envelope] = {}
+
+    @broker.subscriber("tool.a", group_id="ta")
+    async def _ta(body: Envelope, _h: Annotated[dict[str, Any], Context("message.headers")]) -> None:
+        captured["tool.a"] = body
+
+    @broker.subscriber("tool.b", group_id="tb")
+    async def _tb(body: Envelope, _h: Annotated[dict[str, Any], Context("message.headers")]) -> None:
+        captured["tool.b"] = body
+
+    agent = _agent()
+    fake = FakeFanoutBatchStore()
+    ctx = _ctx_with_store(fake, deps={"k": "v"})
+    own = CallFrame(target_topic="a", callback_topic="caller", frame_id="A")
+    env = Envelope(
+        context=SessionRunContext(state=State(), deps={"k": "v"}),
+        internal_workflow_state=WorkflowState(call_stack=Stack([own])),
+    )
+    calls = [Call(target_topic="tool.a", state=State(), tag="tc1"), Call(target_topic="tool.b", state=State(), tag="tc2")]
+
+    async with TestKafkaBroker(broker):
+        await agent._handle_fanout_open(ctx, calls, env, "corr-1", broker)
+
+    state = await fake.read_state("A")
+    assert state is not None
+    assert {s.tag for s in state.open.expected} == {"tc1", "tc2"}
+    assert state.outcomes == {}
+    base = await fake.read_basestate("A")
+    assert base is not None
+    assert base.snapshot.deps == {"k": "v"}
+
+    assert set(captured) == {"tool.a", "tool.b"}
+    open_slot_ids = {s.frame_id for s in state.open.expected}
+    published_callee_ids = set()
+    for topic, tag in (("tool.a", "tc1"), ("tool.b", "tc2")):
+        stack = captured[topic].internal_workflow_state.call_stack._internal_list
+        callee, own_copy = stack[-1], stack[-2]
+        assert callee.target_topic == topic
+        assert callee.tag == tag  # the callee frame carries the tag (echoed on its reply)
+        assert callee.callback_topic == "a.private.return"  # returns to the agent's inbox
+        assert callee.fanout_id is None  # the callee frame is NOT marked
+        assert own_copy.frame_id == "A" and own_copy.fanout_id == "A"  # the node's OWN frame IS
+        published_callee_ids.add(callee.frame_id)
+    assert published_callee_ids == open_slot_ids  # OPEN slots == published callee frame ids
+
+
+# ── sibling fold + re-entry close paths ──────────────────────────────────────
+
+
+async def _open_batch(store: FakeFanoutBatchStore, *, slots: tuple[tuple[str, str], ...] = (("f1", "tc1"), ("f2", "tc2"))) -> None:
+    reg = FanoutOpen(fanout_id="A", node_id="a", expected=[SlotRef(frame_id=f, tag=t) for f, t in slots])
+    own = CallFrame(target_topic="a", callback_topic="caller", frame_id="A")
+    snap = EnvelopeSnapshot(state=State(), stack=WorkflowState(call_stack=Stack([own])), deps={})
+    await store.open("A", reg, snap)
+
+
+def _sibling(store: FakeFanoutBatchStore, *, slot: str, tag: str, value: str) -> tuple[SessionRunContext, Envelope]:
+    state = State()
+    state.add_tool_result(tag, ToolReturn(return_value=value))
+    ctx = SessionRunContext(state=state, deps={})
+    ctx._resources = {FANOUT_STORE_KEY: store}
+    ctx._correlation_id = "corr-1"
+    own = CallFrame(target_topic="a", callback_topic="caller", frame_id="A", fanout_id="A")
+    env = Envelope(
+        context=SessionRunContext(state=state, deps={}),
+        internal_workflow_state=WorkflowState(call_stack=Stack([own])),
+        reply=ReturnMessage(in_reply_to=slot, tag=tag, parts=[]),
+    )
+    return ctx, env
+
+
+async def test_handle_sibling_fold_parks_until_complete() -> None:
+    broker = KafkaBroker("localhost")
+    agent = _agent()
+    fake = FakeFanoutBatchStore()
+    await _open_batch(fake)
+    ctx, env = _sibling(fake, slot="f1", tag="tc1", value="r1")
+    async with TestKafkaBroker(broker):
+        resp = await agent._handle_sibling_fold(ctx, env, "corr-1", broker)
+    state = await fake.read_state("A")
+    assert state is not None and set(state.outcomes) == {"f1"}  # folded
+    assert resp.body.reply is None  # parked → no-reply mirror
+
+
+async def test_handle_sibling_fold_completes_and_publishes_reentry() -> None:
+    broker = KafkaBroker("localhost")
+    reentry: list[Envelope] = []
+
+    @broker.subscriber("a.private.return", group_id="re")
+    async def _re(body: Envelope, _h: Annotated[dict[str, Any], Context("message.headers")]) -> None:
+        reentry.append(body)
+
+    agent = _agent()
+    fake = FakeFanoutBatchStore()
+    await _open_batch(fake)
+    ctx1, env1 = _sibling(fake, slot="f1", tag="tc1", value="r1")
+    ctx2, env2 = _sibling(fake, slot="f2", tag="tc2", value="r2")
+    async with TestKafkaBroker(broker):
+        await agent._handle_sibling_fold(ctx1, env1, "corr-1", broker)  # park
+        await agent._handle_sibling_fold(ctx2, env2, "corr-1", broker)  # complete → re-entry
+    assert len(reentry) == 1
+    assert reentry[0].reply is not None and reentry[0].reply.in_reply_to == "A"

--- a/tests/test_fanout_handler.py
+++ b/tests/test_fanout_handler.py
@@ -1,0 +1,108 @@
+"""PR-4 step 6b: the in-node fan-out machinery on BaseNodeDef.
+
+Tested in isolation against the injected fake store + constructed envelopes (the
+@resource never runs offline, so a fan-out agent just gets `agent.resources[KEY] =
+fake`). These pin the pieces the staged handler wires together in 6b-B:
+
+- _is_fanout_capable: only non-sequential agents fan out durably
+- _resolve_fanout_store: the store comes from ctx.resources, required for fan-out
+- _classify_fanout: marker + reply slot => SIBLING fold / RE-ENTRY close / NORMAL
+"""
+
+import pytest
+
+from calfkit._vendor.pydantic_ai.messages import ModelResponse, TextPart
+from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
+from calfkit.models.envelope import Envelope
+from calfkit.models.reply import ReturnMessage
+from calfkit.models.session_context import CallFrame, SessionRunContext, Stack, WorkflowState
+from calfkit.models.state import State
+from calfkit.nodes import Agent
+from calfkit.nodes._fanout_store import FANOUT_STORE_KEY
+from calfkit.nodes.base import BaseNodeDef
+from tests._fanout_fakes import FakeFanoutBatchStore
+
+
+def _model(_messages: object, _info: AgentInfo) -> ModelResponse:
+    return ModelResponse(parts=[TextPart("ok")])
+
+
+def _agent(*, sequential: bool = False) -> Agent[str]:
+    return Agent(
+        node_id="a",
+        subscribe_topics=["a.in"],
+        model_client=FunctionModel(_model),
+        sequential_only_mode=sequential,
+    )
+
+
+def _envelope(*, frame_id: str, fanout_id: str | None, reply_in_reply_to: str | None) -> Envelope:
+    frame = CallFrame(target_topic="a", callback_topic="caller", frame_id=frame_id, fanout_id=fanout_id)
+    reply = ReturnMessage(in_reply_to=reply_in_reply_to, tag="tc1", parts=[]) if reply_in_reply_to is not None else None
+    return Envelope(
+        context=SessionRunContext(state=State(), deps={}),
+        internal_workflow_state=WorkflowState(call_stack=Stack([frame])),
+        reply=reply,
+    )
+
+
+# ── capability gate ──────────────────────────────────────────────────────────
+
+
+def test_base_node_is_not_fanout_capable() -> None:
+    node = BaseNodeDef(node_id="n", subscribe_topics=["n.in"])
+    assert node._is_fanout_capable is False
+
+
+def test_agent_is_fanout_capable() -> None:
+    assert _agent()._is_fanout_capable is True
+
+
+def test_sequential_agent_is_not_fanout_capable() -> None:
+    assert _agent(sequential=True)._is_fanout_capable is False
+
+
+# ── store resolution ─────────────────────────────────────────────────────────
+
+
+def test_resolve_fanout_store_returns_injected_store() -> None:
+    agent = _agent()
+    fake = FakeFanoutBatchStore()
+    ctx = SessionRunContext(state=State(), deps={})
+    ctx._resources = {FANOUT_STORE_KEY: fake}
+    assert agent._resolve_fanout_store(ctx) is fake
+
+
+def test_resolve_fanout_store_raises_when_absent() -> None:
+    agent = _agent()
+    ctx = SessionRunContext(state=State(), deps={})
+    ctx._resources = {}
+    with pytest.raises(RuntimeError):
+        agent._resolve_fanout_store(ctx)
+
+
+# ── classification ───────────────────────────────────────────────────────────
+
+
+def test_classify_unmarked_frame_is_normal() -> None:
+    env = _envelope(frame_id="A", fanout_id=None, reply_in_reply_to="A")
+    assert _agent()._classify_fanout(env) is None
+
+
+def test_classify_marked_frame_sibling_reply() -> None:
+    # marked frame (fanout_id == frame_id == A); reply addresses a sibling callee (B != A)
+    env = _envelope(frame_id="A", fanout_id="A", reply_in_reply_to="B")
+    assert _agent()._classify_fanout(env) == "sibling"
+
+
+def test_classify_marked_frame_reentry() -> None:
+    # marked frame; reply addresses the fan-out frame itself (in_reply_to == frame_id == A)
+    env = _envelope(frame_id="A", fanout_id="A", reply_in_reply_to="A")
+    assert _agent()._classify_fanout(env) == "reentry"
+
+
+def test_classify_non_capable_node_is_normal() -> None:
+    # a marked frame on a non-fan-out node never classifies as fan-out
+    node = BaseNodeDef(node_id="n", subscribe_topics=["n.in"])
+    env = _envelope(frame_id="A", fanout_id="A", reply_in_reply_to="B")
+    assert node._classify_fanout(env) is None

--- a/tests/test_fanout_handler.py
+++ b/tests/test_fanout_handler.py
@@ -15,11 +15,10 @@ import pytest
 from faststream import Context
 from faststream.kafka import KafkaBroker, TestKafkaBroker
 
-from calfkit._vendor.pydantic_ai.messages import ModelResponse, TextPart, ToolReturn
+from calfkit._vendor.pydantic_ai.messages import ModelResponse, TextPart
 from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
 from calfkit.models import Call
 from calfkit.models.envelope import Envelope
-from calfkit.models.fanout import EnvelopeSnapshot, FanoutOpen, SlotRef
 from calfkit.models.reply import ReturnMessage
 from calfkit.models.session_context import CallFrame, SessionRunContext, Stack, WorkflowState
 from calfkit.models.state import State
@@ -92,6 +91,22 @@ def test_resolve_fanout_store_raises_when_absent() -> None:
     ctx._resources = {}
     with pytest.raises(RuntimeError):
         agent._resolve_fanout_store(ctx)
+
+
+# ── @resource registration ───────────────────────────────────────────────────
+
+
+def test_fanout_agent_registers_durable_store_resource() -> None:
+    # A non-sequential agent registers the node-owned fan-out store @resource (opened by the
+    # worker lifecycle in production; injected by prepare_worker offline). The @resource itself
+    # is not run here — only its registration is asserted.
+    names = {name for name, _ in _agent()._resource_registry()}
+    assert FANOUT_STORE_KEY in names
+
+
+def test_sequential_agent_registers_no_store_resource() -> None:
+    names = {name for name, _ in _agent(sequential=True)._resource_registry()}
+    assert FANOUT_STORE_KEY not in names
 
 
 # ── classification ───────────────────────────────────────────────────────────
@@ -172,59 +187,7 @@ async def test_handle_fanout_open_writes_open_and_publishes_marked_siblings() ->
     assert published_callee_ids == open_slot_ids  # OPEN slots == published callee frame ids
 
 
-# ── sibling fold + re-entry close paths ──────────────────────────────────────
-
-
-async def _open_batch(store: FakeFanoutBatchStore, *, slots: tuple[tuple[str, str], ...] = (("f1", "tc1"), ("f2", "tc2"))) -> None:
-    reg = FanoutOpen(fanout_id="A", node_id="a", expected=[SlotRef(frame_id=f, tag=t) for f, t in slots])
-    own = CallFrame(target_topic="a", callback_topic="caller", frame_id="A")
-    snap = EnvelopeSnapshot(state=State(), stack=WorkflowState(call_stack=Stack([own])), deps={})
-    await store.open("A", reg, snap)
-
-
-def _sibling(store: FakeFanoutBatchStore, *, slot: str, tag: str, value: str) -> tuple[SessionRunContext, Envelope]:
-    state = State()
-    state.add_tool_result(tag, ToolReturn(return_value=value))
-    ctx = SessionRunContext(state=state, deps={})
-    ctx._resources = {FANOUT_STORE_KEY: store}
-    ctx._correlation_id = "corr-1"
-    own = CallFrame(target_topic="a", callback_topic="caller", frame_id="A", fanout_id="A")
-    env = Envelope(
-        context=SessionRunContext(state=state, deps={}),
-        internal_workflow_state=WorkflowState(call_stack=Stack([own])),
-        reply=ReturnMessage(in_reply_to=slot, tag=tag, parts=[]),
-    )
-    return ctx, env
-
-
-async def test_handle_sibling_fold_parks_until_complete() -> None:
-    broker = KafkaBroker("localhost")
-    agent = _agent()
-    fake = FakeFanoutBatchStore()
-    await _open_batch(fake)
-    ctx, env = _sibling(fake, slot="f1", tag="tc1", value="r1")
-    async with TestKafkaBroker(broker):
-        resp = await agent._handle_sibling_fold(ctx, env, "corr-1", broker)
-    state = await fake.read_state("A")
-    assert state is not None and set(state.outcomes) == {"f1"}  # folded
-    assert resp.body.reply is None  # parked → no-reply mirror
-
-
-async def test_handle_sibling_fold_completes_and_publishes_reentry() -> None:
-    broker = KafkaBroker("localhost")
-    reentry: list[Envelope] = []
-
-    @broker.subscriber("a.private.return", group_id="re")
-    async def _re(body: Envelope, _h: Annotated[dict[str, Any], Context("message.headers")]) -> None:
-        reentry.append(body)
-
-    agent = _agent()
-    fake = FakeFanoutBatchStore()
-    await _open_batch(fake)
-    ctx1, env1 = _sibling(fake, slot="f1", tag="tc1", value="r1")
-    ctx2, env2 = _sibling(fake, slot="f2", tag="tc2", value="r2")
-    async with TestKafkaBroker(broker):
-        await agent._handle_sibling_fold(ctx1, env1, "corr-1", broker)  # park
-        await agent._handle_sibling_fold(ctx2, env2, "corr-1", broker)  # complete → re-entry
-    assert len(reentry) == 1
-    assert reentry[0].reply is not None and reentry[0].reply.in_reply_to == "A"
+# NOTE: the isolated `_handle_sibling_fold` tests were removed in the dead-code sweep — that graft
+# helper was subsumed by BaseNodeDef._aggregate. The sibling-fold + re-entry-close behavior is
+# covered by tests/test_staged_pipeline.py::TestAggregate (fold→park, complete→publish re-entry,
+# re-entry→close+restore) and end-to-end by tests/test_durable_fanout_e2e.py.

--- a/tests/test_fanout_records.py
+++ b/tests/test_fanout_records.py
@@ -1,0 +1,82 @@
+"""PR-4 step 1: the durable fan-out record models.
+
+ktables stores these as JSON (`KafkaTable.json(model=...)` decodes via
+`model_validate_json`; `KafkaTableWriter.json(...)` encodes via `model_dump_json`),
+so every record must round-trip through JSON. `FanoutOutcome.result` mirrors
+`State.tool_results`' value type, so a `CalfToolResult` (incl. a `FailedToolCall`)
+must come back TYPED via its discriminator, not as a bare dict. Every value carries
+a `version` defaulting to 1.
+"""
+
+from typing import TypeVar
+
+from pydantic import BaseModel
+
+from calfkit._vendor.pydantic_ai.messages import ToolReturn
+from calfkit.models.fanout import (
+    EnvelopeSnapshot,
+    FanoutBaseState,
+    FanoutOpen,
+    FanoutOutcome,
+    FanoutState,
+    SlotRef,
+)
+from calfkit.models.session_context import CallFrame, Stack, WorkflowState
+from calfkit.models.state import FailedToolCall, State
+
+_M = TypeVar("_M", bound=BaseModel)
+
+
+def _roundtrip(model: _M) -> _M:
+    return type(model).model_validate_json(model.model_dump_json())
+
+
+def test_fanout_open_roundtrips_and_defaults_version() -> None:
+    reg = FanoutOpen(fanout_id="x", node_id="agent", expected=[SlotRef(frame_id="f1", tag="tc1")])
+    assert reg.version == 1
+    rt = _roundtrip(reg)
+    assert rt == reg
+    assert rt.expected[0].frame_id == "f1"
+
+
+def test_fanout_outcome_preserves_typed_tool_return() -> None:
+    outcome = FanoutOutcome(slot="f1", tag="tc1", result=ToolReturn(return_value="ok"))
+    rt = _roundtrip(outcome)
+    assert isinstance(rt.result, ToolReturn)
+    assert rt.result.return_value == "ok"
+
+
+def test_fanout_outcome_preserves_failed_tool_call_marker() -> None:
+    marker = FailedToolCall.build_safe(tool_name="t", tool_call_id="tc1", exc_type="ValueError", exc_message="boom")
+    outcome = FanoutOutcome(slot="f1", tag="tc1", result=marker)
+    rt = _roundtrip(outcome)
+    assert isinstance(rt.result, FailedToolCall)
+    assert rt.result.exc_type == "ValueError"
+
+
+def test_fanout_state_accumulates_outcomes_and_roundtrips() -> None:
+    state = FanoutState(
+        open=FanoutOpen(fanout_id="x", node_id="agent", expected=[SlotRef(frame_id="f1", tag="tc1")]),
+        outcomes={"f1": FanoutOutcome(slot="f1", tag="tc1", result=ToolReturn(return_value="ok"))},
+    )
+    rt = _roundtrip(state)
+    assert rt.outcomes["f1"].slot == "f1"
+    assert isinstance(rt.outcomes["f1"].result, ToolReturn)
+
+
+def test_fanout_state_outcomes_default_empty() -> None:
+    state = FanoutState(open=FanoutOpen(fanout_id="x", node_id="agent", expected=[]))
+    assert state.outcomes == {}
+
+
+def test_envelope_snapshot_and_basestate_roundtrip() -> None:
+    snap = EnvelopeSnapshot(
+        state=State(),
+        stack=WorkflowState(call_stack=Stack([CallFrame(target_topic="t", callback_topic="cb")])),
+        deps={"k": "v"},
+    )
+    base = FanoutBaseState(fanout_id="x", snapshot=snap)
+    rt = _roundtrip(base)
+    assert rt.fanout_id == "x"
+    assert rt.snapshot.deps == {"k": "v"}
+    assert rt.snapshot.stack.current_frame.target_topic == "t"

--- a/tests/test_fanout_records.py
+++ b/tests/test_fanout_records.py
@@ -4,13 +4,15 @@ ktables stores these as JSON (`KafkaTable.json(model=...)` decodes via
 `model_validate_json`; `KafkaTableWriter.json(...)` encodes via `model_dump_json`),
 so every record must round-trip through JSON. `FanoutOutcome.result` mirrors
 `State.tool_results`' value type, so a `CalfToolResult` (incl. a `FailedToolCall`)
-must come back TYPED via its discriminator, not as a bare dict. Every value carries
-a `version` defaulting to 1.
+must come back TYPED via its discriminator, not as a bare dict. `FanoutOpen.expected`
+enforces the N>=2 fan-out invariant at the type (`min_length=2`) — an empty/singleton
+batch is unrepresentable.
 """
 
 from typing import TypeVar
 
-from pydantic import BaseModel
+import pytest
+from pydantic import BaseModel, ValidationError
 
 from calfkit._vendor.pydantic_ai.messages import ToolReturn
 from calfkit.models.fanout import (
@@ -31,12 +33,22 @@ def _roundtrip(model: _M) -> _M:
     return type(model).model_validate_json(model.model_dump_json())
 
 
-def test_fanout_open_roundtrips_and_defaults_version() -> None:
-    reg = FanoutOpen(fanout_id="x", node_id="agent", expected=[SlotRef(frame_id="f1", tag="tc1")])
-    assert reg.version == 1
+def test_fanout_open_roundtrips() -> None:
+    reg = FanoutOpen(fanout_id="x", node_id="agent", expected=[SlotRef(frame_id="f1", tag="tc1"), SlotRef(frame_id="f2", tag="tc2")])
     rt = _roundtrip(reg)
     assert rt == reg
     assert rt.expected[0].frame_id == "f1"
+
+
+def test_fanout_open_rejects_singleton_expected() -> None:
+    # The N>=2 invariant is enforced at the type: a single-slot batch is unrepresentable.
+    with pytest.raises(ValidationError):
+        FanoutOpen(fanout_id="x", node_id="agent", expected=[SlotRef(frame_id="f1", tag="tc1")])
+
+
+def test_fanout_open_rejects_empty_expected() -> None:
+    with pytest.raises(ValidationError):
+        FanoutOpen(fanout_id="x", node_id="agent", expected=[])
 
 
 def test_fanout_outcome_preserves_typed_tool_return() -> None:
@@ -56,7 +68,7 @@ def test_fanout_outcome_preserves_failed_tool_call_marker() -> None:
 
 def test_fanout_state_accumulates_outcomes_and_roundtrips() -> None:
     state = FanoutState(
-        open=FanoutOpen(fanout_id="x", node_id="agent", expected=[SlotRef(frame_id="f1", tag="tc1")]),
+        open=FanoutOpen(fanout_id="x", node_id="agent", expected=[SlotRef(frame_id="f1", tag="tc1"), SlotRef(frame_id="f2", tag="tc2")]),
         outcomes={"f1": FanoutOutcome(slot="f1", tag="tc1", result=ToolReturn(return_value="ok"))},
     )
     rt = _roundtrip(state)
@@ -65,7 +77,8 @@ def test_fanout_state_accumulates_outcomes_and_roundtrips() -> None:
 
 
 def test_fanout_state_outcomes_default_empty() -> None:
-    state = FanoutState(open=FanoutOpen(fanout_id="x", node_id="agent", expected=[]))
+    expected = [SlotRef(frame_id="f1", tag="tc1"), SlotRef(frame_id="f2", tag="tc2")]
+    state = FanoutState(open=FanoutOpen(fanout_id="x", node_id="agent", expected=expected))
     assert state.outcomes == {}
 
 

--- a/tests/test_fanout_store.py
+++ b/tests/test_fanout_store.py
@@ -1,0 +1,102 @@
+"""PR-4 step 3: the FanoutBatchStore contract.
+
+Pins the Protocol contract that BOTH FakeFanoutBatchStore (in-memory, this offline
+lane) and the real KtablesFanoutBatchStore (step 7, the kafka lane) must satisfy:
+open writes basestate+state, read_state/read_basestate reflect them, fold merges an
+outcome idempotently per slot frame id, tombstone deletes both, and a terminally
+unavailable store raises FanoutStoreUnavailableError (which the fold maps to abort).
+"""
+
+import pytest
+
+from calfkit._vendor.pydantic_ai.messages import ToolReturn
+from calfkit.models.fanout import EnvelopeSnapshot, FanoutOpen, FanoutOutcome, SlotRef
+from calfkit.models.session_context import CallFrame, Stack, WorkflowState
+from calfkit.models.state import State
+from calfkit.nodes._fanout_store import FanoutBatchStore, FanoutStoreUnavailableError
+from tests._fanout_fakes import FakeFanoutBatchStore
+
+
+def _open(fanout_id: str = "X") -> FanoutOpen:
+    return FanoutOpen(
+        fanout_id=fanout_id,
+        node_id="agent",
+        expected=[SlotRef(frame_id="f1", tag="tc1"), SlotRef(frame_id="f2", tag="tc2")],
+    )
+
+
+def _snapshot() -> EnvelopeSnapshot:
+    stack = WorkflowState(call_stack=Stack([CallFrame(target_topic="t", callback_topic="cb")]))
+    return EnvelopeSnapshot(state=State(), stack=stack, deps={})
+
+
+def _outcome(slot: str = "f1", tag: str = "tc1", value: str = "ok") -> FanoutOutcome:
+    return FanoutOutcome(slot=slot, tag=tag, result=ToolReturn(return_value=value))
+
+
+@pytest.fixture
+def store() -> FakeFanoutBatchStore:
+    return FakeFanoutBatchStore()
+
+
+async def test_open_writes_state_and_basestate(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    state = await store.read_state("X")
+    assert state is not None
+    assert state.open.fanout_id == "X"
+    assert state.outcomes == {}
+    base = await store.read_basestate("X")
+    assert base is not None
+    assert base.fanout_id == "X"
+
+
+async def test_read_absent_returns_none(store: FakeFanoutBatchStore) -> None:
+    assert await store.read_state("nope") is None
+    assert await store.read_basestate("nope") is None
+
+
+async def test_fold_adds_outcome_and_returns_updated_state(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    updated = await store.fold("X", _outcome("f1", "tc1"))
+    assert set(updated.outcomes) == {"f1"}
+    refreshed = await store.read_state("X")
+    assert refreshed is not None
+    assert refreshed.outcomes["f1"].tag == "tc1"
+
+
+async def test_fold_is_idempotent_per_slot(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    await store.fold("X", _outcome("f1", "tc1"))
+    updated = await store.fold("X", _outcome("f1", "tc1"))  # same slot folded twice
+    assert set(updated.outcomes) == {"f1"}
+
+
+async def test_fold_accumulates_distinct_slots(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    await store.fold("X", _outcome("f1", "tc1"))
+    updated = await store.fold("X", _outcome("f2", "tc2"))
+    assert set(updated.outcomes) == {"f1", "f2"}
+
+
+async def test_tombstone_deletes_both_records(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    await store.tombstone("X")
+    assert await store.read_state("X") is None
+    assert await store.read_basestate("X") is None
+
+
+async def test_tombstone_absent_is_safe(store: FakeFanoutBatchStore) -> None:
+    await store.tombstone("nope")  # idempotent — no raise on an absent batch
+
+
+async def test_unavailable_store_raises_on_read(store: FakeFanoutBatchStore) -> None:
+    await store.open("X", _open(), _snapshot())
+    store.make_unavailable()
+    with pytest.raises(FanoutStoreUnavailableError):
+        await store.read_state("X")
+
+
+def test_fake_satisfies_the_protocol() -> None:
+    # Structural conformance (mypy-checked): the fake IS a FanoutBatchStore.
+    typed: FanoutBatchStore = FakeFanoutBatchStore()
+    assert typed is not None

--- a/tests/test_publish_reentry.py
+++ b/tests/test_publish_reentry.py
@@ -1,0 +1,66 @@
+"""PR-4 step 5: _publish_reentry — the bespoke frame-preserving self-return.
+
+The fan-out closure is a self-published re-entry to the node's own return inbox, NOT a
+ReturnCall (which would pop the frame). This pins the deltas (plan §5): no pop, self-
+addressed to _return_topic, in_reply_to = the fan-out frame's own id, parts = [], context
+state+deps cleared (rebuilt from basestate at close), kind=return, and NOT broadcast-
+mirrored. Follows the project's TestKafkaBroker capture pattern (see test_headers.py).
+"""
+
+from typing import Annotated, Any
+
+from faststream import Context
+from faststream.kafka import KafkaBroker, TestKafkaBroker
+
+from calfkit._protocol import HDR_KIND, decode_header_str
+from calfkit.models.envelope import Envelope
+from calfkit.models.session_context import CallFrame, SessionRunContext, Stack, WorkflowState
+from calfkit.models.state import State
+from calfkit.nodes.base import BaseNodeDef
+
+
+def _fanout_envelope() -> Envelope:
+    # The state at a completing fold: the node's OWN marked fan-out frame on top
+    # (fanout_id == frame_id), with stale context that the re-entry must clear.
+    frame = CallFrame(target_topic="agent", callback_topic="caller.return", frame_id="A", fanout_id="A", tag="agentTag")
+    return Envelope(
+        context=SessionRunContext(state=State(metadata="stale"), deps={"k": "v"}),
+        internal_workflow_state=WorkflowState(call_stack=Stack([frame])),
+    )
+
+
+async def test_publish_reentry_deltas() -> None:
+    broker = KafkaBroker("localhost")
+    captured: dict[str, Any] = {}
+    mirror_hits: list[Any] = []
+
+    @broker.subscriber("agent.private.return", group_id="reentry_cap")
+    async def _cap(
+        body: Envelope,
+        headers: Annotated[dict[str, Any], Context("message.headers")],
+        msg: Annotated[Any, Context("message")],
+    ) -> None:
+        captured["envelope"] = body
+        captured["headers"] = dict(headers)
+        captured["correlation_id"] = msg.correlation_id
+
+    @broker.subscriber("agent.broadcast", group_id="reentry_mirror")
+    async def _mirror(body: Any) -> None:
+        mirror_hits.append(body)
+
+    node = BaseNodeDef(node_id="agent", subscribe_topics=["agent.input"], publish_topic="agent.broadcast")
+
+    async with TestKafkaBroker(broker):
+        await node._publish_reentry(_fanout_envelope(), "corr-123", broker)
+
+    env: Envelope = captured["envelope"]
+    assert env.reply is not None
+    assert env.reply.in_reply_to == "A"  # the fan-out frame's own id (== fanout_id)
+    assert env.reply.tag == "agentTag"
+    assert env.reply.parts == []  # no payload — the closure reads from the durable tables
+    assert env.context.state.metadata is None  # state cleared (was "stale")
+    assert env.context.deps == {}  # deps cleared
+    assert env.internal_workflow_state.current_frame.frame_id == "A"  # NOT popped — frame stays
+    assert decode_header_str(captured["headers"].get(HDR_KIND)) == "return"
+    assert captured["correlation_id"] == "corr-123"
+    assert mirror_hits == []  # NOT broadcast-mirrored

--- a/tests/test_reply_slot_publish.py
+++ b/tests/test_reply_slot_publish.py
@@ -35,9 +35,11 @@ class _CaptureBroker:
 
     def __init__(self) -> None:
         self.published: list[tuple[str, dict[str, str], Any]] = []
+        self.keys: list[bytes] = []
 
     async def publish(self, envelope: Any, *, topic: str, correlation_id: str, key: bytes, headers: dict[str, str]) -> None:
         self.published.append((topic, headers, envelope))
+        self.keys.append(key)
 
 
 def _envelope(
@@ -150,6 +152,36 @@ class TestTailCallStamping:
         _topic, headers, env = broker.published[0]
         assert headers[HDR_KIND] == "call"
         assert env.reply is None
+
+
+class TestCorrelationKeying:
+    """Every point-to-point publish is partition-keyed by ``correlation_id``.
+
+    This is the single-writer affinity the durable fan-out fold and tool-return ordering
+    rest on (one batch's siblings/returns all land on one partition, one owner, serial).
+    A safety-net pin for the staged-handler restructure: a publish that drops or mis-sets
+    the key would fork a batch across partitions and was previously unguarded.
+    """
+
+    async def test_call_publish_is_correlation_keyed(self) -> None:
+        broker = _CaptureBroker()
+        await _run(_CallNode(node_id="n", subscribe_topics=["t"]), _envelope(), broker)
+        assert broker.keys == [_CORR.encode()]
+
+    async def test_returncall_callback_publish_is_correlation_keyed(self) -> None:
+        broker = _CaptureBroker()
+        await _run(_RetNode(node_id="n", subscribe_topics=["t"]), _envelope(), broker)
+        assert broker.keys == [_CORR.encode()]
+
+    async def test_tailcall_publish_is_correlation_keyed(self) -> None:
+        broker = _CaptureBroker()
+        await _run(_TailNode(node_id="n", subscribe_topics=["t"]), _envelope(), broker)
+        assert broker.keys == [_CORR.encode()]
+
+    async def test_fanout_siblings_are_all_correlation_keyed(self) -> None:
+        broker = _CaptureBroker()
+        await _run(_FanNode(node_id="n", subscribe_topics=["t"]), _envelope(), broker)
+        assert broker.keys == [_CORR.encode(), _CORR.encode()]
 
 
 class TestNoReplyMirrorClearsInboundReply:

--- a/tests/test_staged_pipeline.py
+++ b/tests/test_staged_pipeline.py
@@ -1,0 +1,229 @@
+"""Phase-A unit tests for the §6.8 staged-pipeline stage methods on ``BaseNodeDef``
+(return-only — PR-4).
+
+These sealed stage methods (``_classify`` / ``_aggregate`` / ``_execute`` / ``_stray_check``)
+are added additively *before* ``handler`` is rewired to call them, so the flat handler stays
+live and the whole suite stays green until the Phase-B switch. The fault rail (PR-6) extends
+these stages additively (the seam stages 1/3/6 + fault arms are TODO insertion points).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from calfkit._protocol import HDR_KIND
+from calfkit._vendor.pydantic_ai.messages import ToolReturn
+from calfkit.models import ReturnCall
+from calfkit.models.envelope import Envelope
+from calfkit.models.fanout import EnvelopeSnapshot, FanoutOpen, FanoutOutcome, SlotRef
+from calfkit.models.reply import ReturnMessage
+from calfkit.models.session_context import CallFrame, SessionRunContext, Stack, WorkflowState
+from calfkit.models.state import State
+from calfkit.nodes._fanout_store import FANOUT_STORE_KEY
+from calfkit.nodes.base import _CONSUMED, _DECLINED, _BatchClosed, _BatchOpen
+from calfkit.nodes.node import NodeDef
+from tests._fanout_fakes import FakeFanoutBatchStore
+
+
+def _node() -> NodeDef[Any]:
+    return NodeDef(node_id="n", subscribe_topics=["t"])
+
+
+class _FanoutNode(NodeDef[Any]):
+    """A minimal fan-out-capable node (no agent machinery) for unit-testing the stages."""
+
+    @property
+    def _is_fanout_capable(self) -> bool:
+        return True
+
+
+class _BodyNode(NodeDef[Any]):
+    """A fan-out-capable node whose body returns a terminal action (for the _execute tests)."""
+
+    @property
+    def _is_fanout_capable(self) -> bool:
+        return True
+
+    async def run(self, ctx: SessionRunContext) -> Any:
+        return ReturnCall(state=ctx.state, value="done")
+
+
+class _CaptureBroker:
+    """Records (topic, envelope) per publish — for the re-entry self-publish."""
+
+    def __init__(self) -> None:
+        self.published: list[tuple[str, Any]] = []
+
+    async def publish(self, envelope: Any, *, topic: str, correlation_id: str, key: bytes, headers: dict[str, str]) -> None:
+        self.published.append((topic, envelope))
+
+
+def _fanout_node() -> _FanoutNode:
+    return _FanoutNode(node_id="fan", subscribe_topics=["fan.in"])
+
+
+def _store_ctx(store: FakeFanoutBatchStore, *, state: State | None = None, deps: dict[str, Any] | None = None) -> SessionRunContext:
+    ctx = SessionRunContext(state=state if state is not None else State(), deps=deps or {})
+    ctx._resources = {FANOUT_STORE_KEY: store}
+    ctx._correlation_id = "corr-1"
+    return ctx
+
+
+def _marked_env(*, in_reply_to: str, tag: str | None = "tc1", state: State | None = None) -> Envelope:
+    # A marked fan-out frame (fanout_id == frame_id == "A") on top, with a reply slot.
+    frame = CallFrame(target_topic="fan", callback_topic="caller", frame_id="A", fanout_id="A")
+    return Envelope(
+        context=SessionRunContext(state=state if state is not None else State(), deps={}),
+        internal_workflow_state=WorkflowState(call_stack=Stack([frame])),
+        reply=ReturnMessage(in_reply_to=in_reply_to, tag=tag, parts=[]),
+    )
+
+
+def _plain_env(*, reply: ReturnMessage | None = None) -> Envelope:
+    # An ordinary (non-fan-out) delivery: a single unmarked frame on top.
+    frame = CallFrame(target_topic="b", callback_topic="caller", frame_id="A")
+    return Envelope(
+        context=SessionRunContext(state=State(), deps={}),
+        internal_workflow_state=WorkflowState(call_stack=Stack([frame])),
+        reply=reply,
+    )
+
+
+async def _open(store: FakeFanoutBatchStore, *, snap_state: State | None = None, deps: dict[str, Any] | None = None) -> None:
+    own = CallFrame(target_topic="fan", callback_topic="caller", frame_id="A")  # UNMARKED — the pre-stamp snapshot frame
+    snap = EnvelopeSnapshot(state=snap_state if snap_state is not None else State(), stack=WorkflowState(call_stack=Stack([own])), deps=deps or {})
+    reg = FanoutOpen(fanout_id="A", node_id="fan", expected=[SlotRef(frame_id="f1", tag="tc1"), SlotRef(frame_id="f2", tag="tc2")])
+    await store.open("A", reg, snap)
+
+
+class TestClassify:
+    """``_classify`` reads the inbound ``x-calf-kind`` header into the delivery kind that
+    drives stage routing (only ``call``/``return`` exist pre-rail; missing ⇒ ``call``)."""
+
+    def test_missing_kind_header_is_call(self) -> None:
+        assert _node()._classify({}) == "call"
+
+    def test_return_kind_header_is_return(self) -> None:
+        assert _node()._classify({HDR_KIND: "return"}) == "return"
+
+    def test_call_kind_header_is_call(self) -> None:
+        assert _node()._classify({HDR_KIND: "call"}) == "call"
+
+    def test_kind_header_decoded_from_bytes(self) -> None:
+        # Over the wire header values arrive as bytes; _classify must decode them.
+        assert _node()._classify({HDR_KIND: b"return"}) == "return"
+
+
+class TestAggregate:
+    """``_aggregate`` is the durable fold/close stage (§6.8 stage-2). It returns
+    ``_BatchClosed`` (proceed to the body — a completed fan-out close OR a stateless
+    single-call continuation) or ``_BatchOpen`` (park — an incomplete fold or a no-op close).
+    """
+
+    async def test_stateless_continuation_is_batch_closed(self) -> None:
+        # An unmarked frame (a single-call return) is not a fan-out → proceed to the body.
+        node = _fanout_node()
+        frame = CallFrame(target_topic="fan", callback_topic="caller", frame_id="A")  # unmarked
+        env = Envelope(
+            context=SessionRunContext(state=State(), deps={}),
+            internal_workflow_state=WorkflowState(call_stack=Stack([frame])),
+            reply=ReturnMessage(in_reply_to="A", tag="tc1", parts=[]),
+        )
+        result = await node._aggregate(_store_ctx(FakeFanoutBatchStore()), env, "corr-1", _CaptureBroker())
+        assert isinstance(result, _BatchClosed)
+
+    async def test_sibling_fold_incomplete_parks(self) -> None:
+        node = _fanout_node()
+        store = FakeFanoutBatchStore()
+        await _open(store)
+        st = State()
+        st.add_tool_result("tc1", ToolReturn(return_value="r1"))
+        result = await node._aggregate(_store_ctx(store, state=st), _marked_env(in_reply_to="f1", tag="tc1", state=st), "corr-1", _CaptureBroker())
+        assert isinstance(result, _BatchOpen)  # 1 of 2 → parked
+        state = await store.read_state("A")
+        assert state is not None and set(state.outcomes) == {"f1"}
+
+    async def test_sibling_fold_complete_publishes_reentry_and_parks(self) -> None:
+        node = _fanout_node()
+        store = FakeFanoutBatchStore()
+        await _open(store)
+        broker = _CaptureBroker()
+        st1 = State()
+        st1.add_tool_result("tc1", ToolReturn(return_value="r1"))
+        await node._aggregate(_store_ctx(store, state=st1), _marked_env(in_reply_to="f1", tag="tc1", state=st1), "corr-1", broker)
+        st2 = State()
+        st2.add_tool_result("tc2", ToolReturn(return_value="r2"))
+        result = await node._aggregate(_store_ctx(store, state=st2), _marked_env(in_reply_to="f2", tag="tc2", state=st2), "corr-1", broker)
+        assert isinstance(result, _BatchOpen)  # still parked — the re-entry is a fresh delivery
+        assert [t for t, _ in broker.published] == ["fan.private.return"]  # closure re-entry self-published
+        reentry_env = broker.published[0][1]
+        assert reentry_env.reply is not None and reentry_env.reply.in_reply_to == "A"
+
+    async def test_reentry_close_restores_context_and_is_batch_closed(self) -> None:
+        node = _fanout_node()
+        store = FakeFanoutBatchStore()
+        await _open(store, snap_state=State(), deps={"k": "v"})  # snapshot carries deps + a pre-tool state
+        await store.fold("A", FanoutOutcome(slot="f1", tag="tc1", result=ToolReturn(return_value="r1")))
+        await store.fold("A", FanoutOutcome(slot="f2", tag="tc2", result=ToolReturn(return_value="r2")))
+        # The re-entry envelope arrives with cleared context (as _publish_reentry builds it).
+        ctx = _store_ctx(store)
+        env = _marked_env(in_reply_to="A", tag=None)  # in_reply_to == frame_id "A" → re-entry close
+        result = await node._aggregate(ctx, env, "corr-1", _CaptureBroker())
+        assert isinstance(result, _BatchClosed)
+        # ctx restored from the snapshot, with both outcomes materialized into State.
+        assert ctx.state.get_tool_result("tc1") == ToolReturn(return_value="r1")
+        assert ctx.state.get_tool_result("tc2") == ToolReturn(return_value="r2")
+        assert ctx.deps == {"k": "v"}
+        # The envelope stack is restored to the UNMARKED snapshot frame so the resumed body's
+        # ReturnCall unwinds the original fan-out frame back to its caller.
+        assert env.internal_workflow_state.current_frame.frame_id == "A"
+        assert env.internal_workflow_state.current_frame.fanout_id is None
+        assert env.context.deps == {"k": "v"}
+        assert await store.read_state("A") is None  # tombstoned at close
+
+    async def test_reentry_spurious_incomplete_parks(self) -> None:
+        node = _fanout_node()
+        store = FakeFanoutBatchStore()
+        await _open(store)  # opened, no folds → incomplete
+        result = await node._aggregate(_store_ctx(store), _marked_env(in_reply_to="A", tag=None), "corr-1", _CaptureBroker())
+        assert isinstance(result, _BatchOpen)  # spurious early re-entry → no-op park
+        assert await store.read_state("A") is not None  # batch left untouched
+
+
+class TestExecute:
+    """``_execute`` orders the return-only stages: stage-2 ``_aggregate`` (on ``return`` kind)
+    then stage-4 the body. ``_BatchOpen`` → ``_CONSUMED`` (park, body skipped); ``_BatchClosed``
+    → run the body; an all-declined body → ``_DECLINED``. ``call`` kind skips ``_aggregate``."""
+
+    async def test_call_kind_runs_body(self) -> None:
+        node = _BodyNode(node_id="b", subscribe_topics=["b.in"])
+        ctx = SessionRunContext(state=State(), deps={})
+        ctx._correlation_id = "corr-1"
+        result = await node._execute(ctx, "call", _plain_env(), None, None, awaiting_reply=False, correlation_id="corr-1", broker=_CaptureBroker())
+        assert isinstance(result, ReturnCall) and result.value == "done"
+
+    async def test_return_stateless_continuation_runs_body(self) -> None:
+        node = _BodyNode(node_id="b", subscribe_topics=["b.in"])
+        ctx = SessionRunContext(state=State(), deps={})
+        ctx._correlation_id = "corr-1"
+        env = _plain_env(reply=ReturnMessage(in_reply_to="A", tag="tc1", parts=[]))  # unmarked → _BatchClosed
+        result = await node._execute(ctx, "return", env, None, None, awaiting_reply=False, correlation_id="corr-1", broker=_CaptureBroker())
+        assert isinstance(result, ReturnCall)
+
+    async def test_return_parked_fold_is_consumed_without_running_body(self) -> None:
+        node = _BodyNode(node_id="fan", subscribe_topics=["fan.in"])
+        store = FakeFanoutBatchStore()
+        await _open(store)
+        st = State()
+        st.add_tool_result("tc1", ToolReturn(return_value="r1"))
+        ctx = _store_ctx(store, state=st)
+        env = _marked_env(in_reply_to="f1", tag="tc1", state=st)
+        result = await node._execute(ctx, "return", env, None, None, awaiting_reply=False, correlation_id="corr-1", broker=_CaptureBroker())
+        assert result is _CONSUMED  # parked fold — the body never runs
+
+    async def test_all_declined_body_is_declined(self) -> None:
+        node = _fanout_node()  # base run() declines (returns Next)
+        ctx = SessionRunContext(state=State(), deps={})
+        ctx._correlation_id = "corr-1"
+        result = await node._execute(ctx, "call", _plain_env(), None, None, awaiting_reply=False, correlation_id="corr-1", broker=_CaptureBroker())
+        assert result is _DECLINED

--- a/tests/test_staged_pipeline.py
+++ b/tests/test_staged_pipeline.py
@@ -9,7 +9,11 @@ these stages additively (the seam stages 1/3/6 + fault arms are TODO insertion p
 
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+import pytest
+from aiokafka.errors import KafkaError  # type: ignore[import-untyped]
 
 from calfkit._protocol import HDR_KIND
 from calfkit._vendor.pydantic_ai.messages import ToolReturn
@@ -56,6 +60,14 @@ class _CaptureBroker:
 
     async def publish(self, envelope: Any, *, topic: str, correlation_id: str, key: bytes, headers: dict[str, str]) -> None:
         self.published.append((topic, envelope))
+
+
+class _RaisingBroker:
+    """A broker stub whose ``publish`` always raises ``KafkaError`` — exercises the
+    re-entry-publish-failure abort path in ``_aggregate``'s ``FoldComplete`` arm."""
+
+    async def publish(self, envelope: Any, *, topic: str, correlation_id: str, key: bytes, headers: dict[str, str]) -> None:
+        raise KafkaError("simulated re-entry publish failure")
 
 
 def _fanout_node() -> _FanoutNode:
@@ -188,6 +200,91 @@ class TestAggregate:
         result = await node._aggregate(_store_ctx(store), _marked_env(in_reply_to="A", tag=None), "corr-1", _CaptureBroker())
         assert isinstance(result, _BatchOpen)  # spurious early re-entry → no-op park
         assert await store.read_state("A") is not None  # batch left untouched
+
+    async def test_completing_fold_reentry_publish_failure_aborts_and_tombstones(self) -> None:
+        # (#1) The completing fold tries to self-publish the re-entry; if that publish raises
+        # KafkaError, _aggregate must NOT propagate — it aborts (tombstones both records) and
+        # still parks (_BatchOpen), so the caller strands rather than a complete-but-unclosed batch.
+        node = _fanout_node()
+        store = FakeFanoutBatchStore()
+        await _open(store)
+        st1 = State()
+        st1.add_tool_result("tc1", ToolReturn(return_value="r1"))
+        await node._aggregate(_store_ctx(store, state=st1), _marked_env(in_reply_to="f1", tag="tc1", state=st1), "corr-1", _CaptureBroker())
+        # The SECOND fold completes the batch; its re-entry publish raises.
+        st2 = State()
+        st2.add_tool_result("tc2", ToolReturn(return_value="r2"))
+        result = await node._aggregate(_store_ctx(store, state=st2), _marked_env(in_reply_to="f2", tag="tc2", state=st2), "corr-1", _RaisingBroker())
+        assert isinstance(result, _BatchOpen)  # did not propagate; parked
+        assert await store.read_state("A") is None  # aborted: both records tombstoned
+        assert await store.read_basestate("A") is None
+
+    async def test_sibling_reply_without_in_reply_to_does_not_fold(self, caplog: pytest.LogCaptureFixture) -> None:
+        # (#6) A marked sibling reply that carries no in_reply_to is malformed: _aggregate must
+        # short-circuit to park (_BatchOpen), NOT fold (the store's outcomes are unchanged), and
+        # log a distinct "malformed sibling reply" error (proving the guard fired, not the
+        # foreign-stray fallthrough).
+        node = _fanout_node()
+        store = FakeFanoutBatchStore()
+        await _open(store)
+        env = _marked_env(in_reply_to="f1", tag="tc1")
+        env.reply.in_reply_to = None  # malformed: marked sibling but no slot
+        with caplog.at_level(logging.ERROR, logger="calfkit.nodes.base"):
+            result = await node._aggregate(_store_ctx(store), env, "corr-1", _CaptureBroker())
+        assert isinstance(result, _BatchOpen)
+        state = await store.read_state("A")
+        assert state is not None and state.outcomes == {}  # nothing folded
+        assert any("malformed sibling reply" in r.getMessage() for r in caplog.records)
+
+    async def test_sibling_foreign_slot_parks_store_unchanged(self) -> None:
+        # (coverage c) A reply to a slot not in the batch is a foreign stray → park, store untouched.
+        node = _fanout_node()
+        store = FakeFanoutBatchStore()
+        await _open(store)
+        result = await node._aggregate(_store_ctx(store), _marked_env(in_reply_to="f99", tag="tcX"), "corr-1", _CaptureBroker())
+        assert isinstance(result, _BatchOpen)
+        state = await store.read_state("A")
+        assert state is not None and state.outcomes == {}
+
+    async def test_sibling_duplicate_slot_parks_store_unchanged(self) -> None:
+        # (coverage c) A second reply for an already-folded slot is a duplicate stray → park.
+        node = _fanout_node()
+        store = FakeFanoutBatchStore()
+        await _open(store)
+        st = State()
+        st.add_tool_result("tc1", ToolReturn(return_value="r1"))
+        await node._aggregate(_store_ctx(store, state=st), _marked_env(in_reply_to="f1", tag="tc1", state=st), "corr-1", _CaptureBroker())
+        result = await node._aggregate(_store_ctx(store, state=st), _marked_env(in_reply_to="f1", tag="tc1", state=st), "corr-1", _CaptureBroker())
+        assert isinstance(result, _BatchOpen)
+        state = await store.read_state("A")
+        assert state is not None and set(state.outcomes) == {"f1"}  # still just the one fold
+
+    async def test_sibling_fold_unavailable_store_parks_abort_path(self) -> None:
+        # (coverage c) A store that died mid-fold aborts (FoldAbort) but still parks (_BatchOpen).
+        node = _fanout_node()
+        store = FakeFanoutBatchStore()
+        await _open(store)
+        store.make_unavailable()
+        result = await node._aggregate(_store_ctx(store), _marked_env(in_reply_to="f1", tag="tc1"), "corr-1", _CaptureBroker())
+        assert isinstance(result, _BatchOpen)
+
+    async def test_reentry_over_tombstoned_batch_abandons_parks(self) -> None:
+        # (coverage c) A re-entry whose batch is already closed/tombstoned → abandon → park.
+        node = _fanout_node()
+        store = FakeFanoutBatchStore()  # never opened "A"
+        result = await node._aggregate(_store_ctx(store), _marked_env(in_reply_to="A", tag=None), "corr-1", _CaptureBroker())
+        assert isinstance(result, _BatchOpen)
+
+    async def test_reentry_basestate_missing_aborts_parks(self) -> None:
+        # (coverage c) A complete batch whose basestate is gone aborts at close → park.
+        node = _fanout_node()
+        store = FakeFanoutBatchStore()
+        await _open(store)
+        await store.fold("A", FanoutOutcome(slot="f1", tag="tc1", result=ToolReturn(return_value="r1")))
+        await store.fold("A", FanoutOutcome(slot="f2", tag="tc2", result=ToolReturn(return_value="r2")))
+        store._basestate.pop("A")  # white-box: simulate the impossible-by-ordering miss
+        result = await node._aggregate(_store_ctx(store), _marked_env(in_reply_to="A", tag=None), "corr-1", _CaptureBroker())
+        assert isinstance(result, _BatchOpen)
 
 
 class TestExecute:

--- a/tests/test_tool_errors.py
+++ b/tests/test_tool_errors.py
@@ -29,11 +29,10 @@ from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
 from calfkit._vendor.pydantic_ai.models.test import TestModel
 from calfkit.exceptions import ToolExecutionError
 from calfkit.models import SessionRunContext, ToolCallRef, ToolContext
-from calfkit.models.actions import Call, ReturnCall, Silent, TailCall
+from calfkit.models.actions import Call, ReturnCall, TailCall
 from calfkit.models.state import (
     FailedToolCall,
     OverridesState,
-    PendingToolBatch,
     State,
     _calf_tool_result_discriminator,
 )
@@ -439,10 +438,10 @@ async def test_agent_ignores_stale_marker_not_in_latest_tool_calls():
 # ---------------------------------------------------------------------------
 
 
-async def test_agent_parallel_mode_marker_in_batch_triggers_error_after_aggregation():
-    # Parallel mode: the agent waits for both tool replies via
-    # _parallel_state_aggregation, then the error check fires once the batch
-    # is complete.
+async def test_failed_tool_in_completed_batch_raises_tool_execution_error():
+    # Durable model: a completed fan-out batch is materialized and the body re-entered via the
+    # in-node fold, so run() sees all tool results at once. A FailedToolCall among them raises
+    # ToolExecutionError (the return-only strand — the rail PR will escalate a typed fault).
     agent = Agent(
         "agent_parallel",
         system_prompt="x",
@@ -455,15 +454,6 @@ async def test_agent_parallel_mode_marker_in_batch_triggers_error_after_aggregat
     frame_id = "frame-parallel-mixed"
     success_id = "tc-parallel-ok"
     fail_id = "tc-parallel-fail"
-
-    base_state = State()
-    _register_tool_call(base_state, tool_name="happy_tool", tool_call_id=success_id)
-    _register_tool_call(base_state, tool_name="buggy_tool", tool_call_id=fail_id)
-
-    agent._pending_batches[frame_id] = PendingToolBatch(
-        expected_tool_call_ids=frozenset({success_id, fail_id}),
-        base_state=base_state,
-    )
 
     inflight_state = State()
     _register_tool_call(inflight_state, tool_name="happy_tool", tool_call_id=success_id)
@@ -494,48 +484,12 @@ async def test_agent_parallel_mode_marker_in_batch_triggers_error_after_aggregat
     assert err.exc_message == "boom"
 
 
-async def test_agent_parallel_mode_waits_for_incomplete_batch():
-    # Companion check: if only one of two tools has replied, the agent must
-    # return Silent() without raising — even when the one that did reply is
-    # a FailedToolCall. The error check is gated on batch completion.
-    agent = Agent(
-        "agent_parallel_partial",
-        system_prompt="x",
-        subscribe_topics="agent_parallel_partial.input",
-        publish_topic="agent_parallel_partial.output",
-        model_client=TestModel(),
-    )
-
-    correlation_id = "cid-parallel-partial"
-    frame_id = "frame-parallel-partial"
-    pending_id = "tc-parallel-pending"
-    fail_id = "tc-parallel-partial-fail"
-
-    base_state = State()
-    _register_tool_call(base_state, tool_name="slow_tool", tool_call_id=pending_id)
-    _register_tool_call(base_state, tool_name="buggy_tool", tool_call_id=fail_id)
-
-    agent._pending_batches[frame_id] = PendingToolBatch(
-        expected_tool_call_ids=frozenset({pending_id, fail_id}),
-        base_state=base_state,
-    )
-
-    inflight_state = State()
-    _register_tool_call(inflight_state, tool_name="buggy_tool", tool_call_id=fail_id)
-    inflight_state.add_tool_result(
-        fail_id,
-        FailedToolCall(
-            tool_name="buggy_tool",
-            tool_call_id=fail_id,
-            exc_type="ValueError",
-            exc_message="early",
-        ),
-    )
-
-    ctx = _make_ctx(inflight_state, correlation_id=correlation_id, frame_id=frame_id)
-
-    result = await agent.run(ctx)
-    assert isinstance(result, Silent), f"expected Silent while batch incomplete, got {type(result).__name__}"
+# NOTE: the old `test_agent_parallel_mode_waits_for_incomplete_batch` (white-box: set
+# `_pending_batches`, call run(), expect `Silent()` while incomplete) was removed in the durable
+# fan-out cutover. run() is no longer re-entered on an incomplete batch — sibling folds park in the
+# handler (BaseNodeDef._aggregate); run() resumes only at the complete close. The parking behavior
+# is covered durably by tests/test_staged_pipeline.py::TestAggregate.test_sibling_fold_incomplete_parks
+# and TestExecute.test_return_parked_fold_is_consumed_without_running_body.
 
 
 # ---------------------------------------------------------------------------
@@ -1059,15 +1013,6 @@ async def test_agent_parallel_mode_logs_all_failures_before_raising(caplog):
     first_id = "tc-first-fail"
     second_id = "tc-second-fail"
 
-    base_state = State()
-    _register_tool_call(base_state, tool_name="buggy_a", tool_call_id=first_id)
-    _register_tool_call(base_state, tool_name="buggy_b", tool_call_id=second_id)
-
-    agent._pending_batches[frame_id] = PendingToolBatch(
-        expected_tool_call_ids=frozenset({first_id, second_id}),
-        base_state=base_state,
-    )
-
     inflight_state = State()
     _register_tool_call(inflight_state, tool_name="buggy_a", tool_call_id=first_id)
     _register_tool_call(inflight_state, tool_name="buggy_b", tool_call_id=second_id)
@@ -1555,125 +1500,11 @@ async def test_agent_corrupt_marker_with_missing_tool_name_uses_sentinel():
     assert err.tool_call_id == tool_call_id
 
 
-# ---------------------------------------------------------------------------
-# Parallel-same-agent invocations: ``_pending_batches`` is keyed by ``frame_id``,
-# not ``correlation_id``. A supervisor that fans out two ``Call``s to the same
-# agent shares one correlation_id across both invocations — keying on
-# correlation_id used to silently collide the batches and wedge one of them.
-# ---------------------------------------------------------------------------
-
-
-async def test_pending_batches_keyed_by_frame_id_not_correlation_id():
-    # Direct unit-level regression for the collision bug. Two parallel
-    # invocations of the same agent (same correlation_id, different frame_ids)
-    # must each track their own PendingToolBatch independently, and a reply
-    # for invocation A's tool_call_ids must aggregate into A's batch only.
-    agent = Agent(
-        "agent_parallel_same",
-        system_prompt="x",
-        subscribe_topics="agent_parallel_same.input",
-        publish_topic="agent_parallel_same.output",
-        model_client=TestModel(),
-    )
-
-    correlation_id = "cid-shared-by-both"
-
-    # Invocation A
-    frame_a = "frame-A"
-    a_tool_id = "tc-A-1"
-    base_state_a = State()
-    _register_tool_call(base_state_a, tool_name="tool_a", tool_call_id=a_tool_id)
-    agent._pending_batches[frame_a] = PendingToolBatch(
-        expected_tool_call_ids=frozenset({a_tool_id}),
-        base_state=base_state_a,
-    )
-
-    # Invocation B (same correlation_id, different frame_id, disjoint tool_call_ids)
-    frame_b = "frame-B"
-    b_tool_id = "tc-B-1"
-    base_state_b = State()
-    _register_tool_call(base_state_b, tool_name="tool_b", tool_call_id=b_tool_id)
-    agent._pending_batches[frame_b] = PendingToolBatch(
-        expected_tool_call_ids=frozenset({b_tool_id}),
-        base_state=base_state_b,
-    )
-
-    # Both batches coexist — keying on correlation_id would have overwritten one.
-    assert set(agent._pending_batches.keys()) == {frame_a, frame_b}, (
-        f"both per-invocation batches must coexist; got keys={list(agent._pending_batches.keys())}"
-    )
-    assert agent._pending_batches[frame_a].expected_tool_call_ids == frozenset({a_tool_id})
-    assert agent._pending_batches[frame_b].expected_tool_call_ids == frozenset({b_tool_id})
-
-    # Reply for invocation A arrives. ctx carries A's frame_id.
-    a_reply_state = State()
-    _register_tool_call(a_reply_state, tool_name="tool_a", tool_call_id=a_tool_id)
-    a_reply_state.add_tool_result(
-        a_tool_id,
-        ToolReturn(return_value="a-done", metadata={"tool_call_id": a_tool_id}),
-    )
-    ctx_a = _make_ctx(a_reply_state, correlation_id=correlation_id, frame_id=frame_a)
-
-    agent._parallel_state_aggregation(ctx_a)
-
-    # A's batch completed and was popped; B's must be untouched.
-    assert frame_a not in agent._pending_batches, "A's batch must be popped after completion"
-    assert frame_b in agent._pending_batches, "B's batch must NOT be affected by A's reply"
-    assert agent._pending_batches[frame_b].collected_results == {}, "B's batch must not have collected any of A's results"
-
-    # Now B's reply arrives.
-    b_reply_state = State()
-    _register_tool_call(b_reply_state, tool_name="tool_b", tool_call_id=b_tool_id)
-    b_reply_state.add_tool_result(
-        b_tool_id,
-        ToolReturn(return_value="b-done", metadata={"tool_call_id": b_tool_id}),
-    )
-    ctx_b = _make_ctx(b_reply_state, correlation_id=correlation_id, frame_id=frame_b)
-
-    agent._parallel_state_aggregation(ctx_b)
-
-    assert frame_b not in agent._pending_batches, "B's batch must be popped after completion"
-
-
-async def test_parallel_replies_with_wrong_frame_id_do_not_aggregate():
-    # Defense-in-depth: if a tool reply arrives carrying an unrelated frame_id
-    # (e.g. a stale message, a routing error, a reply destined for some other
-    # agent invocation), the aggregator must not absorb its tool_results into
-    # the wrong batch. The batch under the correct frame_id must remain
-    # untouched.
-    agent = Agent(
-        "agent_wrong_frame",
-        system_prompt="x",
-        subscribe_topics="agent_wrong_frame.input",
-        publish_topic="agent_wrong_frame.output",
-        model_client=TestModel(),
-    )
-
-    real_frame = "frame-real"
-    real_tool_id = "tc-real-1"
-    base_state = State()
-    _register_tool_call(base_state, tool_name="tool_real", tool_call_id=real_tool_id)
-    agent._pending_batches[real_frame] = PendingToolBatch(
-        expected_tool_call_ids=frozenset({real_tool_id}),
-        base_state=base_state,
-    )
-
-    # A reply arrives carrying tool_results for ``real_tool_id`` but a
-    # different frame_id — must NOT aggregate into the real batch.
-    wrong_frame = "frame-unrelated"
-    inflight_state = State()
-    _register_tool_call(inflight_state, tool_name="tool_real", tool_call_id=real_tool_id)
-    inflight_state.add_tool_result(
-        real_tool_id,
-        ToolReturn(return_value="leaked", metadata={"tool_call_id": real_tool_id}),
-    )
-    ctx = _make_ctx(inflight_state, frame_id=wrong_frame)
-
-    agent._parallel_state_aggregation(ctx)
-
-    # Real batch is untouched.
-    assert real_frame in agent._pending_batches
-    assert agent._pending_batches[real_frame].collected_results == {}
+# NOTE: the white-box `_parallel_state_aggregation` regressions (per-frame-id batch keying;
+# wrong-frame replies don't aggregate) were removed with the in-process aggregation. The durable
+# fold keys batches by `fanout_id` (the node's own frame_id) in the store, and a foreign-slot reply
+# is a stray — covered by tests/test_fanout_fold.py (test_fold_foreign_slot_is_stray_*) and the
+# fanout_id-keyed records in tests/test_staged_pipeline.py / tests/test_fanout_handler.py.
 
 
 def test_prepare_context_populates_frame_id_from_envelope():

--- a/tests/test_tool_errors.py
+++ b/tests/test_tool_errors.py
@@ -52,8 +52,9 @@ def _make_ctx(
     ctx = SessionRunContext(state=state, deps={})
     # ``_correlation_id`` / ``_frame_id`` are ``PrivateAttr``s populated by
     # ``BaseNodeDef.prepare_context`` in the live path; tests that drive
-    # ``agent.run`` directly must set them here. ``_frame_id`` matters for
-    # parallel-mode aggregation (which keys ``_pending_batches`` on it).
+    # ``agent.run`` directly must set them here. ``_frame_id`` surfaces the
+    # per-invocation frame id (used in the parallel-mode incomplete-batch
+    # diagnostic ``RuntimeError`` raised by ``agent.run``).
     ctx._correlation_id = correlation_id
     if frame_id is not None:
         ctx._frame_id = frame_id
@@ -1509,10 +1510,10 @@ async def test_agent_corrupt_marker_with_missing_tool_name_uses_sentinel():
 
 def test_prepare_context_populates_frame_id_from_envelope():
     # Plumbing regression: ``prepare_context`` must read
-    # ``current_frame.frame_id`` into ``ctx._frame_id`` so that
-    # ``_pending_batches`` lookups in ``agent.run`` see the right key. Without
-    # this, ``ctx.frame_id`` returns ``None`` and every parallel batch lives
-    # under a single ``None`` key, re-introducing the collision bug at runtime.
+    # ``current_frame.frame_id`` into ``ctx._frame_id`` so ``ctx.frame_id``
+    # reports the frame this delivery runs under. Without this, ``ctx.frame_id``
+    # returns ``None``. (Durable fan-out is keyed by ``fanout_id`` in the store,
+    # not by this field, but the per-invocation frame id is still surfaced.)
     import asyncio
 
     from calfkit.models.envelope import Envelope


### PR DESCRIPTION
## What & why

Replaces the in-process tool-batch aggregation (`agent._pending_batches` / `_parallel_state_aggregation`) — **lost on a graceful rebalance/restart and unsafe under multiple replicas** — with a **durable in-node fan-out fold**. A fan-out agent's N parallel tool returns are aggregated in two node-scoped compacted ktables and the turn resumes via a self-published re-entry, so a partition moving mid-batch no longer strands the workflow.

## Design (see ADR-0008)

- **Two node-scoped compacted ktables:** `calf.fanout.{node_id}.state` (`FanoutState`, accumulating per-slot outcomes, LWW) + `calf.fanout.{node_id}.basestate` (write-once `EnvelopeSnapshot`).
- **Self-published re-entry close** (`x-calf-kind: return`, `in_reply_to == fanout_id`) — the resume rides the normal delivery path, surviving a rebalance between completion and resume.
- **`BaseNodeDef.handler` rewritten into the fault-rail §6.8 staged pipeline** (`_classify → _execute[_aggregate → body] → publish`) so the fault-rail PR layers seams/faults **additively** (seam/fault stages are TODO insertion points).
- **`KtablesFanoutBatchStore`** implements the `FanoutBatchStore` Protocol over the four ktables (barrier-RYOW on mutable state, barrier-on-miss on write-once basestate, idempotent writers, null tombstones). Each fan-out agent owns it as a node `@resource`; offline tests inject a fake via `prepare_worker`.
- **Single-writer-safe from transport:** correlation-keyed sibling replies + `group_id = node.name` + `max_workers=1` → one serial folder per batch. Tables give availability; transport gives serialization.

## Scope: return-only

A failed sibling folds as `FailedToolCall` and still strands the caller at close — **today's at-most-once behavior, minus the lost batch**. Typed-fault escalation (and re-homing the fold's `result` field + the seam arms) is the **fault-rail PR**, which this staged pipeline is shaped to receive additively.

## Testing

- **Offline (`make test`): 2899 passed** — staged-pipeline units (`_classify`/`_aggregate`/`_execute`), the durable arc e2e (fake store), the pure fold/close state machine, records, marker carriage, correlation-key pins.
- **`make check`:** clean (ruff + mypy `--strict`, 57 source files).
- **Kafka lane (`make test-kafka`, real Redpanda): 8 passed** — store barrier-RYOW + fold→close→tombstone visibility; a **real-Worker fan-out agent completing over the wire** (the `@resource` opens the real store); and the **2-worker graceful-rebalance continuation** (owner-1 OPENs + leaves, owner-2 folds + closes exactly once — ADR-0008's core availability claim).

## Review status

A deep multi-agent review (bugs / silent-failure / event-driven design / test coverage / type design / simplification) found **no CRITICAL code bug**; the durability/correctness core was independently confirmed sound. Findings — 1 MAJOR robustness gap (an unguarded re-entry-publish failure), 1 MAJOR invariant (`FanoutOpen.expected` N≥2 unenforced), 2 CRITICAL test-coverage gaps for the durable *failure* path, and several MINORs — are **being evaluated**; fixes will land as follow-up commits.

## Follow-ups (not in this PR)
- The deep-review fixes (pending evaluation).
- The fault-rail PR (re-homes the fold + typed-fault escalation + seams).
- Untracked design-spec reconciliation (barrier-bool / acks=all).
