### PR TITLE
docs: design specs for node presence control plane

### DIFF
--- a/docs/designs/agent-discovery-and-ask-spec.md
+++ b/docs/designs/agent-discovery-and-ask-spec.md
@@ -1,0 +1,111 @@
+# Agent Discovery & Ask (Caller-Side)
+
+- **Status:** Draft (design)
+- **Date:** 2026-06-16
+- **Builds on:** [Node Presence Control Plane — Substrate & Shared Primitive](./node-presence-substrate-spec.md), [Capability-Plane Migration & Ops CLI](./capability-plane-migration-and-ops-spec.md)
+- **Scope (Phase 2):** an opt-in agent registry (`calf.agents`), agent discovery (static peers + dynamic `find_agents`), the **caller-side** request/reply ("Ask") adapter, and caller-side trust (opt-in advertise + scoped consume).
+- **Related:** prior agent-discovery assessment; operator ACL plane (#231).
+
+---
+
+## 1. Summary
+
+Build agent-to-agent **discovery** and the **Ask** (request/reply) messaging mode on top of the presence substrate. A discoverable agent advertises an `AgentCard` to `calf.agents`; a calling agent finds peers (statically wired or dynamically queried) and asks one a question, receiving its answer as a normal tool result.
+
+The central design finding (validated against the source): **the callee needs no new handler.** An agent invoked over the standard call path processes the request through its existing `run` and replies through the existing reply slot. The only genuinely new code is a **caller-side adapter** that makes a peer-agent call look like a tool to the calling agent's loop.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- `AgentCard` + `calf.agents` (opt-in discoverable agents).
+- Discovery: explicit `peers=[...]` (static) and a `find_agents` tool (dynamic, default-closed), selecting live peers via the presence/agents views.
+- A caller-side peer-as-tool adapter: seed a sub-conversation, dispatch to the peer, map its reply into `tool_results`.
+- Caller-side trust: a node advertises as discoverable only by opt-in; a caller only asks peers on its include-list.
+
+**Non-goals (explicitly deferred)**
+- **No callee-side handler** — peers are invoked via the existing path (§4).
+- **No error handling** — deadlines, timeouts, dangling-call recovery, retries, and recursion/depth budgets are inherited from the SDK-wide error-propagation work, **not** specced here. (A true per-call deadline is impossible in the suspend-to-Kafka re-entry model without a timer subsystem; `reply_ttl` is a client-only in-process timer and does not apply to a re-entry-driven agent caller.)
+- **No Enlist mode** — multiple agents sharing one live conversation needs concurrent-history merge, which is unsolved/research. Out of scope.
+- **No callee-side admission / operator ACL** — that is #231 (operator-authored, needs caller-identity-on-the-wire). The adapter only *reserves a seam* for it.
+
+## 3. `AgentCard` and the agents topic
+
+```python
+class AgentCard(ControlPlaneRecord):     # topic: calf.agents  (opt-in discoverable agents)
+    schema_version: int = AGENT_CARD_SCHEMA_VERSION
+    ask_topic: str                        # the agent's dispatch topic for Ask requests
+    skills: list[Skill]                   # A2A-style: name, description, tags
+    revision: str | None = None           # deploy revision (rolling-deploy visibility)
+    # inherits identity + liveness from ControlPlaneRecord
+    # deliberately NO system prompt, NO full tool list (don't leak internals)
+```
+
+- Published via the worker's `ControlPlanePublisher` (same heartbeat/tombstone path) **only when the agent opts in** (`discoverable=True`). Presence (`calf.presence`) stays default-on; being a *messageable peer* is the opt-in.
+- Borrows the A2A AgentCard's skills/tags shape (not its HTTP transport). `ask_topic` is the agent's normal dispatch topic — an Ask is just an invocation (§4).
+
+## 4. The callee needs no new handler
+
+A source-grounded trace of how an agent is invoked today (`client.py`, `nodes/base.py`, `nodes/agent.py`):
+
+- A client invokes an agent by seeding a **conversation `State`** (not a payload) and publishing a `Call` to the agent's topic with a `callback_topic`:
+  `State(...)` + `stage_message(ModelRequest.user_text_prompt(...))` (`client.py:73-74`), wrapped with a `CallFrame(callback_topic=...)` (`base.py:346-349`).
+- The agent's entry handler is the inherited `@handler("*")` with **no schema/payload**; `run(self, ctx)` reads input purely from `ctx.state` (`agent.py:174, 289-298`).
+- It returns `ReturnCall(value=parts)` → `_publish_action` mints `ReturnMessage(in_reply_to=frame.frame_id, tag=frame.tag, parts=…)` to `frame.callback_topic` with `x-calf-kind=return` (`base.py:362-387`), projected to typed output by `project_output` (`node_result.py:257-302`).
+
+So a peer agent invoked over the standard path — a seeded sub-conversation `State` sent to its `ask_topic` with `callback_topic` = the caller's return slot — processes it through its existing `run` and replies through the existing slot. **It's a client invocation minus the client.** No `peer.ask` handler, no new schema.
+
+> Why the assessment thought a handler was needed: dispatching a `Call` with a `ToolCallRef` *payload* at an agent silently drops the payload, because the agent's `'*'` handler declares no schema/payload param (`base.py:749-750`). The fix is not to teach the agent to read a payload — it's to invoke it the State way. (Contrast: a tool node *does* re-decorate `@handler("*", schema=ToolCallRef)` and read the payload — `tool.py:84-85`.)
+
+Callee-side trust, when it lands (#231), is a **guard** on this standard handler (checking `x-calf-emitter`), still not a separate handler.
+
+## 5. The caller-side adapter (the new code)
+
+To make a peer call look like a tool to the *calling* agent's loop, add a peer-as-tool provider (likely the body behind the v1-design `Tool.from_agent(...)` / `peers=[...]` surface — verify whether that surface is built or a stub during implementation):
+
+1. **On tool-call:** seed a fresh sub-conversation `State` from the tool args, and emit a `Call` to the peer's `ask_topic` with:
+   - `callback_topic` = the calling node's return slot, and
+   - `tag` = the caller's `tool_call_id` (the `tag` field already exists for exactly this correlation — `reply.py:20-23`, `session_context.py:52-57`).
+2. **On the peer's reply:** translate the inbound `ReturnMessage.parts` into a `ToolReturn` keyed by `tag`, fold it into `state.tool_results`, and resume the caller's loop as if a tool returned.
+
+The wrinkle that makes this genuinely new: a normal tool returns the **same** `State` carrying `tool_results[tag]` (`tool.py:165`), whereas a peer agent returns its **own** reply parts on a **fresh** sub-State — so without this translation the caller's fold finds nothing at `tool_results[tag]`. That translation is the adapter.
+
+Also needed (small): a **node-side State-seeding helper**. Today State-seeding lives only in `Client._build_state_and_overrides` (`client.py:73-74`); nodes need a thin affordance to build a sub-conversation (reachable now via `State()` + `stage_message`, just unsurfaced).
+
+> Note: the peer's `run` treats the seeded user turn as user-role input (POV projection re-roles it). That is inherent to reusing the standard path and is exactly why the trust boundary (§6) matters — a peer must treat an ask as untrusted input.
+
+## 6. Discovery & trust
+
+### 6.1 Discovery read surface
+
+- **Static peer wiring (safe default):** an agent declares `peers=[support_agent, ...]` — an explicit include-list resolved against the `calf.agents` view. The include-list *is* the trust boundary; semantically identical to today's MCP tool selectors.
+- **Dynamic discovery (default-closed):** a `find_agents(query)` tool exposed to the LLM, returning discoverable agents matching skills/tags, filtered to **live** (presence staleness) ∩ **allowed** (scope). Off unless explicitly enabled and scoped.
+
+Both select **live** instances via `ControlPlaneView` (using the substrate's staleness filter) so a caller prefers an online peer. (What happens if the chosen peer dies mid-ask is the error-propagation layer's concern, not this spec's.)
+
+### 6.2 Trust posture (caller-side in v1)
+
+- **Advertise opt-in:** an agent is in `calf.agents` only with `discoverable=True`.
+- **Consume scoped:** the caller's `peers=[...]` / `find_agents` scope bounds who it will ever ask. Caller-side self-restriction is the v1 trust mechanism.
+- **Callee-side admission + operator ACL — deferred to #231.** Rejecting inbound asks from a verified emitter needs caller-identity-on-the-wire that isn't solid yet. The adapter reserves the seam (consult an injected policy view if present); enforcement is caller-side only in v1.
+
+## 7. Phasing
+
+**Phase 2**, after the substrate + capability migration (Phase 1):
+1. `AgentCard` + `calf.agents` + opt-in publishing via `ControlPlanePublisher`.
+2. Static `peers=[...]` resolution against the agents view.
+3. Caller-side peer-as-tool adapter + node-side State-seed helper.
+4. Dynamic `find_agents` tool (default-closed) + caller-side scoping.
+
+**Future (out of scope):** Enlist mode; callee-side admission / operator ACL (#231); per-call deadlines and failure propagation (inherited error-propagation work).
+
+## 8. Testing
+
+- **Unit:** `AgentCard` schema; the `ReturnMessage → ToolReturn` translation in isolation (a peer reply folds into `tool_results[tag]` and resumes the loop); static `peers` resolution against a fake agents view (live-filtered).
+- **Integration (Redpanda lane):** agent A asks peer B over the standard path; B's answer arrives as A's tool result; a non-discoverable agent does not appear in `calf.agents`; a stale peer is excluded from selection.
+- **Explicitly not tested here:** timeout/dangling/recursion behaviour (owned by the error-propagation layer).
+
+## 9. Open questions
+
+- Whether `Tool.from_agent` / `peers=[...]` already exists on `main` or is a stub — determines how much of §5 is new.
+- The `find_agents` result shape and how scope is expressed (skill/tag filter vs explicit allow-list).
+- `Skill` model fields (align with A2A: name, description, tags).

--- a/docs/designs/capability-plane-migration-and-ops-spec.md
+++ b/docs/designs/capability-plane-migration-and-ops-spec.md
@@ -1,0 +1,118 @@
+# Capability-Plane Migration & Ops CLI
+
+- **Status:** Draft (design)
+- **Date:** 2026-06-16
+- **Builds on:** [Node Presence Control Plane — Substrate & Shared Primitive](./node-presence-substrate-spec.md)
+- **Scope:** (1) the shared `ControlPlaneRecord` base + record schemas; (2) migrating the shipped MCP capability plane onto the shared primitive (fixing CRITICAL-1/3/4); (3) the `calfkit nodes` ops view. These ship together in Phase 1, on top of the substrate.
+- **Related:** [MCP Capability Discovery](./mcp-capability-discovery-spec.md), ADR-0001, ADR-0002.
+
+---
+
+## 1. Summary
+
+The substrate spec extracts a shared control-plane primitive. This spec (a) defines the shared record base and the concrete `PresenceRecord` / `CapabilityRecord` schemas, (b) **migrates the shipped MCP capability plane** from its bespoke node-driven writer onto the worker-owned `ControlPlanePublisher` + `ControlPlaneView` — which fixes three live defects (replica flap, heartbeat-masks-staleness, frozen-view blindness) — and (c) adds an out-of-process **ops fleet view** (`calfkit nodes`) over `calf.presence`.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- One shared `ControlPlaneRecord` base so the staleness filter is generic across planes.
+- Move the capability plane onto the primitive with **no loss of behaviour** for tool selectors, while instance-keying records and fixing CRITICAL-1/3/4.
+- A read-only ops CLI for the live fleet.
+
+**Non-goals**
+- No new capability semantics — tools resolution behaves as today, just on the new transport/keying.
+- No error handling / deadlines (inherited from the SDK-wide error-propagation work).
+- Discovery, the Ask layer, and trust — see the [discovery spec](./agent-discovery-and-ask-spec.md).
+
+## 3. Record schemas
+
+The shared `ControlPlaneRecord` base and `PresenceRecord` are defined in the [substrate spec](./node-presence-substrate-spec.md#8-records-the-shared-base-and-presencerecord). `AgentCard` (topic `calf.agents`) is defined in the [discovery spec](./agent-discovery-and-ask-spec.md). This spec defines the migrated `CapabilityRecord`, which extends the same base:
+
+```python
+class CapabilityRecord(ControlPlaneRecord):      # topic: calf.capabilities  (migrated; toolboxes)
+    schema_version: int = CAPABILITY_SCHEMA_VERSION
+    dispatch_topic: str
+    tools: list[CapabilityToolDef]
+    content_updated_at: AwareDatetime            # when `tools` last changed — SEPARATE from last_heartbeat_at
+    # inherits: schema_version, node_id (= toolbox_id), worker_id, started_at, last_heartbeat_at
+```
+
+### The CRITICAL-3 fix is in the schema
+
+The shipped bug: the heartbeat re-stamped a single `published_at`, so a failed tool re-list was never detectable as stale — the liveness refresh masked content rot. Splitting **liveness** (`last_heartbeat_at`, refreshed every tick) from **content currency** (`content_updated_at`, refreshed only when `tools` actually change) lets a consumer distinguish "instance alive, tool list stale." `PresenceRecord` has no mutable content and needs only `last_heartbeat_at`.
+
+## 4. Capability-plane migration
+
+The shipped plane (`calfkit/mcp/mcp_toolbox.py`, `calfkit/models/capability.py`) is node-driven, keyed `toolbox_id`, on topic `mcp.capabilities`. It moves onto the primitive:
+
+### 4.1 Writer: toolbox becomes a content contributor
+
+`MCPToolbox` stops owning its own `KafkaTableWriter`, heartbeat loop, and tombstone. Instead it registers a `current_record()` contributor with the worker's `ControlPlanePublisher`:
+
+- The toolbox still owns its tool list (the MCP session). On startup and on each MCP `tools/list_changed`, it updates its cached `CapabilityRecord` content and bumps `content_updated_at`.
+- The worker's single heartbeat loop pulls that cached record each tick, refreshes `last_heartbeat_at`, and publishes it instance-keyed (`group=toolbox_id`, `member=worker_id`) to `calf.capabilities`.
+- On clean shutdown the worker tombstones the toolbox's `(toolbox_id, worker_id)` key in its ordered pass.
+
+This deletes the bespoke per-node loop/tombstone (DRY), **instance-keys** the record (fixes CRITICAL-1), and inherits the liveness/content split (fixes CRITICAL-3). The toolbox's careful shutdown ordering (flag-first, cancel-then-tombstone) is now the publisher's, applied uniformly.
+
+> A toolbox node now appears in **both** `calf.presence` (as a live node of `kind=toolbox`) and `calf.capabilities` (with its tools). Modest liveness duplication, but each consumer reads exactly one topic.
+
+### 4.2 Reader: capability view on the primitive
+
+The worker's existing capability-view `@resource` becomes a `ControlPlaneView[CapabilityRecord]` over `calf.capabilities` (via the grouped table). Wiring `status`/`failure` closes **CRITICAL-4** (frozen-view blindness).
+
+Selector resolution changes from a flat single-key lookup to a node-centric, liveness-aware one:
+
+- Today: `view.get(toolbox_id)` → one record.
+- After: `view.instances(toolbox_id, include_stale=False)` → live instances; pick one (replicas advertise identical tools, so any live instance's `tools` is correct). This is the **reader-side merge** that makes instance-keying transparent to the agent layer.
+
+The agent still consumes a `Mapping`-shaped abstraction and never imports ktables (existing layering rule preserved).
+
+### 4.3 De-MCP renames (Phase 0, breaking — pre-1.0 hard breaks)
+
+The capability plane is no longer MCP-specific transport; the names should reflect the generalised control plane:
+
+- Topic: `mcp.capabilities` → `calf.capabilities` (on the wire — breaking).
+- Config: `MCPDiscoveryConfig` → `DiscoveryConfig` (public class — breaking); its `heartbeat_interval` / `catchup_timeout` become the shared control-plane knobs, plus a `stale_after` (default `3 × heartbeat_interval`).
+- Resource key: `CAPABILITY_VIEW_RESOURCE_KEY` re-namespaced (`calfkit.mcp.capability_view` → `calfkit.controlplane.capability_view`).
+- Remove `Worker.name` (unused dead code) — its own small cleanup PR.
+
+Sequencing note: these renames touch areas the in-flight run/handler-unification and MCP work also touch; coordinate ordering so the breaking changes land coherently.
+
+## 5. Ops CLI — `calfkit nodes`
+
+Ops usually wants an *out-of-process* fleet view (from a laptop or sidecar), not code inside a worker. Add `calfkit/cli/nodes.py` alongside the existing `cli/run.py`, `cli/topics.py`:
+
+- Opens a transient grouped table / `ControlPlaneView` over `calf.presence`, waits for catch-up, prints the live fleet grouped by `node_id` — `kind`, instance count, per-instance `worker_id` + `age`, stale markers — then exits.
+- Flags: `--watch` (refresh), `--stale` (include stale, annotated), `--kind agent` (filter), `--json` (machine output).
+- Reuses the existing CLI bootstrap (bootstrap-servers resolution, the `_loader` patterns). It is read-only — it never writes the control plane.
+
+This is the concrete surface that makes "ops/observability" real for Phase 1; programmatic access is documented as "construct a `ControlPlaneView` over `calf.presence` yourself."
+
+## 6. Provisioning
+
+`calf.presence` and `calf.capabilities` both need `cleanup.policy=compact`. calfkit's provisioner applies a flat config to all data topics and cannot set per-topic compaction, so compaction is delegated to ktables `ensure_topic` (dev) or to ops (prod, where provisioning is off by default). Document the required topic config; this is consistent with how the shipped capability topic is handled today.
+
+## 7. Phasing
+
+Part of **Phase 1** (with the substrate). Order within Phase 1:
+1. Shared `ControlPlaneRecord` base + `PresenceRecord` + `CapabilityRecord` (with `content_updated_at`).
+2. De-MCP renames + remove `Worker.name` (Phase 0 cleanup, can precede).
+3. Migrate the capability writer/reader onto the primitive (instance-keyed; CRITICAL-1/3/4 fixed).
+4. `calfkit nodes` CLI.
+
+## 8. Testing
+
+- **Unit:** the shared base + both records (schema versioning, tolerant reader); selector resolution against a fake `ControlPlaneView` (dict-backed), including the live-instance merge.
+- **Integration (Redpanda lane):**
+  - **Capability parity:** an agent with MCP tool selectors still resolves the same tools after migration.
+  - **Replica regression (CRITICAL-1):** two workers host the same toolbox; one shuts down cleanly; tools still resolve from the surviving instance.
+  - **Liveness/content split (CRITICAL-3):** a refreshed heartbeat does not move `content_updated_at`; a `tools/list_changed` does.
+  - **Frozen-view (CRITICAL-4):** a degraded/failed reader surfaces via `status`/`failure`.
+  - **Ops CLI:** prints expected fleet rows; `--stale`/`--kind`/`--json` behave.
+
+## 9. Open questions
+
+- Exact resource-key namespace and `DiscoveryConfig` field set.
+- Whether the capability topic rename warrants a one-release dual-read shim, or a clean cut (default: clean cut, pre-1.0).
+- CLI command name (`nodes` vs `fleet`).

--- a/docs/designs/node-presence-substrate-spec.md
+++ b/docs/designs/node-presence-substrate-spec.md
@@ -1,0 +1,182 @@
+# Node Presence Control Plane — Substrate & Shared Primitive
+
+- **Status:** Draft (design)
+- **Date:** 2026-06-16
+- **Scope:** The foundational presence substrate and the reusable control-plane primitive it is built on. This is the base layer; two follow-on specs build on it:
+  - [Capability-Plane Migration & Ops CLI](./capability-plane-migration-and-ops-spec.md)
+  - [Agent Discovery & Ask](./agent-discovery-and-ask-spec.md)
+- **Related:** [MCP Capability Discovery](./mcp-capability-discovery-spec.md) (the shipped precedent this generalises), ADR-0001 (compacted capability topic). External dependency: `ryan-yuuu/ktables#16` (grouped/multimap table).
+
+---
+
+## 1. Summary
+
+Add a compacted-Kafka **presence control plane** that materialises a live view of every node (tool / agent / consumer / toolbox) on the network. Each worker emits a heartbeat record per hosted node to a compacted topic and tombstones it on clean shutdown; every worker broadcast-reads the whole topic, so any process can answer *"which nodes are online, and where?"*.
+
+The shipped **MCP capability plane** (`calfkit/mcp/mcp_toolbox.py`, `calfkit/models/capability.py`) already does heartbeat + tombstone + compacted-view for toolboxes. This spec **extracts the reusable mechanism** from that precedent into a shared primitive and applies it to general node presence. The two follow-on specs migrate the capability plane onto the same primitive and build discovery on top.
+
+## 2. Motivation
+
+- **Ops / observability** wants a fleet view: which tools/agents are up, on which workers, how long they've been silent.
+- **Agent-to-agent discovery** (a later phase) needs a registry of reachable peers to read from.
+- **DRY across control planes.** calfkit already has the capability plane and will gain an operator ACL plane (#231) and a runtime-reconfig plane (#164). All four share the same read shape (a compacted view materialised behind a catch-up gate). Building presence as yet another bespoke plane would be the "needed-patch-rules-mean-the-factoring-is-wrong" anti-pattern. This spec factors the common mechanism once.
+
+The presence *view* is the easy, transferable part. The hard problems (request/reply, trust, budgets) are messaging, and live in the discovery spec — not here.
+
+## 3. Goals / Non-goals
+
+**Goals**
+- A shared, reusable control-plane primitive: a read-side `ControlPlaneView` and a worker-owned write-side `ControlPlanePublisher`.
+- A `PresenceRecord` and a `calf.presence` compacted topic carrying every node's liveness + identity.
+- Instance-keyed records (`node_id` × `worker_id`) so replicas don't clobber each other.
+- Advisory staleness (no TTL, no active eviction).
+- Wire ktables' reader-death signals (`status`/`failure`) so a frozen view is observable.
+
+**Non-goals (explicitly out of scope here)**
+- Any error handling, deadlines, retries, dangling-call recovery, or recursion budgets — these are inherited from the SDK-wide error-propagation work, not specced here.
+- Crash *detection* beyond advisory staleness. A crashed node's record lingers until it reads as stale; there is no reaper.
+- Discovery, messaging, trust enforcement, the ops CLI, and the capability migration — covered in the two follow-on specs.
+
+## 4. Background: what the precedent already proves
+
+From a source-grounded read of the shipped capability plane:
+
+- **Transport works.** ktables (`>=0.2.0`) gives a groupless **broadcast** view (`group_id=None`, all partitions, replay from offset 0) — every worker sees every key, the GlobalKTable model. Writes are `acks=all` + idempotent. Tombstone = `delete(key)` (null value). `barrier()` gives read-your-own-writes. `status`/`failure` expose reader death.
+- **Lifecycle seams exist.** `after_startup` (broker live — spawn a loop) and `on_shutdown` (broker still live — cancel + tombstone) are inherited by **both** `Worker` and every `BaseNodeDef` (`calfkit/worker/lifecycle.py`). `MCPToolbox` already runs a heartbeat loop and an ordered tombstone via these.
+- **Known sharp edges to fix while generalising** (confirmed live on `main`):
+  - **CRITICAL-1 — replica flap:** records keyed per-node (`toolbox_id`) mean one replica's clean tombstone blanks the record cluster-wide. Fixed here by instance-keying.
+  - **CRITICAL-3 — heartbeat masks content staleness:** re-stamping a single `published_at` hides stale content. Fixed by the liveness/content timestamp split (relevant once content-bearing records migrate — see the migration spec).
+  - **CRITICAL-4 — frozen-view blindness:** calfkit never reads `table.status`/`failure`. Fixed by wiring them into `ControlPlaneView`.
+
+These fixes are *why* unifying (rather than adding a parallel plane) is worthwhile: the primitive fixes them once for every plane.
+
+## 5. The shared primitive
+
+Two halves, both reusable by the capability plane, the ACL plane (#231), and the reconfig plane (#164).
+
+### 5.1 Read side — `ControlPlaneView[R]`
+
+A thin, typed wrapper over a ktables grouped/multimap table (see §6), opened as a **worker-level `@resource`** and materialised as a node-centric view in the resource bag behind the catch-up gate.
+
+Responsibilities:
+- Bind one record model `R` to one topic (1:1, by construction).
+- Present a **node-centric** API that hides the composite `node_id × worker_id` key (callers ask about `node_id`).
+- Apply the **advisory staleness** filter (§7) — the one piece of domain semantics the view owns.
+- Surface reader health (`status`, `failure`, `is_caught_up`) so a frozen/degraded view is observable, not silent.
+
+```python
+class ControlPlaneView(Generic[R]):
+    # liveness-aware reads (node-centric; worker_id hidden)
+    def is_online(self, node_id: str) -> bool: ...          # any live instance
+    def instances(self, node_id: str, *, include_stale: bool = False) -> dict[str, R]: ...
+    def online_nodes(self) -> set[str]: ...                 # node_ids with >=1 live instance
+    def snapshot(self, *, include_stale: bool = False) -> dict[str, dict[str, R]]: ...
+
+    # health passthrough (closes frozen-view blindness)
+    @property
+    def status(self) -> TableStatus: ...                    # unstarted|loading|caught_up|degraded|failed
+    @property
+    def failure(self) -> BaseException | None: ...
+    async def barrier(self, timeout: float | None = None) -> bool: ...
+```
+
+The view depends only on the `ControlPlaneRecord` base (§ records spec) for `last_heartbeat_at`; it is otherwise generic over `R`. Consumers never import ktables (the existing layering rule).
+
+### 5.2 Write side — `ControlPlanePublisher`
+
+A single **worker-owned** resource that runs **one** heartbeat loop and **one** ordered tombstone pass for all of the worker's hosted nodes.
+
+Drive model — **worker owns the heartbeat, nodes contribute content** — on a principle:
+
+> Liveness is a per-process fact; record content is a per-node fact.
+
+A node can't be "down" while its worker is "up" (there is no per-node crash independent of the process), so driving the heartbeat per-node would emit N signals for one liveness fact and duplicate the tricky cancel-then-tombstone ordering N times. Instead:
+
+- The worker runs the loop, owns the instance identity (`Worker.id`), and owns the tombstone ordering.
+- Each node exposes a `current_record()` contributor returning its present record content. A plain node contributes presence-only; richer nodes (toolbox, discoverable agent) contribute more (see follow-on specs). The worker treats records opaquely — it never knows about MCP or tools.
+
+Lifecycle wiring (reusing the proven seams):
+- `after_startup` (broker live): publish each node's record once, then spawn the heartbeat loop.
+- Heartbeat tick: for each hosted node, refresh `last_heartbeat_at` and `set(group=node_id, member=worker_id, value=record)`.
+- `on_shutdown` (broker still live): set a shutdown flag synchronously first, cancel-and-await the loop, then tombstone every `(node_id, worker_id)` key the worker owns. This ordering (copied from `MCPToolbox._tombstone_on_shutdown`) prevents a straggler `set()` from resurrecting a tombstoned record.
+
+Crash behaviour is unchanged from the precedent and accepted: a hard crash skips `on_shutdown`, so the record is **not** tombstoned and instead goes stale (§7).
+
+## 6. Keying & the grouped/multimap dependency
+
+**Records are instance-keyed:** `group = node_id`, `member = worker_id` (= `Worker.id`, already documented as a stable wire identity "e.g. for fleet presence"). Readers group by `node_id` to get the set of live instances.
+
+This is required for correctness, not convenience. Multiple replicas of the same node (same `node_id`) run across workers — the default scaling path. If they shared one key, a single replica's clean tombstone would blank the logical node (CRITICAL-1), and concurrent updates would be a lost-update race. Giving each writer **its own key** (`node_id × worker_id`) yields **single-writer-per-key by construction** — no read-modify-write, nothing to serialise, clean independent tombstones. The "collection of instances per node" is then a read-side grouping.
+
+> Note on alternatives considered and rejected: a single node-keyed record with a collection value would require cross-process read-modify-write, which Kafka can't make safe (no broker compare-and-set). Making it safe via single-writer-per-partition forces a co-partitioned aggregator (a stateful consume-aggregate-produce service with ownership/rebalance) — heavy infrastructure this project avoids, and it still wouldn't detect crashes without a TTL. Instance-keying + read-side grouping is the lightweight, canonical secondary-index pattern (Kafka Streams `groupBy` / Faust `group_by`).
+
+**The grouping is packaged in ktables**, not hand-rolled in calfkit, as a grouped/multimap table — `set/delete(group, member, value)` writes + group-keyed reads over a composite key (length-prefixed injective codec, compute-on-read projection). Filed as **`ryan-yuuu/ktables#16`**; calfkit will require `ktables>=0.3.0`. `ControlPlaneView` is the thin typed wrapper that adds the staleness filter; the composite-key mechanics live in ktables.
+
+Because ktables has **no TTL/eviction** and **no change hook**, the view is compute-on-read (fine at control-plane cardinality). A future ktables `changes()` stream (noted in #16) would later enable an incremental index and push-notifications, but is not required here.
+
+## 7. Staleness (advisory)
+
+A tombstone only fires on **clean** shutdown; a crash leaves the record in place, and ktables never evicts. So "is this node actually online?" is a reader-side judgement, not a transport guarantee:
+
+- Each record carries `last_heartbeat_at`, refreshed every heartbeat tick.
+- `ControlPlaneView` computes `age = now - last_heartbeat_at` and treats a member as **stale** when `age > stale_after` (configurable; default `3 × heartbeat_interval`, matching the shipped 90s).
+- The view **never deletes** stale records — it annotates/filters. Two surfaces:
+  - **Annotated (ops):** show all instances with `age`/`is_stale`. Ops *wants* to see a node silent for 5 minutes — that's the signal; hiding it would blind the fleet view.
+  - **Filtered (selection):** `online_nodes()` / `instances(..., include_stale=False)` exclude stale instances so a consumer never selects a probably-dead target.
+
+Documented assumptions (not guarantees):
+- **Clock skew.** `last_heartbeat_at` is the publisher's wall clock; `age` is the reader's. The generous `3×` threshold sits far above normal NTP skew (<1s). This is documented, not enforced with logical clocks — consistent with "document deployment, don't police it."
+- **Crashes linger.** Between a crash and the staleness threshold, a dead node still appears (filtered out only after `stale_after`). Real crash *recovery* (failing pending work) is the error-propagation layer's concern, not this substrate's.
+
+This deliberately rejects TTL hard-eviction and any active sweeper — the same decision the capability plane made, and the one that keeps the substrate infrastructure-free.
+
+## 8. Records: the shared base and `PresenceRecord`
+
+A thin shared base carries identity + liveness, so `ControlPlaneView`'s staleness filter depends on exactly one contract and never on a concrete record type. The base is reused by every plane (`CapabilityRecord` in the migration spec, `AgentCard` in the discovery spec, and later #231/#164):
+
+```python
+class ControlPlaneRecord(BaseModel):
+    model_config = ConfigDict(extra="ignore")   # tolerant reader (additive forward-compat)
+    schema_version: int                          # default set per subclass; major bump => old readers skip
+    node_id: str                                 # = group key (also in value: self-describing wire record)
+    worker_id: str                               # = member key (the instance; Worker.id)
+    started_at: AwareDatetime                    # this instance's boot time -> uptime + restart detection
+    last_heartbeat_at: AwareDatetime             # liveness basis; refreshed every heartbeat tick
+
+class PresenceRecord(ControlPlaneRecord):        # topic: calf.presence
+    schema_version: int = PRESENCE_SCHEMA_VERSION
+    kind: NodeKind          # agent | tool | consumer | toolbox
+    dispatch_topic: str     # where this node is addressable
+```
+
+Keeping `node_id`/`worker_id` in the value (redundant with the key) matches the existing `CapabilityRecord`, which already stores its id in the value — the wire record stays self-describing. Schema evolution follows the existing pattern: per-record `schema_version` + tolerant reader for additive fields; a major bump makes old readers treat newer records as "node invisible" rather than crash.
+
+- `worker_name` is **not** included — `Worker.name` is currently-unused dead code and is removed (its own cleanup PR). If friendly ops names prove desirable once the fleet view exists, re-introduce them then, with `PresenceRecord` as the real consumer.
+- **Topic `calf.presence`** is compacted (`cleanup.policy=compact`). Presence is **default-on** for every node — ops needs the whole fleet. (Being a *messageable peer* is a separate opt-in, handled in the discovery spec.)
+- Provisioning: calfkit's own provisioner applies a flat config to all data topics and cannot set per-topic compaction, so compaction is delegated to ktables `ensure_topic` (dev) / ops (prod) — documented, consistent with the existing capability topic.
+
+## 9. What this substrate unlocks
+
+The primitive is deliberately generic so the following build on it without re-deriving transport:
+
+- **[Capability-Plane Migration & Ops CLI](./capability-plane-migration-and-ops-spec.md)** — migrates the shipped MCP capability plane onto `ControlPlaneView`/`ControlPlanePublisher` (fixing CRITICAL-1/3/4) and adds the `calfkit nodes` ops view over `calf.presence`.
+- **[Agent Discovery & Ask](./agent-discovery-and-ask-spec.md)** — adds `calf.agents` (opt-in discoverable agents) and the caller-side request/reply adapter, reading presence/agents views to select live peers.
+- **Operator ACL plane (#231)** — an operator-authored `AccessPolicyRecord` plane reusing the read-side `ControlPlaneView` (keyed `node_id`, no tombstone — operator-authored, not self-published).
+- **Runtime-reconfig plane (#164)** — the same read-side shape for node reconfiguration.
+
+## 10. Phasing & dependencies
+
+- **Phase 0 (prereqs):** `ktables#16` lands → `ktables>=0.3.0`; extract `ControlPlaneView` + `ControlPlanePublisher`; remove `Worker.name`.
+- **Phase 1 (this substrate):** `PresenceRecord` + `calf.presence` + worker-owned heartbeat for all nodes + `ControlPlaneView` with `status`/`failure` wired.
+- Capability migration and discovery follow in their own specs.
+
+## 11. Testing
+
+- **Unit:** `PresenceRecord` schema versioning / tolerant reader; the staleness filter and node-centric grouping tested over a fake grouped table (a plain dict), zero Kafka.
+- **Integration (Redpanda lane):** heartbeat publish → view reflects it after `barrier()`; clean shutdown tombstones the instance; **the 2-worker same-node replica regression test** — two workers host the same `node_id`; one shuts down cleanly; the node remains online via the surviving instance (the CRITICAL-1 proof).
+
+## 12. Open questions
+
+- Final names: `ControlPlaneView` / `ControlPlanePublisher`, resource-bag key namespace (`calfkit.controlplane.*`).
+- `heartbeat_interval` / `stale_after` config home (generalise the existing `MCPDiscoveryConfig` knob — see the migration spec's rename).
+- Whether `calf.presence` warrants >1 partition (presence is low-volume; single partition is fine — partition count is not load-bearing here).


### PR DESCRIPTION
## Summary

Design specs (no code) for a compacted-Kafka **presence / discovery control plane** that materializes a live view of all online nodes (tools/agents) on the network. Split into three focused, independently-reviewable docs under `docs/designs/`, sequenced Phase 0 → 1 → 2.

It generalizes the shipped MCP capability plane's heartbeat + tombstone + compacted-view pattern into a reusable control-plane primitive, and migrates the capability plane onto it (fixing three live defects in the process).

## Docs

1. **`node-presence-substrate-spec.md`** — the foundation: the `ControlPlaneView` / `ControlPlanePublisher` primitive, the `ControlPlaneRecord` base + `PresenceRecord`, a worker-owned heartbeat with node-contributed content, `node_id × worker_id` instance-keying, and advisory staleness. Depends on **ryan-yuuu/ktables#16** (grouped/multimap table) → `ktables>=0.3.0`.
2. **`capability-plane-migration-and-ops-spec.md`** — `CapabilityRecord`; migrates the shipped MCP capability plane onto the primitive, fixing:
   - replica-flap (one replica's clean tombstone blanking a node cluster-wide) via instance-keying,
   - heartbeat-masks-staleness via a liveness/content timestamp split,
   - frozen-view-blindness by wiring ktables' `status`/`failure`.

   Plus the de-MCP renames and a read-only `calfkit nodes` ops CLI.
3. **`agent-discovery-and-ask-spec.md`** — `AgentCard` + `calf.agents`, static `peers=[...]` + dynamic `find_agents`, and a **caller-side** Ask (request/reply) adapter. A source-grounded trace established that **no callee-side handler is needed** — a peer agent is invoked via the standard call path and replies through the existing reply slot; the only new code is the caller-side peer-as-tool adapter. Trust is caller-side in v1.

## Scope

- **In:** presence substrate, capability migration, ops CLI, discovery, caller-side Ask happy path, caller-side trust (opt-in advertise + scoped consume).
- **Out (explicitly deferred):** all error handling / deadlines / dangling-call recovery / recursion budgets — inherited from the SDK-wide error-propagation work, not specced here (a true per-call deadline is impossible in the suspend-to-Kafka re-entry model; `reply_ttl` is a client-only in-process timer); Enlist mode (shared live conversation — needs concurrent-history merge, unsolved); callee-side admission / operator ACL (#231).

## Dependencies & sequencing

- Blocks on **ktables#16** landing (→ `ktables>=0.3.0`) before Phase 1.
- The Phase 0 de-MCP renames are breaking (pre-1.0) and should be coordinated with the in-flight error-propagation, run/handler-unification, and MCP-adjacent work so the breaking changes land coherently.

Design-only; no implementation in this PR.
