### PR TITLE
ci: test against Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 requires-python = ">=3.10"


### PR DESCRIPTION
## What

Expand the CI test matrix to cover **every stable Python release from 3.10 up** and advertise the new versions in the package metadata.

- `.github/workflows/ci.yml` — test matrix: `["3.10", "3.11", "3.12"]` → `["3.10", "3.11", "3.12", "3.13", "3.14"]`
- `pyproject.toml` — add the `Programming Language :: Python :: 3.13` and `:: 3.14` trove classifiers

## Why

The matrix had drifted behind the current Python release line. As of June 2026, **3.14** is the latest stable (3.14.6); **3.15** is still in beta until Oct 2026 and is intentionally excluded.

## Scope notes

- `requires-python = ">=3.10"` is **unchanged** — it already covers every version upward.
- Lint/type baselines (`ruff target-version = "py310"`, `mypy python_version = "3.10"`) **stay at the 3.10 floor** — they track the minimum supported version, not the max.
- The single-interpreter integration/live lanes (pinned to 3.12) and lint/build/release (pinned to 3.10) are left as-is — those are representative-interpreter lanes, not compatibility matrices.
- README already says "Python 3.10 or later," which remains accurate.

## Verification

Ran the full offline suite locally on both new interpreters:

| Python | Result |
|--------|--------|
| 3.13   | 2967 passed, 6 skipped, 27 deselected |
| 3.14   | 2967 passed, 6 skipped, 27 deselected |

(`27 deselected` = the opt-in `kafka`/`live` lanes.) `make fix` produced no changes and `make check` (ruff + format + mypy) is green.