### PR TITLE
ci: split live-LLM tests into a main-only lane via a live marker

### DIFF
--- a/.github/workflows/integration-live.yml
+++ b/.github/workflows/integration-live.yml
@@ -1,0 +1,57 @@
+name: "Integration: live LLM"
+
+# Runs the live-LLM lane: every test marked `@pytest.mark.live` (selected with
+# `-m live`) -- real model-API round-trips proving our provider integration
+# holds. These tests use FastStream's in-memory `TestKafkaBroker`, so the lane
+# needs NO Docker or broker -- only model-API credentials.
+#
+# These tests are deselected from the default suite (see `addopts` in
+# pyproject.toml, ADR 0007), so `test.yml` never needs credentials. This lane
+# runs ONLY on push-to-main (a post-merge check) and on manual dispatch -- never
+# on pull requests. That keeps the paid, non-deterministic model calls off every
+# PR, and means the provider secret is never exposed to PR (incl. fork) runs, so
+# it can be read unconditionally below.
+#
+# Uses no untrusted-input context vars in run: steps; only static commands.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: # manual, maintainer-triggered (e.g. validate agent behavior on a branch)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  live-llm:
+    name: Live LLM (real model API)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        # No `integration` group: the live tests use the in-memory TestKafkaBroker,
+        # not a real broker, so testcontainers/Docker are not needed.
+        run: uv sync --group dev
+
+      - name: Run live-LLM tests
+        # `-m live` overrides the default `-m "not kafka and not live"` deselection.
+        run: uv run pytest -m live -v --tb=short --timeout=300
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          TEST_LLM_MODEL_NAME: ${{ vars.TEST_LLM_MODEL_NAME }}
+          TEST_REASONING_EFFORT: ${{ vars.TEST_REASONING_EFFORT }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,20 +40,16 @@ jobs:
         run: uv sync --group dev
 
       - name: Run tests
+        # The default suite is fully offline (FunctionModel + in-memory
+        # TestKafkaBroker) and deselects the opt-in `kafka` and `live` lanes
+        # (ADR 0007), so it needs no Docker, network, or credentials. The live
+        # model-API lane runs separately on push-to-main (integration-live.yml).
         run: |
           if [ "${{ matrix.python-version }}" = "3.10" ]; then
             uv run pytest tests/ -v --tb=short --cov=calfkit --cov-report=term-missing --cov-report=xml
           else
             uv run pytest tests/ -v --tb=short
           fi
-        env:
-          OPENAI_API_KEY: ${{
-            (github.event_name == 'push' ||
-             contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'),
-                      github.event.pull_request.author_association))
-            && secrets.OPENAI_API_KEY || '' }}
-          TEST_LLM_MODEL_NAME: ${{ vars.TEST_LLM_MODEL_NAME }}
-          TEST_REASONING_EFFORT: ${{ vars.TEST_REASONING_EFFORT }}
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.10'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ opt-in, so `make test` stays fast and needs no Docker, network, or credentials.
 | Unit / component | nothing — `FunctionModel` + in-memory `TestKafkaBroker` | — | yes |
 | Real broker | a Kafka-protocol broker (Redpanda) | `@pytest.mark.kafka` | no — use `make test-kafka` |
 | Topic provisioning | a broker with topic auto-create **disabled** | `CALF_TEST_KAFKA` env var | no — separate lane |
-| Real LLM | a live model API | `OPENAI_API_KEY` (+ `TEST_LLM_MODEL_NAME`) | skips unless the key is set |
+| Real LLM | a live model API | `@pytest.mark.live` (skips without `OPENAI_API_KEY` + `TEST_LLM_MODEL_NAME`) | no — use `make test-live` |
 
 Default to **offline** tests: a scripted `FunctionModel` stands in for the LLM
 and FastStream's `TestKafkaBroker` stands in for Kafka, so the tests are
@@ -108,6 +108,44 @@ no Docker or `integration` group needed, since testcontainers is never imported:
 ```console
 $ CALF_TEST_KAFKA_BOOTSTRAP=localhost:9092 uv run pytest -m kafka
 ```
