### PR TITLE
docs: clarify the test-taxonomy table's run column in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Before opening a PR, make sure these pass — CI runs the same checks:
 ```console
 $ make fix     # auto-fix lint + formatting (ruff)
 $ make check   # lint, format, and type checks (ruff + mypy)
-$ make test    # run the test suite (real-broker tests excluded)
+$ make test    # run the test suite (real-broker and live-LLM lanes excluded)
 ```
 
 `make help` lists every target. New features and fixes should come with tests
@@ -50,12 +50,12 @@ opt-in, so `make test` stays fast and needs no Docker, network, or credentials.
 
 ### Test taxonomy
 
-| Kind | Needs | Gate | In `make test`? |
+| Kind | Needs | Gate | How to run |
 |---|---|---|---|
-| Unit / component | nothing — `FunctionModel` + in-memory `TestKafkaBroker` | — | yes |
-| Real broker | a Kafka-protocol broker (Redpanda) | `@pytest.mark.kafka` | no — use `make test-kafka` |
-| Topic provisioning | a broker with topic auto-create **disabled** | `CALF_TEST_KAFKA` env var | no — separate lane |
-| Real LLM | a live model API | `@pytest.mark.live` (skips without `OPENAI_API_KEY` + `TEST_LLM_MODEL_NAME`) | no — use `make test-live` |
+| Unit / component | nothing — `FunctionModel` + in-memory `TestKafkaBroker` | — | `make test` (the default lane) |
+| Real broker | a Kafka-protocol broker (Redpanda) | `@pytest.mark.kafka` | `make test-kafka` |
+| Topic provisioning | a broker with topic auto-create **disabled** | `CALF_TEST_KAFKA` env var | own CI lane, no `make` target ([see below](#the-topic-provisioning-lane)) |
+| Real LLM | a live model API | `@pytest.mark.live` | `make test-live` |
 
 Default to **offline** tests: a scripted `FunctionModel` stands in for the LLM
 and FastStream's `TestKafkaBroker` stands in for Kafka, so the tests are


### PR DESCRIPTION
## What

Fix the **Test taxonomy** table in `CONTRIBUTING.md`, plus one related correctness nit.

### 1. Table column header ↔ contents mismatch (the reported issue)

The 4th column was headed **`In make test?`**, but its cells didn't answer a yes/no — they named the *command to run each lane* (`no — use make test-kafka`). Header and contents disagreed.

Renamed the column to **`How to run`** and put the actual entry point in each cell:

| Kind | How to run (before) | How to run (after) |
|---|---|---|
| Unit / component | `yes` | `make test` (the default lane) |
| Real broker | `no — use make test-kafka` | `make test-kafka` |
| Topic provisioning | `no — separate lane` | own CI lane, no `make` target ([link](CONTRIBUTING.md)) |
| Real LLM | `no — use make test-live` | `make test-live` |

> Note: "make command" (the suggested header) doesn't fit the **Topic provisioning** row — it has *no* `make` target. It's gated by the `CALF_TEST_KAFKA` env var via `skip_if_no_kafka` (not the `kafka` marker) and runs in its own CI lane, so that cell links to the section that explains it. Hence the more general `How to run`. The Real LLM gate cell also drops its inline credential parenthetical so the **Gate** column reads uniformly (marker only); the credential-skip detail already lives in the *Writing a live-LLM test* section.

### 2. Correctness nit in Quality gates

The `make test` comment said `(real-broker tests excluded)`. The default suite deselects **both** lanes (`addopts = -m "not kafka and not live"`), so it now reads `(real-broker and live-LLM lanes excluded)`.

## Review of the rest of the doc

I reviewed the entire file against the source. Everything else is **accurate** and left unchanged — verified against the codebase:

- Conventional-commit types + no-parens-in-subject rule → match `.github/workflows/pr-title.yml`
- Squash-merge, **2 approving reviews**, **code-owner review**, **threads resolved** → match the active `main` ruleset
- `@pytest.mark.kafka` / `@pytest.mark.live` gates, `CALF_TEST_KAFKA` / `CALF_TEST_KAFKA_BOOTSTRAP` env vars → match `pyproject.toml`, `tests/utils.py`, `tests/integration/conftest.py`
- All cited example files, fixtures (`kafka_bootstrap`, `topic_namespace`, `container`, `deploy_agent`), `Client.connect`, and `from tests.utils import skip_if_no_live_llm` exist and match
- "Skips cleanly without Docker" and "external broker imports no testcontainers" → confirmed in `tests/integration/conftest.py` (`DockerException` → `pytest.skip`; early `yield` before `importorskip`)
- `integration-live.yml` runs only on push-to-main + manual dispatch → confirmed
- ADR 0007 path and `.github/CODEOWNERS` exist

`make check` passes on the branch (docs-only change).