### PR TITLE
fix: abort the durable fan-out batch on an OPEN-path failure

### DIFF
--- a/calfkit/nodes/_fanout_store.py
+++ b/calfkit/nodes/_fanout_store.py
@@ -201,14 +201,17 @@ async def close_batch(store: FanoutBatchStore, fanout_id: str) -> CloseResult:
 async def abort_batch(store: FanoutBatchStore, fanout_id: str) -> None:
     """Best-effort tombstone of both records (the §4.4 abort cleanup).
 
-    A dead store can't be tombstoned — the corpse is left for the aged-reclaim issue
-    (#220) rather than raising, so an abort never masks itself behind a second failure.
+    A failed tombstone — a dead store (:class:`FanoutStoreUnavailableError`) or a writer error (a raw
+    broker ``KafkaError`` from the real :class:`KtablesFanoutBatchStore`) — is swallowed and logged
+    rather than raised: the corpse is left for the aged-reclaim issue (#220), so an abort never masks
+    itself behind a second failure (which, escaping the handler, would re-open the silent-drop hole
+    the abort exists to close).
     """
     try:
         await store.tombstone(fanout_id)
-    except FanoutStoreUnavailableError:
-        logger.error(
-            "fan-out batch %s could not be tombstoned (store unavailable); the record strands until reclaimed",
+    except Exception:
+        logger.exception(
+            "fan-out batch %s could not be tombstoned (store error); the record strands until reclaimed",
             fanout_id,
         )
 

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -39,6 +39,7 @@ from calfkit.nodes._fanout_store import (
     CloseResume,
     CloseSpurious,
     FanoutBatchStore,
+    FanoutStoreUnavailableError,
     FoldAbort,
     FoldComplete,
     FoldParked,
@@ -530,23 +531,43 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
             expected=[SlotRef(frame_id=fid, tag=call.tag) for fid, call in zip(slot_ids, calls)],
         )
         snapshot = EnvelopeSnapshot(state=ctx.state, stack=envelope.internal_workflow_state, deps=dict(ctx.deps))
-        await store.open(fanout_id, reg, snapshot)
-        for call, slot_id in zip(calls, slot_ids):
-            wf_copy = envelope.internal_workflow_state.model_copy(deep=True)
-            wf_copy.mark_fanout()  # mark the node's OWN (current top) frame, before the callee push
-            wf_copy.invoke_frame(call, self._return_topic, payload=call.body, frame_id=slot_id, tag=call.tag)
-            sibling = Envelope(
-                context=SessionRunContext(state=call.state, deps=envelope.context.deps),
-                internal_workflow_state=wf_copy,
+        try:
+            await store.open(fanout_id, reg, snapshot)
+            for call, slot_id in zip(calls, slot_ids):
+                wf_copy = envelope.internal_workflow_state.model_copy(deep=True)
+                wf_copy.mark_fanout()  # mark the node's OWN (current top) frame, before the callee push
+                wf_copy.invoke_frame(call, self._return_topic, payload=call.body, frame_id=slot_id, tag=call.tag)
+                sibling = Envelope(
+                    context=SessionRunContext(state=call.state, deps=envelope.context.deps),
+                    internal_workflow_state=wf_copy,
+                )
+                await broker.publish(
+                    sibling,
+                    topic=wf_copy.current_frame.target_topic,
+                    correlation_id=correlation_id,
+                    key=correlation_id.encode(),
+                    headers=self._headers("call", route=call.route),
+                )
+        except (KafkaError, FanoutStoreUnavailableError) as exc:
+            # §4.4 dispatch-abort: the batch may be durably registered (basestate+state written) but
+            # cannot complete — a sibling publish failed, or the store failed at OPEN. Tombstone both
+            # records so the orphan open batch is not leaked (reclaimed otherwise only by #220); any
+            # sibling already published then post_closure-stray-floors against the tombstone at its
+            # fold. ERROR-log + strand: the ACK_FIRST offset is already committed, so the inbound is
+            # not redelivered.
+            logger.error(
+                "[%s] fan-out OPEN failed batch=%s node=%s; aborting + caller strands: %r",
+                correlation_id[:8],
+                fanout_id,
+                self.node_id,
+                exc,
             )
-            await broker.publish(
-                sibling,
-                topic=wf_copy.current_frame.target_topic,
-                correlation_id=correlation_id,
-                key=correlation_id.encode(),
-                headers=self._headers("call", route=call.route),
-            )
-        envelope.reply = None  # no-reply mirror (I3): the output is owed by the pending siblings
+            await abort_batch(store, fanout_id)
+            # TODO(fault rail PR-6): escalate a typed fault to the caller (spec §4.4) instead of
+            # stranding — the abort+tombstone here is the return-only precursor, matching the
+            # _aggregate fold/close abort arms the rail likewise upgrades to escalation.
+        envelope.reply = None  # no-reply mirror (I3): nothing was returned point-to-point this hop
+        # (the siblings owe the output; or, on abort above, both records are tombstoned and the caller strands)
         return Response(envelope, headers=self._headers("call"))
 
     async def _aggregate(

--- a/tests/integration/test_fanout_store_kafka.py
+++ b/tests/integration/test_fanout_store_kafka.py
@@ -14,7 +14,7 @@ import pytest
 from calfkit._vendor.pydantic_ai.messages import ToolReturn
 from calfkit.models.fanout import EnvelopeSnapshot, FanoutOpen, FanoutOutcome, SlotRef
 from calfkit.models.session_context import CallFrame, Stack, WorkflowState
-from calfkit.models.state import State
+from calfkit.models.state import FailedToolCall, State
 from calfkit.nodes._fanout_store import (
     CloseResume,
     FoldComplete,
@@ -71,5 +71,37 @@ async def test_fold_across_folds_then_close_and_tombstone(kafka_bootstrap: str, 
         # Tombstoned at close — a barriered re-read sees the delete (RYOW on the null tombstone).
         assert await store.read_state("A") is None
         assert await store.read_basestate("A") is None
+    finally:
+        await store.stop()
+
+
+async def test_failed_tool_call_folds_and_materializes_typed_over_real_broker(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """A return-only tool FAILURE folds and materializes as a TYPED marker over a real broker.
+
+    The offline fake cannot prove this: its fold never crosses real ktables JSON encode/decode, so it
+    can't show that a ``FailedToolCall`` survives the durable ``state`` table round-trip as a typed
+    instance (via the ``CalfToolResult`` discriminator) rather than a bare dict. This is the durable
+    analog of today's tool-failure → caller-strand path; PR-4 is return-only, so the failure rides as
+    a ``CalfToolResult`` marker, not yet a typed fault (the fault rail re-homes ``result`` to
+    parts/fault). Without this, the durable carriage of the core FAILURE path is untested over Kafka.
+    """
+    store = KtablesFanoutBatchStore(bootstrap_servers=kafka_bootstrap, node_id=f"{topic_namespace}-n")
+    await store.start()
+    try:
+        await store.open("A", _reg(), _snapshot())
+        marker = FailedToolCall.build_safe(tool_name="boom", tool_call_id="tc1", exc_type="ValueError", exc_message="kaboom")
+        first = await fold_sibling(store, "A", FanoutOutcome(slot="f1", tag="tc1", result=marker))
+        assert isinstance(first, FoldParked)
+        second = await fold_sibling(store, "A", FanoutOutcome(slot="f2", tag="tc2", result=ToolReturn(return_value="r2")))
+        assert isinstance(second, FoldComplete)
+
+        closed = await close_batch(store, "A")
+        assert isinstance(closed, CloseResume)
+        materialized = closed.snapshot.state.get_tool_result("tc1")
+        assert isinstance(materialized, FailedToolCall)  # typed via the discriminator after a REAL round-trip
+        assert materialized.exc_type == "ValueError"
+        assert materialized.tool_call_id == "tc1"
+        assert closed.snapshot.state.get_tool_result("tc2") == ToolReturn(return_value="r2")
+        assert await store.read_state("A") is None  # tombstoned at close
     finally:
         await store.stop()

--- a/tests/test_fanout_fold.py
+++ b/tests/test_fanout_fold.py
@@ -9,7 +9,10 @@ over the in-memory fake so wiring them into the staged handler (step 6) is no re
 - abort_batch   : best-effort tombstone of both records (the §4.4 abort cleanup)
 """
 
+import logging
+
 import pytest
+from aiokafka.errors import KafkaError  # type: ignore[import-untyped]
 
 from calfkit._vendor.pydantic_ai.messages import ToolReturn
 from calfkit.models.fanout import EnvelopeSnapshot, FanoutOpen, FanoutOutcome, SlotRef
@@ -189,6 +192,37 @@ async def test_close_materialization_failure_on_missing_tag_aborts(store: FakeFa
     assert await store.read_state("X") is None  # the un-closable batch is tombstoned
 
 
+async def test_close_duplicate_tag_materializes_last_write_wins(store: FakeFanoutBatchStore) -> None:
+    # Two DISTINCT slots carrying the SAME tag (an anomaly — the agent mints distinct tool_call_ids,
+    # so nothing produces this in practice; the types do not enforce tag-uniqueness across slots)
+    # materialize into one tool_results[tag] key: close does a last-write-wins overwrite and still
+    # resumes cleanly. Pinned so PR-6 (which re-homes the materialization loop onto parts/fault) is
+    # aware of the behavior before touching it.
+    reg = FanoutOpen(fanout_id="X", node_id="agent", expected=[SlotRef(frame_id="f1", tag="dup"), SlotRef(frame_id="f2", tag="dup")])
+    await store.open("X", reg, _snapshot())
+    await fold_sibling(store, "X", FanoutOutcome(slot="f1", tag="dup", result=ToolReturn(return_value="first")))
+    await fold_sibling(store, "X", FanoutOutcome(slot="f2", tag="dup", result=ToolReturn(return_value="second")))
+    result = await close_batch(store, "X")
+    assert isinstance(result, CloseResume)
+    # outcomes is insertion-ordered, so the second fold (f2) wins the last-write-wins overwrite.
+    assert result.snapshot.state.get_tool_result("dup") == ToolReturn(return_value="second")
+
+
+async def test_close_tag_present_result_none_resumes_without_crashing(store: FakeFanoutBatchStore) -> None:
+    # A folded outcome with a tag but result=None — a marked sibling whose tag had no
+    # state.tool_results entry (base.py reads tool_results.get(tag), which can be None) — is
+    # materialized as add_tool_result(tag, None). This is a return-only anomaly; pin that close
+    # RESUMES (does not crash or abort) and the None lands, so the batch never hangs. The semantics of
+    # a None result are revisited by the rail (FanoutOutcome gains parts/fault).
+    await store.open("X", _open(), _snapshot())
+    await fold_sibling(store, "X", FanoutOutcome(slot="f1", tag="tc1", result=None))
+    await fold_sibling(store, "X", _outcome("f2", "tc2", value="ok"))
+    result = await close_batch(store, "X")
+    assert isinstance(result, CloseResume)
+    assert result.snapshot.state.get_tool_result("tc1") is None
+    assert await store.read_state("X") is None  # closed + tombstoned
+
+
 # ── abort_batch + sequential re-fan-out ──────────────────────────────────────
 
 
@@ -203,6 +237,22 @@ async def test_abort_batch_on_unavailable_store_is_best_effort(store: FakeFanout
     await store.open("X", _open(), _snapshot())
     store.make_unavailable()
     await abort_batch(store, "X")  # must not raise
+
+
+async def test_abort_batch_swallows_non_store_unavailable_tombstone_failure(caplog: pytest.LogCaptureFixture) -> None:
+    # abort_batch is best-effort: its docstring promises it "never masks itself behind a second
+    # failure." A tombstone that raises a NON-FanoutStoreUnavailableError (e.g. a raw KafkaError from
+    # the real writer's producer) must be swallowed + logged, not propagated — else the abort itself
+    # would escape the handler and re-open the silent-drop hole the abort exists to close.
+    class _TombstoneRaises(FakeFanoutBatchStore):
+        async def tombstone(self, fanout_id: str) -> None:
+            raise KafkaError("simulated writer failure during tombstone")
+
+    store = _TombstoneRaises()
+    await store.open("X", _open(), _snapshot())
+    with caplog.at_level(logging.ERROR):
+        await abort_batch(store, "X")  # must not raise
+    assert any("could not be tombstoned" in r.getMessage() for r in caplog.records)
 
 
 async def test_reopen_after_close_starts_fresh_batch(store: FakeFanoutBatchStore) -> None:

--- a/tests/test_fanout_handler.py
+++ b/tests/test_fanout_handler.py
@@ -9,9 +9,11 @@ fake`). These pin the pieces the staged handler wires together in 6b-B:
 - _classify_fanout: marker + reply slot => SIBLING fold / RE-ENTRY close / NORMAL
 """
 
+import logging
 from typing import Annotated, Any, cast
 
 import pytest
+from aiokafka.errors import KafkaError  # type: ignore[import-untyped]
 from faststream import Context
 from faststream.kafka import KafkaBroker, TestKafkaBroker
 from pydantic import ValidationError
@@ -226,6 +228,14 @@ class _CaptureBroker:
         self.published.append((topic, headers, envelope))
 
 
+class _RaisingBroker:
+    """Node-side broker stub whose ``publish`` always raises ``KafkaError`` — exercises the OPEN
+    dispatch-abort (§4.4): a sibling publish failing after the batch is durably registered."""
+
+    async def publish(self, envelope: Envelope, *, topic: str, correlation_id: str, key: bytes, headers: dict[str, str]) -> None:
+        raise KafkaError("simulated sibling publish failure")
+
+
 class _SingleCallFanoutNode(NodeDef[Any]):
     """A fan-out-capable node whose body returns a ONE-element list[Call]."""
 
@@ -262,6 +272,54 @@ async def test_single_call_list_does_not_open_durable_batch() -> None:
     callee = broker.published[0][2].internal_workflow_state.current_frame
     assert callee.target_topic == "only.tool"
     assert callee.fanout_id is None  # not marked: this is not a durable fan-out
+
+
+# ── OPEN dispatch-abort path (§4.4) ──────────────────────────────────────────
+
+
+async def test_handle_fanout_open_sibling_publish_failure_aborts_and_tombstones() -> None:
+    # (§4.4 dispatch-abort) After the batch is registered, a sibling publish that raises must NOT
+    # propagate out of the handler: _handle_fanout_open tombstones both records (so the orphan open
+    # batch is not leaked to #220) and returns the no-reply mirror, stranding the caller. Any already-
+    # published sibling's later reply then post_closure-stray-floors against the tombstone.
+    agent = _agent()
+    fake = FakeFanoutBatchStore()
+    ctx = _ctx_with_store(fake)
+    own = CallFrame(target_topic="a", callback_topic="caller", frame_id="A")
+    env = Envelope(
+        context=SessionRunContext(state=State(), deps={}),
+        internal_workflow_state=WorkflowState(call_stack=Stack([own])),
+    )
+    calls = [Call(target_topic="tool.a", state=State(), tag="tc1"), Call(target_topic="tool.b", state=State(), tag="tc2")]
+
+    resp = await agent._handle_fanout_open(ctx, calls, env, "corr-1", cast(Any, _RaisingBroker()))
+
+    assert resp is not None  # returned the no-reply mirror — did NOT propagate the KafkaError
+    assert await fake.read_state("A") is None  # aborted: both records tombstoned
+    assert await fake.read_basestate("A") is None
+
+
+async def test_handle_fanout_open_store_failure_does_not_propagate(caplog: pytest.LogCaptureFixture) -> None:
+    # (§4.4 dispatch-abort) If the durable store fails at OPEN (terminal unavailability, or a writer
+    # error in the real store), _handle_fanout_open best-effort tombstones and returns rather than
+    # letting the exception escape the handler (which under ACK_FIRST would drop the message and leak
+    # any partial registration with no cleanup).
+    agent = _agent()
+    fake = FakeFanoutBatchStore()
+    fake.make_unavailable()  # store.open raises FanoutStoreUnavailableError
+    ctx = _ctx_with_store(fake)
+    own = CallFrame(target_topic="a", callback_topic="caller", frame_id="A")
+    env = Envelope(
+        context=SessionRunContext(state=State(), deps={}),
+        internal_workflow_state=WorkflowState(call_stack=Stack([own])),
+    )
+    calls = [Call(target_topic="tool.a", state=State(), tag="tc1"), Call(target_topic="tool.b", state=State(), tag="tc2")]
+
+    with caplog.at_level(logging.ERROR, logger="calfkit.nodes.base"):
+        resp = await agent._handle_fanout_open(ctx, calls, env, "corr-1", cast(Any, _CaptureBroker()))
+
+    assert resp is not None  # did not propagate
+    assert any("fan-out OPEN failed" in r.getMessage() for r in caplog.records)
 
 
 # ── @resource preconditions (coverage d) ─────────────────────────────────────


### PR DESCRIPTION
## Summary

A follow-up to #233 (durable in-node fan-out) fixing the one likely-real gap it left: **`_handle_fanout_open` published the marked siblings in an unguarded loop after registering the batch.** If a sibling `broker.publish` raises a `KafkaError` — or the store fails at OPEN — the exception propagates out of the handler. Under `ACK_FIRST` the offset is already committed, so the inbound message is dropped **and** the durably-registered batch is leaked into both ktables as an orphan that can never complete (reclaimable only by the future #220), while the original caller strands with no record.

#233 already implemented the fold-abort and re-entry-publish-failure abort arms (both `→ abort_batch`), but not this one — so the OPEN path contradicted the PR's own "tombstone, minus the corpse" discipline. This implements the in-node spec **§4.4 dispatch-abort** arm (return-only precursor).

## Changes

**`calfkit/nodes/base.py` — `_handle_fanout_open`:** wrap the `store.open` + sibling-publish region; on `KafkaError` / `FanoutStoreUnavailableError`, best-effort `abort_batch` (tombstone both records) + ERROR-log + return the no-reply mirror, so the caller strands cleanly with no corpse. Any already-published sibling's later reply then `post_closure`-stray-floors against the tombstone at its fold. Typed-fault escalation to the caller is a `TODO(fault rail PR-6)` — it needs the fault wire model, matching the existing `_aggregate` fold/close abort arms the rail likewise upgrades.

**`calfkit/nodes/_fanout_store.py` — `abort_batch`:** swallow-and-log **any** tombstone failure (was `FanoutStoreUnavailableError`-only), honouring its docstring's "never masks itself behind a second failure" — a writer `KafkaError` during the real store's tombstone previously escaped the fold/close abort paths too.

## Tests

- `test_handle_fanout_open_sibling_publish_failure_aborts_and_tombstones` — a publish failure → no-propagate + both records tombstoned.
- `test_handle_fanout_open_store_failure_does_not_propagate` — a store failure at OPEN → no-propagate + ERROR-logged.
- `test_abort_batch_swallows_non_store_unavailable_tombstone_failure` — pins the hardening.
- Two `close_batch` materialization edge-case pins (duplicate-`tag` LWW; `tag`-present/`result`-None) before PR-6 re-homes that loop.
- **kafka lane:** `test_failed_tool_call_folds_and_materializes_typed_over_real_broker` — a `FailedToolCall` folds through real ktables and materializes back as a typed marker (the durable-failure carriage the offline fake can't prove).

## Gates

- `make check` clean (ruff + format + mypy `--strict`, 57 files)
- Offline suite **2920 passed**
- Offline fan-out **90 passed**; **kafka lane 9 passed** (incl. the 2-worker graceful-rebalance proof + the new failure test)

> Note: three stale passages in the (untracked) in-node design spec were also corrected locally (`barrier()` returns `bool` not raises; `node_id` validated on `BaseNodeSchema.__post_init__`; the dead `version` field struck) — not part of this diff, since the spec is untracked until the feature ships.