+
+### Writing a live-LLM test
+
+Live-LLM tests prove our integration with a real model provider holds (real
+tool-calling, structured output, multi-turn). They use the in-memory
+`TestKafkaBroker` — no broker needed, only credentials. Carry the `live` marker
+and the `skip_if_no_live_llm` gate so the test skips cleanly when credentials are
+absent:
+
+```python
+import pytest
+
+from tests.utils import skip_if_no_live_llm
+
+pytestmark = pytest.mark.live  # opt the whole module into the live lane
+
+
+@skip_if_no_live_llm
+async def test_agent_answers(container, deploy_agent) -> None:
+    ...
+```
+
+The marker decides whether the `live` lane selects the test; `skip_if_no_live_llm`
+makes it skip cleanly (rather than erroring on a real request) when
+`OPENAI_API_KEY` or `TEST_LLM_MODEL_NAME` is unset. For working examples, see
+`tests/integration/test_agent_workers.py` and
+`tests/integration/test_agent_output_types.py`.
+
+### Running the live-LLM lane
+
+```console
+$ make test-live      # runs `-m live`; needs OPENAI_API_KEY + TEST_LLM_MODEL_NAME
+```
+
+Without credentials the lane skips cleanly rather than failing. In CI these tests
+run **only on push-to-main** (and on manual dispatch) via `integration-live.yml`,
+never on pull requests — so the paid, non-deterministic model calls stay off
+every PR and the provider secret is never exposed to PR runs.
 
 ### The topic-provisioning lane
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help check lint-check lint-fix format-check format-fix type-check test test-kafka fix build build-wheel clean publish-test
+.PHONY: help check lint-check lint-fix format-check format-fix type-check test test-kafka test-live fix build build-wheel clean publish-test
 
 # Default target
 help:
@@ -9,8 +9,9 @@ help:
 	@echo "    make lint-check   - Run linter (ruff check)"
 	@echo "    make format-check - Check code formatting (ruff format --check)"
 	@echo "    make type-check   - Run type checker (mypy)"
-	@echo "    make test         - Run tests (pytest; real-broker tests deselected)"
+	@echo "    make test         - Run tests (pytest; opt-in kafka + live lanes deselected)"
 	@echo "    make test-kafka   - Run real-broker tests only (needs Docker; -m kafka)"
+	@echo "    make test-live    - Run live model-API tests only (needs OPENAI_API_KEY + TEST_LLM_MODEL_NAME; -m live)"
 	@echo ""
 	@echo "  Fixes:"
 	@echo "    make fix          - Fix all auto-fixable issues (lint + format)"
@@ -46,12 +47,16 @@ type-check:
 	@echo "✓ Type check passed"
 
 test:
-	@echo "Running tests (real-broker 'kafka' tests deselected by default)..."
+	@echo "Running tests (opt-in 'kafka' and 'live' lanes deselected by default)..."
 	@uv run pytest tests/ -v
 
 test-kafka:
 	@echo "Running real-broker (Redpanda) tests... (requires Docker)"
 	@uv run --group integration pytest -m kafka -v --timeout=120
+
+test-live:
+	@echo "Running live model-API tests... (requires OPENAI_API_KEY + TEST_LLM_MODEL_NAME)"
+	@uv run pytest -m live -v --timeout=300
 
 # === Fixes ===
 

--- a/docs/adr/0007-external-dependency-tests-opt-in-via-orthogonal-markers.md
+++ b/docs/adr/0007-external-dependency-tests-opt-in-via-orthogonal-markers.md
@@ -21,14 +21,16 @@ at collection time: it is slow, flaky, and turns a cold or absent broker into a
 exactly that anti-pattern and was migrated off it.
 
 The decision is **orthogonal, composable pytest markers, one per external
