### PR TITLE
feat: control-plane substrate: generic node discoverability machinery

### DIFF
--- a/calfkit/__init__.py
+++ b/calfkit/__init__.py
@@ -1,6 +1,7 @@
 from importlib.metadata import version
 
 from calfkit.client import Client, InvocationHandle, InvocationResult
+from calfkit.controlplane import ControlPlaneConfig, ControlPlaneIdentity, ControlPlaneRecord, ControlPlaneView, advertises
 from calfkit.exceptions import DeserializationError, LifecycleConfigError, NodeFaultError
 from calfkit.models import ErrorReport, FaultTypes, ToolContext
 from calfkit.nodes import Agent, BaseNodeDef, ConsumerFn, ConsumerNode, NodeDef, ToolNodeDef, agent_tool, consumer
@@ -39,6 +40,12 @@ __all__ = [
     "LifecycleContext",
     "ResourceSetupContext",
     "ServingContext",
+    # control plane
+    "ControlPlaneConfig",
+    "ControlPlaneIdentity",
+    "ControlPlaneRecord",
+    "ControlPlaneView",
+    "advertises",
     # exceptions
     "DeserializationError",
     "LifecycleConfigError",

--- a/calfkit/__init__.py
+++ b/calfkit/__init__.py
@@ -1,7 +1,7 @@
 from importlib.metadata import version
 
 from calfkit.client import Client, InvocationHandle, InvocationResult
-from calfkit.controlplane import ControlPlaneConfig, ControlPlaneIdentity, ControlPlaneRecord, ControlPlaneView, advertises
+from calfkit.controlplane import ControlPlaneConfig, ControlPlaneRecord, ControlPlaneStamp, ControlPlaneView, advertises
 from calfkit.exceptions import DeserializationError, LifecycleConfigError, NodeFaultError
 from calfkit.models import ErrorReport, FaultTypes, ToolContext
 from calfkit.nodes import Agent, BaseNodeDef, ConsumerFn, ConsumerNode, NodeDef, ToolNodeDef, agent_tool, consumer
@@ -42,8 +42,8 @@ __all__ = [
     "ServingContext",
     # control plane
     "ControlPlaneConfig",
-    "ControlPlaneIdentity",
     "ControlPlaneRecord",
+    "ControlPlaneStamp",
     "ControlPlaneView",
     "advertises",
     # exceptions

--- a/calfkit/controlplane/__init__.py
+++ b/calfkit/controlplane/__init__.py
@@ -1,0 +1,21 @@
+"""The reusable control-plane substrate.
+
+Generic machinery — a record base, a worker-owned publisher, and a per-topic
+view — that any control plane (capability discovery, agent discovery, and future
+access-policy / reconfig planes) builds on to advertise nodes to a compacted
+topic and read a live view of them. See
+``docs/designs/control-plane-substrate-spec.md`` for the full design.
+"""
+
+from calfkit.controlplane.advert import advertises
+from calfkit.controlplane.config import ControlPlaneConfig
+from calfkit.controlplane.records import ControlPlaneIdentity, ControlPlaneRecord
+from calfkit.controlplane.view import ControlPlaneView
+
+__all__ = [
+    "ControlPlaneConfig",
+    "ControlPlaneIdentity",
+    "ControlPlaneRecord",
+    "ControlPlaneView",
+    "advertises",
+]

--- a/calfkit/controlplane/__init__.py
+++ b/calfkit/controlplane/__init__.py
@@ -9,13 +9,13 @@ topic and read a live view of them. See
 
 from calfkit.controlplane.advert import advertises
 from calfkit.controlplane.config import ControlPlaneConfig
-from calfkit.controlplane.records import ControlPlaneIdentity, ControlPlaneRecord
+from calfkit.controlplane.records import ControlPlaneRecord, ControlPlaneStamp
 from calfkit.controlplane.view import ControlPlaneView
 
 __all__ = [
     "ControlPlaneConfig",
-    "ControlPlaneIdentity",
     "ControlPlaneRecord",
+    "ControlPlaneStamp",
     "ControlPlaneView",
     "advertises",
 ]

--- a/calfkit/controlplane/advert.py
+++ b/calfkit/controlplane/advert.py
@@ -1,0 +1,155 @@
+"""Per-subclass collection of control-plane adverts marked with :func:`advertises`.
+
+Mirrors the :mod:`calfkit._registry` handler pattern: a class-body decorator only
+stamps metadata onto the method (the class object does not exist yet);
+:meth:`AdvertRegistryMixin.__init_subclass__` does the collection once the class is
+built. An advert binds a node *type* to one control-plane topic + record schema;
+instances of the type all advertise to that topic, differing only in the content
+their factory returns. Factories resolve to bound methods at access time, so an
+override — even one that does not re-apply :func:`advertises` — is reflected.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from typing import Any, ClassVar, TypeVar
+
+from calfkit._registry import _unwrap
+from calfkit.controlplane.records import ControlPlaneRecord
+from calfkit.exceptions import RegistryConfigError
+
+__all__ = ["AdvertInfo", "AdvertRegistryMixin", "advert_info", "advertises"]
+
+_ADVERT_ATTR = "__calf_advert__"
+
+_MethodT = TypeVar("_MethodT", bound=Callable[..., Any])
+
+
+@dataclass(frozen=True, slots=True)
+class AdvertInfo:
+    """Metadata stamped on a method by :func:`advertises`.
+
+    ``topic`` is the control-plane topic the record is published to and its unique
+    key in the registry; ``record`` is the :class:`ControlPlaneRecord` subclass the
+    factory returns; ``name`` is the attribute name the factory is bound under
+    (set authoritatively during collection, used to resolve the bound method).
+    """
+
+    topic: str
+    record: type[ControlPlaneRecord]
+    name: str
+
+    def __post_init__(self) -> None:
+        if not self.topic:
+            raise ValueError("AdvertInfo.topic must be non-empty")
+        if not self.name:
+            raise ValueError("AdvertInfo.name must be non-empty")
+
+
+def advertises(topic: str, *, record: type[ControlPlaneRecord]) -> Callable[[_MethodT], _MethodT]:
+    """Mark a method as a control-plane advert factory for :class:`AdvertRegistryMixin`.
+
+    Returns the method **unchanged** — it stays an ordinary, callable method; the
+    only effect is an :class:`AdvertInfo` marker read by
+    :meth:`AdvertRegistryMixin.__init_subclass__` when the owning class is built.
+
+    The decorated method is a *content factory*: it takes a
+    :class:`~calfkit.controlplane.records.ControlPlaneIdentity` (stamped by the
+    worker-owned publisher) and returns a fully-formed ``record`` instance —
+    typically ``record(**identity.model_dump(), <content>)``.
+
+    The publisher *pulls* this factory once per heartbeat tick, so any "content
+    currency" timestamp the record carries (e.g. a ``content_updated_at``) must come
+    from a value the node tracks and advances only when its content actually changes
+    — never ``now()`` computed inside the factory (that would move it every tick and
+    mask content staleness).
+
+    The ``(topic, record)`` binding is per node *type*: every instance advertises
+    to the same topic with the same schema (a topic's view decodes exactly one
+    record type). **One topic ⇒ one record schema** must also hold across *all*
+    node types (a deployment-time contract — a foreign schema on a topic is
+    poison-skipped by the reader); that cross-type case is not enforceable here.
+
+    Args:
+        topic: The control-plane topic this type advertises to. Unique per class
+            hierarchy — a duplicate raises
+            :class:`~calfkit.exceptions.RegistryConfigError` at class definition.
+        record: The :class:`ControlPlaneRecord` subclass the factory returns.
+
+    Raises:
+        ValueError: If ``topic`` is empty, or ``record`` is not a
+            ``ControlPlaneRecord`` subclass.
+    """
+    if not topic:
+        raise ValueError("advertises() topic must be non-empty")
+    if not (isinstance(record, type) and issubclass(record, ControlPlaneRecord)):
+        raise ValueError(f"advertises() record must be a ControlPlaneRecord subclass, got {record!r}")
+
+    def _decorate(method: _MethodT) -> _MethodT:
+        target = _unwrap(method)
+        # ``name`` is a placeholder here (the real attribute name is resolved in
+        # __init_subclass__, which knows the class-body key); only validity matters.
+        setattr(target, _ADVERT_ATTR, AdvertInfo(topic=topic, record=record, name=getattr(target, "__name__", topic)))
+        return method
+
+    return _decorate
+
+
+def advert_info(method: Callable[..., Any]) -> AdvertInfo | None:
+    """Return the :class:`AdvertInfo` for a method, or ``None`` if unmarked.
+
+    Accepts a plain function or a bound/unbound method (it unwraps ``__func__``),
+    so it works on the values returned by :meth:`AdvertRegistryMixin.control_plane_adverts`.
+    """
+    info: AdvertInfo | None = getattr(_unwrap(method), _ADVERT_ATTR, None)
+    return info
+
+
+class AdvertRegistryMixin:
+    """Collects :func:`advertises`-marked methods, per subclass, keyed by topic.
+
+    Each subclass gets its **own** registry, merged across the MRO (an override
+    that re-applies :func:`advertises` replaces the inherited entry — most-derived
+    wins) and built in :meth:`__init_subclass__`. Topics must be unique within a
+    class hierarchy, else :class:`~calfkit.exceptions.RegistryConfigError` is
+    raised at class definition.
+    """
+
+    # topic -> AdvertInfo; assigned fresh per subclass. The empty default on the
+    # base is a never-mutated sentinel.
+    _adverts: ClassVar[dict[str, AdvertInfo]] = {}
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+
+        # Walk base -> derived so the most-derived definition of an attribute wins.
+        # Bind AdvertInfo.name to the real attribute key (authoritative for
+        # resolution), independent of the function's __name__.
+        marked: dict[str, AdvertInfo] = {}  # attr -> info
+        for klass in reversed(cls.__mro__):
+            for attr, member in vars(klass).items():
+                info = advert_info(member)
+                if info is not None:
+                    marked[attr] = replace(info, name=attr)
+
+        topic_to_attr: dict[str, str] = {}
+        topic_to_info: dict[str, AdvertInfo] = {}
+        for attr, info in marked.items():
+            owner = topic_to_attr.get(info.topic)
+            if owner is not None and owner != attr:
+                raise RegistryConfigError(
+                    f"{cls.__qualname__}: control-plane topic {info.topic!r} is registered by both "
+                    f"{owner!r} and {attr!r}; topics must be unique per class"
+                )
+            topic_to_attr[info.topic] = attr
+            topic_to_info[info.topic] = info
+        cls._adverts = topic_to_info
+
+    def control_plane_adverts(self) -> dict[str, Callable[..., ControlPlaneRecord]]:
+        """Return this instance's advert factories as ``{topic: bound method}``.
+
+        Each value is a method already bound to ``self``. A fresh dict is returned
+        each call, so mutating it cannot corrupt the per-class registry.
+        """
+        return {topic: getattr(self, info.name) for topic, info in type(self)._adverts.items()}

--- a/calfkit/controlplane/advert.py
+++ b/calfkit/controlplane/advert.py
@@ -45,6 +45,8 @@ class AdvertInfo:
             raise ValueError("AdvertInfo.topic must be non-empty")
         if not self.name:
             raise ValueError("AdvertInfo.name must be non-empty")
+        if not (isinstance(self.record, type) and issubclass(self.record, ControlPlaneRecord)):
+            raise ValueError(f"AdvertInfo.record must be a ControlPlaneRecord subclass, got {self.record!r}")
 
 
 def advertises(topic: str, *, record: type[ControlPlaneRecord]) -> Callable[[_MethodT], _MethodT]:
@@ -68,8 +70,9 @@ def advertises(topic: str, *, record: type[ControlPlaneRecord]) -> Callable[[_Me
     The ``(topic, record)`` binding is per node *type*: every instance advertises
     to the same topic with the same schema (a topic's view decodes exactly one
     record type). **One topic ⇒ one record schema** must also hold across *all*
-    node types (a deployment-time contract — a foreign schema on a topic is
-    poison-skipped by the reader); that cross-type case is not enforceable here.
+    node types (a deployment-time contract — a foreign payload that fails to decode is
+    dropped by ktables below the view, so that node silently vanishes); that cross-type
+    case is not enforceable here.
 
     Args:
         topic: The control-plane topic this type advertises to. Unique per class

--- a/calfkit/controlplane/advert.py
+++ b/calfkit/controlplane/advert.py
@@ -57,9 +57,10 @@ def advertises(topic: str, *, record: type[ControlPlaneRecord]) -> Callable[[_Me
     :meth:`AdvertRegistryMixin.__init_subclass__` when the owning class is built.
 
     The decorated method is a *content factory*: it takes a
-    :class:`~calfkit.controlplane.records.ControlPlaneIdentity` (stamped by the
-    worker-owned publisher) and returns a fully-formed ``record`` instance —
-    typically ``record(**identity.model_dump(), <content>)``.
+    :class:`~calfkit.controlplane.records.ControlPlaneStamp` (the worker-stamped
+    boot/liveness fields) and returns a fully-formed ``record`` instance —
+    typically ``record(**stamp.model_dump(), <content>)``. Node identity is the wire
+    key, never in the record value, so there is nothing for the factory to get wrong.
 
     The publisher *pulls* this factory once per heartbeat tick, so any "content
     currency" timestamp the record carries (e.g. a ``content_updated_at``) must come

--- a/calfkit/controlplane/advert.py
+++ b/calfkit/controlplane/advert.py
@@ -56,11 +56,16 @@ def advertises(topic: str, *, record: type[ControlPlaneRecord]) -> Callable[[_Me
     only effect is an :class:`AdvertInfo` marker read by
     :meth:`AdvertRegistryMixin.__init_subclass__` when the owning class is built.
 
-    The decorated method is a *content factory*: it takes a
-    :class:`~calfkit.controlplane.records.ControlPlaneStamp` (the worker-stamped
+    The decorated method is a *content factory*: it takes a **bare**
+    :class:`~calfkit.controlplane.records.ControlPlaneStamp` (the three worker-stamped
     boot/liveness fields) and returns a fully-formed ``record`` instance —
     typically ``record(**stamp.model_dump(), <content>)``. Node identity is the wire
     key, never in the record value, so there is nothing for the factory to get wrong.
+    Splat the stamp, never a full record: because ``ControlPlaneRecord`` *is-a*
+    ``ControlPlaneStamp``, splatting a record would smuggle in ``schema_version`` and
+    the record's own content keys (a duplicate-kwarg ``TypeError`` the type checker
+    cannot see). The publisher always passes a bare stamp, so this only bites a
+    hand-rolled caller.
 
     The publisher *pulls* this factory once per heartbeat tick, so any "content
     currency" timestamp the record carries (e.g. a ``content_updated_at``) must come

--- a/calfkit/controlplane/config.py
+++ b/calfkit/controlplane/config.py
@@ -10,6 +10,7 @@ it arrives on the record (spec §5, §9).
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 STALE_MULTIPLIER = 3
@@ -39,9 +40,10 @@ class ControlPlaneConfig:
     bootstrap_servers: str | None = None
 
     def __post_init__(self) -> None:
-        if self.heartbeat_interval <= 0:
-            raise ValueError(f"heartbeat_interval must be > 0, got {self.heartbeat_interval}")
-        if self.catchup_timeout <= 0:
-            raise ValueError(f"catchup_timeout must be > 0, got {self.catchup_timeout}")
-        if self.stale_after is not None and self.stale_after <= 0:
-            raise ValueError(f"stale_after must be > 0 or None, got {self.stale_after}")
+        # `not isfinite(...)` guards NaN/inf, which slip past every `<= 0` comparison.
+        if not math.isfinite(self.heartbeat_interval) or self.heartbeat_interval <= 0:
+            raise ValueError(f"heartbeat_interval must be a finite number > 0, got {self.heartbeat_interval}")
+        if not math.isfinite(self.catchup_timeout) or self.catchup_timeout <= 0:
+            raise ValueError(f"catchup_timeout must be a finite number > 0, got {self.catchup_timeout}")
+        if self.stale_after is not None and (not math.isfinite(self.stale_after) or self.stale_after <= 0):
+            raise ValueError(f"stale_after must be a finite number > 0 or None, got {self.stale_after}")

--- a/calfkit/controlplane/config.py
+++ b/calfkit/controlplane/config.py
@@ -1,0 +1,47 @@
+"""Worker-level control-plane configuration (spec §11).
+
+Optional tuning for the control-plane substrate. The knobs split by side:
+``heartbeat_interval`` is the *publisher's* (and is stamped on every record, so it
+reaches readers); ``stale_after`` and ``catchup_timeout`` are the *view's*;
+``bootstrap_servers`` applies to whichever side opens a table. A reader in a
+different process than the writer needs no agreement on ``heartbeat_interval`` —
+it arrives on the record (spec §5, §9).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+STALE_MULTIPLIER = 3
+"""Default staleness threshold = ``STALE_MULTIPLIER × record.heartbeat_interval``
+when a reader sets no explicit ``stale_after`` (spec §9)."""
+
+
+@dataclass(frozen=True)
+class ControlPlaneConfig:
+    """Tuning for the control-plane substrate; every field is optional.
+
+    Args:
+        heartbeat_interval: Seconds between record re-publishes (the publisher's
+            loop cadence). Also stamped on every record so a reader can judge
+            staleness without knowing this value.
+        stale_after: Read-side override/floor for the staleness threshold. ``None``
+            (default) derives ``STALE_MULTIPLIER × record.heartbeat_interval``.
+        catchup_timeout: Bound on a view's catch-up gate.
+        bootstrap_servers: Override for the control-plane Kafka cluster. ``None``
+            (default) derives from the connected client; set only for the
+            split-cluster case (control plane on different brokers than data).
+    """
+
+    heartbeat_interval: float = 30.0
+    stale_after: float | None = None
+    catchup_timeout: float = 30.0
+    bootstrap_servers: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.heartbeat_interval <= 0:
+            raise ValueError(f"heartbeat_interval must be > 0, got {self.heartbeat_interval}")
+        if self.catchup_timeout <= 0:
+            raise ValueError(f"catchup_timeout must be > 0, got {self.catchup_timeout}")
+        if self.stale_after is not None and self.stale_after <= 0:
+            raise ValueError(f"stale_after must be > 0 or None, got {self.stale_after}")

--- a/calfkit/controlplane/publisher.py
+++ b/calfkit/controlplane/publisher.py
@@ -15,7 +15,7 @@ import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
-from calfkit.controlplane.records import ControlPlaneIdentity
+from calfkit.controlplane.records import ControlPlaneStamp
 
 if TYPE_CHECKING:
     from pydantic import AwareDatetime
@@ -105,6 +105,9 @@ class ControlPlanePublisher:
                 except asyncio.CancelledError:
                     raise
                 except Exception:
+                    # Accepted (spec §3): a persistently-failing advert logs every tick and its node
+                    # goes stale (alive but unpublished). Escalation/recovery is the SDK-wide
+                    # error-propagation layer's concern, not this loop's.
                     logger.exception(
                         "control-plane publish failed node=%s topic=%s; retry next tick",
                         node.node_id,
@@ -114,12 +117,10 @@ class ControlPlanePublisher:
     async def _publish_one(self, ctx: ServingContext, node: BaseNodeDef, info: AdvertInfo, now: AwareDatetime) -> None:
         assert self._started_at is not None  # set in start() before any publish
         writer = ctx.resources[control_plane_writer_key(info.topic)]  # KeyError => wiring bug (fail-loud at start)
-        identity = ControlPlaneIdentity(
-            node_id=node.node_id,
-            worker_id=self._worker_id,
+        stamp = ControlPlaneStamp(
             started_at=self._started_at,
             last_heartbeat_at=now,
             heartbeat_interval=self._config.heartbeat_interval,
         )
-        record = getattr(node, info.name)(identity)  # opaque ControlPlaneRecord
+        record = getattr(node, info.name)(stamp)  # opaque ControlPlaneRecord; identity is the wire key
         await writer.set(node.node_id, self._worker_id, record)

--- a/calfkit/controlplane/publisher.py
+++ b/calfkit/controlplane/publisher.py
@@ -28,6 +28,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def control_plane_writer_key(topic: str) -> str:
+    """The worker resource-bag key for the control-plane writer of ``topic``.
+
+    The single shared contract between the worker (which registers the writer
+    ``@resource`` under this key) and the publisher (which looks it up in
+    ``ctx.resources``). One public home for the key, so neither side reaches into
+    a private of the other.
+    """
+    return f"calfkit.controlplane.writer.{topic}"
+
+
 class ControlPlanePublisher:
     """Worker-owned heartbeat publisher + ordered tombstone (spec §7, ADR-0011)."""
 
@@ -42,6 +53,9 @@ class ControlPlanePublisher:
         self._adverts = adverts
         self._config = config
         self._task: asyncio.Task[None] | None = None
+        # Set in stop() before the loop is cancelled; the seam a future publish_now()
+        # will check. The tick loop's resurrection-safety is cancel-before-delete, NOT
+        # this flag (the loop never reads it).
         self._shutting_down = False
         self._started_at: AwareDatetime | None = None
 
@@ -74,7 +88,9 @@ class ControlPlanePublisher:
             with contextlib.suppress(asyncio.CancelledError):
                 await task
         for node, info in self._adverts:
-            writer = ctx.resources.get(self._writer_key(info.topic))
+            # Best-effort: a missing writer at shutdown (e.g. a resource that failed to
+            # open) must not raise mid-teardown and abort the remaining tombstones.
+            writer = ctx.resources.get(control_plane_writer_key(info.topic))
             if writer is not None:
                 await writer.delete(node.node_id, self._worker_id)
 
@@ -97,7 +113,7 @@ class ControlPlanePublisher:
 
     async def _publish_one(self, ctx: ServingContext, node: BaseNodeDef, info: AdvertInfo, now: AwareDatetime) -> None:
         assert self._started_at is not None  # set in start() before any publish
-        writer = ctx.resources[self._writer_key(info.topic)]  # KeyError => wiring bug (fail-loud at start)
+        writer = ctx.resources[control_plane_writer_key(info.topic)]  # KeyError => wiring bug (fail-loud at start)
         identity = ControlPlaneIdentity(
             node_id=node.node_id,
             worker_id=self._worker_id,
@@ -107,7 +123,3 @@ class ControlPlanePublisher:
         )
         record = getattr(node, info.name)(identity)  # opaque ControlPlaneRecord
         await writer.set(node.node_id, self._worker_id, record)
-
-    @staticmethod
-    def _writer_key(topic: str) -> str:
-        return f"calfkit.controlplane.writer.{topic}"

--- a/calfkit/controlplane/publisher.py
+++ b/calfkit/controlplane/publisher.py
@@ -1,0 +1,113 @@
+"""Write side of the control-plane substrate: the worker-owned publisher (spec §7).
+
+One publisher per worker runs **one** heartbeat loop and **one** ordered tombstone
+pass for every hosted node's adverts (ADR-0011). Startup is **fail-loud** (a publish
+failure aborts boot); loop ticks are **per-advert resilient**. Content is *pulled*
+from each advert factory every tick (pull-only); all writes funnel through here, so
+a future ``publish_now()`` push plugs into the same shutdown-flag serialization.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from calfkit.controlplane.records import ControlPlaneIdentity
+
+if TYPE_CHECKING:
+    from pydantic import AwareDatetime
+
+    from calfkit.controlplane.advert import AdvertInfo
+    from calfkit.controlplane.config import ControlPlaneConfig
+    from calfkit.nodes.base import BaseNodeDef
+    from calfkit.worker.lifecycle import ServingContext
+
+logger = logging.getLogger(__name__)
+
+
+class ControlPlanePublisher:
+    """Worker-owned heartbeat publisher + ordered tombstone (spec §7, ADR-0011)."""
+
+    def __init__(
+        self,
+        *,
+        worker_id: str,
+        adverts: list[tuple[BaseNodeDef, AdvertInfo]],
+        config: ControlPlaneConfig,
+    ) -> None:
+        self._worker_id = worker_id
+        self._adverts = adverts
+        self._config = config
+        self._task: asyncio.Task[None] | None = None
+        self._shutting_down = False
+        self._started_at: AwareDatetime | None = None
+
+    async def start(self, ctx: ServingContext) -> None:
+        """``after_startup``: capture boot time, publish each advert once (FAIL-LOUD), spawn the loop.
+
+        A publish failure here propagates and aborts worker startup — a node that
+        cannot advertise must surface, not start silently degraded. The lifecycle
+        then runs no ``on_shutdown``, so a partially-published record simply goes
+        stale (crash-equivalent, accepted).
+        """
+        self._started_at = datetime.now(tz=timezone.utc)
+        for node, info in self._adverts:
+            await self._publish_one(ctx, node, info, self._started_at)
+        self._task = asyncio.create_task(self._loop(ctx), name="control-plane-heartbeat")
+
+    async def stop(self, ctx: ServingContext) -> None:
+        """``on_shutdown``: flag first, cancel+await the loop, then tombstone the cross-product.
+
+        Cancel-before-delete is what makes the tombstone win: after ``await task``
+        the loop (and any in-flight ``set``) is fully resolved/cancelled, so no
+        ``set`` can land after a ``delete``. The tombstone target is the declared
+        cross-product ``{(node_id, topic)}`` — deletes are idempotent, so no
+        per-key success bookkeeping is needed.
+        """
+        self._shutting_down = True
+        task, self._task = self._task, None
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        for node, info in self._adverts:
+            writer = ctx.resources.get(self._writer_key(info.topic))
+            if writer is not None:
+                await writer.delete(node.node_id, self._worker_id)
+
+    async def _loop(self, ctx: ServingContext) -> None:
+        """Per-tick, per-advert resilient: a bad advert is logged; the rest still publish."""
+        while True:
+            await asyncio.sleep(self._config.heartbeat_interval)
+            now = datetime.now(tz=timezone.utc)
+            for node, info in self._adverts:
+                try:
+                    await self._publish_one(ctx, node, info, now)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception(
+                        "control-plane publish failed node=%s topic=%s; retry next tick",
+                        node.node_id,
+                        info.topic,
+                    )
+
+    async def _publish_one(self, ctx: ServingContext, node: BaseNodeDef, info: AdvertInfo, now: AwareDatetime) -> None:
+        assert self._started_at is not None  # set in start() before any publish
+        writer = ctx.resources[self._writer_key(info.topic)]  # KeyError => wiring bug (fail-loud at start)
+        identity = ControlPlaneIdentity(
+            node_id=node.node_id,
+            worker_id=self._worker_id,
+            started_at=self._started_at,
+            last_heartbeat_at=now,
+            heartbeat_interval=self._config.heartbeat_interval,
+        )
+        record = getattr(node, info.name)(identity)  # opaque ControlPlaneRecord
+        await writer.set(node.node_id, self._worker_id, record)
+
+    @staticmethod
+    def _writer_key(topic: str) -> str:
+        return f"calfkit.controlplane.writer.{topic}"

--- a/calfkit/controlplane/records.py
+++ b/calfkit/controlplane/records.py
@@ -1,0 +1,53 @@
+"""Control-plane record base + identity envelope (spec §5).
+
+The shared base every concrete control-plane record extends: identity (which
+node, which worker instance) plus liveness (when it last heartbeat, and the
+writer's cadence). The control-plane view's staleness filter depends on this
+base and nothing else, so it stays generic over the concrete record type.
+"""
+
+from __future__ import annotations
+
+from pydantic import AwareDatetime, BaseModel, ConfigDict
+
+
+class ControlPlaneRecord(BaseModel):
+    """One node instance's self-published advertisement on a control-plane topic.
+
+    Identity + liveness only; concrete records (capability, agent card, ...) add
+    their use-case content. The base intentionally declares ``schema_version``
+    with **no default** so it is abstract-by-omission: every concrete subclass
+    must set ``schema_version: int = N``. That default is load-bearing — the
+    control-plane view derives its reader version from it and rejects a record
+    type that lacks one.
+
+    ``heartbeat_interval`` is the *writer's* cadence, carried on the wire so any
+    reader (including a config-less out-of-process one) can judge staleness
+    against the writer's interval rather than its own config (spec §9).
+    """
+
+    model_config = ConfigDict(extra="ignore")  # tolerant reader (additive forward-compat)
+
+    schema_version: int
+    node_id: str
+    worker_id: str
+    started_at: AwareDatetime
+    last_heartbeat_at: AwareDatetime
+    heartbeat_interval: float
+
+
+class ControlPlaneIdentity(BaseModel):
+    """The identity + liveness envelope the publisher stamps on each tick.
+
+    Exactly the non-``schema_version`` fields of :class:`ControlPlaneRecord`, so a
+    factory composes a complete record as ``R(**identity.model_dump(), <content>)``.
+    Frozen: built fresh per tick, never mutated.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    node_id: str
+    worker_id: str
+    started_at: AwareDatetime
+    last_heartbeat_at: AwareDatetime
+    heartbeat_interval: float

--- a/calfkit/controlplane/records.py
+++ b/calfkit/controlplane/records.py
@@ -26,7 +26,7 @@ class ControlPlaneRecord(BaseModel):
     against the writer's interval rather than its own config (spec §9).
     """
 
-    model_config = ConfigDict(extra="ignore")  # tolerant reader (additive forward-compat)
+    model_config = ConfigDict(extra="ignore", frozen=True)  # tolerant reader; immutable value object
 
     schema_version: int
     node_id: str

--- a/calfkit/controlplane/records.py
+++ b/calfkit/controlplane/records.py
@@ -11,43 +11,39 @@ from __future__ import annotations
 from pydantic import AwareDatetime, BaseModel, ConfigDict
 
 
-class ControlPlaneRecord(BaseModel):
+class ControlPlaneStamp(BaseModel):
+    """The worker-stamped per-instance fields, spread into every record by the publisher.
+
+    Boot time + liveness + the writer's cadence — everything the *worker* (not the node)
+    owns and stamps on each tick. Node identity (``node_id`` × ``worker_id``) is the wire
+    **key**, never duplicated here. Frozen: built fresh per tick, never mutated.
+
+    ``heartbeat_interval`` is the writer's cadence, carried on the wire so any reader
+    (including a config-less out-of-process one) can judge staleness against the writer's
+    interval rather than its own config (spec §9).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    started_at: AwareDatetime  # this instance's boot time -> uptime / restart detection
+    last_heartbeat_at: AwareDatetime  # liveness basis; refreshed every heartbeat tick
+    heartbeat_interval: float  # the writer's cadence (seconds)
+
+
+class ControlPlaneRecord(ControlPlaneStamp):
     """One node instance's self-published advertisement on a control-plane topic.
 
-    Identity + liveness only; concrete records (capability, agent card, ...) add
-    their use-case content. The base intentionally declares ``schema_version``
-    with **no default** so it is abstract-by-omission: every concrete subclass
-    must set ``schema_version: int = N``. That default is load-bearing — the
-    control-plane view derives its reader version from it and rejects a record
-    type that lacks one.
+    The worker :class:`ControlPlaneStamp` (inherited) plus ``schema_version``; concrete
+    records (capability, agent card, ...) add their use-case content. **Identity
+    (``node_id`` × ``worker_id``) is the wire key, never carried in the value** — every
+    reader derives it from the key, so there is nothing to drift.
 
-    ``heartbeat_interval`` is the *writer's* cadence, carried on the wire so any
-    reader (including a config-less out-of-process one) can judge staleness
-    against the writer's interval rather than its own config (spec §9).
+    The base intentionally declares ``schema_version`` with **no default** so it is
+    abstract-by-omission: every concrete subclass must set ``schema_version: int = N``.
+    That default is load-bearing — the control-plane view derives its reader version from
+    it and rejects a record type that lacks one.
     """
 
     model_config = ConfigDict(extra="ignore", frozen=True)  # tolerant reader; immutable value object
 
     schema_version: int
-    node_id: str
-    worker_id: str
-    started_at: AwareDatetime
-    last_heartbeat_at: AwareDatetime
-    heartbeat_interval: float
-
-
-class ControlPlaneIdentity(BaseModel):
-    """The identity + liveness envelope the publisher stamps on each tick.
-
-    Exactly the non-``schema_version`` fields of :class:`ControlPlaneRecord`, so a
-    factory composes a complete record as ``R(**identity.model_dump(), <content>)``.
-    Frozen: built fresh per tick, never mutated.
-    """
-
-    model_config = ConfigDict(frozen=True)
-
-    node_id: str
-    worker_id: str
-    started_at: AwareDatetime
-    last_heartbeat_at: AwareDatetime
-    heartbeat_interval: float

--- a/calfkit/controlplane/view.py
+++ b/calfkit/controlplane/view.py
@@ -1,0 +1,160 @@
+"""Read side of the control-plane substrate (spec §8).
+
+A thin, typed wrapper over a ktables ``GroupedKafkaTable`` that collapses the
+instance-keyed (``node_id × worker_id``) storage to a live ``node_id -> record``
+view, applying advisory staleness and a schema-version filter. Generic over the
+record type ``R``; it knows only the :class:`ControlPlaneRecord` base (for
+liveness), so it stays use-case-blind.
+
+ktables is imported lazily inside :meth:`ControlPlaneView.open` (the existing
+in-function pattern in ``worker.py``), so importing this module pulls no ktables
+— which keeps the node layer ktables-free even though ``BaseNodeDef`` transitively
+imports the ``calfkit.controlplane`` package.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
+
+from pydantic_core import PydanticUndefined
+
+from calfkit.controlplane.config import STALE_MULTIPLIER
+from calfkit.controlplane.records import ControlPlaneRecord
+from calfkit.exceptions import RegistryConfigError
+
+if TYPE_CHECKING:
+    from ktables import TableStatus
+
+R = TypeVar("R", bound=ControlPlaneRecord)
+
+
+class GroupedTableReader(Protocol):
+    """The subset of ktables' ``GroupedKafkaTable`` read API the view uses.
+
+    A plain dict-backed fake satisfies it, which is the entire unit-test strategy
+    (no broker, no ktables).
+    """
+
+    def groups(self) -> set[str]: ...
+
+    def members(self, group: str) -> dict[str, Any]: ...
+
+    @property
+    def status(self) -> TableStatus: ...
+
+    @property
+    def failure(self) -> BaseException | None: ...
+
+    @property
+    def is_caught_up(self) -> bool: ...
+
+    async def barrier(self, timeout: float | None = None) -> bool: ...
+
+    async def wait_until_caught_up(self, timeout: float | None = None) -> bool: ...
+
+    async def start(self) -> None: ...
+
+    async def stop(self) -> None: ...
+
+
+class ControlPlaneView(Generic[R]):
+    """A live, collapsed ``node_id -> record`` view of one control-plane topic.
+
+    Reads are liveness-aware: a node's instances are filtered to the supported,
+    non-stale set, then collapsed to one (the most-recently-heartbeated). This
+    gives the invariant ``get(g) is not None  <=>  g in online_nodes()``.
+    """
+
+    def __init__(self, table: GroupedTableReader, record_type: type[R], *, stale_after: float | None = None) -> None:
+        field = record_type.model_fields["schema_version"]
+        if field.default is PydanticUndefined:
+            raise RegistryConfigError(
+                f"{record_type.__name__} must set `schema_version: int = N`; a control-plane record "
+                "needs a concrete schema_version default for the view's version filter"
+            )
+        self._table = table
+        self._record_type = record_type
+        self._reader_version: int = field.default
+        self._stale_after = stale_after
+
+    # -- collapsed, liveness-aware reads -------------------------------------
+
+    def get(self, node_id: str) -> R | None:
+        """The one live record for ``node_id`` (most-recent heartbeat), or ``None``."""
+        live = self._live_members(node_id)
+        if not live:
+            return None
+        return max(live.values(), key=lambda record: record.last_heartbeat_at)
+
+    def online_nodes(self) -> set[str]:
+        """The node ids with at least one supported, non-stale instance."""
+        return {group for group in self._table.groups() if self._live_members(group)}
+
+    def snapshot(self) -> dict[str, R]:
+        """A ``node_id -> live record`` map for every online node."""
+        return {group: record for group in self.online_nodes() if (record := self.get(group)) is not None}
+
+    def _live_members(self, node_id: str) -> dict[str, R]:
+        """Members that are supported (schema) and live (staleness) — filter, no tie-break."""
+        now = datetime.now(tz=timezone.utc)
+        live: dict[str, R] = {}
+        for worker_id, record in self._table.members(node_id).items():
+            if record.schema_version > self._reader_version:
+                continue  # skip records written by a newer schema major (spec §8)
+            threshold = self._stale_after if self._stale_after is not None else STALE_MULTIPLIER * record.heartbeat_interval
+            if (now - record.last_heartbeat_at).total_seconds() > threshold:
+                continue  # stale (spec §9)
+            live[worker_id] = record
+        return live
+
+    # -- health passthrough (closes frozen-view blindness, spec §9) ----------
+
+    @property
+    def status(self) -> TableStatus:
+        return self._table.status
+
+    @property
+    def failure(self) -> BaseException | None:
+        return self._table.failure
+
+    @property
+    def is_caught_up(self) -> bool:
+        return self._table.is_caught_up
+
+    async def barrier(self, timeout: float | None = None) -> bool:
+        return await self._table.barrier(timeout)
+
+    async def wait_until_caught_up(self, timeout: float | None = None) -> bool:
+        return await self._table.wait_until_caught_up(timeout)
+
+    async def start(self) -> None:
+        await self._table.start()
+
+    async def stop(self) -> None:
+        await self._table.stop()
+
+    # -- construction over a real grouped table ------------------------------
+
+    @classmethod
+    def open(
+        cls,
+        *,
+        bootstrap_servers: str,
+        topic: str,
+        record_type: type[R],
+        catchup_timeout: float = 30.0,
+        ensure_topic: bool = False,
+        stale_after: float | None = None,
+    ) -> ControlPlaneView[R]:  # pragma: no cover - exercised in the kafka lane
+        """Open a view over a real ``GroupedKafkaTable``. The caller still awaits ``start()``."""
+        from ktables import GroupedKafkaTable
+
+        table: GroupedTableReader = GroupedKafkaTable.json(
+            bootstrap_servers=bootstrap_servers,
+            topic=topic,
+            model=record_type,
+            catchup_timeout=catchup_timeout,
+            ensure_topic=ensure_topic,
+        )
+        return cls(table, record_type, stale_after=stale_after)

--- a/calfkit/controlplane/view.py
+++ b/calfkit/controlplane/view.py
@@ -14,6 +14,7 @@ imports the ``calfkit.controlplane`` package.
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
 
@@ -25,6 +26,8 @@ from calfkit.exceptions import RegistryConfigError
 
 if TYPE_CHECKING:
     from ktables import TableStatus
+
+logger = logging.getLogger(__name__)
 
 R = TypeVar("R", bound=ControlPlaneRecord)
 
@@ -77,36 +80,68 @@ class ControlPlaneView(Generic[R]):
         self._record_type = record_type
         self._reader_version: int = field.default
         self._stale_after = stale_after
+        self._logged_skips: set[tuple[str, str, int]] = set()  # (node, worker, version) already warned about
 
     # -- collapsed, liveness-aware reads -------------------------------------
 
     def get(self, node_id: str) -> R | None:
         """The one live record for ``node_id`` (most-recent heartbeat), or ``None``."""
-        live = self._live_members(node_id)
-        if not live:
-            return None
-        return max(live.values(), key=lambda record: record.last_heartbeat_at)
+        live = self._live_members(node_id, datetime.now(tz=timezone.utc))
+        return max(live.values(), key=lambda record: record.last_heartbeat_at) if live else None
 
     def online_nodes(self) -> set[str]:
         """The node ids with at least one supported, non-stale instance."""
-        return {group for group in self._table.groups() if self._live_members(group)}
+        now = datetime.now(tz=timezone.utc)
+        return {group for group in self._table.groups() if self._live_members(group, now)}
 
     def snapshot(self) -> dict[str, R]:
-        """A ``node_id -> live record`` map for every online node."""
-        return {group: record for group in self.online_nodes() if (record := self.get(group)) is not None}
+        """A ``node_id -> live record`` map for every online node.
 
-    def _live_members(self, node_id: str) -> dict[str, R]:
-        """Members that are supported (schema) and live (staleness) — filter, no tie-break."""
+        Uses one ``now`` for the whole snapshot (consistent across groups) and
+        computes each group's live set exactly once — it never recomputes via
+        ``online_nodes()``/``get()`` nor samples the clock twice for one group.
+        """
         now = datetime.now(tz=timezone.utc)
+        out: dict[str, R] = {}
+        for group in self._table.groups():
+            live = self._live_members(group, now)
+            if live:
+                out[group] = max(live.values(), key=lambda record: record.last_heartbeat_at)
+        return out
+
+    def _live_members(self, node_id: str, now: datetime) -> dict[str, R]:
+        """Members that are supported (schema) and live (staleness) — filter, no tie-break."""
         live: dict[str, R] = {}
         for worker_id, record in self._table.members(node_id).items():
             if record.schema_version > self._reader_version:
-                continue  # skip records written by a newer schema major (spec §8)
+                self._log_schema_skip(node_id, worker_id, record.schema_version)
+                continue
             threshold = self._stale_after if self._stale_after is not None else STALE_MULTIPLIER * record.heartbeat_interval
             if (now - record.last_heartbeat_at).total_seconds() > threshold:
                 continue  # stale (spec §9)
             live[worker_id] = record
         return live
+
+    def _log_schema_skip(self, node_id: str, worker_id: str, schema_version: int) -> None:
+        """Warn once per ``(node, worker, version)`` that a newer-schema record is hidden (spec §8).
+
+        A record from a newer schema major decodes fine but is unsupported here, so it
+        is filtered out — which would otherwise make a live node silently vanish from the
+        view. Dedup keeps this off the read hot-path; a further major re-warns, and it
+        self-heals once the reader upgrades.
+        """
+        key = (node_id, worker_id, schema_version)
+        if key in self._logged_skips:
+            return
+        self._logged_skips.add(key)
+        logger.warning(
+            "control-plane view hiding node=%s worker=%s: record schema_version=%d > reader version=%d "
+            "(node invisible to this reader until it upgrades)",
+            node_id,
+            worker_id,
+            schema_version,
+            self._reader_version,
+        )
 
     # -- health passthrough (closes frozen-view blindness, spec §9) ----------
 

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -16,6 +16,7 @@ from pydantic import PydanticSchemaGenerationError, TypeAdapter, ValidationError
 from calfkit._protocol import HDR_EMITTER, HDR_EMITTER_KIND, HDR_ERROR_TYPE, HDR_KIND, HDR_ROUTE, MessageKind, NodeKind, decode_header_str
 from calfkit._registry import RegistryMixin, handler
 from calfkit._routing import is_concrete_route_key, match_chain
+from calfkit.controlplane.advert import AdvertRegistryMixin
 from calfkit.exceptions import NodeFaultError, RegistryConfigError, SeamContractError, safe_exc_message
 from calfkit.models import (
     Call,
@@ -217,7 +218,7 @@ class _SlotFailed:
 # ---------------------------------------------------------------------------
 
 
-class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin):
+class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin, AdvertRegistryMixin):
     _worker: "Worker | None" = None
     """Back-reference to the owning worker, set by ``Worker._add_node``. ``None``
     for a node not attached to a worker. Used by :meth:`_effective_resources` to

--- a/calfkit/worker/worker.py
+++ b/calfkit/worker/worker.py
@@ -9,6 +9,8 @@ from faststream import FastStream
 from typing_extensions import Self
 
 from calfkit.client import Client
+from calfkit.controlplane.config import ControlPlaneConfig
+from calfkit.controlplane.publisher import ControlPlanePublisher
 from calfkit.models.capability import CAPABILITY_VIEW_RESOURCE_KEY, CapabilityRecord
 from calfkit.models.tool_dispatch import ToolSelector
 from calfkit.nodes import BaseNodeDef
@@ -17,6 +19,7 @@ from calfkit.worker.lifecycle import (
     PHASE_PAIRS,
     LifecycleContext,
     LifecycleHookMixin,
+    ResourceGenFn,
     ResourceSetupContext,
     ServingContext,
     SupportsLifecycleHooks,
@@ -66,6 +69,7 @@ class Worker(LifecycleHookMixin):
         id: str | None = None,
         name: str | None = None,
         mcp_discovery: MCPDiscoveryConfig | None = None,
+        control_plane: ControlPlaneConfig | None = None,
     ):
         """Initialize a worker.
 
@@ -90,6 +94,10 @@ class Worker(LifecycleHookMixin):
                 (topic, catch-up timeout, bootstrap override). Entirely
                 optional — the Capability View is auto-registered with
                 defaults whenever a hosted agent declares MCP tool selectors.
+            control_plane: Optional tuning for the control-plane substrate
+                (heartbeat interval, staleness, catch-up timeout, bootstrap
+                override). The publisher is auto-registered with defaults
+                whenever a hosted node declares an advert (``@advertises``).
         """
         if id is not None and not id.strip():
             raise ValueError("id must be a non-empty string or None")
@@ -97,6 +105,7 @@ class Worker(LifecycleHookMixin):
             raise ValueError("name must be a non-empty string or None")
         self._client = client
         self._mcp_discovery = mcp_discovery if mcp_discovery is not None else MCPDiscoveryConfig()
+        self._control_plane = control_plane if control_plane is not None else ControlPlaneConfig()
         self._max_workers = max_workers
         self._group_id = group_id
         self._extra_publish_kwargs = extra_publish_kwargs
@@ -105,6 +114,7 @@ class Worker(LifecycleHookMixin):
         self._id = id if id is not None else uuid_utils.uuid7().hex
         self._name = name if name is not None else self._id
         self._started = False
+        self._control_plane_publisher: ControlPlanePublisher | None = None
 
         # Lifecycle bracket stacks. ``resource`` brackets (callbacks + @resource)
         # are entered before the broker starts and torn down after it stops;
@@ -222,6 +232,55 @@ class Worker(LifecycleHookMixin):
             bootstrap = servers if isinstance(servers, str) else ",".join(servers) if servers else None
         return bootstrap
 
+    def _maybe_register_control_plane(self) -> None:
+        """Auto-register the control-plane publisher + per-topic writers (spec §7).
+
+        Zero user wiring: iff any hosted node declares an advert (``@advertises``),
+        register ONE ``GroupedKafkaTableWriter`` resource per distinct advert topic
+        and wire the worker-owned :class:`ControlPlanePublisher` into the serving
+        lifecycle (``after_startup`` publishes + heartbeats; ``on_shutdown``
+        tombstones). Done synchronously here, before the resource phase, so the
+        writers exist when the publisher starts. Idempotent (guarded by the
+        publisher being set once).
+        """
+        if self._control_plane_publisher is not None:
+            return
+        adverts = [(node, info) for node in self._nodes for info in type(node)._adverts.values()]
+        if not adverts:
+            return
+        # Distinct topics => distinct writer keys, registered once; the publisher-set
+        # guard above makes the whole method idempotent, so no per-key dedup is needed.
+        for topic in {info.topic for _, info in adverts}:
+            self.resource(name=ControlPlanePublisher._writer_key(topic))(self._make_control_plane_writer_resource(topic))
+        publisher = ControlPlanePublisher(worker_id=self.id, adverts=adverts, config=self._control_plane)
+        self._control_plane_publisher = publisher
+        self.after_startup(publisher.start)
+        self.on_shutdown(publisher.stop)
+
+    def _make_control_plane_writer_resource(self, topic: str) -> ResourceGenFn["Worker"]:
+        """Build the ``@resource`` genfn that opens a ``GroupedKafkaTableWriter`` for ``topic``."""
+
+        async def _resource(ctx: ResourceSetupContext["Worker"]) -> AsyncIterator[Any]:
+            from ktables import GroupedKafkaTableWriter  # ktables import stays in the worker layer
+
+            bootstrap = self._control_plane.bootstrap_servers or self._derive_bootstrap_servers()
+            if not bootstrap:
+                raise RuntimeError(
+                    f"cannot derive Kafka bootstrap servers for control-plane topic {topic!r} "
+                    "(client built without connect()?); set ControlPlaneConfig(bootstrap_servers=...)."
+                )
+            writer: GroupedKafkaTableWriter[Any] = GroupedKafkaTableWriter.json(
+                bootstrap_servers=bootstrap,
+                topic=topic,
+                # Writers ensure only in dev/CI; production topics are ops-governed.
+                ensure_topic=self._client._provisioning.enabled,
+            )
+            await writer.start()
+            yield writer
+            await writer.stop()
+
+        return _resource
+
     def register_handlers(self) -> None:
         """Register FastStream subscribers + publishers for every node.
 
@@ -233,6 +292,7 @@ class Worker(LifecycleHookMixin):
             logger.debug("register_handlers() called again; skipping (already prepared)")
             return
         self._maybe_register_capability_view()
+        self._maybe_register_control_plane()
         # Record the nodes we are about to register as the single source of
         # truth for ``_declare_startup_topics``. Snapshot (not alias) so later
         # ``add_nodes`` calls can't retroactively widen the provisioned set

--- a/calfkit/worker/worker.py
+++ b/calfkit/worker/worker.py
@@ -10,7 +10,7 @@ from typing_extensions import Self
 
 from calfkit.client import Client
 from calfkit.controlplane.config import ControlPlaneConfig
-from calfkit.controlplane.publisher import ControlPlanePublisher
+from calfkit.controlplane.publisher import ControlPlanePublisher, control_plane_writer_key
 from calfkit.models.capability import CAPABILITY_VIEW_RESOURCE_KEY, CapabilityRecord
 from calfkit.models.tool_dispatch import ToolSelector
 from calfkit.nodes import BaseNodeDef
@@ -251,7 +251,7 @@ class Worker(LifecycleHookMixin):
         # Distinct topics => distinct writer keys, registered once; the publisher-set
         # guard above makes the whole method idempotent, so no per-key dedup is needed.
         for topic in {info.topic for _, info in adverts}:
-            self.resource(name=ControlPlanePublisher._writer_key(topic))(self._make_control_plane_writer_resource(topic))
+            self.resource(name=control_plane_writer_key(topic))(self._make_control_plane_writer_resource(topic))
         publisher = ControlPlanePublisher(worker_id=self.id, adverts=adverts, config=self._control_plane)
         self._control_plane_publisher = publisher
         self.after_startup(publisher.start)

--- a/docs/adr/0010-instance-keyed-control-plane-storage-collapsed-view.md
+++ b/docs/adr/0010-instance-keyed-control-plane-storage-collapsed-view.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # Control-plane records are instance-keyed, but the view collapses to one record per node

--- a/docs/adr/0010-instance-keyed-control-plane-storage-collapsed-view.md
+++ b/docs/adr/0010-instance-keyed-control-plane-storage-collapsed-view.md
@@ -34,6 +34,16 @@ Considered and rejected:
   avoids, and it still wouldn't detect crashes without a TTL. Rejected. Instance-keying with a
   read-side grouping is the lightweight, canonical secondary-index pattern.
 
+Identity lives **only in the key**, never in the record value. The value carries the worker stamp
+(boot time, last heartbeat, cadence) + `schema_version` + content; `node_id`/`worker_id` are the wire
+key (group × member) and every reader derives them from it. Duplicating them in the value would be
+redundant and — worse — *driftable* (a factory could return a value whose `node_id` disagreed with
+its key, and the collapsed view reads value and key from different sides). Keeping identity key-only
+makes that disagreement unrepresentable; the modest cost is that a raw value-only dump identifies a
+record by its key rather than a self-describing `node_id` field. The base `ControlPlaneRecord` then
+extends a small `ControlPlaneStamp` (boot + liveness + cadence) so those worker-stamped fields are
+declared once.
+
 A related record-shape decision, made for the same reason — correct reads across the read/write
 process boundary: **the writer's heartbeat cadence travels on the record.** Whether an instance is
 still alive ("staleness") is judged on the *read* side, but a reader is routinely a *different*

--- a/docs/adr/0010-instance-keyed-control-plane-storage-collapsed-view.md
+++ b/docs/adr/0010-instance-keyed-control-plane-storage-collapsed-view.md
@@ -1,0 +1,54 @@
+---
+status: proposed
+---
+
+# Control-plane records are instance-keyed, but the view collapses to one record per node
+
+A control-plane topic carries one self-published record per node that advertises on it.
+Multiple replicas of the same node (same `node_id`) run across workers — that is the default
+scaling path, not an edge case. If records were keyed flat by `node_id`, the replicas would share
+one key: their heartbeats clobber each other under last-write-wins (the liveness timestamp flaps
+between replicas' clocks), and — worse — one replica's clean-shutdown tombstone `delete`s the key,
+blanking a node that is still alive on another replica. That is the replica-flap defect (CRITICAL-1
+in the prior capability-plane review).
+
+We store records **instance-keyed** in a ktables `GroupedKafkaTable`: `group = node_id`,
+`member = worker_id` (= `Worker.id`). Each writer owns its own key, so writes are
+single-writer-per-key by construction — no cross-process read-modify-write, no lost-update race, and
+each replica's tombstone removes only its own member. The "set of instances per node" becomes a
+read-side grouping rather than a contended shared value.
+
+The read side, `ControlPlaneView`, **collapses** that grouping back to a live `node_id → record`
+map: stale members are filtered out and one live record is returned per node (replicas of a node
+advertise equivalent content, so any live instance answers; ties break on most-recent heartbeat).
+`worker_id` and the per-instance structure are deliberately hidden from consumers in v1.
+
+Considered and rejected:
+
+- **Flat keying by `node_id`.** Simplest — the table *is* the `node_id → record` map with no
+  collapse — but it carries the replica flap and the lost-update race under the multi-replica
+  default. Rejected.
+- **A single node-keyed record holding a collection of instances.** Needs cross-process
+  read-modify-write, which Kafka cannot make safe without a co-partitioned aggregator (a stateful
+  consume-aggregate-produce service with ownership/rebalance) — heavy infrastructure this project
+  avoids, and it still wouldn't detect crashes without a TTL. Rejected. Instance-keying with a
+  read-side grouping is the lightweight, canonical secondary-index pattern.
+
+A related record-shape decision, made for the same reason — correct reads across the read/write
+process boundary: **the writer's heartbeat cadence travels on the record.** Whether an instance is
+still alive ("staleness") is judged on the *read* side, but a reader is routinely a *different*
+process than the writer (an agent worker reads a plane a toolbox worker writes), or a config-less
+out-of-process reader (an ops CLI). If the staleness threshold lived only in the reader's config, a
+reader defaulting to `3 × 30s` would wrongly mark a writer that heartbeats every `60s` as stale. So
+`ControlPlaneRecord` carries `heartbeat_interval`, and the view derives `stale_after = N ×
+record.heartbeat_interval` from the value on the wire. *Rejected:* keeping the threshold in reader
+config and documenting that readers must match the writers' cadence — it silently false-positives
+staleness on any mismatch and is uncomputable for a reader that never publishes. The cost is one
+small float duplicated on every record; the benefit is that staleness is self-describing and immune
+to reader/writer config drift.
+
+Consequences: collapsing in the view defers per-instance access; if a future use case needs all
+instances of a node (e.g. load-balancing asks across replicas), an `instances(node_id) ->
+dict[worker_id, R]` accessor is a purely additive change — the grouped storage already holds the
+data. The keying is on the wire (the composite Kafka message key), so changing it later is a topic
+re-key (a migration); that is why it is fixed now rather than deferred.

--- a/docs/adr/0011-worker-owned-control-plane-publisher.md
+++ b/docs/adr/0011-worker-owned-control-plane-publisher.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # The worker owns the control-plane publisher; nodes contribute only record content

--- a/docs/adr/0011-worker-owned-control-plane-publisher.md
+++ b/docs/adr/0011-worker-owned-control-plane-publisher.md
@@ -1,0 +1,38 @@
+---
+status: proposed
+---
+
+# The worker owns the control-plane publisher; nodes contribute only record content
+
+A node advertises a record to a control-plane topic, re-published periodically as a liveness
+heartbeat and tombstoned on clean shutdown. The obvious approach — the one the shipped MCP capability
+plane uses — is per-node: each node owns its own writer, its own heartbeat loop, and its own
+tombstone (`MCPToolboxNode._capability_writer` / `_heartbeat_loop` / `_tombstone_on_shutdown`). We move
+all of that up to the worker.
+
+The deciding fact is that **liveness is a per-process fact, while record content is a per-node
+fact.** A node cannot be "down" while its hosting worker is "up" — there is no per-node crash
+independent of the process. So a per-node heartbeat emits N liveness signals for one liveness fact,
+and duplicates the genuinely tricky cancel-then-tombstone ordering N times (the flag-first /
+cancel-the-loop / then-`delete` dance that stops a straggler `set()` from resurrecting a tombstoned
+record).
+
+We therefore make the **worker** own a single `ControlPlanePublisher`: one heartbeat loop and one
+ordered tombstone pass for every hosted node, owning the instance identity (`worker_id`), the writes
+themselves, and the shutdown ordering. A **node contributes only its record content** via a
+class-level `@advertises(topic, record)` factory that the worker calls with a worker-stamped
+identity envelope (`node_id`, `worker_id`, `started_at`, `last_heartbeat_at`). The worker treats the
+returned record opaquely — it never imports `CapabilityRecord` or `AgentCard` — which is what keeps
+the substrate generic across every control plane (capability, agents, and the future access-policy
+and reconfig planes).
+
+Considered and rejected: **per-node writers** (the shipped pattern). Rejected for the N-signals and
+N-tombstone-dances duplication, and because centralizing the resurrection-safe ordering *once* is
+the substrate's whole reason to exist.
+
+Consequences: content propagation is **pull** — the loop calls each advert factory once per tick, so
+a content change lands at the next heartbeat rather than instantly. All writes funnel through the
+publisher (serialized against the tombstone pass), so a later `publish_now()` push for immediate
+propagation is an additive extension rather than a redesign. The node/worker split means a node
+author writes a small content factory, not lifecycle or transport plumbing; the publisher is
+auto-registered on a worker whenever any hosted node declares an advert, so there is no wiring to do.

--- a/docs/control-plane-howto.md
+++ b/docs/control-plane-howto.md
@@ -1,0 +1,154 @@
+# How to add a control plane to your nodes
+
+This guide shows you how to make a fleet of nodes publish a record onto a
+control-plane topic and read it back as a live, collapsed view of which nodes are
+online and what they offer. This is the pattern behind capability discovery,
+agent discovery, and access-policy planes.
+
+It assumes you already work with calfkit nodes and workers. For *why* the
+substrate is shaped this way — instance-keying, advisory staleness, the
+worker/node split — read [About the control-plane substrate](control-plane-substrate.md)
+instead.
+
+> The records and nodes below are **illustrative**. The substrate ships as
+> machinery; concrete planes land in their own changes. Use these as a template,
+> not as an import.
+
+## 1. Define the record
+
+Subclass `ControlPlaneRecord` and add your plane's content. The one hard rule:
+**set a concrete `schema_version`** — the base omits it on purpose so a forgotten
+version fails loudly when you open a view, not silently at read time.
+
+```python
+from calfkit import ControlPlaneRecord
+
+class ServiceCard(ControlPlaneRecord):
+    schema_version: int = 1      # required: every record type pins its own version
+    dispatch_topic: str          # your plane's content...
+    role: str
+```
+
+Do not add `node_id`/`worker_id` fields — identity is the wire key, not record
+content. Inherited from the base you already get `started_at`,
+`last_heartbeat_at`, and `heartbeat_interval`; the publisher fills those.
+
+## 2. Advertise it from a node
+
+Decorate a method with `@advertises(topic=..., record=...)` on any node (the
+hook lives on every `BaseNodeDef` subclass — agents, tool nodes, consumers). The
+method is a *content factory*: it receives a bare `ControlPlaneStamp` and returns
+a fully-formed record.
+
+```python
+from calfkit import ControlPlaneStamp, advertises
+from calfkit.nodes import BaseNodeDef
+
+class WeatherTool(BaseNodeDef):
+
+    @advertises(topic="calf.services", record=ServiceCard)
+    def _service_card(self, stamp: ControlPlaneStamp) -> ServiceCard:
+        return ServiceCard(
+            **stamp.model_dump(),                 # boot + liveness + cadence
+            dispatch_topic=self.subscribe_topics[0],
+            role="weather",
+        )
+```
+
+Two things to get right, both because the publisher re-runs this factory on every
+heartbeat tick:
+
+- **Splat the stamp, never a full record.** `**stamp.model_dump()` spreads the
+  three worker-stamped fields. (A `ControlPlaneRecord` is itself a stamp, so
+  splatting one would smuggle in duplicate keys — a `TypeError` the type checker
+  cannot catch.)
+- **If your record carries a "last changed" timestamp,** return a value the node
+  tracks and advances only on a real change — never `now()` computed in the
+  factory, which would move every tick and mask content staleness.
+
+Declaring two adverts for the same topic on one class fails at class-definition
+time with `RegistryConfigError`.
+
+## 3. Host the node — publishing is automatic
+
+Host the node on a `Worker`. When any hosted node declares an advert, the worker
+auto-wires the publisher and one writer per advert topic; there is nothing else
+to register.
+
+```python
+from calfkit.client.client import Client
+from calfkit.worker.worker import Worker
+
+client = Client.connect("kafka:9092")
+worker = Worker(client, nodes=[WeatherTool(node_id="weather-1", subscribe_topics=["weather-1.in"])])
+await worker.run()   # after_startup publishes once + starts the heartbeat; on_shutdown tombstones
+```
+
+To tune the publisher, pass a config (every field has a working default, so this
+is optional):
+
+```python
+from calfkit import ControlPlaneConfig
+
+worker = Worker(client, nodes=[...], control_plane=ControlPlaneConfig(heartbeat_interval=15.0))
+```
+
+## 4. Read the plane
+
+Open a `ControlPlaneView` over the same topic with the same record type, start
+it, and wait for it to catch up before the first read. The view presents a live,
+collapsed `node_id → record` map.
+
+```python
+from calfkit import ControlPlaneView
+
+view: ControlPlaneView[ServiceCard] = ControlPlaneView.open(
+    bootstrap_servers="kafka:9092",
+    topic="calf.services",
+    record_type=ServiceCard,
+)
+await view.start()
+try:
+    await view.barrier()                 # wait until the compacted log has replayed
+    card = view.get("weather-1")         # the one live record, or None
+    online = view.online_nodes()         # {node_id, ...} with a live instance
+    everyone = view.snapshot()           # {node_id: record} for all online nodes
+finally:
+    await view.stop()
+```
+
+The reader needs no agreement with the writer on cadence — `heartbeat_interval`
+arrives on each record, so staleness is judged correctly even from a different
+process or a different Kafka cluster (point `bootstrap_servers` wherever the
+plane lives).
+
+To tie the view's lifecycle to a worker instead of managing it by hand, open it
+inside a `@resource` (open + `start()` on setup, `stop()` on teardown); see
+[worker lifecycle](worker-lifecycle.md).
+
+## Adapt it
+
+- **Tune staleness on the read side.** By default a node drops out of the view
+  after `3 × heartbeat_interval` with no fresh record. Override with
+  `ControlPlaneView.open(..., stale_after=45.0)` to set an explicit threshold.
+
+- **Create the topic.** With provisioning enabled (dev/CI) the worker's writer
+  creates the compacted topic idempotently — bring up either side first. In
+  production, create it out-of-band like any governed topic
+  (`cleanup.policy=compact`, RF ≥ 3); see [topic provisioning](topic-provisioning.md).
+  A view does not create topics unless you pass `ensure_topic=True`.
+
+- **Evolve the schema.** Adding a field is safe: records are tolerant readers and
+  ignore unknown fields, so old and new writers interoperate. For a *breaking*
+  change, bump `schema_version`. A view hides records whose `schema_version`
+  exceeds its own and logs a one-time warning per instance, so a node on a newer
+  schema is invisible (not misread) to an old reader until that reader upgrades.
+
+- **Expect crash vs. clean-shutdown to differ.** A node that *crashes* keeps its
+  last record until it ages out (stale-after); a node that shuts down *cleanly*
+  tombstones itself and disappears at once. Both are intended — see the
+  [explanation](control-plane-substrate.md#liveness-is-advisory-and-it-travels-on-the-record).
+
+See also: [About the control-plane substrate](control-plane-substrate.md) for the
+reasoning, and the [design spec](designs/control-plane-substrate-spec.md) for the
+exact contract.

--- a/docs/control-plane-substrate.md
+++ b/docs/control-plane-substrate.md
@@ -1,0 +1,242 @@
+# About the control-plane substrate
+
+calfkit nodes run spread across many workers and many processes. A recurring
+question follows from that: *how does one part of the mesh learn what else
+exists — which tools are online, which agents can be asked, what a node is
+allowed to do — without standing up a central registry service or wiring
+point-to-point chatter between every pair of nodes?*
+
+The **control-plane substrate** is the shared answer. This document is
+**understanding-oriented**: it explains what a control plane is, the one design
+decision the whole thing turns on, and — the part most worth your time — how
+discovery, access-policy, and other future planes are all the *same* machinery
+over *different* topics. It is not a step-by-step guide (see
+[How to add a control plane to your nodes](control-plane-howto.md)) and not the
+full contract (see the [design spec](designs/control-plane-substrate-spec.md)).
+Read it while thinking about a design, not while mid-task.
+
+The short version, which the rest unpacks:
+
+> A *control plane* is a compacted Kafka topic that nodes self-publish onto and
+> others read back as a live map. The substrate is the reusable machinery for
+> that — a record base, a worker-owned publisher, and a per-topic view —
+> deliberately separated from any single use. The one load-bearing decision:
+> records are keyed per **running instance** (`node_id × worker_id`) and
+> collapsed to one-record-per-node on read, so a node's replicas — the normal
+> scaling path — never clobber each other.
+
+---
+
+## The data plane and the control plane
+
+Borrowing the distinction from networking, Kafka, and Kubernetes: the **data
+plane** is the traffic that does the work — the calls, replies, and events nodes
+exchange on their own topics. The **control plane** is metadata *about the nodes
+themselves*: who is online, what each one offers, what each is permitted to do.
+
+The substrate carries only control-plane data. It advertises *that* a node
+exists and *what* it offers; it never carries a work message. Actually *calling*
+a node you discovered is the data plane's job — see
+[the peer-node pattern](peer-node-pattern.md) for the call side.
+
+## Three pieces
+
+A control plane is built from three generic types in `calfkit.controlplane`:
+
+- **`ControlPlaneRecord` — the *what*.** A frozen pydantic model, one per node
+  instance, living on a topic. It extends `ControlPlaneStamp` (the worker-stamped
+  `started_at`, `last_heartbeat_at`, and the writer's `heartbeat_interval`) and
+  adds a `schema_version`. A concrete plane subclasses it and adds its content —
+  a capability record might add `tools`, an agent card an `ask_topic`, an ACL
+  record an allow-list.
+- **`ControlPlanePublisher` — the *write side*.** One per worker. On a timed
+  loop it builds a fresh stamp, asks each hosted node's advert factory for a
+  record, and writes it. Boot is fail-loud (a node that cannot advertise stops
+  the worker rather than running dark); each subsequent tick is per-advert
+  resilient. A clean shutdown tombstones the records it wrote.
+- **`ControlPlaneView[R]` — the *read side*.** A typed wrapper that presents the
+  topic as a live `node_id → record` map, hiding records that are stale or from
+  an unsupported schema.
+
+Writer and reader are decoupled through the topic. They are routinely in
+*different processes* — an agent's worker reads the capability plane that a
+toolbox's worker writes — and can even sit on different Kafka clusters. Nothing
+holds an object reference across that gap; the topic is the only shared thing.
+
+## Why instance-keying, and why collapse
+
+This is the decision the substrate turns on, so it is worth unfolding.
+
+Replicas of a node share a `node_id` — running three copies of an agent for
+throughput is the *normal* path, not an edge case. If records were keyed flat by
+`node_id`, those replicas would share one key. Two bad things follow: their
+heartbeats overwrite each other under last-write-wins (the liveness timestamp
+flaps between replicas' clocks), and — worse — when one replica shuts down
+cleanly its tombstone *deletes the key*, blanking a node that is still alive on
+another replica. That is the replica-flap defect.
+
+The fix is to key records per running instance: `group = node_id`,
+`member = worker_id`, stored in a ktables `GroupedKafkaTable`. Now each writer
+owns its own key. Writes are single-writer-per-key by construction — no
+cross-process read-modify-write, no lost-update race — and each replica's
+tombstone removes only its own member. "The set of instances of a node" becomes
+a *read-side grouping* rather than a contended shared value.
+
+The view then **collapses** that grouping back to what a consumer actually wants:
+one live record per node. Stale members are filtered out and the most-recently
+heartbeated survivor is returned (replicas advertise equivalent content, so any
+live one answers). The per-instance structure is deliberately hidden in v1; if a
+later use case needs all instances of a node — say, to load-balance across
+replicas — an `instances(node_id)` accessor is a purely additive change, because
+the grouped storage already holds the data.
+
+One detail makes this robust: **identity lives only in the key, never in the
+record value.** The value carries the stamp, `schema_version`, and content;
+`node_id`/`worker_id` are the wire key and every reader derives them from it.
+Duplicating identity inside the value would make it *driftable* — a factory could
+return a value whose `node_id` disagreed with its key. Keeping identity key-only
+makes that disagreement unrepresentable. The reasoning is recorded in
+[ADR-0010](adr/0010-instance-keyed-control-plane-storage-collapsed-view.md).
+
+## Liveness is advisory, and it travels on the record
+
+Whether an instance is still alive is judged on the *read* side: a record older
+than `N × heartbeat_interval` is treated as stale and hidden (default `N = 3`).
+
+The subtlety is that the reader is often a *different process* than the writer,
+or a config-less out-of-process reader like an ops CLI. If the staleness
+threshold lived only in the reader's config, a reader defaulting to `3 × 30s`
+would wrongly mark a writer that heartbeats every `60s` as stale. So the writer's
+cadence rides **on the record** (`heartbeat_interval`), and the view derives its
+threshold from the value on the wire rather than from its own config — immune to
+reader/writer drift. A reader can still override with an explicit `stale_after`.
+
+"Advisory" is the operative word. Staleness is a heuristic over wall-clock
+heartbeats, not a lease or a consensus protocol. A *crashed* node lingers in the
+view until its records age past the threshold; a *cleanly shut down* node removes
+itself at once via the tombstone. That asymmetry is intentional — it is what lets
+the plane cost nothing more than a compacted topic, with no lease service to run.
+It is also why a control plane is for *discovery*, not for correctness-critical
+fencing: treat "online" as "very probably reachable," not as a guarantee.
+
+## What a reader sees: pull, compaction, catch-up
+
+Content is **pulled** from the node's factory every tick. The worker stamps
+liveness fresh each time, while the record's own content only changes when the
+node's underlying state does. A content change therefore lands within one
+heartbeat interval — good enough for discovery, and a sub-tick push path is a
+clean additive extension if a future consumer ever needs it.
+
+The topic is **compacted** (`cleanup.policy=compact`): Kafka keeps the last
+record per key and physically drops tombstoned keys, so the log stays
+proportional to the number of live instances rather than growing forever. A fresh
+reader rebuilds the entire map by replaying that compacted log.
+
+Reads are therefore **eventually consistent**, and the view is honest about it.
+It exposes catch-up gates (`barrier()`, `wait_until_caught_up()`, `is_caught_up`)
+so a consumer can wait for the log to replay before its first read, and it passes
+through the table's `status`/`failure` so a degraded reader is *observable*
+rather than silently serving an empty map.
+
+## The worker drives liveness; the node owns content
+
+The publisher is **worker-owned** — one loop and one tombstone pass per worker,
+covering every node it hosts. Liveness is a worker concern: the heartbeat
+reflects the health of the *process*, so the process should own it. A node
+contributes only *content*, through its `@advertises` factory; it never imports
+ktables and never runs a loop. This split, recorded in
+[ADR-0011](adr/0011-worker-owned-control-plane-publisher.md), is what lets a node
+be use-case-rich while the worker stays use-case-blind: the worker calls an
+opaque factory and publishes an opaque record, knowing nothing about capabilities
+or ACLs.
+
+## How future planes build on it
+
+This is the reason the substrate exists as machinery rather than as one feature.
+A new control plane is just **three small things**: a `ControlPlaneRecord`
+subclass, an `@advertises` factory on the nodes that participate, and a
+`ControlPlaneView[R]` over the plane's own topic. Everything else — keying,
+collapse, staleness, tombstones, catch-up — comes for free.
+
+- **Discoverability planes** (capability discovery, agent discovery) are the
+  straightforward case: nodes *self-publish* what they offer as a heartbeat. A
+  capability record carries a node's tools and dispatch topic; an agent card
+  carries an ask-topic and skills. A consumer opens a `ControlPlaneView` over the
+  plane and selects peers from the live map. The write side is exactly the
+  heartbeat publisher described above.
+
+- **An access-policy / ACL plane** ([#231](https://github.com/calf-ai/calfkit-sdk/issues/231))
+  reuses the read side *unchanged* but has a different **write authority**: its
+  records say who may call whom, and they are *operator-authored*, not
+  self-published liveness. This is the sharpest illustration of why the substrate
+  is shaped the way it is — the read machinery (`ControlPlaneView`, collapse,
+  catch-up, health) is reused verbatim; only who writes the records, and why,
+  differs.
+
+That difference in write authority is also why each plane gets **its own topic**
+rather than sharing one:
+
+1. **One topic ⇒ one record schema.** A view decodes exactly one record type; a
+   foreign payload on a shared topic would fail to decode and the node behind it
+   would silently vanish. Separate topics keep each plane's schema isolated.
+2. **Different write authorities.** A heartbeat plane is self-published and
+   expires; an ACL plane is operator-authored durable policy that should *not*
+   "go stale." One staleness posture cannot fit both.
+3. **Different lifecycles.** Retention, access control, and partitioning are
+   reasonably set per plane.
+
+So the design is *machinery + per-use-case topics* — one generic view over many
+topics — not a single shared "presence" topic. Each plane keeps its own schema,
+authority, and lifecycle while sharing every line of the substrate.
+
+## Choices and alternatives
+
+The shape above was chosen against several plausible alternatives, each rejected
+for a concrete reason:
+
+- **Flat `node_id` keying.** Simplest — the table *is* the `node_id → record`
+  map, no collapse needed — but it carries the replica flap and a lost-update
+  race under the multi-replica default. Rejected.
+- **One node-keyed record holding a collection of instances.** Needs
+  cross-process read-modify-write, which Kafka cannot make safe without a
+  co-partitioned aggregator (a stateful consume-aggregate-produce service with
+  its own ownership and rebalance handling) — heavy infrastructure this project
+  avoids, and it still wouldn't detect crashes without a TTL. Instance-keying
+  with a read-side grouping is the lightweight, canonical secondary-index
+  pattern. Rejected.
+- **One shared control-plane topic for everything.** Fails the one-schema-per-
+  topic rule and conflates write authorities and lifecycles. Rejected in favour
+  of per-use-case topics.
+- **Staleness from reader config.** Silently false-positives on any cadence
+  mismatch and is uncomputable for a reader that never publishes. Rejected;
+  cadence travels on the record instead.
+- **A central registry service.** A process to deploy, scale, secure, and fail.
+  The compacted topic *is* the registry, replicated and made durable by Kafka.
+  Rejected.
+
+## What the substrate deliberately is not
+
+- **Not messaging or RPC.** It is a directory, not a transport. Discovering a
+  node tells you it exists and how to reach it; the call itself goes over the
+  data plane.
+- **Not a presence feature.** Presence was dropped from v1; the substrate is the
+  registry-only foundation that a presence or discovery feature would build on,
+  not the feature itself.
+- **Not per-instance, yet.** v1 collapses to one record per node and has no push
+  path. Both are additive extensions, deferred until an adopter needs them.
+- **Not a fence against operational failures.** Rebalance and crash-during-publish
+  edge cases are out of scope by design; liveness is at-most-once and advisory,
+  and durable tables handle the graceful cases.
+
+---
+
+See also:
+[How to add a control plane to your nodes](control-plane-howto.md) for the
+recipe, the [design spec](designs/control-plane-substrate-spec.md) for the full
+contract, and [ADR-0010](adr/0010-instance-keyed-control-plane-storage-collapsed-view.md)
+/ [ADR-0011](adr/0011-worker-owned-control-plane-publisher.md) for the two
+decisions above.
+
+*The source tree is always the source of truth. The types and behaviour
+described here live in `calfkit/controlplane/`; if you find code that
+contradicts this document, trust the code and flag the doc for reconciliation.*

--- a/docs/designs/control-plane-substrate-impl-plan.md
+++ b/docs/designs/control-plane-substrate-impl-plan.md
@@ -1,0 +1,411 @@
+# Control-Plane Substrate — Implementation Plan
+
+- **Implements:** [`control-plane-substrate-spec.md`](./control-plane-substrate-spec.md)
+- **ADRs:** 0010 (instance-keyed storage, collapsed view, cadence-on-record), 0011 (worker-owned publisher).
+- **Method:** strict TDD (`/test-driven-development`), red→green per step; 100% coverage of new code (`/pytest-coverage`).
+- **Shape:** one cohesive PR built in the ordered steps below (pure machinery, no concrete plane). Adopters (capability migration, agent discovery) are separate later PRs.
+- **Dependency:** `ktables>=0.3.0` (already on `main`).
+
+---
+
+## 1. Principles & constraints
+
+1. **TDD.** Every step writes failing tests first, then the minimal implementation. No implementation code lands without a test that exercised it red.
+2. **Layering — keep the node layer ktables-free.** `calfkit/nodes/base.py` may import the **advert decorator + mixin** (pure Python, no ktables), but must **not** import the view or publisher (which touch ktables). Only `view.py` and `publisher.py` import `ktables`; only the worker wiring file imports the publisher. This preserves the existing rule that the agent/node layer never imports ktables (today only `worker.py` and `mcp/mcp_toolbox.py` do).
+3. **Use-case-blind machinery.** Neither the publisher nor the worker wiring imports any concrete record type. The view is generic over `R` (bound to `ControlPlaneRecord`) and is constructed by consumers (tests in v1).
+4. **No concrete plane.** v1 ships only the machinery; the integration vehicle is a **test-only** `ControlPlaneRecord` subclass + test node type.
+5. **Mirror existing idioms.** `@advertises` mirrors `@handler`/`RegistryMixin` (`calfkit/_registry.py`); the worker wiring mirrors `_maybe_register_capability_view` (`calfkit/worker/worker.py`); the publisher lifecycle mirrors `MCPToolboxNode` (`calfkit/mcp/mcp_toolbox.py`).
+
+## 2. Module layout
+
+New package `calfkit/controlplane/`:
+
+| File | Contents | Imports ktables? |
+|---|---|---|
+| `calfkit/controlplane/__init__.py` | Public exports | no (re-exports only) |
+| `calfkit/controlplane/records.py` | `ControlPlaneRecord` base, `ControlPlaneIdentity` envelope | no |
+| `calfkit/controlplane/advert.py` | `advertises` decorator, `AdvertInfo`, `AdvertRegistryMixin`, `advert_info` | no |
+| `calfkit/controlplane/config.py` | `ControlPlaneConfig`, `STALE_MULTIPLIER` | no |
+| `calfkit/controlplane/view.py` | `ControlPlaneView[R]` (+ `GroupedTableReader` Protocol for fakes) | **yes** (`GroupedKafkaTable`) |
+| `calfkit/controlplane/publisher.py` | `ControlPlanePublisher` | **yes** (`GroupedKafkaTableWriter`) |
+
+Touched existing files:
+
+| File | Change |
+|---|---|
+| `calfkit/nodes/base.py` | add `AdvertRegistryMixin` to `BaseNodeDef`'s bases (alongside `LifecycleHookMixin, RegistryMixin`); import from `calfkit.controlplane.advert` (the submodule, **not** the package `__init__`, to avoid pulling ktables into the node layer) |
+| `calfkit/worker/worker.py` | add `control_plane: ControlPlaneConfig` ctor param + `self._control_plane`; add `_maybe_register_control_plane()` (called from `register_handlers`); add `_make_control_plane_writer_resource(topic)` |
+| `calfkit/__init__.py` (or top-level exports) | export `ControlPlaneRecord`, `ControlPlaneIdentity`, `advertises`, `ControlPlaneView`, `ControlPlaneConfig` (per the existing top-level-export convention) |
+
+## 3. Component designs (precise signatures)
+
+### 3.1 `records.py`
+
+```python
+from pydantic import AwareDatetime, BaseModel, ConfigDict
+
+class ControlPlaneRecord(BaseModel):
+    model_config = ConfigDict(extra="ignore")    # tolerant reader (additive forward-compat)
+    schema_version: int                          # NO default on the base; each subclass sets one
+    node_id: str
+    worker_id: str
+    started_at: AwareDatetime
+    last_heartbeat_at: AwareDatetime
+    heartbeat_interval: float                    # the WRITER's cadence (seconds) — the C1 field
+
+class ControlPlaneIdentity(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    node_id: str
+    worker_id: str
+    started_at: AwareDatetime
+    last_heartbeat_at: AwareDatetime
+    heartbeat_interval: float
+```
+
+- The base intentionally has **no** `schema_version` default, so it is abstract-by-omission (a subclass *must* set one — `schema_version: int = N`). This is load-bearing: `ControlPlaneView` derives its reader version from that default and **rejects a record type without one** at construction (§3.4), so a missing default fails loud at view build, not as a `TypeError` on every read. Concrete records construct as `MyRecord(**identity.model_dump(), <content>)`.
+- `ControlPlaneIdentity` is what the publisher stamps and passes to factories; its 5 fields are exactly the base's non-`schema_version` fields, so `**identity.model_dump()` fills them.
+
+### 3.2 `advert.py`
+
+```python
+_ADVERT_ATTR = "__calf_advert__"
+
+@dataclass(frozen=True)
+class AdvertInfo:
+    topic: str
+    record: type[ControlPlaneRecord]
+    name: str                                    # the method/attr name on the owning class
+
+def advertises(topic: str, *, record: type[ControlPlaneRecord]) -> Callable[[F], F]:
+    # eager validation: topic non-empty; record is a ControlPlaneRecord subclass.
+    # _decorate: setattr(_unwrap(method), _ADVERT_ATTR, AdvertInfo(topic, record, method.__name__)); return method UNCHANGED.
+
+def advert_info(method) -> AdvertInfo | None: ...  # getattr(_unwrap(method), _ADVERT_ATTR, None)
+
+class AdvertRegistryMixin:
+    _adverts: ClassVar[dict[str, AdvertInfo]] = {}   # topic -> info; fresh per subclass
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)          # CHAIN — RegistryMixin also defines this
+        # walk reversed(cls.__mro__), collect _ADVERT_ATTR-marked members into {attr: info}
+        # (most-derived wins, like _handlers); build {topic: info} with topic-uniqueness:
+        #   duplicate topic across two attrs => RegistryConfigError at class definition.
+        cls._adverts = ...
+    def control_plane_adverts(self) -> dict[str, Callable[[ControlPlaneIdentity], ControlPlaneRecord]]:
+        return {topic: getattr(self, info.name) for topic, info in type(self)._adverts.items()}
+```
+
+- `_unwrap`, `RegistryConfigError`, and the marker+`__init_subclass__` structure are copied from `_registry.py` (do **not** re-implement subtly differently). Reuse `_registry._unwrap` and `calfkit.exceptions.RegistryConfigError`.
+- Coexistence with `@handler`: distinct marker attr (`__calf_advert__` ≠ `__calf_handler__`) and a separate `_adverts` registry; both `__init_subclass__`s chain via `super()`. Verified feasible.
+- `getattr(self, info.name)` resolves the **bound** method at access time, so an override-without-redecorate is reflected (same semantics as `RegistryMixin.handlers`).
+
+### 3.3 `config.py`
+
+```python
+STALE_MULTIPLIER = 3
+
+@dataclass(frozen=True)
+class ControlPlaneConfig:
+    heartbeat_interval: float = 30.0     # WRITE side: loop cadence; stamped on every record
+    stale_after: float | None = None     # READ side: override/floor; None => STALE_MULTIPLIER * record.heartbeat_interval
+    catchup_timeout: float = 30.0        # READ side: view catch-up gate bound
+    bootstrap_servers: str | None = None # both sides: split-cluster escape hatch
+    def __post_init__(self):
+        # validate heartbeat_interval > 0, catchup_timeout > 0, stale_after is None or > 0
+```
+
+### 3.4 `view.py`
+
+```python
+@runtime_checkable
+class GroupedTableReader(Protocol):       # the subset of GroupedKafkaTable the view needs; a dict-backed fake satisfies it
+    def groups(self) -> set[str]: ...
+    def members(self, group: str) -> dict[str, Any]: ...
+    @property
+    def status(self) -> "TableStatus": ...
+    @property
+    def failure(self) -> BaseException | None: ...
+    @property
+    def is_caught_up(self) -> bool: ...
+    async def barrier(self, timeout: float | None = None) -> bool: ...
+    async def wait_until_caught_up(self, timeout: float | None = None) -> bool: ...
+    async def start(self) -> None: ...
+    async def stop(self) -> None: ...
+
+R = TypeVar("R", bound=ControlPlaneRecord)
+
+class ControlPlaneView(Generic[R]):
+    def __init__(self, table: GroupedTableReader, record_type: type[R], *, stale_after: float | None = None):
+        # Resolve the reader's supported version from R's schema_version DEFAULT — and reject a
+        # record type that has no default. The abstract base ControlPlaneRecord (and any subclass
+        # that forgot the default) has `model_fields["schema_version"].default is PydanticUndefined`;
+        # comparing that with `>` later would TypeError on EVERY read. Catch it HERE, loudly:
+        #   field = record_type.model_fields["schema_version"]
+        #   if field.default is PydanticUndefined:
+        #       raise RegistryConfigError(f"{record_type.__name__} must set `schema_version: int = N`")
+        #   self._reader_version: int = field.default
+
+    @classmethod
+    def open(cls, *, bootstrap_servers, topic, record_type, catchup_timeout=30.0,
+             ensure_topic=False, stale_after=None) -> "ControlPlaneView[R]":
+        # builds GroupedKafkaTable.json(model=record_type, ...) and wraps it. (Caller still awaits .start().)
+
+    # collapsed, liveness-aware reads
+    def get(self, node_id: str) -> R | None
+    def online_nodes(self) -> set[str]
+    def snapshot(self) -> dict[str, R]
+
+    # health passthrough
+    @property
+    def status(self) -> TableStatus
+    @property
+    def failure(self) -> BaseException | None
+    @property
+    def is_caught_up(self) -> bool
+    async def barrier(self, timeout=None) -> bool
+    async def wait_until_caught_up(self, timeout=None) -> bool
+    async def start(self) -> None
+    async def stop(self) -> None
+
+    # internal
+    def _live_members(self, node_id) -> dict[str, R]   # filter: supported schema + live
+```
+
+Collapse / filter algorithm (the C2 + m4 invariants):
+
+```
+reader_version = self._reader_version    # R's schema_version default, validated non-undefined in __init__
+now = datetime.now(tz=utc)
+_live_members(node_id):
+    out = {}
+    for worker_id, rec in table.members(node_id).items():     # ktables already decoded each to R
+        if rec.schema_version > reader_version:    continue   # schema-skip (log once)
+        threshold = self._stale_after if self._stale_after is not None else STALE_MULTIPLIER * rec.heartbeat_interval
+        if (now - rec.last_heartbeat_at).total_seconds() > threshold:  continue   # stale
+        out[worker_id] = rec
+    return out
+get(node_id):       live = _live_members(node_id); return None if not live else max(live.values(), key=lambda r: r.last_heartbeat_at)
+online_nodes():     return {g for g in table.groups() if self._live_members(g)}
+snapshot():         return {g: self.get(g) for g in online_nodes()}     # all non-None by construction
+```
+
+This guarantees `get(g) is not None ⟺ g ∈ online_nodes()` (filter-then-tie-break, never the reverse). `status`/`failure`/`is_caught_up`/`barrier`/`start`/`stop`/`wait_until_caught_up` delegate to the table.
+
+### 3.5 `publisher.py`
+
+```python
+class ControlPlanePublisher:
+    def __init__(self, *, worker_id: str, adverts: list[tuple[BaseNodeDef, AdvertInfo]],
+                 config: ControlPlaneConfig):
+        self._worker_id = worker_id
+        self._adverts = adverts                 # (node, AdvertInfo)
+        self._config = config
+        self._task: asyncio.Task | None = None
+        self._shutting_down = False
+        self._started_at: AwareDatetime | None = None
+
+    async def start(self, ctx: ServingContext) -> None:        # registered as worker after_startup
+        # capture started_at, then publish each advert ONCE. A failure here PROPAGATES, aborting
+        # boot (fail-loud, matching MCPToolboxNode._publish_on_startup) — a node that cannot advertise
+        # must surface, not start silently degraded. Only after a clean first publish do we spawn
+        # the heartbeat loop.
+        self._started_at = datetime.now(tz=utc)
+        for node, info in self._adverts:
+            await self._publish_one(ctx, node, info, self._started_at)
+        self._task = asyncio.create_task(self._loop(ctx), name="control-plane-heartbeat")
+
+    async def stop(self, ctx: ServingContext) -> None:         # registered as worker on_shutdown
+        # flag FIRST (synchronous, no await above), cancel+await loop, THEN tombstone the declared
+        # cross-product. Cancel-before-delete is what makes the tombstone win — after `await task`
+        # the loop (incl. any in-flight `set`) is fully resolved/cancelled, so no `set` lands after.
+        self._shutting_down = True
+        task, self._task = self._task, None
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        for node, info in self._adverts:
+            writer = ctx.resources.get(self._writer_key(info.topic))
+            if writer is not None:
+                await writer.delete(node.node_id, self._worker_id)   # idempotent; declared cross-product
+
+    async def _loop(self, ctx) -> None:
+        # loop ticks are per-advert RESILIENT: a single bad advert is logged and the rest still
+        # publish; everything retries next tick (compaction/heartbeat heals). CancelledError propagates.
+        while True:
+            await asyncio.sleep(self._config.heartbeat_interval)
+            now = datetime.now(tz=utc)
+            for node, info in self._adverts:
+                try:
+                    await self._publish_one(ctx, node, info, now)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception("control-plane publish failed node=%s topic=%s; retry next tick",
+                                     node.node_id, info.topic)
+
+    async def _publish_one(self, ctx, node, info, now) -> None:
+        assert self._started_at is not None        # set in start() before any publish (also narrows for mypy)
+        writer = ctx.resources[self._writer_key(info.topic)]   # KeyError => wiring bug (fail-loud at start)
+        identity = ControlPlaneIdentity(
+            node_id=node.node_id, worker_id=self._worker_id, started_at=self._started_at,
+            last_heartbeat_at=now, heartbeat_interval=self._config.heartbeat_interval)
+        record = getattr(node, info.name)(identity)            # opaque ControlPlaneRecord
+        await writer.set(node.node_id, self._worker_id, record)
+
+    @staticmethod
+    def _writer_key(topic: str) -> str:
+        return f"calfkit.controlplane.writer.{topic}"
+```
+
+Notes:
+- `_publish_one` pulls content from the factory each call (pull-only). **Startup is fail-loud:** `start` publishes each advert once and lets any failure propagate (aborting boot, like `MCPToolboxNode._publish_on_startup`; on such a failure the lifecycle runs no `on_shutdown`, so a partially-published record simply goes stale — crash-equivalent and accepted). **Loop ticks are resilient:** `_loop` catches per-advert (log-and-continue; re-raise `CancelledError`), mirroring `MCPToolboxNode._heartbeat_loop`.
+- **Resurrection safety:** `stop` cancels-and-`await`s the loop *before* any `delete`, so no in-flight `set` can land after a `delete` (after `await task`, the task — including any in-flight `set` — is fully resolved or cancelled; the subsequent `delete` therefore wins). The `_shutting_down` flag is set synchronously first; it is the seam a future `publish_now()` push will check.
+- The publisher never imports a concrete record type — `getattr(node, info.name)(identity)` returns an opaque `ControlPlaneRecord`.
+
+### 3.6 Worker wiring (`worker.py`)
+
+```python
+# __init__: control_plane: ControlPlaneConfig | None = None
+self._control_plane = control_plane if control_plane is not None else ControlPlaneConfig()
+
+def _maybe_register_control_plane(self) -> None:
+    adverts = [(node, info) for node in self._nodes for info in type(node)._adverts.values()]
+    if not adverts:
+        return
+    topics = {info.topic for _, info in adverts}
+    for topic in topics:
+        key = ControlPlanePublisher._writer_key(topic)
+        if any(name == key for name, _ in self._resource_cms()):
+            continue
+        self.resource(name=key)(self._make_control_plane_writer_resource(topic))
+    publisher = ControlPlanePublisher(worker_id=self.id, adverts=adverts, config=self._control_plane)
+    self._control_plane_publisher = publisher
+    self.after_startup(publisher.start)
+    self.on_shutdown(publisher.stop)
+
+def _make_control_plane_writer_resource(self, topic: str):
+    async def _resource(ctx) -> AsyncIterator[GroupedKafkaTableWriter]:
+        from ktables import GroupedKafkaTableWriter
+        bootstrap = self._control_plane.bootstrap_servers or self._derive_bootstrap_servers()
+        if not bootstrap:
+            raise RuntimeError(f"cannot derive bootstrap servers for control-plane topic {topic!r}; "
+                               "set ControlPlaneConfig(bootstrap_servers=...).")
+        writer = GroupedKafkaTableWriter.json(
+            bootstrap_servers=bootstrap, topic=topic,
+            ensure_topic=self._client._provisioning.enabled,
+        )
+        await writer.start()
+        yield writer
+        await writer.stop()
+    return _resource
+
+# in register_handlers(), after self._maybe_register_capability_view():
+self._maybe_register_control_plane()
+```
+
+Sequencing (verified against the lifecycle): `register_handlers` runs in `_on_startup` (pre-broker) → registers the writer `@resource`s **and** the publisher's `after_startup`/`on_shutdown` hooks synchronously → the resource phase opens the writers → `after_startup` runs `publisher.start` (writers already in `ctx.resources`) → `on_shutdown` runs `publisher.stop` (writers still alive; resources close only after `after_shutdown`). A node added via `add_nodes()` after `register_handlers` (which latches `_prepared`) does not join a plane — document this boundary.
+
+## 4. Build order (TDD steps)
+
+> Each step: write the listed tests (red) → implement → green → `make fix && make check`.
+
+**Step 0 — package scaffold.** Create `calfkit/controlplane/__init__.py` (empty exports stub). No tests.
+
+**Step 1 — records (`records.py`).**
+- Tests (`tests/test_controlplane_records.py`): a test subclass `_Rec(ControlPlaneRecord)` with `schema_version=1` + a content field; construct via `_Rec(**identity.model_dump(), content=...)`; assert all base fields populate. Tolerant reader (extra field ignored). Base alone (no `schema_version`) → `ValidationError`. `ControlPlaneIdentity` is frozen.
+- Implement `records.py`.
+
+**Step 2 — advert decorator + mixin (`advert.py`) + attach to `BaseNodeDef`.**
+- Tests (`tests/test_controlplane_advert.py`): decorator returns the method unchanged (still directly callable) + stamps `AdvertInfo`; `__init_subclass__` collects `_adverts` per class; MRO override (re-decorate and override-without-redecorate both resolve to the most-derived method); duplicate topic on two methods of one class → `RegistryConfigError`; a class with **both** `@handler` and `@advertises` collects both registries independently (coexistence); a node with no adverts has empty `_adverts`. `control_plane_adverts(self)` returns `{topic: bound method}`.
+- Implement `advert.py`; add `AdvertRegistryMixin` to `BaseNodeDef` bases. Run the **full** node/handler suite to confirm no regression from the extra `__init_subclass__`.
+
+**Step 3 — config (`config.py`).**
+- Tests (`tests/test_controlplane_config.py`): defaults; `__post_init__` rejects non-positive `heartbeat_interval`/`catchup_timeout` and non-positive `stale_after` (None allowed); frozen.
+- Implement `config.py`.
+
+**Step 4 — view (`view.py`).**
+- Tests (`tests/test_controlplane_view.py`), all offline against a **dict-backed fake** table satisfying `GroupedTableReader`:
+  - `get`/`online_nodes`/`snapshot` over multiple groups/members.
+  - **Collapse:** multiple live members → most-recent `last_heartbeat_at` wins.
+  - **Staleness from the record's cadence:** a member with old `last_heartbeat_at` relative to *its own* `heartbeat_interval` is excluded; a reader `stale_after` override takes precedence.
+  - **Invariant:** `get(g) is not None ⟺ g ∈ online_nodes()` across mixed live/stale members.
+  - **Schema-skip:** a member with `schema_version` > reader version is excluded from all reads.
+  - **Health passthrough:** `status`/`failure`/`is_caught_up` reflect the fake's values; `barrier`/`start`/`stop` delegate.
+  - **Defaultless record type rejected:** constructing `ControlPlaneView` with a record type whose `schema_version` has no default raises a clear `RegistryConfigError` (red-first — guards the `PydanticUndefined` bug), not a later read-time `TypeError`.
+- Implement `view.py` (the `.open()` classmethod is covered by the integration step, not unit — it touches ktables).
+
+**Step 5 — publisher (`publisher.py`).**
+- Tests (`tests/test_controlplane_publisher.py`), offline against a **fake writer** (records `set`/`delete` calls) and a fake `ServingContext`:
+  - `start` captures `started_at`, publishes each advert once with a correct `ControlPlaneIdentity` (incl. `heartbeat_interval` from config), keyed `(node_id, worker_id)`, to the right topic's writer.
+  - **Liveness/content split (the §6 contract):** with a content-bearing test record whose `content_updated_at` is a node-tracked field, two ticks without a content change leave `content_updated_at` fixed while `last_heartbeat_at` advances; a content change moves both. (Drive two publishes via `_publish_one` with an advancing `now`, or run `_loop` at a short interval.)
+  - **Tombstone:** `stop` deletes the **declared cross-product** `(node_id, worker_id)` on every advert's topic writer; idempotent (delete of an unwritten key tolerated).
+  - **Ordering:** `stop` sets `_shutting_down` and cancels+awaits the loop before any `delete` (assert no `set` recorded after the first `delete`).
+  - **Startup is fail-loud, loop is resilient:** a factory/`set` failure during `start` **propagates** (aborts boot); during a `_loop` tick the same failure is logged, the loop survives, and other adverts in that tick still publish.
+- Implement `publisher.py`.
+
+**Step 6 — worker wiring (`worker.py`).**
+- Tests (`tests/test_controlplane_worker_wiring.py`), offline:
+  - `_maybe_register_control_plane` registers the publisher + one writer resource per distinct topic **iff** a hosted node has adverts; no adverts → nothing registered (publisher dormant).
+  - Idempotent (a second `register_handlers` does not double-register).
+  - Two node types on the same topic → one writer resource for that topic.
+  - Bootstrap derivation error path raises a clear message when underivable.
+- Implement the worker changes (ctor param, `_maybe_register_control_plane`, `_make_control_plane_writer_resource`, call site in `register_handlers`).
+
+**Step 7 — integration (kafka lane, `tests/integration/test_controlplane_substrate_kafka.py`).** Marked `@pytest.mark.kafka`, using the `kafka_bootstrap` fixture (`tests/integration/conftest.py`). A test-only record + test node type:
+  - **Round-trip:** a worker hosting an advertising node → a `ControlPlaneView.open(...)` over the topic reflects the node after `barrier()`; `get`/`online_nodes` correct.
+  - **Tombstone:** clean worker shutdown → the view drops the node after `barrier()`.
+  - **2-worker same-node replica regression (ADR-0010 / CRITICAL-1 proof):** two workers host the same `node_id`; one shuts down cleanly; the node stays online via the survivor.
+  - **Frozen-view:** a view pointed at an unreachable broker (or after the table fails) surfaces via `status`/`failure` (CRITICAL-4) — best-effort; keep robust.
+
+**Step 8 — exports, docs, polish.**
+- Top-level exports (`calfkit/__init__.py`): `ControlPlaneRecord`, `ControlPlaneIdentity`, `advertises`, `ControlPlaneView`, `ControlPlaneConfig` (follow the existing export style + `__all__`).
+- `calfkit/controlplane/__init__.py` exports all public symbols.
+- `/pytest-coverage` to 100% on the new modules; `make fix && make check` clean (offline lane) + `make test-kafka` green.
+- Flip ADR-0010 / ADR-0011 `status: proposed → accepted` at merge.
+
+## 5. Test plan summary
+
+| Layer | Where | Broker? |
+|---|---|---|
+| records, advert, config, view, publisher, worker-wiring | `tests/test_controlplane_*.py` | **no** (dict-backed fake table, fake writer, `TestKafkaBroker` where a broker object is needed) |
+| substrate round-trip / tombstone / replica regression / frozen-view | `tests/integration/test_controlplane_substrate_kafka.py` | **yes** (`@pytest.mark.kafka`, testcontainers) |
+
+- ktables' own semantics (catch-up gate, tombstone delivery, reader death) are **not** re-tested — covered by the ktables suite. calfkit tests only its policy layers: collapse, staleness-from-cadence, schema-skip, advert collection, publisher ordering/tombstone-set, wiring trigger.
+- The dict-backed fake table satisfies `GroupedTableReader` (a `Protocol`), so view unit tests need zero ktables.
+
+## 6. Cross-cutting invariants to enforce (each has a test above, except #5)
+
+1. **Filter-then-tie-break** in the view → `get(g) is not None ⟺ g ∈ online_nodes()` (Step 4).
+2. **Staleness derives from `record.heartbeat_interval`**, not reader config (Step 4) — the C1 fix.
+3. **Schema-skip lives in the view filter** (Step 4) — the m4 fix.
+4. **`content_updated_at` is node-tracked, never `now()` in a factory** — enforced by docstring on `@advertises` + the §6 contract + the Step 5 split test. The substrate cannot police it (use-case-blind); it is tested via the test record.
+5. **One topic ⇒ one schema** — a documented deployment-time contract; **no test (not policeable across node types)** — note it in the `advertises` and `ControlPlaneView` docstrings.
+6. **Tombstone = declared cross-product, idempotent** (Step 5).
+7. **Resurrection-safety:** flag-first, cancel-and-await loop before delete (Step 5).
+8. **Wiring sequence:** writer resources + serving hooks registered synchronously in `register_handlers`, before the resource phase (Step 6).
+
+## 7. Risks & edge cases
+
+- **`__init_subclass__` chaining.** Adding `AdvertRegistryMixin` to `BaseNodeDef` means two mixins define `__init_subclass__`; both must call `super().__init_subclass__(**kwargs)`. `RegistryMixin` already does. Mitigation: Step 2 runs the full existing node suite to confirm no handler-collection regression. MRO order of the bases doesn't matter (each collects into its own attr).
+- **Bootstrap on the read side.** `ControlPlaneView.open()` needs bootstrap + topic only (no writer config — cadence rides on records). A worker-hosted reader can pass `worker._derive_bootstrap_servers()`; an out-of-process reader passes its own. (v1 has no production reader; this is for adopters/tests.)
+- **Clock for staleness.** The view uses `datetime.now(tz=utc)`; unit tests set record timestamps in the past/future to exercise the threshold (no clock injection needed).
+- **`started_at` semantics.** Captured once at `publisher.start` (the worker's serving start), shared by all of this worker's records — matches "this instance's boot time."
+- **Heterogeneous cadence.** Because the threshold is computed per-member from `record.heartbeat_interval`, two writers on different intervals are each judged correctly.
+- **`add_nodes()` after prepare.** Does not join a plane (documented); not a v1 feature.
+- **`ensure_topic` provisioning.** Writers and (adopter) views set `ensure_topic=self._client._provisioning.enabled`; in prod (provisioning off) the topic is ops-governed and a missing topic fails loudly — consistent with the capability topic.
+
+## 8. Out of scope (deferred, additive later)
+
+- No concrete plane (capability/agent) — separate adopter PRs.
+- No `publish_now()` push — the `_shutting_down` flag + single write path leave the seam ready.
+- No `instances(node_id)` / annotated (`include_stale`) reads — additive when an adopter (ops, load-balancing) needs them.
+- No per-topic config override of the `@advertises` topic — additive.
+- No error-propagation concerns (deadlines, dangling, budgets).
+
+## 9. Definition of done
+
+- All Step 1–7 tests green. `/pytest-coverage` 100% on the offline-testable logic in `calfkit/controlplane/*` and the new worker code; the thin ktables-touching glue (`ControlPlaneView.open()`, the writer `@resource`) runs only in the kafka lane, so tag it `# pragma: no cover -- exercised in the kafka lane` for the offline `/pytest-coverage` pass (matching the existing repo convention).
+- `make fix && make check` clean (`make check` = lint + format + type only, no tests); `make test` (offline) and `make test-kafka` (integration) both green.
+- Public exports in place; docstrings carry the §6 invariants (one-schema, content-timestamp contract).
+- Spec + ADRs unchanged by implementation (or any necessary correction folded back, with a note); ADR-0010/0011 flipped to `accepted` at merge.
+- No node-layer ktables import introduced (grep `calfkit/nodes/` for `ktables` stays empty).

--- a/docs/designs/control-plane-substrate-impl-plan.md
+++ b/docs/designs/control-plane-substrate-impl-plan.md
@@ -23,7 +23,7 @@ New package `calfkit/controlplane/`:
 | File | Contents | Imports ktables? |
 |---|---|---|
 | `calfkit/controlplane/__init__.py` | Public exports | no (re-exports only) |
-| `calfkit/controlplane/records.py` | `ControlPlaneRecord` base, `ControlPlaneIdentity` envelope | no |
+| `calfkit/controlplane/records.py` | `ControlPlaneStamp` envelope, `ControlPlaneRecord` base (extends it) | no |
 | `calfkit/controlplane/advert.py` | `advertises` decorator, `AdvertInfo`, `AdvertRegistryMixin`, `advert_info` | no |
 | `calfkit/controlplane/config.py` | `ControlPlaneConfig`, `STALE_MULTIPLIER` | no |
 | `calfkit/controlplane/view.py` | `ControlPlaneView[R]` (+ `GroupedTableReader` Protocol for fakes) | **yes** (`GroupedKafkaTable`) |
@@ -35,7 +35,7 @@ Touched existing files:
 |---|---|
 | `calfkit/nodes/base.py` | add `AdvertRegistryMixin` to `BaseNodeDef`'s bases (alongside `LifecycleHookMixin, RegistryMixin`); import from `calfkit.controlplane.advert` (the submodule, **not** the package `__init__`, to avoid pulling ktables into the node layer) |
 | `calfkit/worker/worker.py` | add `control_plane: ControlPlaneConfig` ctor param + `self._control_plane`; add `_maybe_register_control_plane()` (called from `register_handlers`); add `_make_control_plane_writer_resource(topic)` |
-| `calfkit/__init__.py` (or top-level exports) | export `ControlPlaneRecord`, `ControlPlaneIdentity`, `advertises`, `ControlPlaneView`, `ControlPlaneConfig` (per the existing top-level-export convention) |
+| `calfkit/__init__.py` (or top-level exports) | export `ControlPlaneRecord`, `ControlPlaneStamp`, `advertises`, `ControlPlaneView`, `ControlPlaneConfig` (per the existing top-level-export convention) |
 
 ## 3. Component designs (precise signatures)
 
@@ -44,26 +44,21 @@ Touched existing files:
 ```python
 from pydantic import AwareDatetime, BaseModel, ConfigDict
 
-class ControlPlaneRecord(BaseModel):
-    model_config = ConfigDict(extra="ignore")    # tolerant reader (additive forward-compat)
-    schema_version: int                          # NO default on the base; each subclass sets one
-    node_id: str
-    worker_id: str
+class ControlPlaneStamp(BaseModel):
+    model_config = ConfigDict(frozen=True)
     started_at: AwareDatetime
     last_heartbeat_at: AwareDatetime
     heartbeat_interval: float                    # the WRITER's cadence (seconds) — the C1 field
 
-class ControlPlaneIdentity(BaseModel):
-    model_config = ConfigDict(frozen=True)
-    node_id: str
-    worker_id: str
-    started_at: AwareDatetime
-    last_heartbeat_at: AwareDatetime
-    heartbeat_interval: float
+class ControlPlaneRecord(ControlPlaneStamp):
+    model_config = ConfigDict(extra="ignore", frozen=True)  # tolerant reader (additive forward-compat)
+    schema_version: int                          # NO default on the base; each subclass sets one
 ```
 
-- The base intentionally has **no** `schema_version` default, so it is abstract-by-omission (a subclass *must* set one — `schema_version: int = N`). This is load-bearing: `ControlPlaneView` derives its reader version from that default and **rejects a record type without one** at construction (§3.4), so a missing default fails loud at view build, not as a `TypeError` on every read. Concrete records construct as `MyRecord(**identity.model_dump(), <content>)`.
-- `ControlPlaneIdentity` is what the publisher stamps and passes to factories; its 5 fields are exactly the base's non-`schema_version` fields, so `**identity.model_dump()` fills them.
+- **Identity is the wire key, not a value field (ADR-0010 Option D).** `node_id`/`worker_id` are the ktables composite key (group × member); they never live in the record value, so a value can never disagree with its key. The record carries only the worker stamp (boot + liveness + cadence) + `schema_version` + content.
+- `ControlPlaneRecord` **extends** `ControlPlaneStamp`, so the three worker-stamped fields are declared exactly once. A record *is-a* stamp-plus-`schema_version`-plus-content; `model_config` merges along the MRO (the record adds `extra="ignore"`; `frozen` is inherited).
+- The base intentionally has **no** `schema_version` default, so it is abstract-by-omission (a subclass *must* set one — `schema_version: int = N`). This is load-bearing: `ControlPlaneView` derives its reader version from that default and **rejects a record type without one** at construction (§3.4), so a missing default fails loud at view build, not as a `TypeError` on every read. Concrete records construct as `MyRecord(**stamp.model_dump(), <content>)`.
+- `ControlPlaneStamp` is what the publisher builds fresh each tick and passes to factories; its 3 fields are exactly the base's non-`schema_version` fields, so `**stamp.model_dump()` fills them.
 
 ### 3.2 `advert.py`
 
@@ -90,7 +85,7 @@ class AdvertRegistryMixin:
         # (most-derived wins, like _handlers); build {topic: info} with topic-uniqueness:
         #   duplicate topic across two attrs => RegistryConfigError at class definition.
         cls._adverts = ...
-    def control_plane_adverts(self) -> dict[str, Callable[[ControlPlaneIdentity], ControlPlaneRecord]]:
+    def control_plane_adverts(self) -> dict[str, Callable[[ControlPlaneStamp], ControlPlaneRecord]]:
         return {topic: getattr(self, info.name) for topic, info in type(self)._adverts.items()}
 ```
 
@@ -245,22 +240,22 @@ class ControlPlanePublisher:
 
     async def _publish_one(self, ctx, node, info, now) -> None:
         assert self._started_at is not None        # set in start() before any publish (also narrows for mypy)
-        writer = ctx.resources[self._writer_key(info.topic)]   # KeyError => wiring bug (fail-loud at start)
-        identity = ControlPlaneIdentity(
-            node_id=node.node_id, worker_id=self._worker_id, started_at=self._started_at,
-            last_heartbeat_at=now, heartbeat_interval=self._config.heartbeat_interval)
-        record = getattr(node, info.name)(identity)            # opaque ControlPlaneRecord
-        await writer.set(node.node_id, self._worker_id, record)
+        writer = ctx.resources[control_plane_writer_key(info.topic)]   # KeyError => wiring bug (fail-loud at start)
+        stamp = ControlPlaneStamp(
+            started_at=self._started_at,
+            last_heartbeat_at=now, heartbeat_interval=self._config.heartbeat_interval)   # NO identity (Option D)
+        record = getattr(node, info.name)(stamp)              # opaque ControlPlaneRecord
+        await writer.set(node.node_id, self._worker_id, record)   # identity is the wire key
 
-    @staticmethod
-    def _writer_key(topic: str) -> str:
-        return f"calfkit.controlplane.writer.{topic}"
+# module-level: the one shared writer-resource-key contract between worker and publisher
+def control_plane_writer_key(topic: str) -> str:
+    return f"calfkit.controlplane.writer.{topic}"
 ```
 
 Notes:
 - `_publish_one` pulls content from the factory each call (pull-only). **Startup is fail-loud:** `start` publishes each advert once and lets any failure propagate (aborting boot, like `MCPToolboxNode._publish_on_startup`; on such a failure the lifecycle runs no `on_shutdown`, so a partially-published record simply goes stale — crash-equivalent and accepted). **Loop ticks are resilient:** `_loop` catches per-advert (log-and-continue; re-raise `CancelledError`), mirroring `MCPToolboxNode._heartbeat_loop`.
 - **Resurrection safety:** `stop` cancels-and-`await`s the loop *before* any `delete`, so no in-flight `set` can land after a `delete` (after `await task`, the task — including any in-flight `set` — is fully resolved or cancelled; the subsequent `delete` therefore wins). The `_shutting_down` flag is set synchronously first; it is the seam a future `publish_now()` push will check.
-- The publisher never imports a concrete record type — `getattr(node, info.name)(identity)` returns an opaque `ControlPlaneRecord`.
+- The publisher never imports a concrete record type — `getattr(node, info.name)(stamp)` returns an opaque `ControlPlaneRecord`.
 
 ### 3.6 Worker wiring (`worker.py`)
 
@@ -312,7 +307,7 @@ Sequencing (verified against the lifecycle): `register_handlers` runs in `_on_st
 **Step 0 — package scaffold.** Create `calfkit/controlplane/__init__.py` (empty exports stub). No tests.
 
 **Step 1 — records (`records.py`).**
-- Tests (`tests/test_controlplane_records.py`): a test subclass `_Rec(ControlPlaneRecord)` with `schema_version=1` + a content field; construct via `_Rec(**identity.model_dump(), content=...)`; assert all base fields populate. Tolerant reader (extra field ignored). Base alone (no `schema_version`) → `ValidationError`. `ControlPlaneIdentity` is frozen.
+- Tests (`tests/test_controlplane_records.py`): a test subclass `_Rec(ControlPlaneRecord)` with `schema_version=1` + a content field; construct via `_Rec(**stamp.model_dump(), content=...)`; assert all base fields populate; assert identity (`node_id`/`worker_id`) is **not** a value field. Tolerant reader (extra field ignored). Base alone (no `schema_version`) → `ValidationError`. Both `ControlPlaneStamp` and `ControlPlaneRecord` are frozen.
 - Implement `records.py`.
 
 **Step 2 — advert decorator + mixin (`advert.py`) + attach to `BaseNodeDef`.**
@@ -336,7 +331,7 @@ Sequencing (verified against the lifecycle): `register_handlers` runs in `_on_st
 
 **Step 5 — publisher (`publisher.py`).**
 - Tests (`tests/test_controlplane_publisher.py`), offline against a **fake writer** (records `set`/`delete` calls) and a fake `ServingContext`:
-  - `start` captures `started_at`, publishes each advert once with a correct `ControlPlaneIdentity` (incl. `heartbeat_interval` from config), keyed `(node_id, worker_id)`, to the right topic's writer.
+  - `start` captures `started_at`, publishes each advert once with a correct `ControlPlaneStamp` (incl. `heartbeat_interval` from config), keyed `(node_id, worker_id)`, to the right topic's writer.
   - **Liveness/content split (the §6 contract):** with a content-bearing test record whose `content_updated_at` is a node-tracked field, two ticks without a content change leave `content_updated_at` fixed while `last_heartbeat_at` advances; a content change moves both. (Drive two publishes via `_publish_one` with an advancing `now`, or run `_loop` at a short interval.)
   - **Tombstone:** `stop` deletes the **declared cross-product** `(node_id, worker_id)` on every advert's topic writer; idempotent (delete of an unwritten key tolerated).
   - **Ordering:** `stop` sets `_shutting_down` and cancels+awaits the loop before any `delete` (assert no `set` recorded after the first `delete`).
@@ -358,7 +353,7 @@ Sequencing (verified against the lifecycle): `register_handlers` runs in `_on_st
   - **Frozen-view:** a view pointed at an unreachable broker (or after the table fails) surfaces via `status`/`failure` (CRITICAL-4) — best-effort; keep robust.
 
 **Step 8 — exports, docs, polish.**
-- Top-level exports (`calfkit/__init__.py`): `ControlPlaneRecord`, `ControlPlaneIdentity`, `advertises`, `ControlPlaneView`, `ControlPlaneConfig` (follow the existing export style + `__all__`).
+- Top-level exports (`calfkit/__init__.py`): `ControlPlaneRecord`, `ControlPlaneStamp`, `advertises`, `ControlPlaneView`, `ControlPlaneConfig` (follow the existing export style + `__all__`).
 - `calfkit/controlplane/__init__.py` exports all public symbols.
 - `/pytest-coverage` to 100% on the new modules; `make fix && make check` clean (offline lane) + `make test-kafka` green.
 - Flip ADR-0010 / ADR-0011 `status: proposed → accepted` at merge.

--- a/docs/designs/control-plane-substrate-impl-plan.md
+++ b/docs/designs/control-plane-substrate-impl-plan.md
@@ -269,15 +269,15 @@ Notes:
 self._control_plane = control_plane if control_plane is not None else ControlPlaneConfig()
 
 def _maybe_register_control_plane(self) -> None:
+    if self._control_plane_publisher is not None:   # idempotent: only wire once
+        return
     adverts = [(node, info) for node in self._nodes for info in type(node)._adverts.values()]
     if not adverts:
         return
-    topics = {info.topic for _, info in adverts}
-    for topic in topics:
-        key = ControlPlanePublisher._writer_key(topic)
-        if any(name == key for name, _ in self._resource_cms()):
-            continue
-        self.resource(name=key)(self._make_control_plane_writer_resource(topic))
+    # distinct topics => distinct keys, registered once; the guard above makes the whole
+    # method idempotent, so no per-key dedup is needed.
+    for topic in {info.topic for _, info in adverts}:
+        self.resource(name=control_plane_writer_key(topic))(self._make_control_plane_writer_resource(topic))
     publisher = ControlPlanePublisher(worker_id=self.id, adverts=adverts, config=self._control_plane)
     self._control_plane_publisher = publisher
     self.after_startup(publisher.start)

--- a/docs/designs/control-plane-substrate-spec.md
+++ b/docs/designs/control-plane-substrate-spec.md
@@ -76,9 +76,9 @@ A node **type** declares what it advertises with a class-level marker decorator,
 class SomeNode(BaseNodeDef):
 
     @advertises(topic="calf.capabilities", record=CapabilityRecord)
-    def _capability_record(self, identity: ControlPlaneIdentity) -> CapabilityRecord:
+    def _capability_record(self, stamp: ControlPlaneStamp) -> CapabilityRecord:
         return CapabilityRecord(
-            **identity.model_dump(),                 # worker-stamped identity + liveness
+            **stamp.model_dump(),                    # worker-stamped boot + liveness + cadence
             dispatch_topic=self.subscribe_topics[0],
             tools=self._current_tools,               # per-instance, node-owned content
             content_updated_at=self._tools_changed_at,
@@ -92,7 +92,7 @@ Design properties (all locked):
 - **Per node type, structural.** The `(topic, record)` binding lives at class scope. Instances of one type therefore advertise to the *same* topic with the *same* schema — required, because a topic's view decodes exactly one `R`; instances differ only in content and identity. The binding is collected per subclass via `__init_subclass__` (the `@handler` pattern: marker-not-wrapper — the method is returned unchanged; MRO-merged so a subclass override wins; fail-fast at class-definition on a duplicate topic, raising `RegistryConfigError`).
 - **One topic ⇒ one record schema (a global, deployment-time invariant).** A topic's `ControlPlaneView` decodes exactly one `R`, so *every* advert on a given topic — across *all* node types, not only instances of one type — must use the same record schema. The per-class duplicate-topic check above cannot catch two *different* types colliding on one topic with different schemas; that is a deployment-time contract (documented, not policed, per the framework's "document, don't police" rule). The failure mode if violated is silent: a foreign-schema payload fails the view's decode and is poison-skipped one layer below, dropping that node from the view.
 - **Opt-in.** A node is on a plane **iff** it declares an `@advertises` method for it. A node with none contributes nothing. A type may declare more than one advert (one per plane it participates in).
-- **Content-only contributor.** The decorated method is a `factory(identity) -> R`: the worker builds and passes the identity envelope, the node composes a complete, valid record in one shot — no placeholder fields, no "these are ignored" contract.
+- **Content-only contributor.** The decorated method is a `factory(stamp) -> R`: the worker builds and passes the `ControlPlaneStamp` envelope (boot + liveness + cadence; identity is the wire key, never in the value — ADR-0010), the node composes a complete, valid record in one shot — no placeholder fields, no "these are ignored" contract.
 - **Worker is use-case-blind.** The worker calls the factory and publishes the result opaquely; it never imports any concrete record type.
 
 **Content propagation is pull-only.** The worker loop calls each advert factory once per heartbeat tick, so a content change (a node mutating its own cached content, e.g. on an MCP `tools/list_changed`) lands at the **next tick** (≤ `heartbeat_interval`). Pull is *correct* (the factory reads the node's current content) and supports the liveness/content split (the worker stamps `last_heartbeat_at` fresh every tick while the record's own `content_updated_at` only moves on a real change). All writes funnel through the publisher (§7), so a future `publish_now()` nudge for immediate propagation is a clean additive extension — deferred until a consumer proves it needs sub-tick latency (only content-mutating planes like capability would; agent cards are effectively static).
@@ -114,11 +114,13 @@ Adverts are bound at `register_handlers` and `_prepared` is latched there, so a 
 
 **One writer per distinct topic.** The publisher opens **one `GroupedKafkaTableWriter` per distinct advert topic** across all hosted nodes; the single loop routes each `(node, advert)` write to that advert's topic writer.
 
-**Instance-keyed publish.** Per tick, for each hosted node and each of its adverts, the publisher builds a fresh `ControlPlaneIdentity` (`node_id=node.node_id`, `worker_id=worker.id`, `started_at`, `last_heartbeat_at=now`, `heartbeat_interval` from config), calls the advert factory, and writes:
+**Instance-keyed publish.** Per tick, for each hosted node and each of its adverts, the publisher builds a fresh `ControlPlaneStamp` (`started_at`, `last_heartbeat_at=now`, `heartbeat_interval` from config — **no identity**, per ADR-0010 Option D), calls the advert factory, and writes the returned record keyed by identity:
 
 ```python
-writer.set(group=node_id, member=worker_id, value=record)
+writer.set(group=node.node_id, member=worker_id, value=record)
 ```
+
+Identity (`node_id × worker_id`) is the wire key alone; the publisher derives it from `node.node_id` and its own `worker_id`, never from the record value.
 
 **Lifecycle** (lifting the proven `MCPToolboxNode` structure to the worker, applied uniformly):
 
@@ -217,7 +219,7 @@ The substrate is deliberately generic so each adopter is mechanical: **define a 
 ## 14. Testing
 
 - **Unit (no broker):**
-  - `ControlPlaneRecord` / `ControlPlaneIdentity` schema versioning + tolerant reader.
+  - `ControlPlaneStamp` / `ControlPlaneRecord` structure (record extends stamp; identity is the wire key, not a value field), schema versioning + tolerant reader.
   - `@advertises` collection: per-type binding, MRO override, duplicate-topic → `RegistryConfigError`, marker-not-wrapper (the decorated method stays directly callable).
   - The view's collapse + staleness filter over a fake grouped table (a plain dict): stale exclusion, the filter-then-tie-break ordering, the `get(g) is not None ⟺ g ∈ online_nodes()` invariant, and skipping a member whose `schema_version` exceeds the reader's.
   - **Staleness derives from the record's `heartbeat_interval`** — a reader configured with a *different* `heartbeat_interval` still judges a writer's records correctly.

--- a/docs/designs/control-plane-substrate-spec.md
+++ b/docs/designs/control-plane-substrate-spec.md
@@ -116,7 +116,7 @@ One **worker-owned** publisher runs **one** heartbeat loop and **one** ordered t
 **Auto-registration, sequenced (zero user wiring).** The wiring follows the existing `_maybe_register_capability_view` pattern, stated explicitly because the substrate spans multiple topics:
 
 1. During `register_handlers` (pre-broker), the worker scans the hosted node **types** for `@advertises` bindings (available at class-definition time via `__init_subclass__`, like `_handlers`).
-2. If any exist, it computes the **union of advert topics** and — **synchronously here, before the resource phase** — registers the publisher plus one writer `@resource` per distinct topic (`self.resource(key)(...)`, idempotent by name). Registering the writer resources at this point is what guarantees they exist when the resource phase runs.
+2. If any exist, it computes the **union of advert topics** and — **synchronously here, before the resource phase** — registers the publisher plus one writer `@resource` per distinct topic — one per topic, and the whole step is guarded by the publisher being set once, so it never re-registers a name. Registering the writer resources at this point is what guarantees they exist when the resource phase runs.
 3. The resource phase opens each `GroupedKafkaTableWriter` (`.json(...)`, `ensure_topic` gated on provisioning), landing them in the worker bag.
 4. `after_startup` publishes each advert once, then spawns the single heartbeat loop.
 
@@ -159,6 +159,7 @@ class ControlPlaneView(Generic[R]):
     @property
     def is_caught_up(self) -> bool: ...
     async def barrier(self, timeout: float | None = None) -> bool: ...
+    async def wait_until_caught_up(self, timeout: float | None = None) -> bool: ...
     async def start(self) -> None: ...
     async def stop(self) -> None: ...
 ```

--- a/docs/designs/control-plane-substrate-spec.md
+++ b/docs/designs/control-plane-substrate-spec.md
@@ -51,30 +51,20 @@ Defined in `CONTEXT.md` (Control plane section): **Control plane**, **Control Pl
 
 ## 5. The shared record base
 
-A thin base carries identity + liveness so the view's staleness filter depends on exactly one contract and never on a concrete record type. Every concrete plane's record extends it.
+A thin base carries the worker's per-instance liveness so the view's staleness filter depends on exactly one contract and never on a concrete record type. **Node identity (`node_id` × `worker_id`) is the wire key, never carried in the value** — every reader derives it from the key (the `GroupedKafkaTable`'s group × member), so there is nothing to drift.
 
 ```python
-class ControlPlaneRecord(BaseModel):
+class ControlPlaneStamp(BaseModel):              # frozen; the worker stamps these each tick
+    started_at: AwareDatetime                    # this instance's boot time -> uptime / restart detection
+    last_heartbeat_at: AwareDatetime             # liveness basis; refreshed every heartbeat tick
+    heartbeat_interval: float                    # the WRITER's cadence; lets any reader judge staleness (§9)
+
+class ControlPlaneRecord(ControlPlaneStamp):     # the base advertisement
     model_config = ConfigDict(extra="ignore")    # tolerant reader (additive forward-compat)
     schema_version: int                          # default set per subclass; a major bump => old readers skip
-    node_id: str                                 # = group key (kept in the value: self-describing wire record)
-    worker_id: str                               # = member key (the instance; Worker.id)
-    started_at: AwareDatetime                    # this instance's boot time -> uptime + restart detection
-    last_heartbeat_at: AwareDatetime             # liveness basis; refreshed every heartbeat tick
-    heartbeat_interval: float                    # the WRITER's cadence (seconds); lets any reader judge
-                                                 # staleness without knowing the writer's config (§9)
 ```
 
-The worker stamps all five identity/liveness fields; a concrete record adds only its use-case content. Carrying `heartbeat_interval` **on the record** is deliberate (the C1 decision): staleness is judged on the read side, and a reader is routinely a *different* process than the writer — and may be a config-less out-of-process reader — so the staleness threshold cannot live only in the reader's config; it must travel on the wire (§9, §11). The worker hands the stamped fields to the content factory as an **identity envelope**:
-
-```python
-class ControlPlaneIdentity(BaseModel):           # frozen; built fresh by the worker each tick
-    node_id: str
-    worker_id: str
-    started_at: AwareDatetime
-    last_heartbeat_at: AwareDatetime
-    heartbeat_interval: float                    # from the publisher's ControlPlaneConfig
-```
+The record **extends the stamp** (tidy structural form), so the three worker-stamped fields are declared once. A concrete record adds only its use-case content; the factory composes it as `R(**stamp.model_dump(), <content>)` and the publisher writes it under the wire key `(node_id, worker_id)` — the factory never supplies identity, so a value can't disagree with its key. Carrying `heartbeat_interval` **on the record** is deliberate (the C1 decision): staleness is judged on the read side, and a reader is routinely a *different* process than the writer — and may be a config-less out-of-process reader — so the staleness threshold cannot live only in the reader's config; it must travel on the wire (§9, §11).
 
 Schema evolution follows the existing capability pattern: per-record `schema_version` + a tolerant reader for additive fields; a major bump makes old readers treat newer records as "node invisible" (skip + log) rather than crash. The base provides `last_heartbeat_at` (the liveness basis); a content-bearing record that needs to distinguish "alive but content unchanged" adds its own `content_updated_at` (e.g. capability — see the migration spec), refreshed only when content actually changes, never by the heartbeat.
 
@@ -137,6 +127,8 @@ writer.set(group=node_id, member=worker_id, value=record)
 - *`on_shutdown`* (broker live, before stop) — set the shutdown flag **synchronously first** (no await above it), cancel-and-await the loop, then run the tombstone pass. The tombstone target is the **declared cross-product** `{(node_id, topic) : node ∈ hosted, advert ∈ type(node)'s adverts}` — `writer.delete(group=node_id, member=worker_id)` on each, **idempotent** (deleting a key never written is a harmless no-op), so the publisher needs no per-key success bookkeeping that could drift from the loop's in-flight state. **Resurrection-safety invariant:** once the flag is set, no new `set()` may be issued by *either* the tick loop *or* a future `publish_now()`, and the flag is set synchronously before the loop is cancelled — generalising `MCPToolboxNode._tombstone_on_shutdown` so a straggler write can never land after its `delete()`.
 
 **Crash behaviour** (unchanged, accepted): a hard crash skips `on_shutdown`, so the record is **not** tombstoned and instead goes stale (§9).
+
+**Persistent advert failure** (accepted, §3): the heartbeat loop is per-advert resilient — a single failing advert is logged and the rest still publish. A *persistently* failing advert (e.g. a content factory that keeps raising) logs each tick and its node goes stale while alive; escalation/recovery is the SDK-wide error-propagation layer's concern, not this loop's.
 
 **Bootstrap & provisioning.** Bootstrap servers are derived via the existing chain (`worker._derive_bootstrap_servers()` → `client.server_urls` → broker connection kwargs → explicit `ControlPlaneConfig.bootstrap_servers`). Topic compaction (`cleanup.policy=compact`) is delegated to ktables `ensure_topic` in dev/CI (provisioning enabled) or to ops in production (provisioning off by default), consistent with how the capability topic is handled today — calfkit's own provisioner cannot set compaction on a single topic in isolation (its `topic_configs` apply flat to every data topic it creates), whereas ktables `ensure_topic` defaults to `cleanup.policy=compact` for exactly this topic.
 

--- a/docs/designs/control-plane-substrate-spec.md
+++ b/docs/designs/control-plane-substrate-spec.md
@@ -1,0 +1,245 @@
+# Control-Plane Substrate — Generic Discoverability Machinery
+
+- **Status:** Draft (design) — converged in the 2026-06-18 design discussion
+- **Date:** 2026-06-18
+- **Scope:** v1 is the **reusable control-plane substrate itself** — the machinery that lets any node type advertise a record to a compacted topic and lets any worker read a live view of it. It ships as pure machinery with **no concrete plane**; the known consumers (capability discovery, agent discovery) adopt it in their own later PRs.
+- **Supersedes (for v1):** [`node-presence-substrate-spec.md`](./node-presence-substrate-spec.md). That spec framed the substrate around an always-on **presence** plane and an ops fleet view; v1 drops presence and the ops CLI entirely (see §3). The substrate-spec's §5.2 "every node contributes a presence record" framing is corrected here: presence is gone, and the contributor mechanism exists only for opt-in advertisers.
+- **Related:** ADR-0010 (instance-keyed storage, collapsed view, staleness cadence on the record), ADR-0011 (worker-owned publisher), ADR-0001 (the compacted capability topic this generalises). The follow-on adopter specs — [capability-plane migration](./capability-plane-migration-and-ops-spec.md) and [agent discovery & Ask](./agent-discovery-and-ask-spec.md) — build on this and are otherwise out of scope here.
+- **Dependency:** `ktables>=0.3.0` (already on `main`): provides `GroupedKafkaTable` / `GroupedKafkaTableWriter`.
+
+---
+
+## 1. Summary
+
+Add a reusable **control-plane substrate**: the machinery a node type uses to advertise a record to a compacted Kafka topic, and the machinery a worker uses to read a live, node-centric view of that topic. It has three pieces:
+
+- **`ControlPlaneRecord`** — the shared base every concrete record extends (identity + liveness).
+- **`ControlPlanePublisher`** — one worker-owned writer that heartbeats every hosted node's advertised records and tombstones them on clean shutdown.
+- **`ControlPlaneView[R]`** — the per-worker read-side materialisation of one control-plane topic, presented as a collapsed `node_id → record` map with an advisory-staleness filter.
+
+The substrate is **generic over the record type and parameterised by topic**: each use case (capability discovery, agent discovery, and the future access-policy and reconfig planes) instantiates it on its **own** topic with its **own** record subclass. v1 ships and tests the machinery only; it does not ship a concrete plane.
+
+This generalises the shipped MCP capability plane (`calfkit/mcp/mcp_toolbox.py`, `calfkit/models/capability.py`), which today hand-rolls heartbeat + tombstone + a single-keyed view per toolbox. That plane is **not** migrated in this PR — it keeps running on its bespoke machinery until its own migration PR adopts this substrate.
+
+## 2. Motivation
+
+- **One mechanism, many planes.** calfkit already has the capability plane and will gain agent discovery (#241), an operator ACL plane (#231), and a runtime-reconfig plane (#164). All share the same read/write shape (a compacted topic materialised behind a catch-up gate, self-published with heartbeat + tombstone). Building each bespoke is the "needed-patch-rules-mean-the-factoring-is-wrong" anti-pattern; this factors the common mechanism once.
+- **Discoverability is the v1 use.** The immediate need is for node types to be discoverable to the rest of the mesh via a global ktable. The *registry* (advertise + find) is the transferable, well-understood part; messaging (request/reply) is a separate, harder concern handled in the discovery spec, not here.
+- **Fix latent defects once.** Generalising lets the substrate fix, for every adopter, the defects the bespoke capability plane carries: the replica flap (ADR-0010) and frozen-view blindness (§9).
+
+## 3. Goals / Non-goals
+
+**Goals**
+- A generic, reusable control-plane primitive: `ControlPlaneRecord` base, `ControlPlanePublisher` (write), `ControlPlaneView[R]` (read).
+- A node-type-level plug-in interface (`@advertises`) so a use case declares "instances of this type publish record `R` to topic `T`," contributing only content.
+- Instance-keyed storage (`node_id × worker_id`) with a collapsed `node_id → record` view.
+- Advisory staleness (no TTL, no eviction).
+- Reader-death observability (`status` / `failure`) wired through the view.
+- Designed against the capability + agent record shapes so those planes adopt it mechanically.
+
+**Non-goals (explicitly out of scope)**
+- **No concrete plane.** v1 ships the machinery; capability migration, agent discovery, ACL, and reconfig are their own PRs.
+- **No messaging.** Request/reply ("Ask"), peer-as-tool adapters, and trust enforcement live in the discovery spec.
+- **No presence plane and no ops CLI.** The always-on ops fleet roster is dropped from v1 (its only consumer was ops/observability, off the request path); it may return later as just another adopter of this substrate.
+- **No push path in v1.** Content propagation is pull-only; `publish_now()` is reserved as an additive extension (§6).
+- **No error handling** — deadlines, retries, dangling-call recovery, recursion budgets — these are the SDK-wide error-propagation layer's concern.
+- **No capability-plane changes** and **no de-MCP renames** (`mcp.capabilities` → `calf.capabilities`, `MCPDiscoveryConfig` → …); those land with the capability migration PR.
+
+## 4. Vocabulary
+
+Defined in `CONTEXT.md` (Control plane section): **Control plane**, **Control Plane Record**, **Control Plane View**, **Control Plane Publisher**, **Advisory staleness**. This spec uses those terms precisely.
+
+## 5. The shared record base
+
+A thin base carries identity + liveness so the view's staleness filter depends on exactly one contract and never on a concrete record type. Every concrete plane's record extends it.
+
+```python
+class ControlPlaneRecord(BaseModel):
+    model_config = ConfigDict(extra="ignore")    # tolerant reader (additive forward-compat)
+    schema_version: int                          # default set per subclass; a major bump => old readers skip
+    node_id: str                                 # = group key (kept in the value: self-describing wire record)
+    worker_id: str                               # = member key (the instance; Worker.id)
+    started_at: AwareDatetime                    # this instance's boot time -> uptime + restart detection
+    last_heartbeat_at: AwareDatetime             # liveness basis; refreshed every heartbeat tick
+    heartbeat_interval: float                    # the WRITER's cadence (seconds); lets any reader judge
+                                                 # staleness without knowing the writer's config (§9)
+```
+
+The worker stamps all five identity/liveness fields; a concrete record adds only its use-case content. Carrying `heartbeat_interval` **on the record** is deliberate (the C1 decision): staleness is judged on the read side, and a reader is routinely a *different* process than the writer — and may be a config-less out-of-process reader — so the staleness threshold cannot live only in the reader's config; it must travel on the wire (§9, §11). The worker hands the stamped fields to the content factory as an **identity envelope**:
+
+```python
+class ControlPlaneIdentity(BaseModel):           # frozen; built fresh by the worker each tick
+    node_id: str
+    worker_id: str
+    started_at: AwareDatetime
+    last_heartbeat_at: AwareDatetime
+    heartbeat_interval: float                    # from the publisher's ControlPlaneConfig
+```
+
+Schema evolution follows the existing capability pattern: per-record `schema_version` + a tolerant reader for additive fields; a major bump makes old readers treat newer records as "node invisible" (skip + log) rather than crash. The base provides `last_heartbeat_at` (the liveness basis); a content-bearing record that needs to distinguish "alive but content unchanged" adds its own `content_updated_at` (e.g. capability — see the migration spec), refreshed only when content actually changes, never by the heartbeat.
+
+## 6. The plug-in interface — `@advertises`
+
+A node **type** declares what it advertises with a class-level marker decorator, modelled directly on the existing `@handler` / `RegistryMixin` machinery (`calfkit/_registry.py`):
+
+```python
+class SomeNode(BaseNodeDef):
+
+    @advertises(topic="calf.capabilities", record=CapabilityRecord)
+    def _capability_record(self, identity: ControlPlaneIdentity) -> CapabilityRecord:
+        return CapabilityRecord(
+            **identity.model_dump(),                 # worker-stamped identity + liveness
+            dispatch_topic=self.subscribe_topics[0],
+            tools=self._current_tools,               # per-instance, node-owned content
+            content_updated_at=self._tools_changed_at,
+        )
+```
+
+(The example uses `CapabilityRecord` illustratively — it is a future adopter's record, not part of v1. `dispatch_topic`/`tools`/`content_updated_at` are concrete-record fields the substrate base knows nothing about; `subscribe_topics[0]` is the addressable-node convention and is only meaningful for a node with a public inbox — not every plane's record is addressable, e.g. the operator ACL plane.)
+
+Design properties (all locked):
+
+- **Per node type, structural.** The `(topic, record)` binding lives at class scope. Instances of one type therefore advertise to the *same* topic with the *same* schema — required, because a topic's view decodes exactly one `R`; instances differ only in content and identity. The binding is collected per subclass via `__init_subclass__` (the `@handler` pattern: marker-not-wrapper — the method is returned unchanged; MRO-merged so a subclass override wins; fail-fast at class-definition on a duplicate topic, raising `RegistryConfigError`).
+- **One topic ⇒ one record schema (a global, deployment-time invariant).** A topic's `ControlPlaneView` decodes exactly one `R`, so *every* advert on a given topic — across *all* node types, not only instances of one type — must use the same record schema. The per-class duplicate-topic check above cannot catch two *different* types colliding on one topic with different schemas; that is a deployment-time contract (documented, not policed, per the framework's "document, don't police" rule). The failure mode if violated is silent: a foreign-schema payload fails the view's decode and is poison-skipped one layer below, dropping that node from the view.
+- **Opt-in.** A node is on a plane **iff** it declares an `@advertises` method for it. A node with none contributes nothing. A type may declare more than one advert (one per plane it participates in).
+- **Content-only contributor.** The decorated method is a `factory(identity) -> R`: the worker builds and passes the identity envelope, the node composes a complete, valid record in one shot — no placeholder fields, no "these are ignored" contract.
+- **Worker is use-case-blind.** The worker calls the factory and publishes the result opaquely; it never imports any concrete record type.
+
+**Content propagation is pull-only.** The worker loop calls each advert factory once per heartbeat tick, so a content change (a node mutating its own cached content, e.g. on an MCP `tools/list_changed`) lands at the **next tick** (≤ `heartbeat_interval`). Pull is *correct* (the factory reads the node's current content) and supports the liveness/content split (the worker stamps `last_heartbeat_at` fresh every tick while the record's own `content_updated_at` only moves on a real change). All writes funnel through the publisher (§7), so a future `publish_now()` nudge for immediate propagation is a clean additive extension — deferred until a consumer proves it needs sub-tick latency (only content-mutating planes like capability would; agent cards are effectively static).
+
+> **Contract — a factory must not re-stamp content timestamps on a tick.** Because the substrate re-runs the factory on *every* tick (unlike the shipped capability plane, which caches the built record and only re-stamps its timestamp), any "content currency" field a concrete record carries — e.g. capability's `content_updated_at` — must be returned from **a value the node tracks and advances only when its content actually changes** (the `self._tools_changed_at` in the example), never `now()` computed inside the factory. Writing `now()` in the factory re-rots the heartbeat-masks-content-staleness defect (CRITICAL-3) on every tick. The worker is use-case-blind and cannot enforce this (it does not know which field is "content"), so it is a documented contract, tested at the substrate layer with a content-bearing test record (§14).
+
+## 7. Write side — `ControlPlanePublisher`
+
+One **worker-owned** publisher runs **one** heartbeat loop and **one** ordered tombstone pass for every hosted node, per ADR-0011.
+
+**Auto-registration, sequenced (zero user wiring).** The wiring follows the existing `_maybe_register_capability_view` pattern, stated explicitly because the substrate spans multiple topics:
+
+1. During `register_handlers` (pre-broker), the worker scans the hosted node **types** for `@advertises` bindings (available at class-definition time via `__init_subclass__`, like `_handlers`).
+2. If any exist, it computes the **union of advert topics** and — **synchronously here, before the resource phase** — registers the publisher plus one writer `@resource` per distinct topic (`self.resource(key)(...)`, idempotent by name). Registering the writer resources at this point is what guarantees they exist when the resource phase runs.
+3. The resource phase opens each `GroupedKafkaTableWriter` (`.json(...)`, `ensure_topic` gated on provisioning), landing them in the worker bag.
+4. `after_startup` publishes each advert once, then spawns the single heartbeat loop.
+
+Adverts are bound at `register_handlers` and `_prepared` is latched there, so a node added via `add_nodes()` **after** the worker is prepared does **not** join a plane (no writer is registered for its topics) — the same boundary the capability path already has. Declare all advertising nodes before the worker starts.
+
+**One writer per distinct topic.** The publisher opens **one `GroupedKafkaTableWriter` per distinct advert topic** across all hosted nodes; the single loop routes each `(node, advert)` write to that advert's topic writer.
+
+**Instance-keyed publish.** Per tick, for each hosted node and each of its adverts, the publisher builds a fresh `ControlPlaneIdentity` (`node_id=node.node_id`, `worker_id=worker.id`, `started_at`, `last_heartbeat_at=now`, `heartbeat_interval` from config), calls the advert factory, and writes:
+
+```python
+writer.set(group=node_id, member=worker_id, value=record)
+```
+
+**Lifecycle** (lifting the proven `MCPToolboxNode` structure to the worker, applied uniformly):
+
+- *resource phase* — open the per-topic writers (`GroupedKafkaTableWriter.json(...)`, `ensure_topic` gated on provisioning).
+- *`after_startup`* (broker live) — publish each advert once, then spawn the single heartbeat loop.
+- *`on_shutdown`* (broker live, before stop) — set the shutdown flag **synchronously first** (no await above it), cancel-and-await the loop, then run the tombstone pass. The tombstone target is the **declared cross-product** `{(node_id, topic) : node ∈ hosted, advert ∈ type(node)'s adverts}` — `writer.delete(group=node_id, member=worker_id)` on each, **idempotent** (deleting a key never written is a harmless no-op), so the publisher needs no per-key success bookkeeping that could drift from the loop's in-flight state. **Resurrection-safety invariant:** once the flag is set, no new `set()` may be issued by *either* the tick loop *or* a future `publish_now()`, and the flag is set synchronously before the loop is cancelled — generalising `MCPToolboxNode._tombstone_on_shutdown` so a straggler write can never land after its `delete()`.
+
+**Crash behaviour** (unchanged, accepted): a hard crash skips `on_shutdown`, so the record is **not** tombstoned and instead goes stale (§9).
+
+**Bootstrap & provisioning.** Bootstrap servers are derived via the existing chain (`worker._derive_bootstrap_servers()` → `client.server_urls` → broker connection kwargs → explicit `ControlPlaneConfig.bootstrap_servers`). Topic compaction (`cleanup.policy=compact`) is delegated to ktables `ensure_topic` in dev/CI (provisioning enabled) or to ops in production (provisioning off by default), consistent with how the capability topic is handled today — calfkit's own provisioner cannot set compaction on a single topic in isolation (its `topic_configs` apply flat to every data topic it creates), whereas ktables `ensure_topic` defaults to `cleanup.policy=compact` for exactly this topic.
+
+## 8. Read side — `ControlPlaneView[R]`
+
+A thin, typed wrapper over a `GroupedKafkaTable`, generic over `R` and knowing only the `ControlPlaneRecord` base (for `last_heartbeat_at`). Per ADR-0010 the storage is instance-keyed but the view is **collapsed**:
+
+```python
+class ControlPlaneView(Generic[R]):
+    # collapsed, liveness-aware reads (one live record per node; worker_id hidden)
+    def online_nodes(self) -> set[str]: ...        # node_ids with >= 1 live instance
+    def get(self, node_id: str) -> R | None: ...   # one live record, or None
+    def snapshot(self) -> dict[str, R]: ...        # node_id -> live record (the registry map)
+
+    # health passthrough (closes frozen-view blindness)
+    @property
+    def status(self) -> TableStatus: ...           # unstarted|loading|caught_up|degraded|failed
+    @property
+    def failure(self) -> BaseException | None: ...
+    @property
+    def is_caught_up(self) -> bool: ...
+    async def barrier(self, timeout: float | None = None) -> bool: ...
+    async def start(self) -> None: ...
+    async def stop(self) -> None: ...
+```
+
+- **Collapse rule (precise).** For each group (`node_id`): first **filter** members to those that are decodable, **supported** (`schema_version ≤` the reader's version for `R`), and **live** (`age ≤ stale_after`, §9). If that filtered set is empty the node is **not online** and `get()` returns `None`; otherwise `get()` returns `max(filtered, key=last_heartbeat_at)`. `online_nodes()` is the set of groups whose filtered set is non-empty, and `snapshot()` maps each such group to its collapsed record. This makes `get(g) is not None ⟺ g ∈ online_nodes()` an **invariant** — the order is *filter-then-tie-break*, never tie-break-then-filter (the latter could select a member the filter rejected, making `get()` and `online_nodes()` disagree about the same node). Ties break on the *writer's* `last_heartbeat_at`, which is best-effort under clock skew — acceptable because replicas advertise equivalent content. The result is `Mapping`-shaped (`node_id → record`).
+- **Schema-skip lives in the view, not the consumer.** Because the collapsed view returns `R` directly (with no per-consumer resolution layer to host it), version tolerance is folded into the same filter as staleness: a member whose `schema_version` exceeds the reader's version for `R` is skipped (and logged), so `get()`/`snapshot()` only ever return supported, live records — version tolerance is a substrate concern, not something each adopter re-derives. (A payload that fails to *decode* at all — an incompatible schema on the topic — is poison-skipped by ktables one layer below and logged as a decode error; see the one-topic-one-schema invariant in §6.)
+- **Advisory staleness is the view's one piece of domain logic** (§9). `online_nodes`/`get`/`snapshot` are live-only by construction.
+- **Gating-agnostic.** The view exposes catch-up signals but does **not** impose boot-gating. Each consumer chooses: a capability view gates its `@resource` on catch-up (agents need tools at boot); a discovery view loads in the background. Gating is a consumer-wiring decision, not a property of the view.
+- **Consumer-instantiated; not auto-wired in v1.** Because v1 has no concrete plane, nothing opens a view in production — v1 ships the view as a class exercised by tests. Each adopter PR opens its own view over its own topic (capability over `calf.capabilities`, etc.). (Contrast the publisher, which *is* auto-wired so any advertiser works out of the box.) The consumer supplies the view's bootstrap servers (its own `ControlPlaneConfig.bootstrap_servers`, or its worker's `_derive_bootstrap_servers()`); a fully out-of-process reader needs only bootstrap + topic and **no writer config at all**, because the staleness cadence rides on the records (§9).
+- **Layering rule preserved.** The view is typed as a `Mapping`-like abstraction; consumers never import ktables, and a plain dict satisfies the type for unit tests.
+
+Per-instance access (`instances(node_id) -> dict[worker_id, R]`) is intentionally **not** exposed in v1; it is a purely additive future addition (the grouped storage already holds the data) for a use case that needs all replicas, e.g. load-balancing. Note that capability tool-resolution does **not** need it — the collapsed `get(toolbox_id)` *is* the "pick one live instance" reader-side merge. The only deferred consumers are the ops fleet view and replica-aware load-balancing; the capability-migration spec's current `instances(...)` wording predates the collapse decision and should be reconciled to `get(...)` when that PR lands.
+
+## 9. Staleness (advisory)
+
+A tombstone fires only on **clean** shutdown; a crash leaves the record in place and ktables never evicts. So "is this node online?" is a reader-side judgement, not a transport guarantee:
+
+- Each record carries `last_heartbeat_at` (refreshed every tick) **and `heartbeat_interval`** — the writer's cadence (§5).
+- The view treats a member as **stale** when `age = now - last_heartbeat_at > stale_after`, where `stale_after` defaults to `N × record.heartbeat_interval` (`N = 3`) — **derived from the cadence carried on the record**, so a reader judges staleness against the *writer's* declared interval regardless of the reader's own config (and a config-less out-of-process reader works with no extra knowledge). A consumer may set an explicit `stale_after` override/floor, but the default needs no reader/writer config agreement. The collapsed reads exclude stale members so a consumer never selects a probably-dead instance.
+- The view **never deletes** — there is no TTL and no sweeper.
+
+Documented assumptions (not enforced): `last_heartbeat_at` is the publisher's wall clock and `age` is the reader's; the generous `N = 3` threshold sits well above normal NTP skew. Between a crash and the threshold, a dead instance still appears (filtered only after `stale_after`); real crash *recovery* (failing pending work) is the error-propagation layer's concern, not this substrate's.
+
+Wiring `status`/`failure` through the view closes **frozen-view blindness**: a degraded/failed reader is observable rather than silently serving a stale snapshot.
+
+## 10. Storage & keying
+
+Per ADR-0010: storage is a `GroupedKafkaTable`, `group = node_id`, `member = worker_id`. Each writer owns its own key (single-writer-per-key by construction) — no read-modify-write, no lost-update race, independent tombstones. This is what makes correct multi-replica operation possible and is why the keying is fixed now (it is the on-the-wire composite message key; changing it later is a topic re-key). The composite key uses ktables' default length-prefixed injective codec; the projection to a `node_id → record` map is compute-on-read (fine at control-plane cardinality — one small record per node-instance, compacted). A future ktables change-stream would later enable an incremental index, but is not required.
+
+## 11. Config — `ControlPlaneConfig`
+
+A new generic, worker-level config holds the knobs (topics are **not** here — they live in `@advertises`):
+
+```python
+@dataclass(frozen=True)
+class ControlPlaneConfig:
+    # WRITE side (publisher)
+    heartbeat_interval: float = 30.0     # loop cadence; also STAMPED on every record (§5) so a reader
+                                         #   can judge staleness without knowing this value
+    # READ side (view)
+    stale_after: float | None = None     # optional override/floor; None => derive N * record.heartbeat_interval
+    catchup_timeout: float = 30.0        # bound on the view's catch-up gate
+    # BOTH sides
+    bootstrap_servers: str | None = None # split-cluster escape hatch; else derived from the client
+```
+
+The knobs split by side: `heartbeat_interval` is the publisher's (and is stamped on records, so it reaches readers); `stale_after` and `catchup_timeout` are the view's; `bootstrap_servers` applies to whichever side opens a table. A reader in a different process than the writer needs **no** agreement on `heartbeat_interval` — it arrives on the record (the C1 decision).
+
+`ControlPlaneConfig` is introduced *alongside* the still-live `MCPDiscoveryConfig` (which keeps serving the un-migrated capability plane). That temporary duplication is intentional and collapses when the capability migration PR folds `MCPDiscoveryConfig` into `ControlPlaneConfig`.
+
+## 12. Naming
+
+The `ControlPlane*` family (not `Discovery*`): the substrate is broader than discovery — the same machinery carries the future access-policy and reconfig planes, which are not discovery. "Discovery" is the v1 *use case*; "control plane" is the *category*. Resource-bag keys live under the `calfkit.controlplane.*` namespace.
+
+## 13. What this unlocks — and how adopters use it
+
+The substrate is deliberately generic so each adopter is mechanical: **define a record subclass, declare an `@advertises` factory, and (on the read side) open a `ControlPlaneView` over the topic.**
+
+- **Capability-plane migration** ([spec](./capability-plane-migration-and-ops-spec.md)) — `CapabilityRecord(ControlPlaneRecord)` with `tools` + `content_updated_at`; `MCPToolboxNode` replaces its bespoke writer/heartbeat/tombstone with one `@advertises("calf.capabilities", CapabilityRecord)` factory; the worker's capability view becomes a (boot-gated) `ControlPlaneView[CapabilityRecord]`. Instance-keying fixes the replica flap; the collapsed `view.get(toolbox_id)` keeps the agent-side resolution API unchanged. (Reconcile that spec's §4.2 `instances(...)` wording to `get(...)`; its ops fleet view needs the deferred `instances()`/annotated reads, added additively when ops lands.)
+- **Agent discovery** ([spec](./agent-discovery-and-ask-spec.md)) — `AgentCard(ControlPlaneRecord)` with `ask_topic` + `skills`; a discoverable agent declares `@advertises("calf.agents", AgentCard)`; peer selection opens a `ControlPlaneView[AgentCard]`. (The Ask messaging layer is separate.)
+- **Operator ACL plane (#231)** and **runtime-reconfig plane (#164)** — reuse the read-side `ControlPlaneView`; their write side differs (operator-authored, not self-published heartbeats), which is exactly why per-use-case topics + a generic view (rather than one shared topic) is the right factoring.
+
+## 14. Testing
+
+- **Unit (no broker):**
+  - `ControlPlaneRecord` / `ControlPlaneIdentity` schema versioning + tolerant reader.
+  - `@advertises` collection: per-type binding, MRO override, duplicate-topic → `RegistryConfigError`, marker-not-wrapper (the decorated method stays directly callable).
+  - The view's collapse + staleness filter over a fake grouped table (a plain dict): stale exclusion, the filter-then-tie-break ordering, the `get(g) is not None ⟺ g ∈ online_nodes()` invariant, and skipping a member whose `schema_version` exceeds the reader's.
+  - **Staleness derives from the record's `heartbeat_interval`** — a reader configured with a *different* `heartbeat_interval` still judges a writer's records correctly.
+  - **Liveness/content split (the §6 contract):** an unchanged-content tick keeps a content-bearing test record's `content_updated_at` fixed while `last_heartbeat_at` advances; a content change moves both.
+  - The publisher's tick (publish-once + heartbeat cadence) and ordered tombstone against a fake writer (records `set`/`delete` calls), including the flag-first ordering and the declared-cross-product tombstone set across multiple topics.
+- **Integration (kafka lane, real broker):**
+  - advertise → `ControlPlaneView` reflects it after `barrier()`.
+  - clean shutdown tombstones the instance; the view drops it.
+  - **2-worker same-node replica regression** (the ADR-0010 / CRITICAL-1 proof): two workers host the same `node_id`; one shuts down cleanly; the node stays online via the surviving instance.
+  - degraded/failed reader surfaces via `status`/`failure`.
+- v1 ships a **test-only** `ControlPlaneRecord` subclass and a test `BaseNodeDef` declaring `@advertises` as the integration vehicle (there is no production advertiser in v1, so the publisher is dormant in real deployments until the first adopter).
+- ktables' own semantics (catch-up gate, tombstones, reader death) are **not** re-tested in calfkit — they are covered by the ktables suite; calfkit tests its policy layers (collapse, staleness, advert collection, publisher ordering) only.
+
+## 15. Open questions
+
+- Exact resource-bag key strings under `calfkit.controlplane.*` (e.g. the publisher key, per-topic writer keys).
+- Whether `@advertises` should reuse `RegistryMixin` directly or get a parallel sibling mixin (same mechanism, separate registry) — an implementation detail to settle in the build.
+- The collapse selection (live-filter then most-recent `last_heartbeat_at`) is specified in §8; revisit only if a real adopter needs a different selection policy.

--- a/tests/integration/test_controlplane_substrate_kafka.py
+++ b/tests/integration/test_controlplane_substrate_kafka.py
@@ -1,0 +1,156 @@
+"""Integration (kafka lane): the control-plane substrate end-to-end on a real broker.
+
+A worker-owned ControlPlanePublisher writes instance-keyed records to a real
+GroupedKafkaTable; a ControlPlaneView reads them back collapsed. Covers the
+advertise→read round-trip, the clean-shutdown tombstone, the 2-worker same-node
+replica regression (ADR-0010 / CRITICAL-1), and degraded-view observability
+(CRITICAL-4). Broker supplied by the ``kafka_bootstrap`` fixture.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import Awaitable, Callable
+from types import SimpleNamespace
+
+import pytest
+from aiokafka.errors import KafkaConnectionError
+from ktables import GroupedKafkaTable, GroupedKafkaTableWriter
+
+from calfkit.controlplane import ControlPlaneConfig, ControlPlaneIdentity, ControlPlaneRecord, ControlPlaneView
+from calfkit.controlplane.advert import AdvertInfo, advertises
+from calfkit.controlplane.publisher import ControlPlanePublisher
+from calfkit.nodes import BaseNodeDef
+
+pytestmark = pytest.mark.kafka
+
+
+class _Rec(ControlPlaneRecord):
+    schema_version: int = 1
+    kind: str
+
+
+def _only_advert(node: BaseNodeDef) -> AdvertInfo:
+    return next(iter(type(node)._adverts.values()))
+
+
+async def _start_publisher(
+    bootstrap: str, topic: str, node: BaseNodeDef, worker_id: str, *, ensure_topic: bool
+) -> tuple[GroupedKafkaTableWriter[_Rec], ControlPlanePublisher, SimpleNamespace]:
+    writer: GroupedKafkaTableWriter[_Rec] = GroupedKafkaTableWriter.json(bootstrap_servers=bootstrap, topic=topic, ensure_topic=ensure_topic)
+    await writer.start()
+    pub = ControlPlanePublisher(
+        worker_id=worker_id,
+        adverts=[(node, _only_advert(node))],
+        config=ControlPlaneConfig(heartbeat_interval=0.05, bootstrap_servers=bootstrap),
+    )
+    ctx = SimpleNamespace(resources={ControlPlanePublisher._writer_key(topic): writer})
+    await pub.start(ctx)
+    return writer, pub, ctx
+
+
+async def _poll(refresh: Callable[[], Awaitable[object]], predicate: Callable[[], bool], *, tries: int = 300, delay: float = 0.02) -> bool:
+    for _ in range(tries):
+        await refresh()
+        if predicate():
+            return True
+        await asyncio.sleep(delay)
+    return predicate()
+
+
+async def test_advertise_roundtrip_and_clean_tombstone(kafka_bootstrap: str, topic_namespace: str) -> None:
+    topic = f"{topic_namespace}.presence"
+
+    class _Node(BaseNodeDef):
+        @advertises(topic=topic, record=_Rec)
+        def _record(self, identity: ControlPlaneIdentity) -> _Rec:
+            return _Rec(**identity.model_dump(), kind="agent")
+
+    node = _Node(node_id="agent-1", subscribe_topics=["agent-1.in"])
+    writer, pub, ctx = await _start_publisher(kafka_bootstrap, topic, node, "w1", ensure_topic=True)
+    view: ControlPlaneView[_Rec] = ControlPlaneView.open(bootstrap_servers=kafka_bootstrap, topic=topic, record_type=_Rec, ensure_topic=False)
+    await view.start()
+    try:
+        # round-trip: the advertised node shows up, collapsed, with its content
+        assert await _poll(view.barrier, lambda: view.get("agent-1") is not None)
+        record = view.get("agent-1")
+        assert record is not None and record.kind == "agent"
+        assert view.online_nodes() == {"agent-1"}
+
+        # clean shutdown tombstones the instance; the view drops the node
+        await pub.stop(ctx)
+        assert await _poll(view.barrier, lambda: view.get("agent-1") is None)
+        assert view.online_nodes() == set()
+    finally:
+        if pub._task is not None:
+            await pub.stop(ctx)
+        await view.stop()
+        await writer.stop()
+
+
+async def test_two_worker_same_node_replica_regression(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """ADR-0010 / CRITICAL-1: one replica's clean tombstone must not blank a node
+    that is still alive on another replica."""
+    topic = f"{topic_namespace}.presence"
+
+    class _Node(BaseNodeDef):
+        @advertises(topic=topic, record=_Rec)
+        def _record(self, identity: ControlPlaneIdentity) -> _Rec:
+            return _Rec(**identity.model_dump(), kind="agent")
+
+    # Two instances of the SAME node_id, hosted by two workers (members w-a, w-b).
+    node_a = _Node(node_id="shared", subscribe_topics=["shared.in"])
+    node_b = _Node(node_id="shared", subscribe_topics=["shared.in"])
+    writer_a, pub_a, ctx_a = await _start_publisher(kafka_bootstrap, topic, node_a, "w-a", ensure_topic=True)
+    writer_b, pub_b, ctx_b = await _start_publisher(kafka_bootstrap, topic, node_b, "w-b", ensure_topic=False)
+
+    raw: GroupedKafkaTable[_Rec] = GroupedKafkaTable.json(bootstrap_servers=kafka_bootstrap, topic=topic, model=_Rec, ensure_topic=False)
+    view: ControlPlaneView[_Rec] = ControlPlaneView.open(bootstrap_servers=kafka_bootstrap, topic=topic, record_type=_Rec, ensure_topic=False)
+    await raw.start()
+    await view.start()
+    try:
+        # both instances present under the one node_id
+        assert await _poll(raw.barrier, lambda: {"w-a", "w-b"} <= set(raw.members("shared")))
+
+        # worker A shuts down cleanly: it tombstones ONLY its own member key
+        await pub_a.stop(ctx_a)
+        assert await _poll(raw.barrier, lambda: "w-a" not in raw.members("shared"))
+
+        # the node is STILL online via the surviving instance (the proof)
+        assert "w-b" in raw.members("shared")
+        await view.barrier()
+        assert view.get("shared") is not None
+        assert view.online_nodes() == {"shared"}
+
+        # and when B also leaves, the node finally goes offline
+        await pub_b.stop(ctx_b)
+        assert await _poll(view.barrier, lambda: view.get("shared") is None)
+    finally:
+        for pub, ctx in ((pub_a, ctx_a), (pub_b, ctx_b)):
+            if pub._task is not None:
+                await pub.stop(ctx)
+        await raw.stop()
+        await view.stop()
+        await writer_a.stop()
+        await writer_b.stop()
+
+
+async def test_unreachable_view_fails_loud(topic_namespace: str) -> None:
+    """CRITICAL-4 (integration): a view that cannot reach its broker fails LOUDLY at
+    ``start()`` rather than silently serving an empty snapshot. (The status/failure
+    passthrough for a *connected-but-failing* reader is unit-tested separately —
+    ktables raises on an unreachable broker rather than serving degraded.)"""
+    view: ControlPlaneView[_Rec] = ControlPlaneView.open(
+        bootstrap_servers="127.0.0.1:1",  # nothing listening
+        topic=f"{topic_namespace}.presence",
+        record_type=_Rec,
+        catchup_timeout=3.0,
+        ensure_topic=False,
+    )
+    try:
+        with pytest.raises(KafkaConnectionError):
+            await view.start()
+    finally:
+        with contextlib.suppress(Exception):
+            await view.stop()

--- a/tests/integration/test_controlplane_substrate_kafka.py
+++ b/tests/integration/test_controlplane_substrate_kafka.py
@@ -18,7 +18,7 @@ import pytest
 from aiokafka.errors import KafkaConnectionError
 from ktables import GroupedKafkaTable, GroupedKafkaTableWriter
 
-from calfkit.controlplane import ControlPlaneConfig, ControlPlaneIdentity, ControlPlaneRecord, ControlPlaneView
+from calfkit.controlplane import ControlPlaneConfig, ControlPlaneRecord, ControlPlaneStamp, ControlPlaneView
 from calfkit.controlplane.advert import AdvertInfo, advertises
 from calfkit.controlplane.publisher import ControlPlanePublisher, control_plane_writer_key
 from calfkit.nodes import BaseNodeDef
@@ -64,7 +64,7 @@ async def test_advertise_roundtrip_and_clean_tombstone(kafka_bootstrap: str, top
 
     class _Node(BaseNodeDef):
         @advertises(topic=topic, record=_Rec)
-        def _record(self, identity: ControlPlaneIdentity) -> _Rec:
+        def _record(self, identity: ControlPlaneStamp) -> _Rec:
             return _Rec(**identity.model_dump(), kind="agent")
 
     node = _Node(node_id="agent-1", subscribe_topics=["agent-1.in"])
@@ -96,7 +96,7 @@ async def test_two_worker_same_node_replica_regression(kafka_bootstrap: str, top
 
     class _Node(BaseNodeDef):
         @advertises(topic=topic, record=_Rec)
-        def _record(self, identity: ControlPlaneIdentity) -> _Rec:
+        def _record(self, identity: ControlPlaneStamp) -> _Rec:
             return _Rec(**identity.model_dump(), kind="agent")
 
     # Two instances of the SAME node_id, hosted by two workers (members w-a, w-b).
@@ -171,7 +171,7 @@ async def test_worker_wiring_round_trip(kafka_bootstrap: str, topic_namespace: s
 
     class _Node(BaseNodeDef):
         @advertises(topic=topic, record=_Rec)
-        def _record(self, identity: ControlPlaneIdentity) -> _Rec:
+        def _record(self, identity: ControlPlaneStamp) -> _Rec:
             return _Rec(**identity.model_dump(), kind="agent")
 
     node = _Node(node_id="agent-1", subscribe_topics=["agent-1.in"])

--- a/tests/integration/test_controlplane_substrate_kafka.py
+++ b/tests/integration/test_controlplane_substrate_kafka.py
@@ -20,7 +20,7 @@ from ktables import GroupedKafkaTable, GroupedKafkaTableWriter
 
 from calfkit.controlplane import ControlPlaneConfig, ControlPlaneIdentity, ControlPlaneRecord, ControlPlaneView
 from calfkit.controlplane.advert import AdvertInfo, advertises
-from calfkit.controlplane.publisher import ControlPlanePublisher
+from calfkit.controlplane.publisher import ControlPlanePublisher, control_plane_writer_key
 from calfkit.nodes import BaseNodeDef
 
 pytestmark = pytest.mark.kafka
@@ -45,7 +45,7 @@ async def _start_publisher(
         adverts=[(node, _only_advert(node))],
         config=ControlPlaneConfig(heartbeat_interval=0.05, bootstrap_servers=bootstrap),
     )
-    ctx = SimpleNamespace(resources={ControlPlanePublisher._writer_key(topic): writer})
+    ctx = SimpleNamespace(resources={control_plane_writer_key(topic): writer})
     await pub.start(ctx)
     return writer, pub, ctx
 
@@ -154,3 +154,50 @@ async def test_unreachable_view_fails_loud(topic_namespace: str) -> None:
     finally:
         with contextlib.suppress(Exception):
             await view.stop()
+
+
+async def test_worker_wiring_round_trip(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """The worker's OWN auto-wired publisher + writer resource round-trip on a real broker.
+
+    Drives the worker-built `ControlPlanePublisher` against the worker-registered writer
+    `@resource` (looked up under `control_plane_writer_key`) — so the worker-registers ↔
+    publisher-looks-up key seam is exercised end-to-end, not via a hand-built publisher.
+    """
+    from calfkit.client.client import Client
+    from calfkit.provisioning import ProvisioningConfig
+    from calfkit.worker.worker import Worker
+
+    topic = f"{topic_namespace}.presence"
+
+    class _Node(BaseNodeDef):
+        @advertises(topic=topic, record=_Rec)
+        def _record(self, identity: ControlPlaneIdentity) -> _Rec:
+            return _Rec(**identity.model_dump(), kind="agent")
+
+    node = _Node(node_id="agent-1", subscribe_topics=["agent-1.in"])
+    client = Client.connect(kafka_bootstrap, provisioning=ProvisioningConfig(enabled=True))
+    worker = Worker(client, nodes=[node], control_plane=ControlPlaneConfig(heartbeat_interval=0.05, bootstrap_servers=kafka_bootstrap))
+    worker._maybe_register_control_plane()
+
+    key = control_plane_writer_key(topic)
+    [(_, genfn)] = [(n, g) for n, g in worker._resource_cms() if n == key]  # the worker-registered writer resource
+    writer_gen = genfn(None)  # type: ignore[arg-type]
+    writer = await anext(writer_gen)  # ensure_topic=True via provisioning creates the compacted topic
+    pub = worker._control_plane_publisher
+    assert pub is not None
+    ctx = SimpleNamespace(resources={key: writer})  # the bag the publisher reads under the same key
+    view: ControlPlaneView[_Rec] = ControlPlaneView.open(bootstrap_servers=kafka_bootstrap, topic=topic, record_type=_Rec, ensure_topic=False)
+    await view.start()
+    try:
+        await pub.start(ctx)  # looks up the writer under control_plane_writer_key — the key the worker registered
+        assert await _poll(view.barrier, lambda: view.get("agent-1") is not None)
+        rec = view.get("agent-1")
+        assert rec is not None and rec.kind == "agent"
+        await pub.stop(ctx)
+        assert await _poll(view.barrier, lambda: view.get("agent-1") is None)
+    finally:
+        if pub._task is not None:
+            await pub.stop(ctx)
+        await view.stop()
+        with pytest.raises(StopAsyncIteration):
+            await anext(writer_gen)

--- a/tests/test_controlplane_advert.py
+++ b/tests/test_controlplane_advert.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 import pytest
 
 from calfkit._registry import RegistryMixin, handler
-from calfkit.controlplane import ControlPlaneIdentity, ControlPlaneRecord, advertises
+from calfkit.controlplane import ControlPlaneRecord, ControlPlaneStamp, advertises
 from calfkit.controlplane.advert import AdvertInfo, AdvertRegistryMixin, advert_info
 from calfkit.exceptions import RegistryConfigError
 from calfkit.nodes import BaseNodeDef
@@ -21,9 +21,9 @@ class _Rec2(ControlPlaneRecord):
     other: str
 
 
-def _identity() -> ControlPlaneIdentity:
+def _stamp() -> ControlPlaneStamp:
     ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    return ControlPlaneIdentity(node_id="n1", worker_id="w1", started_at=ts, last_heartbeat_at=ts, heartbeat_interval=30.0)
+    return ControlPlaneStamp(started_at=ts, last_heartbeat_at=ts, heartbeat_interval=30.0)
 
 
 # -- decorator ---------------------------------------------------------------
@@ -32,7 +32,7 @@ def _identity() -> ControlPlaneIdentity:
 def test_decorator_returns_method_unchanged_and_stamps_marker() -> None:
     class T(AdvertRegistryMixin):
         @advertises(topic="t", record=_Rec)
-        def _r(self, identity: ControlPlaneIdentity) -> _Rec:
+        def _r(self, identity: ControlPlaneStamp) -> _Rec:
             return _Rec(**identity.model_dump(), content="x")
 
     # the method is still directly callable (marker-not-wrapper)
@@ -40,7 +40,7 @@ def test_decorator_returns_method_unchanged_and_stamps_marker() -> None:
     assert isinstance(info, AdvertInfo)
     assert info.topic == "t"
     assert info.record is _Rec
-    assert T()._r(_identity()).content == "x"
+    assert T()._r(_stamp()).content == "x"
 
 
 def test_advertises_rejects_empty_topic() -> None:
@@ -62,7 +62,7 @@ def test_advertises_rejects_non_record_type() -> None:
 def test_collection_per_type() -> None:
     class T(AdvertRegistryMixin):
         @advertises(topic="calf.x", record=_Rec)
-        def _r(self, identity: ControlPlaneIdentity) -> _Rec:
+        def _r(self, identity: ControlPlaneStamp) -> _Rec:
             return _Rec(**identity.model_dump(), content="x")
 
     assert set(T._adverts) == {"calf.x"}
@@ -70,7 +70,7 @@ def test_collection_per_type() -> None:
     # control_plane_adverts resolves bound factories
     factories = T().control_plane_adverts()
     assert set(factories) == {"calf.x"}
-    assert factories["calf.x"](_identity()).content == "x"
+    assert factories["calf.x"](_stamp()).content == "x"
 
 
 def test_duplicate_topic_raises_at_class_definition() -> None:
@@ -78,11 +78,11 @@ def test_duplicate_topic_raises_at_class_definition() -> None:
 
         class T(AdvertRegistryMixin):
             @advertises(topic="dup", record=_Rec)
-            def _a(self, identity: ControlPlaneIdentity) -> _Rec:
+            def _a(self, identity: ControlPlaneStamp) -> _Rec:
                 return _Rec(**identity.model_dump(), content="a")
 
             @advertises(topic="dup", record=_Rec)
-            def _b(self, identity: ControlPlaneIdentity) -> _Rec:
+            def _b(self, identity: ControlPlaneStamp) -> _Rec:
                 return _Rec(**identity.model_dump(), content="b")
 
 
@@ -97,31 +97,31 @@ def test_no_adverts_is_empty() -> None:
 def test_mro_override_redecorated_most_derived_wins() -> None:
     class Base(AdvertRegistryMixin):
         @advertises(topic="t", record=_Rec)
-        def _r(self, identity: ControlPlaneIdentity) -> _Rec:
+        def _r(self, identity: ControlPlaneStamp) -> _Rec:
             return _Rec(**identity.model_dump(), content="base")
 
     class Derived(Base):
         @advertises(topic="t", record=_Rec2)  # re-decorated: new record type wins
-        def _r(self, identity: ControlPlaneIdentity) -> _Rec2:  # type: ignore[override]
+        def _r(self, identity: ControlPlaneStamp) -> _Rec2:  # type: ignore[override]
             return _Rec2(**identity.model_dump(), other="derived")
 
     assert Derived._adverts["t"].record is _Rec2
-    assert Derived().control_plane_adverts()["t"](_identity()).other == "derived"
+    assert Derived().control_plane_adverts()["t"](_stamp()).other == "derived"
 
 
 def test_mro_override_without_redecorate_resolves_to_override() -> None:
     class Base(AdvertRegistryMixin):
         @advertises(topic="t", record=_Rec)
-        def _r(self, identity: ControlPlaneIdentity) -> _Rec:
+        def _r(self, identity: ControlPlaneStamp) -> _Rec:
             return _Rec(**identity.model_dump(), content="base")
 
     class Derived(Base):
-        def _r(self, identity: ControlPlaneIdentity) -> _Rec:  # override, NOT re-decorated
+        def _r(self, identity: ControlPlaneStamp) -> _Rec:  # override, NOT re-decorated
             return _Rec(**identity.model_dump(), content="derived")
 
     # advert still registered (inherited), bound factory is the override
     assert set(Derived._adverts) == {"t"}
-    assert Derived().control_plane_adverts()["t"](_identity()).content == "derived"
+    assert Derived().control_plane_adverts()["t"](_stamp()).content == "derived"
 
 
 # -- coexistence with @handler ----------------------------------------------
@@ -133,7 +133,7 @@ def test_coexists_with_handler_registry() -> None:
         async def run(self, ctx: object) -> None: ...
 
         @advertises(topic="t", record=_Rec)
-        def _r(self, identity: ControlPlaneIdentity) -> _Rec:
+        def _r(self, identity: ControlPlaneStamp) -> _Rec:
             return _Rec(**identity.model_dump(), content="x")
 
     assert "*" in T._handlers
@@ -143,7 +143,7 @@ def test_coexists_with_handler_registry() -> None:
 def test_basenodedef_collects_adverts_and_keeps_handlers() -> None:
     class _Node(BaseNodeDef):
         @advertises(topic="calf.node", record=_Rec)
-        def _r(self, identity: ControlPlaneIdentity) -> _Rec:
+        def _r(self, identity: ControlPlaneStamp) -> _Rec:
             return _Rec(**identity.model_dump(), content="x")
 
     # adverts collected via the mixin attached to BaseNodeDef

--- a/tests/test_controlplane_advert.py
+++ b/tests/test_controlplane_advert.py
@@ -164,3 +164,13 @@ def test_advert_info_rejects_empty_topic() -> None:
 def test_advert_info_rejects_empty_name() -> None:
     with pytest.raises(ValueError, match="name"):
         AdvertInfo(topic="t", record=_Rec, name="")
+
+
+def test_advert_info_rejects_non_record_type() -> None:
+    # AdvertInfo is public/constructible directly; self-validate the record type
+    # (parity with the @advertises decorator and HandlerInfo's self-validation).
+    class NotARecord:
+        pass
+
+    with pytest.raises(ValueError, match="ControlPlaneRecord"):
+        AdvertInfo(topic="t", record=NotARecord, name="x")  # type: ignore[arg-type]

--- a/tests/test_controlplane_advert.py
+++ b/tests/test_controlplane_advert.py
@@ -1,0 +1,166 @@
+"""Unit tests for the @advertises decorator + AdvertRegistryMixin (spec §6, plan §3.2)."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from calfkit._registry import RegistryMixin, handler
+from calfkit.controlplane import ControlPlaneIdentity, ControlPlaneRecord, advertises
+from calfkit.controlplane.advert import AdvertInfo, AdvertRegistryMixin, advert_info
+from calfkit.exceptions import RegistryConfigError
+from calfkit.nodes import BaseNodeDef
+
+
+class _Rec(ControlPlaneRecord):
+    schema_version: int = 1
+    content: str
+
+
+class _Rec2(ControlPlaneRecord):
+    schema_version: int = 1
+    other: str
+
+
+def _identity() -> ControlPlaneIdentity:
+    ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return ControlPlaneIdentity(node_id="n1", worker_id="w1", started_at=ts, last_heartbeat_at=ts, heartbeat_interval=30.0)
+
+
+# -- decorator ---------------------------------------------------------------
+
+
+def test_decorator_returns_method_unchanged_and_stamps_marker() -> None:
+    class T(AdvertRegistryMixin):
+        @advertises(topic="t", record=_Rec)
+        def _r(self, identity: ControlPlaneIdentity) -> _Rec:
+            return _Rec(**identity.model_dump(), content="x")
+
+    # the method is still directly callable (marker-not-wrapper)
+    info = advert_info(T._r)
+    assert isinstance(info, AdvertInfo)
+    assert info.topic == "t"
+    assert info.record is _Rec
+    assert T()._r(_identity()).content == "x"
+
+
+def test_advertises_rejects_empty_topic() -> None:
+    with pytest.raises(ValueError, match="topic"):
+        advertises(topic="", record=_Rec)
+
+
+def test_advertises_rejects_non_record_type() -> None:
+    class NotARecord:
+        pass
+
+    with pytest.raises(ValueError, match="ControlPlaneRecord"):
+        advertises(topic="t", record=NotARecord)  # type: ignore[type-var]
+
+
+# -- collection --------------------------------------------------------------
+
+
+def test_collection_per_type() -> None:
+    class T(AdvertRegistryMixin):
+        @advertises(topic="calf.x", record=_Rec)
+        def _r(self, identity: ControlPlaneIdentity) -> _Rec:
+            return _Rec(**identity.model_dump(), content="x")
+
+    assert set(T._adverts) == {"calf.x"}
+    assert T._adverts["calf.x"].record is _Rec
+    # control_plane_adverts resolves bound factories
+    factories = T().control_plane_adverts()
+    assert set(factories) == {"calf.x"}
+    assert factories["calf.x"](_identity()).content == "x"
+
+
+def test_duplicate_topic_raises_at_class_definition() -> None:
+    with pytest.raises(RegistryConfigError, match="unique per class"):
+
+        class T(AdvertRegistryMixin):
+            @advertises(topic="dup", record=_Rec)
+            def _a(self, identity: ControlPlaneIdentity) -> _Rec:
+                return _Rec(**identity.model_dump(), content="a")
+
+            @advertises(topic="dup", record=_Rec)
+            def _b(self, identity: ControlPlaneIdentity) -> _Rec:
+                return _Rec(**identity.model_dump(), content="b")
+
+
+def test_no_adverts_is_empty() -> None:
+    class T(AdvertRegistryMixin):
+        pass
+
+    assert T._adverts == {}
+    assert T().control_plane_adverts() == {}
+
+
+def test_mro_override_redecorated_most_derived_wins() -> None:
+    class Base(AdvertRegistryMixin):
+        @advertises(topic="t", record=_Rec)
+        def _r(self, identity: ControlPlaneIdentity) -> _Rec:
+            return _Rec(**identity.model_dump(), content="base")
+
+    class Derived(Base):
+        @advertises(topic="t", record=_Rec2)  # re-decorated: new record type wins
+        def _r(self, identity: ControlPlaneIdentity) -> _Rec2:  # type: ignore[override]
+            return _Rec2(**identity.model_dump(), other="derived")
+
+    assert Derived._adverts["t"].record is _Rec2
+    assert Derived().control_plane_adverts()["t"](_identity()).other == "derived"
+
+
+def test_mro_override_without_redecorate_resolves_to_override() -> None:
+    class Base(AdvertRegistryMixin):
+        @advertises(topic="t", record=_Rec)
+        def _r(self, identity: ControlPlaneIdentity) -> _Rec:
+            return _Rec(**identity.model_dump(), content="base")
+
+    class Derived(Base):
+        def _r(self, identity: ControlPlaneIdentity) -> _Rec:  # override, NOT re-decorated
+            return _Rec(**identity.model_dump(), content="derived")
+
+    # advert still registered (inherited), bound factory is the override
+    assert set(Derived._adverts) == {"t"}
+    assert Derived().control_plane_adverts()["t"](_identity()).content == "derived"
+
+
+# -- coexistence with @handler ----------------------------------------------
+
+
+def test_coexists_with_handler_registry() -> None:
+    class T(RegistryMixin, AdvertRegistryMixin):
+        @handler("*")
+        async def run(self, ctx: object) -> None: ...
+
+        @advertises(topic="t", record=_Rec)
+        def _r(self, identity: ControlPlaneIdentity) -> _Rec:
+            return _Rec(**identity.model_dump(), content="x")
+
+    assert "*" in T._handlers
+    assert "t" in T._adverts
+
+
+def test_basenodedef_collects_adverts_and_keeps_handlers() -> None:
+    class _Node(BaseNodeDef):
+        @advertises(topic="calf.node", record=_Rec)
+        def _r(self, identity: ControlPlaneIdentity) -> _Rec:
+            return _Rec(**identity.model_dump(), content="x")
+
+    # adverts collected via the mixin attached to BaseNodeDef
+    assert set(_Node._adverts) == {"calf.node"}
+    # the inherited run handler ('*') is still present (registries are independent)
+    assert "*" in _Node._handlers
+
+
+def test_basenodedef_without_adverts_is_empty() -> None:
+    assert BaseNodeDef._adverts == {}
+
+
+def test_advert_info_rejects_empty_topic() -> None:
+    with pytest.raises(ValueError, match="topic"):
+        AdvertInfo(topic="", record=_Rec, name="x")
+
+
+def test_advert_info_rejects_empty_name() -> None:
+    with pytest.raises(ValueError, match="name"):
+        AdvertInfo(topic="t", record=_Rec, name="")

--- a/tests/test_controlplane_config.py
+++ b/tests/test_controlplane_config.py
@@ -1,0 +1,49 @@
+"""Unit tests for ControlPlaneConfig (spec §11, plan §3.3)."""
+
+import dataclasses
+
+import pytest
+
+from calfkit.controlplane import ControlPlaneConfig
+from calfkit.controlplane.config import STALE_MULTIPLIER
+
+
+def test_defaults() -> None:
+    cfg = ControlPlaneConfig()
+    assert cfg.heartbeat_interval == 30.0
+    assert cfg.stale_after is None
+    assert cfg.catchup_timeout == 30.0
+    assert cfg.bootstrap_servers is None
+
+
+def test_stale_multiplier_is_three() -> None:
+    assert STALE_MULTIPLIER == 3
+
+
+def test_rejects_nonpositive_heartbeat_interval() -> None:
+    with pytest.raises(ValueError, match="heartbeat_interval"):
+        ControlPlaneConfig(heartbeat_interval=0)
+
+
+def test_rejects_nonpositive_catchup_timeout() -> None:
+    with pytest.raises(ValueError, match="catchup_timeout"):
+        ControlPlaneConfig(catchup_timeout=-1.0)
+
+
+def test_stale_after_none_is_allowed() -> None:
+    assert ControlPlaneConfig(stale_after=None).stale_after is None
+
+
+def test_rejects_nonpositive_stale_after() -> None:
+    with pytest.raises(ValueError, match="stale_after"):
+        ControlPlaneConfig(stale_after=0)
+
+
+def test_positive_stale_after_allowed() -> None:
+    assert ControlPlaneConfig(stale_after=45.0).stale_after == 45.0
+
+
+def test_is_frozen() -> None:
+    cfg = ControlPlaneConfig()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cfg.heartbeat_interval = 10.0  # type: ignore[misc]

--- a/tests/test_controlplane_config.py
+++ b/tests/test_controlplane_config.py
@@ -47,3 +47,15 @@ def test_is_frozen() -> None:
     cfg = ControlPlaneConfig()
     with pytest.raises(dataclasses.FrozenInstanceError):
         cfg.heartbeat_interval = 10.0  # type: ignore[misc]
+
+
+def test_rejects_nonfinite_fields() -> None:
+    # NaN slips past every `> 0` / `<= 0` comparison, so guard finiteness explicitly:
+    # nan heartbeat => hot loop + poisoned staleness; nan stale_after => nothing ever stale.
+    for bad in (float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="heartbeat_interval"):
+            ControlPlaneConfig(heartbeat_interval=bad)
+        with pytest.raises(ValueError, match="catchup_timeout"):
+            ControlPlaneConfig(catchup_timeout=bad)
+        with pytest.raises(ValueError, match="stale_after"):
+            ControlPlaneConfig(stale_after=bad)

--- a/tests/test_controlplane_publisher.py
+++ b/tests/test_controlplane_publisher.py
@@ -1,0 +1,218 @@
+"""Unit tests for ControlPlanePublisher (spec §7, plan §3.5) — fake writer + ctx, no broker."""
+
+import asyncio
+import contextlib
+from collections.abc import Callable
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pydantic import AwareDatetime
+
+from calfkit.controlplane import ControlPlaneConfig, ControlPlaneIdentity, ControlPlaneRecord
+from calfkit.controlplane.advert import AdvertInfo
+from calfkit.controlplane.publisher import ControlPlanePublisher
+
+
+class _Rec(ControlPlaneRecord):
+    schema_version: int = 1
+    content: str
+
+
+class _CapRec(ControlPlaneRecord):
+    schema_version: int = 1
+    content_updated_at: AwareDatetime
+
+
+class _Node:
+    """A node stand-in exposing a fixed factory method named ``make_record``."""
+
+    def __init__(self, node_id: str, factory: Callable[[ControlPlaneIdentity], ControlPlaneRecord]) -> None:
+        self.node_id = node_id
+        self._factory = factory
+
+    def make_record(self, identity: ControlPlaneIdentity) -> ControlPlaneRecord:
+        return self._factory(identity)
+
+
+def _advert(topic: str, record: type[ControlPlaneRecord] = _Rec) -> AdvertInfo:
+    return AdvertInfo(topic=topic, record=record, name="make_record")
+
+
+def _rec_factory(content: str = "x") -> Callable[[ControlPlaneIdentity], ControlPlaneRecord]:
+    def factory(identity: ControlPlaneIdentity) -> ControlPlaneRecord:
+        return _Rec(**identity.model_dump(), content=content)
+
+    return factory
+
+
+def _cap_factory(content_updated_at: datetime) -> Callable[[ControlPlaneIdentity], ControlPlaneRecord]:
+    def factory(identity: ControlPlaneIdentity) -> ControlPlaneRecord:
+        return _CapRec(**identity.model_dump(), content_updated_at=content_updated_at)
+
+    return factory
+
+
+def _boom_factory() -> Callable[[ControlPlaneIdentity], ControlPlaneRecord]:
+    def factory(identity: ControlPlaneIdentity) -> ControlPlaneRecord:
+        raise RuntimeError("factory boom")
+
+    return factory
+
+
+class _Writer:
+    def __init__(self, log: list[tuple[str, str, str]] | None = None) -> None:
+        self.sets: list[tuple[str, str, ControlPlaneRecord]] = []
+        self.deletes: list[tuple[str, str]] = []
+        self._log = log
+
+    async def set(self, group: str, member: str, value: ControlPlaneRecord) -> None:
+        self.sets.append((group, member, value))
+        if self._log is not None:
+            self._log.append(("set", group, member))
+
+    async def delete(self, group: str, member: str) -> None:
+        self.deletes.append((group, member))
+        if self._log is not None:
+            self._log.append(("delete", group, member))
+
+
+class _Ctx:
+    def __init__(self, resources: dict[str, _Writer]) -> None:
+        self.resources = resources
+
+
+def _key(topic: str) -> str:
+    return ControlPlanePublisher._writer_key(topic)
+
+
+# -- startup: one-shot publish + identity ------------------------------------
+
+
+async def test_start_publishes_each_advert_once_with_identity() -> None:
+    writer = _Writer()
+    node = _Node("n1", _rec_factory("x"))
+    info = _advert("t")
+    pub = ControlPlanePublisher(worker_id="wkr", adverts=[(node, info)], config=ControlPlaneConfig(heartbeat_interval=3600.0))
+    ctx = _Ctx({_key("t"): writer})
+    await pub.start(ctx)
+    try:
+        assert len(writer.sets) == 1
+        group, member, record = writer.sets[0]
+        assert (group, member) == ("n1", "wkr")
+        assert record.node_id == "n1" and record.worker_id == "wkr"
+        assert record.heartbeat_interval == 3600.0  # stamped from config
+        assert record.started_at == pub._started_at
+    finally:
+        await pub.stop(ctx)
+
+
+async def test_start_is_fail_loud_on_factory_error() -> None:
+    node = _Node("n1", _boom_factory())
+    pub = ControlPlanePublisher(worker_id="wkr", adverts=[(node, _advert("t"))], config=ControlPlaneConfig())
+    ctx = _Ctx({_key("t"): _Writer()})
+    with pytest.raises(RuntimeError, match="factory boom"):
+        await pub.start(ctx)  # propagates -> aborts boot
+
+
+async def test_start_is_fail_loud_on_missing_writer() -> None:
+    node = _Node("n1", _rec_factory())
+    pub = ControlPlanePublisher(worker_id="wkr", adverts=[(node, _advert("t"))], config=ControlPlaneConfig())
+    ctx = _Ctx({})  # writer resource missing -> wiring bug
+    with pytest.raises(KeyError):
+        await pub.start(ctx)
+
+
+# -- shutdown: tombstone the declared cross-product, after publish -----------
+
+
+async def test_stop_tombstones_declared_cross_product() -> None:
+    w1, w2 = _Writer(), _Writer()
+    node = _Node("n1", _rec_factory())
+    pub = ControlPlanePublisher(
+        worker_id="wkr",
+        adverts=[(node, _advert("t1")), (node, _advert("t2"))],
+        config=ControlPlaneConfig(heartbeat_interval=3600.0),
+    )
+    ctx = _Ctx({_key("t1"): w1, _key("t2"): w2})
+    await pub.start(ctx)
+    await pub.stop(ctx)
+    assert w1.deletes == [("n1", "wkr")]
+    assert w2.deletes == [("n1", "wkr")]
+
+
+async def test_stop_deletes_after_publish_and_sets_flag() -> None:
+    log: list[tuple[str, str, str]] = []
+    writer = _Writer(log=log)
+    node = _Node("n1", _rec_factory())
+    pub = ControlPlanePublisher(worker_id="wkr", adverts=[(node, _advert("t"))], config=ControlPlaneConfig(heartbeat_interval=3600.0))
+    ctx = _Ctx({_key("t"): writer})
+    await pub.start(ctx)
+    await pub.stop(ctx)
+    assert [op[0] for op in log] == ["set", "delete"]  # publish, then tombstone
+    assert pub._shutting_down is True
+    assert pub._task is None
+
+
+# -- pull model: liveness advances, content currency does not ----------------
+
+
+async def test_content_updated_at_fixed_across_ticks() -> None:
+    writer = _Writer()
+    content_ts = datetime(2026, 1, 1, tzinfo=timezone.utc)  # node-tracked, never moves here
+    node = _Node("n1", _cap_factory(content_ts))
+    info = _advert("cap", record=_CapRec)
+    pub = ControlPlanePublisher(worker_id="wkr", adverts=[(node, info)], config=ControlPlaneConfig(heartbeat_interval=3600.0))
+    ctx = _Ctx({_key("cap"): writer})
+    await pub.start(ctx)  # publish #1
+    later = datetime.now(tz=timezone.utc) + timedelta(seconds=10)
+    await pub._publish_one(ctx, node, info, later)  # publish #2 with advanced now
+    await pub.stop(ctx)
+    r1, r2 = writer.sets[0][2], writer.sets[1][2]
+    assert r1.content_updated_at == r2.content_updated_at == content_ts  # content currency fixed
+    assert r2.last_heartbeat_at > r1.last_heartbeat_at  # liveness advanced
+
+
+# -- loop resilience ---------------------------------------------------------
+
+
+async def test_loop_is_resilient_to_one_bad_advert() -> None:
+    good_writer, bad_writer = _Writer(), _Writer()
+    good = _Node("good", _rec_factory())
+    bad = _Node("bad", _boom_factory())
+    pub = ControlPlanePublisher(
+        worker_id="wkr",
+        adverts=[(bad, _advert("bad")), (good, _advert("good"))],
+        config=ControlPlaneConfig(heartbeat_interval=0.01),
+    )
+    ctx = _Ctx({_key("good"): good_writer, _key("bad"): bad_writer})
+    pub._started_at = datetime.now(tz=timezone.utc)  # start() would set this
+    task = asyncio.create_task(pub._loop(ctx))
+    await asyncio.sleep(0.06)  # ~6 ticks
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+    assert len(good_writer.sets) >= 2  # good advert keeps publishing despite the bad one raising
+    assert bad_writer.sets == []  # the bad advert never succeeds, but does not kill the loop
+
+
+async def test_loop_cancellation_during_publish_propagates() -> None:
+    """A cancel landing mid-publish propagates cleanly (the loop re-raises CancelledError)."""
+    entered = asyncio.Event()
+    release = asyncio.Event()  # never set: the writer blocks until cancelled
+
+    class _BlockingWriter:
+        async def set(self, group: str, member: str, value: ControlPlaneRecord) -> None:
+            entered.set()
+            await release.wait()
+
+        async def delete(self, group: str, member: str) -> None: ...
+
+    node = _Node("n1", _rec_factory())
+    pub = ControlPlanePublisher(worker_id="wkr", adverts=[(node, _advert("t"))], config=ControlPlaneConfig(heartbeat_interval=0.01))
+    ctx = _Ctx({_key("t"): _BlockingWriter()})  # type: ignore[dict-item]
+    pub._started_at = datetime.now(tz=timezone.utc)  # start() would set this
+    task = asyncio.create_task(pub._loop(ctx))
+    await asyncio.wait_for(entered.wait(), timeout=1.0)  # loop is now awaiting inside _publish_one
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/test_controlplane_publisher.py
+++ b/tests/test_controlplane_publisher.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from pydantic import AwareDatetime
 
-from calfkit.controlplane import ControlPlaneConfig, ControlPlaneIdentity, ControlPlaneRecord
+from calfkit.controlplane import ControlPlaneConfig, ControlPlaneRecord, ControlPlaneStamp
 from calfkit.controlplane.advert import AdvertInfo
 from calfkit.controlplane.publisher import ControlPlanePublisher, control_plane_writer_key
 
@@ -26,11 +26,11 @@ class _CapRec(ControlPlaneRecord):
 class _Node:
     """A node stand-in exposing a fixed factory method named ``make_record``."""
 
-    def __init__(self, node_id: str, factory: Callable[[ControlPlaneIdentity], ControlPlaneRecord]) -> None:
+    def __init__(self, node_id: str, factory: Callable[[ControlPlaneStamp], ControlPlaneRecord]) -> None:
         self.node_id = node_id
         self._factory = factory
 
-    def make_record(self, identity: ControlPlaneIdentity) -> ControlPlaneRecord:
+    def make_record(self, identity: ControlPlaneStamp) -> ControlPlaneRecord:
         return self._factory(identity)
 
 
@@ -38,22 +38,22 @@ def _advert(topic: str, record: type[ControlPlaneRecord] = _Rec) -> AdvertInfo:
     return AdvertInfo(topic=topic, record=record, name="make_record")
 
 
-def _rec_factory(content: str = "x") -> Callable[[ControlPlaneIdentity], ControlPlaneRecord]:
-    def factory(identity: ControlPlaneIdentity) -> ControlPlaneRecord:
+def _rec_factory(content: str = "x") -> Callable[[ControlPlaneStamp], ControlPlaneRecord]:
+    def factory(identity: ControlPlaneStamp) -> ControlPlaneRecord:
         return _Rec(**identity.model_dump(), content=content)
 
     return factory
 
 
-def _cap_factory(content_updated_at: datetime) -> Callable[[ControlPlaneIdentity], ControlPlaneRecord]:
-    def factory(identity: ControlPlaneIdentity) -> ControlPlaneRecord:
+def _cap_factory(content_updated_at: datetime) -> Callable[[ControlPlaneStamp], ControlPlaneRecord]:
+    def factory(identity: ControlPlaneStamp) -> ControlPlaneRecord:
         return _CapRec(**identity.model_dump(), content_updated_at=content_updated_at)
 
     return factory
 
 
-def _boom_factory() -> Callable[[ControlPlaneIdentity], ControlPlaneRecord]:
-    def factory(identity: ControlPlaneIdentity) -> ControlPlaneRecord:
+def _boom_factory() -> Callable[[ControlPlaneStamp], ControlPlaneRecord]:
+    def factory(identity: ControlPlaneStamp) -> ControlPlaneRecord:
         raise RuntimeError("factory boom")
 
     return factory
@@ -98,8 +98,7 @@ async def test_start_publishes_each_advert_once_with_identity() -> None:
     try:
         assert len(writer.sets) == 1
         group, member, record = writer.sets[0]
-        assert (group, member) == ("n1", "wkr")
-        assert record.node_id == "n1" and record.worker_id == "wkr"
+        assert (group, member) == ("n1", "wkr")  # identity is the wire key
         assert record.heartbeat_interval == 3600.0  # stamped from config
         assert record.started_at == pub._started_at
     finally:

--- a/tests/test_controlplane_publisher.py
+++ b/tests/test_controlplane_publisher.py
@@ -10,7 +10,7 @@ from pydantic import AwareDatetime
 
 from calfkit.controlplane import ControlPlaneConfig, ControlPlaneIdentity, ControlPlaneRecord
 from calfkit.controlplane.advert import AdvertInfo
-from calfkit.controlplane.publisher import ControlPlanePublisher
+from calfkit.controlplane.publisher import ControlPlanePublisher, control_plane_writer_key
 
 
 class _Rec(ControlPlaneRecord):
@@ -82,7 +82,7 @@ class _Ctx:
 
 
 def _key(topic: str) -> str:
-    return ControlPlanePublisher._writer_key(topic)
+    return control_plane_writer_key(topic)
 
 
 # -- startup: one-shot publish + identity ------------------------------------
@@ -170,6 +170,7 @@ async def test_content_updated_at_fixed_across_ticks() -> None:
     r1, r2 = writer.sets[0][2], writer.sets[1][2]
     assert r1.content_updated_at == r2.content_updated_at == content_ts  # content currency fixed
     assert r2.last_heartbeat_at > r1.last_heartbeat_at  # liveness advanced
+    assert r1.started_at == r2.started_at == pub._started_at  # boot time fixed across ticks
 
 
 # -- loop resilience ---------------------------------------------------------
@@ -216,3 +217,52 @@ async def test_loop_cancellation_during_publish_propagates() -> None:
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+async def test_start_partial_failure_publishes_first_and_spawns_no_loop() -> None:
+    # advert #1 publishes, advert #2's factory raises -> start() propagates (fail-loud),
+    # and NO heartbeat loop is spawned (the publish loop precedes create_task) -> no orphan task.
+    w_ok, w_bad = _Writer(), _Writer()
+    ok = _Node("ok", _rec_factory())
+    bad = _Node("bad", _boom_factory())
+    pub = ControlPlanePublisher(worker_id="wkr", adverts=[(ok, _advert("ok")), (bad, _advert("bad"))], config=ControlPlaneConfig())
+    ctx = _Ctx({_key("ok"): w_ok, _key("bad"): w_bad})
+    with pytest.raises(RuntimeError, match="factory boom"):
+        await pub.start(ctx)
+    assert len(w_ok.sets) == 1  # first advert published before the failure
+    assert pub._task is None  # no loop spawned -> no orphan task leaked
+
+
+async def test_loop_sleeps_at_the_configured_interval(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Deterministic cadence check: the loop sleeps exactly heartbeat_interval each tick.
+    recorded: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        recorded.append(delay)
+        raise asyncio.CancelledError  # stop the loop right after its first interval sleep
+
+    monkeypatch.setattr("calfkit.controlplane.publisher.asyncio.sleep", fake_sleep)
+    node = _Node("n1", _rec_factory())
+    pub = ControlPlanePublisher(worker_id="wkr", adverts=[(node, _advert("t"))], config=ControlPlaneConfig(heartbeat_interval=42.0))
+    ctx = _Ctx({_key("t"): _Writer()})
+    pub._started_at = datetime.now(tz=timezone.utc)
+    with pytest.raises(asyncio.CancelledError):
+        await pub._loop(ctx)
+    assert recorded == [42.0]
+
+
+async def test_started_at_shared_across_nodes() -> None:
+    # One boot time, shared by every hosted node's record (the restart-detection basis).
+    writer = _Writer()
+    n1, n2 = _Node("n1", _rec_factory()), _Node("n2", _rec_factory())
+    pub = ControlPlanePublisher(
+        worker_id="wkr",
+        adverts=[(n1, _advert("t")), (n2, _advert("t"))],
+        config=ControlPlaneConfig(heartbeat_interval=3600.0),
+    )
+    ctx = _Ctx({_key("t"): writer})
+    await pub.start(ctx)
+    try:
+        assert {record.started_at for _, _, record in writer.sets} == {pub._started_at}
+    finally:
+        await pub.stop(ctx)

--- a/tests/test_controlplane_records.py
+++ b/tests/test_controlplane_records.py
@@ -1,0 +1,74 @@
+"""Unit tests for the control-plane record base + identity envelope (spec §5)."""
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from calfkit.controlplane import ControlPlaneIdentity, ControlPlaneRecord
+
+
+class _Rec(ControlPlaneRecord):
+    """A concrete record: sets the required schema_version default + adds content."""
+
+    schema_version: int = 1
+    content: str
+
+
+def _identity(**overrides: object) -> ControlPlaneIdentity:
+    base: dict[str, object] = dict(
+        node_id="n1",
+        worker_id="w1",
+        started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        last_heartbeat_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        heartbeat_interval=30.0,
+    )
+    base.update(overrides)
+    return ControlPlaneIdentity(**base)  # type: ignore[arg-type]
+
+
+def test_subclass_constructs_from_identity_plus_content() -> None:
+    """A concrete record is built as `R(**identity.model_dump(), <content>)`."""
+    ident = _identity()
+    rec = _Rec(**ident.model_dump(), content="hello")
+    assert rec.schema_version == 1
+    assert rec.node_id == "n1"
+    assert rec.worker_id == "w1"
+    assert rec.started_at == datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert rec.last_heartbeat_at == datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert rec.heartbeat_interval == 30.0
+    assert rec.content == "hello"
+
+
+def test_tolerant_reader_ignores_unknown_fields() -> None:
+    """extra='ignore' — a newer writer's added field decodes without error and is dropped."""
+    ident = _identity()
+    data = {**ident.model_dump(mode="json"), "content": "x", "future_field": 123}
+    rec = _Rec.model_validate(data)
+    assert rec.content == "x"
+    assert not hasattr(rec, "future_field")
+
+
+def test_base_has_no_schema_version_default() -> None:
+    """The base intentionally has no schema_version default (abstract-by-omission, spec §5)."""
+    ident = _identity()
+    with pytest.raises(ValidationError):
+        ControlPlaneRecord(**ident.model_dump())  # missing required schema_version
+
+
+def test_identity_is_frozen() -> None:
+    """ControlPlaneIdentity is a frozen envelope — built once per tick, never mutated."""
+    ident = _identity()
+    with pytest.raises(ValidationError):
+        ident.node_id = "other"  # type: ignore[misc]
+
+
+def test_identity_carries_the_five_envelope_fields() -> None:
+    """The identity envelope is exactly the base's non-schema_version fields (spec §5)."""
+    assert set(ControlPlaneIdentity.model_fields) == {
+        "node_id",
+        "worker_id",
+        "started_at",
+        "last_heartbeat_at",
+        "heartbeat_interval",
+    }

--- a/tests/test_controlplane_records.py
+++ b/tests/test_controlplane_records.py
@@ -1,11 +1,11 @@
-"""Unit tests for the control-plane record base + identity envelope (spec §5)."""
+"""Unit tests for the control-plane record base + worker stamp (spec §5)."""
 
 from datetime import datetime, timezone
 
 import pytest
 from pydantic import ValidationError
 
-from calfkit.controlplane import ControlPlaneIdentity, ControlPlaneRecord
+from calfkit.controlplane import ControlPlaneRecord, ControlPlaneStamp
 
 
 class _Rec(ControlPlaneRecord):
@@ -15,35 +15,48 @@ class _Rec(ControlPlaneRecord):
     content: str
 
 
-def _identity(**overrides: object) -> ControlPlaneIdentity:
+def _stamp(**overrides: object) -> ControlPlaneStamp:
     base: dict[str, object] = dict(
-        node_id="n1",
-        worker_id="w1",
         started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
         last_heartbeat_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
         heartbeat_interval=30.0,
     )
     base.update(overrides)
-    return ControlPlaneIdentity(**base)  # type: ignore[arg-type]
+    return ControlPlaneStamp(**base)  # type: ignore[arg-type]
 
 
-def test_subclass_constructs_from_identity_plus_content() -> None:
-    """A concrete record is built as `R(**identity.model_dump(), <content>)`."""
-    ident = _identity()
-    rec = _Rec(**ident.model_dump(), content="hello")
+def test_subclass_constructs_from_stamp_plus_content() -> None:
+    """A concrete record is built as `R(**stamp.model_dump(), <content>)`."""
+    stamp = _stamp()
+    rec = _Rec(**stamp.model_dump(), content="hello")
     assert rec.schema_version == 1
-    assert rec.node_id == "n1"
-    assert rec.worker_id == "w1"
     assert rec.started_at == datetime(2026, 1, 1, tzinfo=timezone.utc)
     assert rec.last_heartbeat_at == datetime(2026, 1, 1, tzinfo=timezone.utc)
     assert rec.heartbeat_interval == 30.0
     assert rec.content == "hello"
 
 
+def test_identity_is_not_carried_in_the_value() -> None:
+    """node_id / worker_id are the wire key, never duplicated in the record value (Option D)."""
+    assert "node_id" not in ControlPlaneRecord.model_fields
+    assert "worker_id" not in ControlPlaneRecord.model_fields
+    assert "node_id" not in _Rec.model_fields
+
+
+def test_record_is_a_stamp_plus_schema_version() -> None:
+    """Tidy structural form: the record extends the stamp, so worker fields are declared once."""
+    assert issubclass(ControlPlaneRecord, ControlPlaneStamp)
+    assert set(ControlPlaneRecord.model_fields) == {"started_at", "last_heartbeat_at", "heartbeat_interval", "schema_version"}
+
+
+def test_stamp_carries_only_worker_owned_fields() -> None:
+    assert set(ControlPlaneStamp.model_fields) == {"started_at", "last_heartbeat_at", "heartbeat_interval"}
+
+
 def test_tolerant_reader_ignores_unknown_fields() -> None:
     """extra='ignore' — a newer writer's added field decodes without error and is dropped."""
-    ident = _identity()
-    data = {**ident.model_dump(mode="json"), "content": "x", "future_field": 123}
+    stamp = _stamp()
+    data = {**stamp.model_dump(mode="json"), "content": "x", "future_field": 123}
     rec = _Rec.model_validate(data)
     assert rec.content == "x"
     assert not hasattr(rec, "future_field")
@@ -51,24 +64,18 @@ def test_tolerant_reader_ignores_unknown_fields() -> None:
 
 def test_base_has_no_schema_version_default() -> None:
     """The base intentionally has no schema_version default (abstract-by-omission, spec §5)."""
-    ident = _identity()
+    stamp = _stamp()
     with pytest.raises(ValidationError):
-        ControlPlaneRecord(**ident.model_dump())  # missing required schema_version
+        ControlPlaneRecord(**stamp.model_dump())  # missing required schema_version
 
 
-def test_identity_is_frozen() -> None:
-    """ControlPlaneIdentity is a frozen envelope — built once per tick, never mutated."""
-    ident = _identity()
+def test_stamp_is_frozen() -> None:
+    stamp = _stamp()
     with pytest.raises(ValidationError):
-        ident.node_id = "other"  # type: ignore[misc]
+        stamp.heartbeat_interval = 99.0  # type: ignore[misc]
 
 
-def test_identity_carries_the_five_envelope_fields() -> None:
-    """The identity envelope is exactly the base's non-schema_version fields (spec §5)."""
-    assert set(ControlPlaneIdentity.model_fields) == {
-        "node_id",
-        "worker_id",
-        "started_at",
-        "last_heartbeat_at",
-        "heartbeat_interval",
-    }
+def test_record_is_frozen() -> None:
+    rec = _Rec(**_stamp().model_dump(), content="x")
+    with pytest.raises(ValidationError):
+        rec.content = "y"  # type: ignore[misc]

--- a/tests/test_controlplane_view.py
+++ b/tests/test_controlplane_view.py
@@ -14,16 +14,14 @@ class _Rec(ControlPlaneRecord):
     content: str
 
 
-def _rec(worker_id: str, *, age_s: float = 0.0, hb: float = 30.0, schema_version: int = 1, content: str = "x") -> _Rec:
+def _rec(worker_id: str, *, age_s: float = 0.0, hb: float = 30.0, schema_version: int = 1, content: str | None = None) -> _Rec:
     now = datetime.now(tz=timezone.utc)
     return _Rec(
         schema_version=schema_version,
-        node_id="n",
-        worker_id=worker_id,
         started_at=now,
         last_heartbeat_at=now - timedelta(seconds=age_s),
         heartbeat_interval=hb,
-        content=content,
+        content=content if content is not None else worker_id,  # default content = the instance label (identity is the key)
     )
 
 
@@ -84,7 +82,7 @@ def _view(data: dict[str, dict[str, _Rec]], **kwargs: Any) -> ControlPlaneView[_
 def test_get_returns_live_record() -> None:
     v = _view({"a": {"w1": _rec("w1")}})
     rec = v.get("a")
-    assert rec is not None and rec.worker_id == "w1"
+    assert rec is not None and rec.content == "w1"
     assert v.online_nodes() == {"a"}
     assert set(v.snapshot()) == {"a"}
 
@@ -97,7 +95,7 @@ def test_get_none_for_unknown_node() -> None:
 def test_collapse_picks_most_recent_live_instance() -> None:
     v = _view({"a": {"w1": _rec("w1", age_s=20.0), "w2": _rec("w2", age_s=1.0)}})
     rec = v.get("a")
-    assert rec is not None and rec.worker_id == "w2"  # freshest heartbeat wins
+    assert rec is not None and rec.content == "w2"  # freshest heartbeat wins
 
 
 def test_stale_member_excluded() -> None:
@@ -169,7 +167,7 @@ def test_collapse_filters_stale_before_tiebreak() -> None:
         }
     )
     rec = v.get("a")
-    assert rec is not None and rec.worker_id == "w_old_live"
+    assert rec is not None and rec.content == "w_old_live"
     assert v.online_nodes() == {"a"}
 
 
@@ -184,7 +182,7 @@ def test_collapse_filters_newer_schema_before_tiebreak() -> None:
         }
     )
     rec = v.get("a")
-    assert rec is not None and rec.worker_id == "w_old_live"
+    assert rec is not None and rec.content == "w_old_live"
     assert v.online_nodes() == {"a"}
 
 

--- a/tests/test_controlplane_view.py
+++ b/tests/test_controlplane_view.py
@@ -1,0 +1,177 @@
+"""Unit tests for ControlPlaneView (spec §8, plan §3.4) — dict-backed fake, no broker."""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from calfkit.controlplane import ControlPlaneRecord, ControlPlaneView
+from calfkit.exceptions import RegistryConfigError
+
+
+class _Rec(ControlPlaneRecord):
+    schema_version: int = 1
+    content: str
+
+
+def _rec(worker_id: str, *, age_s: float = 0.0, hb: float = 30.0, schema_version: int = 1, content: str = "x") -> _Rec:
+    now = datetime.now(tz=timezone.utc)
+    return _Rec(
+        schema_version=schema_version,
+        node_id="n",
+        worker_id=worker_id,
+        started_at=now,
+        last_heartbeat_at=now - timedelta(seconds=age_s),
+        heartbeat_interval=hb,
+        content=content,
+    )
+
+
+class _FakeTable:
+    """A minimal GroupedTableReader: ``group -> {member -> record}``."""
+
+    def __init__(
+        self,
+        data: dict[str, dict[str, _Rec]],
+        *,
+        status: str = "caught_up",
+        failure: BaseException | None = None,
+        is_caught_up: bool = True,
+    ) -> None:
+        self._data = data
+        self._status = status
+        self._failure = failure
+        self._is_caught_up = is_caught_up
+
+    def groups(self) -> set[str]:
+        return set(self._data)
+
+    def members(self, group: str) -> dict[str, Any]:
+        return dict(self._data.get(group, {}))
+
+    @property
+    def status(self) -> Any:
+        return self._status
+
+    @property
+    def failure(self) -> BaseException | None:
+        return self._failure
+
+    @property
+    def is_caught_up(self) -> bool:
+        return self._is_caught_up
+
+    async def barrier(self, timeout: float | None = None) -> bool:
+        return self._is_caught_up
+
+    async def wait_until_caught_up(self, timeout: float | None = None) -> bool:
+        return self._is_caught_up
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+
+def _view(data: dict[str, dict[str, _Rec]], **kwargs: Any) -> ControlPlaneView[_Rec]:
+    return ControlPlaneView(_FakeTable(data, **kwargs), _Rec)
+
+
+# -- collapsed reads ---------------------------------------------------------
+
+
+def test_get_returns_live_record() -> None:
+    v = _view({"a": {"w1": _rec("w1")}})
+    rec = v.get("a")
+    assert rec is not None and rec.worker_id == "w1"
+    assert v.online_nodes() == {"a"}
+    assert set(v.snapshot()) == {"a"}
+
+
+def test_get_none_for_unknown_node() -> None:
+    v = _view({"a": {"w1": _rec("w1")}})
+    assert v.get("missing") is None
+
+
+def test_collapse_picks_most_recent_live_instance() -> None:
+    v = _view({"a": {"w1": _rec("w1", age_s=20.0), "w2": _rec("w2", age_s=1.0)}})
+    rec = v.get("a")
+    assert rec is not None and rec.worker_id == "w2"  # freshest heartbeat wins
+
+
+def test_stale_member_excluded() -> None:
+    # age 100s > 3*30 = 90 threshold -> stale; sole member -> node offline
+    v = _view({"a": {"w1": _rec("w1", age_s=100.0, hb=30.0)}})
+    assert v.get("a") is None
+    assert v.online_nodes() == set()
+
+
+def test_staleness_uses_record_heartbeat_interval() -> None:
+    # same age (100s), different cadence: hb=60 -> threshold 180 (live); hb=10 -> threshold 30 (stale)
+    v = _view(
+        {
+            "live": {"w1": _rec("w1", age_s=100.0, hb=60.0)},
+            "dead": {"w1": _rec("w1", age_s=100.0, hb=10.0)},
+        }
+    )
+    assert v.online_nodes() == {"live"}
+
+
+def test_stale_after_override_takes_precedence() -> None:
+    # member age 100s, hb=30 (would be live at 90); explicit stale_after=50 -> stale
+    v = ControlPlaneView(_FakeTable({"a": {"w1": _rec("w1", age_s=100.0, hb=30.0)}}), _Rec, stale_after=50.0)
+    assert v.get("a") is None
+
+
+def test_get_iff_online_invariant() -> None:
+    v = _view(
+        {
+            "online": {"w1": _rec("w1", age_s=1.0), "w2": _rec("w2", age_s=100.0)},  # one live, one stale
+            "offline": {"w1": _rec("w1", age_s=100.0)},  # all stale
+        }
+    )
+    online = v.online_nodes()
+    for node in ("online", "offline"):
+        assert (v.get(node) is not None) == (node in online)
+    assert online == {"online"}
+
+
+def test_schema_skip_excludes_newer_records() -> None:
+    # reader version = _Rec default (1); a v2 record is skipped
+    v = _view({"a": {"w1": _rec("w1", schema_version=2)}})
+    assert v.get("a") is None
+    assert v.online_nodes() == set()
+
+
+def test_snapshot_maps_online_nodes_to_collapsed_records() -> None:
+    v = _view({"a": {"w1": _rec("w1", content="A")}, "b": {"w1": _rec("w1", content="B")}})
+    snap = v.snapshot()
+    assert {k: r.content for k, r in snap.items()} == {"a": "A", "b": "B"}
+
+
+# -- defaultless record type -------------------------------------------------
+
+
+def test_rejects_record_type_without_schema_version_default() -> None:
+    with pytest.raises(RegistryConfigError, match="schema_version"):
+        ControlPlaneView(_FakeTable({}), ControlPlaneRecord)  # base has no default
+
+
+# -- health passthrough ------------------------------------------------------
+
+
+def test_health_properties_passthrough() -> None:
+    err = RuntimeError("boom")
+    v = _view({}, status="degraded", failure=err, is_caught_up=False)
+    assert v.status == "degraded"
+    assert v.failure is err
+    assert v.is_caught_up is False
+
+
+async def test_async_health_delegates() -> None:
+    v = _view({}, is_caught_up=True)
+    assert await v.barrier() is True
+    assert await v.wait_until_caught_up() is True
+    await v.start()
+    await v.stop()

--- a/tests/test_controlplane_view.py
+++ b/tests/test_controlplane_view.py
@@ -144,6 +144,50 @@ def test_schema_skip_excludes_newer_records() -> None:
     assert v.online_nodes() == set()
 
 
+def test_schema_skip_is_logged_once_per_member(caplog: pytest.LogCaptureFixture) -> None:
+    # spec §8: a newer-schema member is skipped AND logged (so a vanishing node is observable).
+    v = _view({"a": {"w1": _rec("w1", schema_version=2)}})
+    with caplog.at_level("WARNING"):
+        v.get("a")
+        v.get("a")  # second read must NOT re-log the same (node, worker, version)
+    skip_logs = [r for r in caplog.records if "schema" in r.getMessage().lower() and r.levelname == "WARNING"]
+    assert len(skip_logs) == 1
+    msg = skip_logs[0].getMessage()
+    assert "a" in msg and "w1" in msg
+
+
+def test_collapse_filters_stale_before_tiebreak() -> None:
+    # The member with the NEWEST heartbeat is stale (tiny cadence); the live member is
+    # older. filter-then-tie-break must return the older LIVE one — a tie-break-then-filter
+    # bug would pick the freshest, find it stale, and wrongly return None.
+    v = _view(
+        {
+            "a": {
+                "w_fresh_stale": _rec("w_fresh_stale", age_s=2.0, hb=0.1),  # newest hb, but stale (0.3s threshold)
+                "w_old_live": _rec("w_old_live", age_s=5.0, hb=100.0),  # older hb, but live (300s threshold)
+            }
+        }
+    )
+    rec = v.get("a")
+    assert rec is not None and rec.worker_id == "w_old_live"
+    assert v.online_nodes() == {"a"}
+
+
+def test_collapse_filters_newer_schema_before_tiebreak() -> None:
+    # The newest-heartbeat member is a newer (unsupported) schema; the live one is older+supported.
+    v = _view(
+        {
+            "a": {
+                "w_fresh_newschema": _rec("w_fresh_newschema", age_s=1.0, schema_version=2),
+                "w_old_live": _rec("w_old_live", age_s=5.0),
+            }
+        }
+    )
+    rec = v.get("a")
+    assert rec is not None and rec.worker_id == "w_old_live"
+    assert v.online_nodes() == {"a"}
+
+
 def test_snapshot_maps_online_nodes_to_collapsed_records() -> None:
     v = _view({"a": {"w1": _rec("w1", content="A")}, "b": {"w1": _rec("w1", content="B")}})
     snap = v.snapshot()

--- a/tests/test_controlplane_view.py
+++ b/tests/test_controlplane_view.py
@@ -154,6 +154,18 @@ def test_schema_skip_is_logged_once_per_member(caplog: pytest.LogCaptureFixture)
     assert "a" in msg and "w1" in msg
 
 
+def test_schema_skip_dedup_is_per_member_not_per_node(caplog: pytest.LogCaptureFixture) -> None:
+    # The dedup key includes worker_id, so a SECOND newer-schema member on the same node
+    # must still log — one suppressed warning must not hide another instance vanishing.
+    v = _view({"a": {"w1": _rec("w1", schema_version=2), "w2": _rec("w2", schema_version=2)}})
+    with caplog.at_level("WARNING"):
+        v.get("a")
+        v.get("a")  # repeat reads must not multiply the warnings
+    skip_logs = [r for r in caplog.records if "schema" in r.getMessage().lower() and r.levelname == "WARNING"]
+    assert len(skip_logs) == 2  # one per distinct member, deduped across reads
+    assert {"w1", "w2"} == {w for w in ("w1", "w2") if any(w in r.getMessage() for r in skip_logs)}
+
+
 def test_collapse_filters_stale_before_tiebreak() -> None:
     # The member with the NEWEST heartbeat is stale (tiny cadence); the live member is
     # older. filter-then-tie-break must return the older LIVE one — a tie-break-then-filter

--- a/tests/test_controlplane_worker_wiring.py
+++ b/tests/test_controlplane_worker_wiring.py
@@ -12,7 +12,7 @@ from typing import Any
 import pytest
 
 from calfkit.client.client import Client
-from calfkit.controlplane import ControlPlaneConfig, ControlPlaneIdentity, ControlPlaneRecord, advertises
+from calfkit.controlplane import ControlPlaneConfig, ControlPlaneRecord, ControlPlaneStamp, advertises
 from calfkit.controlplane.publisher import control_plane_writer_key
 from calfkit.nodes import BaseNodeDef
 from calfkit.worker.worker import Worker
@@ -25,23 +25,23 @@ class _Rec(ControlPlaneRecord):
 
 class _OneTopic(BaseNodeDef):
     @advertises(topic="calf.a", record=_Rec)
-    def _ra(self, identity: ControlPlaneIdentity) -> _Rec:
+    def _ra(self, identity: ControlPlaneStamp) -> _Rec:
         return _Rec(**identity.model_dump(), content="a")
 
 
 class _AlsoTopicA(BaseNodeDef):
     @advertises(topic="calf.a", record=_Rec)
-    def _r(self, identity: ControlPlaneIdentity) -> _Rec:
+    def _r(self, identity: ControlPlaneStamp) -> _Rec:
         return _Rec(**identity.model_dump(), content="other")
 
 
 class _TwoTopics(BaseNodeDef):
     @advertises(topic="calf.a", record=_Rec)
-    def _ra(self, identity: ControlPlaneIdentity) -> _Rec:
+    def _ra(self, identity: ControlPlaneStamp) -> _Rec:
         return _Rec(**identity.model_dump(), content="a")
 
     @advertises(topic="calf.b", record=_Rec)
-    def _rb(self, identity: ControlPlaneIdentity) -> _Rec:
+    def _rb(self, identity: ControlPlaneStamp) -> _Rec:
         return _Rec(**identity.model_dump(), content="b")
 
 

--- a/tests/test_controlplane_worker_wiring.py
+++ b/tests/test_controlplane_worker_wiring.py
@@ -13,7 +13,7 @@ import pytest
 
 from calfkit.client.client import Client
 from calfkit.controlplane import ControlPlaneConfig, ControlPlaneIdentity, ControlPlaneRecord, advertises
-from calfkit.controlplane.publisher import ControlPlanePublisher
+from calfkit.controlplane.publisher import control_plane_writer_key
 from calfkit.nodes import BaseNodeDef
 from calfkit.worker.worker import Worker
 
@@ -58,7 +58,7 @@ def resource_names(worker: Worker) -> list[str]:
 
 
 def _wkey(topic: str) -> str:
-    return ControlPlanePublisher._writer_key(topic)
+    return control_plane_writer_key(topic)
 
 
 # -- registration mechanics --------------------------------------------------
@@ -194,3 +194,25 @@ async def test_writer_ensure_topic_follows_provisioning(fake_writer: type[_FakeW
     gen, writer = await _drive(worker, "calf.a")
     assert writer.kwargs["ensure_topic"] is True
     await _close(gen)
+
+
+# -- call-site + lifecycle boundary ------------------------------------------
+
+
+def test_register_handlers_wires_the_control_plane() -> None:
+    # the real call site: register_handlers() must invoke the control-plane wiring
+    client = Client.connect("kafka:9092")
+    worker = Worker(client, nodes=[_node(_OneTopic, "n1")])
+    worker.register_handlers()
+    assert _wkey("calf.a") in resource_names(worker)
+    assert worker._control_plane_publisher is not None
+
+
+def test_node_added_after_prepare_does_not_join_a_plane() -> None:
+    # _prepared latches at register_handlers; a node added afterward is not wired (documented boundary)
+    client = Client.connect("kafka:9092")
+    worker = Worker(client, nodes=[_node(_OneTopic, "n1")])
+    worker.register_handlers()  # latches _prepared
+    worker.add_nodes(_node(_TwoTopics, "n2"))  # advertises calf.a + calf.b
+    worker.register_handlers()  # guarded no-op
+    assert _wkey("calf.b") not in resource_names(worker)  # the late node's new topic never wired

--- a/tests/test_controlplane_worker_wiring.py
+++ b/tests/test_controlplane_worker_wiring.py
@@ -1,0 +1,196 @@
+"""Worker auto-wiring of the control-plane publisher + per-topic writers (plan §3.6).
+
+Registration mechanics only (no broker); the live path is the kafka-lane integration
+test. Mirrors tests/test_worker_capability_view.py.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from calfkit.client.client import Client
+from calfkit.controlplane import ControlPlaneConfig, ControlPlaneIdentity, ControlPlaneRecord, advertises
+from calfkit.controlplane.publisher import ControlPlanePublisher
+from calfkit.nodes import BaseNodeDef
+from calfkit.worker.worker import Worker
+
+
+class _Rec(ControlPlaneRecord):
+    schema_version: int = 1
+    content: str
+
+
+class _OneTopic(BaseNodeDef):
+    @advertises(topic="calf.a", record=_Rec)
+    def _ra(self, identity: ControlPlaneIdentity) -> _Rec:
+        return _Rec(**identity.model_dump(), content="a")
+
+
+class _AlsoTopicA(BaseNodeDef):
+    @advertises(topic="calf.a", record=_Rec)
+    def _r(self, identity: ControlPlaneIdentity) -> _Rec:
+        return _Rec(**identity.model_dump(), content="other")
+
+
+class _TwoTopics(BaseNodeDef):
+    @advertises(topic="calf.a", record=_Rec)
+    def _ra(self, identity: ControlPlaneIdentity) -> _Rec:
+        return _Rec(**identity.model_dump(), content="a")
+
+    @advertises(topic="calf.b", record=_Rec)
+    def _rb(self, identity: ControlPlaneIdentity) -> _Rec:
+        return _Rec(**identity.model_dump(), content="b")
+
+
+class _PlainNode(BaseNodeDef):
+    pass
+
+
+def _node(cls: type[BaseNodeDef], node_id: str) -> BaseNodeDef:
+    return cls(node_id=node_id, subscribe_topics=[f"{node_id}.in"])
+
+
+def resource_names(worker: Worker) -> list[str]:
+    return [name for name, _ in worker._resource_cms()]
+
+
+def _wkey(topic: str) -> str:
+    return ControlPlanePublisher._writer_key(topic)
+
+
+# -- registration mechanics --------------------------------------------------
+
+
+def test_registered_when_a_node_advertises() -> None:
+    client = Client.connect("kafka:9092")
+    worker = Worker(client, nodes=[_node(_OneTopic, "n1")])
+    worker._maybe_register_control_plane()
+    assert _wkey("calf.a") in resource_names(worker)
+    pub = worker._control_plane_publisher
+    assert pub is not None
+    assert pub.start in worker._hooks_for("after_startup")
+    assert pub.stop in worker._hooks_for("on_shutdown")
+
+
+def test_not_registered_without_adverts() -> None:
+    client = Client.connect("kafka:9092")
+    worker = Worker(client, nodes=[_node(_PlainNode, "p")])
+    worker._maybe_register_control_plane()
+    assert worker._control_plane_publisher is None
+    assert not any(name.startswith("calfkit.controlplane.writer.") for name in resource_names(worker))
+
+
+def test_idempotent_on_repeat_calls() -> None:
+    client = Client.connect("kafka:9092")
+    worker = Worker(client, nodes=[_node(_OneTopic, "n1")])
+    worker._maybe_register_control_plane()
+    worker._maybe_register_control_plane()  # must not raise duplicate-name or double-wire
+    assert resource_names(worker).count(_wkey("calf.a")) == 1
+    assert worker._hooks_for("after_startup").count(worker._control_plane_publisher.start) == 1  # type: ignore[union-attr]
+
+
+def test_two_node_types_same_topic_share_one_writer() -> None:
+    client = Client.connect("kafka:9092")
+    worker = Worker(client, nodes=[_node(_OneTopic, "n1"), _node(_AlsoTopicA, "n2")])
+    worker._maybe_register_control_plane()
+    assert resource_names(worker).count(_wkey("calf.a")) == 1  # one writer for the shared topic
+    assert len(worker._control_plane_publisher._adverts) == 2  # type: ignore[union-attr]  # both nodes advertise
+
+
+def test_one_node_two_topics_two_writers() -> None:
+    client = Client.connect("kafka:9092")
+    worker = Worker(client, nodes=[_node(_TwoTopics, "n1")])
+    worker._maybe_register_control_plane()
+    names = resource_names(worker)
+    assert _wkey("calf.a") in names
+    assert _wkey("calf.b") in names
+
+
+def test_control_plane_config_accepted_and_defaulted() -> None:
+    client = Client.connect("kafka:9092")
+    assert Worker(client, control_plane=ControlPlaneConfig(heartbeat_interval=10.0))._control_plane.heartbeat_interval == 10.0
+    assert Worker(client)._control_plane == ControlPlaneConfig()
+
+
+# -- the writer resource (fake GroupedKafkaTableWriter) ----------------------
+
+
+class _FakeWriter:
+    instances: list[_FakeWriter] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.started = False
+        self.stopped = False
+        _FakeWriter.instances.append(self)
+
+    @classmethod
+    def json(cls, **kwargs: Any) -> _FakeWriter:
+        return cls(**kwargs)
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+@pytest.fixture
+def fake_writer(monkeypatch: pytest.MonkeyPatch) -> type[_FakeWriter]:
+    _FakeWriter.instances = []
+    monkeypatch.setattr("ktables.GroupedKafkaTableWriter", _FakeWriter)
+    return _FakeWriter
+
+
+async def _drive(worker: Worker, topic: str) -> tuple[AsyncIterator[Any], _FakeWriter]:
+    gen = worker._make_control_plane_writer_resource(topic)(None)  # type: ignore[arg-type]
+    writer = await anext(gen)
+    return gen, writer
+
+
+async def _close(gen: AsyncIterator[Any]) -> None:
+    with pytest.raises(StopAsyncIteration):
+        await anext(gen)
+
+
+async def test_writer_opens_with_config_and_lifecycle(fake_writer: type[_FakeWriter]) -> None:
+    client = Client.connect("kafka:9092")
+    worker = Worker(client)
+    gen, writer = await _drive(worker, "calf.a")
+    assert writer.started and not writer.stopped
+    assert writer.kwargs["topic"] == "calf.a"
+    assert writer.kwargs["bootstrap_servers"] == "kafka:9092"
+    assert writer.kwargs["ensure_topic"] is False  # provisioning disabled by default
+    await _close(gen)
+    assert writer.stopped
+
+
+async def test_writer_bootstrap_override_wins(fake_writer: type[_FakeWriter]) -> None:
+    client = Client.connect("kafka:9092")
+    worker = Worker(client, control_plane=ControlPlaneConfig(bootstrap_servers="cp-kafka:9092"))
+    gen, writer = await _drive(worker, "calf.a")
+    assert writer.kwargs["bootstrap_servers"] == "cp-kafka:9092"
+    await _close(gen)
+
+
+async def test_writer_underivable_bootstrap_raises(fake_writer: type[_FakeWriter]) -> None:
+    client = Client.connect("kafka:9092")
+    client._server_urls = None
+    client.broker._connection_kwargs = {}
+    worker = Worker(client)
+    with pytest.raises(RuntimeError, match="bootstrap_servers"):
+        await _drive(worker, "calf.a")
+    assert fake_writer.instances == []  # failed before construction
+
+
+async def test_writer_ensure_topic_follows_provisioning(fake_writer: type[_FakeWriter]) -> None:
+    from calfkit.provisioning import ProvisioningConfig
+
+    client = Client.connect("kafka:9092", provisioning=ProvisioningConfig(enabled=True))
+    worker = Worker(client)
+    gen, writer = await _drive(worker, "calf.a")
+    assert writer.kwargs["ensure_topic"] is True
+    await _close(gen)


### PR DESCRIPTION
## Summary

A reusable, ktables-backed **control-plane substrate**: any node type can advertise itself to a compacted topic, and any worker can read a live, collapsed node-centric view of what's online. This is the generic *machinery* — capability discovery and agent discovery adopt it in later PRs.

Re-scoped from #239 (whose original framing was an always-on *presence* plane + ops view): the design discussion landed on building the **generic discoverability substrate** first, with presence/ops deferred. This implements the substrate + advisory staleness; the presence view and `calfkit nodes` CLI are not in scope here.

**Design:** [`control-plane-substrate-spec.md`](docs/designs/control-plane-substrate-spec.md) · ADR-0010 (instance-keyed storage + collapsed view) · ADR-0011 (worker-owned publisher) · [`impl-plan`](docs/designs/control-plane-substrate-impl-plan.md).

## What it adds

New package `calfkit/controlplane/`:
- **`ControlPlaneRecord`** base + **`ControlPlaneIdentity`** envelope (identity + liveness; carries the writer's `heartbeat_interval` so any reader — even a config-less out-of-process one — judges staleness against the writer's cadence).
- **`@advertises(topic, record)`** + **`AdvertRegistryMixin`** — a per-node-type marker decorator mirroring `@handler`/`RegistryMixin` (separate registry, collected via `__init_subclass__`).
- **`ControlPlaneConfig`** — heartbeat / staleness / catch-up / bootstrap knobs.
- **`ControlPlaneView[R]`** — collapsed `node_id → record` reads (`get` / `online_nodes` / `snapshot`), advisory staleness derived from each record's own cadence, schema-version skip, and `status` / `failure` passthrough (closes frozen-view blindness). `get(g) is not None ⟺ g ∈ online_nodes()`.
- **`ControlPlanePublisher`** — one worker-owned heartbeat loop + one ordered tombstone for all hosted nodes; fail-loud startup, per-advert-resilient ticks, resurrection-safe shutdown.

The worker auto-wires the publisher + one writer per advert topic whenever a hosted node advertises (zero user wiring). Storage is **instance-keyed (`node_id × worker_id`)**, so a replica's clean tombstone can't blank a still-live node (ADR-0010); the view collapses to one live record per node.

Touched (additive only): `nodes/base.py` (+`AdvertRegistryMixin` base), `worker/worker.py` (+`control_plane` config + auto-wiring), top-level exports.

## Testing
- `make check` clean (lint + format + type, 66 source files).
- **Offline:** 56 new unit tests (dict-backed fakes, no broker); full suite **3126 passed**, no regressions.
- **Kafka lane:** 3 integration tests incl. the **2-worker same-node replica regression (CRITICAL-1 proof)** on real Redpanda; full lane **32 passed**.
- **100% coverage** on `calfkit.controlplane`; the node layer is verified **ktables-free at import**.

## Notable decisions
- Separate `AdvertRegistryMixin` (not reusing `RegistryMixin`) — adverts (publish sources, topic-keyed) and route-handlers (dispatch targets, route-matched) are distinct concerns.
- A view pointed at an **unreachable** broker fails *loud* at `start()` (ktables raises) rather than silently serving empty — the integration test asserts that; the degraded `status`/`failure` passthrough is unit-tested.
- ADR-0010 / ADR-0011 are `proposed`; flip to `accepted` on merge.

## Checklist
- [x] `make fix` + `make check` clean
- [x] TDD; 100% coverage on the new package
- [x] Offline + kafka lanes green
- [x] ADRs + spec included

Re: #239 (implements the substrate; presence/ops deferred).
