### PR TITLE
refactor!: rename toolbox_id/server_name to name on the MCP toolbox types

### DIFF
--- a/calfkit/mcp/mcp_toolbox.py
+++ b/calfkit/mcp/mcp_toolbox.py
@@ -53,13 +53,13 @@ class MCPToolboxNode(BaseNodeDef):
 
     def __init__(
         self,
-        server_name: str,
+        name: str,
         connection_params: StreamableHttpParameters | StdioServerParameters,
     ):
-        super().__init__(node_id=server_name, subscribe_topics=[f"mcp_server.{server_name}"])
+        super().__init__(node_id=name, subscribe_topics=[f"mcp_server.{name}"])
         self._connection_params = connection_params
-        self._session_resource_key = f"mcp_session.{server_name}"
-        self._writer_resource_key = f"mcp_writer.{server_name}"
+        self._session_resource_key = f"mcp_session.{name}"
+        self._writer_resource_key = f"mcp_writer.{name}"
         self._heartbeat_task: asyncio.Task[None] | None = None
         self._relist_tasks: set[asyncio.Task[None]] = set()
         self._shutting_down = False
@@ -102,7 +102,7 @@ class MCPToolboxNode(BaseNodeDef):
         warning.
         """
         return MCPToolbox(
-            toolbox_id=self.node_id,
+            name=self.node_id,
             include=tuple(include) if include is not None else None,
             strict=strict,
         )
@@ -282,15 +282,15 @@ class MCPToolbox:
     compare and hash equal.
     """
 
-    toolbox_id: str
+    name: str
     include: tuple[str, ...] | None = None
     strict: bool = False
 
     def __post_init__(self) -> None:
-        if not self.toolbox_id:
-            raise ValueError("toolbox_id must be non-empty")
+        if not self.name:
+            raise ValueError("name must be non-empty")
         if self.include is not None and not isinstance(self.include, tuple):
             object.__setattr__(self, "include", tuple(self.include))
 
     def resolve_tools(self, view: Mapping[str, CapabilityRecord]) -> SelectorResult:
-        return resolve_capability(view, self.toolbox_id, include=self.include, strict=self.strict)
+        return resolve_capability(view, self.name, include=self.include, strict=self.strict)

--- a/tests/test_mcp_toolbox.py
+++ b/tests/test_mcp_toolbox.py
@@ -82,7 +82,7 @@ class TestMintingAndParity:
 
         ref = make_toolbox().select(include=["search"], strict=True)
         assert isinstance(ref, MCPToolbox)
-        assert ref.toolbox_id == "github" and ref.include == ("search",) and ref.strict
+        assert ref.name == "github" and ref.include == ("search",) and ref.strict
 
     def test_toolbox_resolution_delegates_to_its_ref(self) -> None:
         from calfkit.mcp import MCPToolbox


### PR DESCRIPTION
## What

Give both MCP toolbox constructors the same ergonomic `name` arg:

| Type | Before | After |
| --- | --- | --- |
| `MCPToolbox` (call-side handle) | `MCPToolbox(toolbox_id="docs")` | **`MCPToolbox(name="docs")`** |
| `MCPToolboxNode` (host) | `MCPToolboxNode(server_name="docs", connection_params=…)` | **`MCPToolboxNode(name="docs", connection_params=…)`** |

The pair is now symmetric on a single user-facing vocabulary: `name`.

## Scope (deliberate boundary)

Only the **user-facing constructor vocabulary** changes. The control plane keeps its identity vocabulary unchanged — **no wire-format change**:

- `CapabilityRecord.toolbox_id` (the serialized capability-topic key) — untouched
- `resolve_capability(toolbox_id=…)` param + `view.get(...)` — untouched
- `SelectorResult.toolbox_id` diagnostic + agent log reads — untouched
- framework internals keep `node_id`

So: **user-facing constructors say `name`; internals say `node_id`; the wire says `toolbox_id`.**

## Compatibility

- Positional construction is unaffected: `MCPToolbox("docs")`, `MCPToolboxNode("docs", connection_params=…)`.
- **BREAKING**: keyword args change — `MCPToolbox(toolbox_id=…)` → `MCPToolbox(name=…)`, `MCPToolboxNode(server_name=…)` → `MCPToolboxNode(name=…)`.

## Verification

- `make check` clean (lint + format + type-check, 60 files).
- Offline suite: **3070 passed, 6 skipped, 47 deselected** (kafka/live run in CI).
- Confirmed zero `server_name` remaining; the only surviving `toolbox_id=` construction is the `CapabilityRecord` wire model (intentional).

No ADR — a reversible, unsurprising constructor-arg rename on the user-facing handle/host.