-dependency**, deselected by default. `kafka` (a real broker) is registered now;
-`llm` (a real model API) is the planned second axis for the existing real-API
-tests, which for now keep their `skip_if_no_openai_key` gate. Markers are
+dependency**, deselected by default. Two axes are registered: `kafka` (a real
+broker) and `live` (a real model API). Markers are
 registered under `--strict-markers` (an unregistered marker is an error, not a
-silent no-op), and `addopts = ["--strict-markers", "-m", "not kafka"]` makes the
-broker lane opt-in: a bare `pytest` / `make test` deselects it and needs no
-Docker, while `-m kafka` / `make test-kafka` overrides the default selection. A
-both-axes test would simply carry both markers. The broker itself is a
+silent no-op), and `addopts = ["--strict-markers", "-m", "not kafka and not live"]`
+makes both lanes opt-in: a bare `pytest` / `make test` deselects them and needs no
+Docker, network, or credentials, while `-m kafka` / `make test-kafka` (or `-m live`
+/ `make test-live`) overrides the default selection. A
+both-axes test would simply carry both markers (and is then selected by either
+lane; each axis's clean-skip gate keeps it green where only one dependency is
+provisioned). The broker itself is a
 session-scoped single-node Redpanda started and torn down by **testcontainers**
 from inside the test session, so neither developers nor CI hand-run one;
 `CALF_TEST_KAFKA_BOOTSTRAP` is an escape hatch to reuse an external broker
@@ -46,7 +48,19 @@ DISABLED — which testcontainers' `RedpandaContainer` (it runs `redpanda start
 testcontainers lane is consequently far simpler than the provisioning one: no
 manual `docker run`, health-wait, or config steps. The Redpanda image tag is
 pinned and bumped deliberately, because the library's default
-(`RedpandaContainer`'s built-in `v23.1.13`) is years stale. And the `llm` axis
-is reserved but unwired: when it lands it should also close the latent gap where
-`skip_if_no_openai_key` checks only `OPENAI_API_KEY` while the model fixture also
-hard-requires `TEST_LLM_MODEL_NAME`. Decided 2026-06-14.
+(`RedpandaContainer`'s built-in `v23.1.13`) is years stale. Decided 2026-06-14.
+
+**Landed 2026-06-16 — the `live` axis.** The reserved second axis shipped as
+`live` (not `llm`): provider-agnostic, and distinct from `kafka`, which is also
+network-bound (so `network`/`remote_data` would not disambiguate the two lanes).
+The two live-LLM files carry `pytestmark = pytest.mark.live`, and their gate is
+now `skip_if_no_live_llm`, which closes the latent gap this ADR flagged — it
+requires BOTH `OPENAI_API_KEY` and `TEST_LLM_MODEL_NAME` (the model fixture reads
+the latter with `os.environ[...]`, so a key alone would have errored mid-setup
+instead of skipping). Unlike the `kafka` lane (which also runs on path-filtered
+PRs), the `live` lane runs **only on push-to-main and on manual dispatch, never
+on PRs** (`integration-live.yml`): the model calls are paid and
+non-deterministic, and keeping them off PRs also means the provider secret is
+never exposed to PR (incl. fork) runs — so `test.yml` dropped its conditional
+secret injection entirely. The default-suite coverage baseline re-levels on the
+next push to main once the live tests no longer contribute to it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,12 +92,16 @@ omit = ["calfkit/_vendor/*"]
 asyncio_mode = "auto"
 testpaths = ["tests"]
 # --strict-markers: an unregistered marker is an error, not a silent no-op.
-# -m "not kafka": real-broker tests are OPT-IN. They are deselected by default
-# so a bare `pytest` / `make test` never needs Docker; run them with `-m kafka`
-# (see `make test-kafka`), whose CLI -m overrides this default selection.
-addopts = ["--strict-markers", "-m", "not kafka"]
+# -m "not kafka and not live": external-dependency tests are OPT-IN, one
+# orthogonal marker per dependency (ADR 0007). They are deselected by default so
+# a bare `pytest` / `make test` never needs Docker, a network, or credentials.
+# Run a lane with `-m kafka` (`make test-kafka`) or `-m live` (`make test-live`),
+# whose CLI -m overrides this default selection. A test needing both carries both
+# markers (and is then selected by either lane).
+addopts = ["--strict-markers", "-m", "not kafka and not live"]
 markers = [
     "kafka: requires a real Kafka/Redpanda broker (testcontainers-managed unless CALF_TEST_KAFKA_BOOTSTRAP names an external broker)",
+    "live: requires a real model API (set OPENAI_API_KEY and TEST_LLM_MODEL_NAME); main-only CI lane, never on PRs",
 ]
 
 [dependency-groups]

--- a/tests/integration/test_agent_output_types.py
+++ b/tests/integration/test_agent_output_types.py
@@ -1,16 +1,22 @@
+import pytest
 from faststream.kafka import KafkaBroker, TestKafkaBroker
 from pydantic import BaseModel
 
 from calfkit._vendor.pydantic_ai import models
 from calfkit.client import Client
 from tests.providers import Response, agent_name, prepare_worker, user_name
-from tests.utils import skip_if_no_openai_key
+from tests.utils import skip_if_no_live_llm
+
+# Every test here drives a real model API. Opt the whole module into the `live`
+# lane (deselected by default — see ADR 0007); `skip_if_no_live_llm` then skips
+# cleanly when credentials are absent.
+pytestmark = pytest.mark.live
 
 # Ensure model requests are allowed for integration tests
 models.ALLOW_MODEL_REQUESTS = True
 
 
-@skip_if_no_openai_key
+@skip_if_no_live_llm
 async def test_structured_output_agent_with_dataclass(container, deploy_structured_agent):
     prepare_worker(container)
 
@@ -44,7 +50,7 @@ async def test_structured_output_agent_with_dataclass(container, deploy_structur
         print(f"structured_output: {result.output}")
 
 
-@skip_if_no_openai_key
+@skip_if_no_live_llm
 async def test_structured_output_agent_with_list(container, deploy_structured_agent_factory):
     deploy_structured_agent_factory(list[str])
     prepare_worker(container)
@@ -85,7 +91,7 @@ class Box(BaseModel):
     unit: str
 
 
-@skip_if_no_openai_key
+@skip_if_no_live_llm
 async def test_structured_output_agent_with_basemodel(container, deploy_structured_agent_factory):
     deploy_structured_agent_factory(Box)
     prepare_worker(container)

--- a/tests/integration/test_agent_workers.py
+++ b/tests/integration/test_agent_workers.py
@@ -1,3 +1,4 @@
+import pytest
 from faststream.kafka import KafkaBroker, TestKafkaBroker
 
 from calfkit._vendor.pydantic_ai import models
@@ -10,13 +11,18 @@ from tests.providers import (
     prepare_worker,
     user_name,
 )
-from tests.utils import print_message_history, skip_if_no_openai_key
+from tests.utils import print_message_history, skip_if_no_live_llm
+
+# Every test here drives a real model API. Opt the whole module into the `live`
+# lane (deselected by default — see ADR 0007); `skip_if_no_live_llm` then skips
+# cleanly when credentials are absent.
+pytestmark = pytest.mark.live
 
 # Ensure model requests are allowed for integration tests
 models.ALLOW_MODEL_REQUESTS = True
 
 
-@skip_if_no_openai_key
+@skip_if_no_live_llm
 async def test_simple_agent_q_and_a(container, deploy_agent):
     prepare_worker(container)
 
@@ -33,7 +39,7 @@ async def test_simple_agent_q_and_a(container, deploy_agent):
         print(f"Response message: {result.output}")
 
 
-@skip_if_no_openai_key
+@skip_if_no_live_llm
 async def test_simple_agent_with_tool(container, deploy_agent, deploy_multiple_agent_tools):
     deploy_agent.add_tools(deploy_multiple_agent_tools[2])
     prepare_worker(container)
@@ -53,7 +59,7 @@ async def test_simple_agent_with_tool(container, deploy_agent, deploy_multiple_a
         assert "1967" in result.output
 
 
-@skip_if_no_openai_key
+@skip_if_no_live_llm
 async def test_simple_agent_with_multiple_tools(container, deploy_agent, deploy_multiple_agent_tools):
     deploy_agent.add_tools(*deploy_multiple_agent_tools)
     prepare_worker(container)
@@ -76,7 +82,7 @@ async def test_simple_agent_with_multiple_tools(container, deploy_agent, deploy_
         assert "snow" in result.output.lower()
 
 
-@skip_if_no_openai_key
+@skip_if_no_live_llm
 async def test_simple_agent_with_multiturn_convo(container, deploy_agent, deploy_multiple_agent_tools):
     deploy_agent.add_tools(*deploy_multiple_agent_tools)
     prepare_worker(container)
@@ -112,7 +118,7 @@ async def test_simple_agent_with_multiturn_convo(container, deploy_agent, deploy
         print_message_history(result.message_history)
 
 
-@skip_if_no_openai_key
+@skip_if_no_live_llm
 async def test_simple_agent_with_injected_deps(container, deploy_agent, deploy_caller_id_agent_tool):
     deploy_agent.add_tools(deploy_caller_id_agent_tool)
     prepare_worker(container)
@@ -151,7 +157,7 @@ async def test_simple_agent_with_injected_deps(container, deploy_agent, deploy_c
         print_message_history(result.message_history)
 
 
-@skip_if_no_openai_key
+@skip_if_no_live_llm
 async def test_structured_output_agent(container, deploy_structured_agent):
     prepare_worker(container)
 

--- a/tests/test_skip_if_no_live_marker.py
+++ b/tests/test_skip_if_no_live_marker.py
@@ -1,0 +1,52 @@
+"""Unit test for the ``skip_if_no_live_llm`` gate in ``tests.utils``.
+
+This is NOT a live-LLM test: it verifies the clean-skip gate exists and is
+driven SYNCHRONOUSLY by env vars (an instant ``os.getenv`` check), with NO live
+API call at collection time. It's a normal offline unit test that always runs.
+
+The gate guards the ``live`` lane the same way ``skip_if_no_kafka`` guards the
+broker lane: even when a test is selected (``-m live``), it skips cleanly if the
+credentials are absent rather than erroring on a real request. Both
+``OPENAI_API_KEY`` (the provider key) and ``TEST_LLM_MODEL_NAME`` (which the
+model fixture hard-requires) must be set — see ADR 0007.
+
+The gate's logic is exercised through the ``_live_llm_enabled`` helper, which
+reads ``os.getenv`` on each call. We test it directly rather than reloading the
+module: ``tests.utils`` calls ``load_dotenv()`` at import, and ``.env`` carries
+both vars, so a reload would silently repopulate anything we cleared.
+"""
+
+import pytest
+
+from tests.utils import _live_llm_enabled, skip_if_no_live_llm
+
+
+def test_skip_if_no_live_llm_is_a_mark_decorator() -> None:
+    assert isinstance(skip_if_no_live_llm, type(pytest.mark.skipif(True, reason="x")))
+
+
+def test_gate_open_only_when_both_vars_set(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("TEST_LLM_MODEL_NAME", "gpt-test")
+    assert _live_llm_enabled() is True
+
+
+def test_gate_closed_when_key_unset(monkeypatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("TEST_LLM_MODEL_NAME", "gpt-test")
+    assert _live_llm_enabled() is False
+
+
+def test_gate_closed_when_model_name_unset(monkeypatch) -> None:
+    """A present key alone must NOT open the gate: the model fixture reads
+    ``TEST_LLM_MODEL_NAME`` directly, so without it the test would error on a
+    KeyError instead of skipping cleanly (the latent gap ADR 0007 calls out)."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("TEST_LLM_MODEL_NAME", raising=False)
+    assert _live_llm_enabled() is False
+
+
+def test_gate_closed_when_both_unset(monkeypatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("TEST_LLM_MODEL_NAME", raising=False)
+    assert _live_llm_enabled() is False

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,10 +15,30 @@ from calfkit._vendor.pydantic_ai.messages import (
 
 load_dotenv()
 
-# Skip integration tests if OpenAI API key is not available
-skip_if_no_openai_key = pytest.mark.skipif(
-    not os.getenv("OPENAI_API_KEY"),
-    reason="Skipping integration test: OPENAI_API_KEY not set in environment",
+
+def _live_llm_enabled() -> bool:
+    """Return True if a live model API is reachable for the ``live`` lane.
+
+    Driven SYNCHRONOUSLY by env vars — an instant ``os.getenv`` check, never a
+    live API probe at collection time (a probe would be slow, flaky, and turn a
+    missing key into a collection error rather than a clean skip).
+
+    Requires BOTH credentials the live tests depend on: ``OPENAI_API_KEY`` (the
+    provider key) and ``TEST_LLM_MODEL_NAME`` (which the model-client fixture in
+    ``tests/conftest.py`` reads with ``os.environ[...]`` — absent, it raises a
+    ``KeyError`` mid-setup instead of skipping). Gating on both closes that gap
+    (see ADR 0007). The dedicated ``live`` CI lane sets both; locally the tests
+    skip cleanly when either is unset.
+    """
+    return bool(os.getenv("OPENAI_API_KEY") and os.getenv("TEST_LLM_MODEL_NAME"))
+
+
+# Skip live-LLM tests unless real-provider credentials are present. This is the
+# clean-skip safety net for the opt-in ``live`` lane (`-m live`): a selected test
+# with no credentials skips rather than erroring on a real request.
+skip_if_no_live_llm = pytest.mark.skipif(
+    not _live_llm_enabled(),
+    reason="Skipping live-LLM test: set OPENAI_API_KEY and TEST_LLM_MODEL_NAME to enable",
 )
 
 


### PR DESCRIPTION
## What & why

Real model-API tests previously ran inside the **default** suite (`pytest tests/`), gated only by `OPENAI_API_KEY`. That meant they executed on every push **and on trusted-author PRs** — paid, non-deterministic model calls on PRs, with the provider secret injected via a trusted-author conditional.

This lands the **`live` axis that ADR 0007 reserved** as planned future work: an opt-in pytest marker, deselected by default, that runs in its own CI lane **only on push-to-main and manual dispatch — never on PRs**. It mirrors the existing `kafka` opt-in marker exactly (one orthogonal marker per external dependency).

The live-API surface was already cornered in two files (`test_agent_workers.py`, `test_agent_output_types.py`) — the sole consumers of the real model-client fixtures — so the separation is clean and the default suite needs no Docker, network, or credentials.

## Changes

- **`pyproject.toml`** — register the `live` marker; default selection is now `-m "not kafka and not live"`.
- **The two real-API files** — `pytestmark = pytest.mark.live`.
- **`tests/utils.py`** — `skip_if_no_openai_key` → `skip_if_no_live_llm`, now requiring **both** `OPENAI_API_KEY` and `TEST_LLM_MODEL_NAME`. This closes the latent gap ADR 0007 flagged: the model fixture reads `TEST_LLM_MODEL_NAME` via `os.environ[...]`, so a key alone used to `KeyError` mid-setup instead of skipping cleanly.
- **`tests/test_skip_if_no_live_marker.py`** (new) — unit test for the gate helper.
- **`.github/workflows/integration-live.yml`** (new) — `on: push:main + workflow_dispatch`; runs `-m live`; no Docker (in-memory `TestKafkaBroker`); reads `secrets.OPENAI_API_KEY` unconditionally — safe because it never runs on PRs. Reuses the same secret/vars `test.yml` already used; no new repo config needed.
- **`.github/workflows/test.yml`** — drop the live-creds env block and the trusted-author secret injection (now unnecessary; a fork-PR-secret-exposure win).
- **`Makefile`** — `make test-live`.
- **`CONTRIBUTING.md`** + **ADR 0007** — taxonomy/sections updated; ADR amended in place to mark the `live` axis landed and record the main-only CI policy.

## Marker semantics

`-m` is a boolean over labels: a test marked both `kafka` and `live` is selected by `-m kafka` alone, by `-m live` alone, and by `-m "kafka and live"`; only the default `not kafka and not live` excludes it. Each axis's clean-skip gate keeps a both-axes test green in a lane that provisions only one dependency. (No both-axes tests exist today.)

## Verification

- `make check` green (ruff + mypy, 57 files).
- Offline suite: **2903 passed, 6 skipped, 26 deselected** (26 = 18 live + 8 kafka).
- `-m live` with credentials emptied → **18 skipped, no API call**.
- `-m kafka` lane unaffected (8); both workflow YAMLs parse with correct triggers.

## Note

Per the agreed approach, the default-suite **coverage baseline re-levels once** on the next push to main (the OpenAI-adapter lines that only live tests exercised leave the PR coverage run). Documented in ADR 0007.
