### PR TITLE
test: real-broker integration tests for the fault rail, policy seams & in-node fan-out

### DIFF
--- a/docs/designs/fault-rail-fanout-behavior-catalogue.md
+++ b/docs/designs/fault-rail-fanout-behavior-catalogue.md
@@ -1,0 +1,286 @@
+# Fault Rail, Policy Seams & In-Node Fan-out — Behavior Catalogue
+
+**Status:** Reference (living) · **Date:** 2026-06-18
+**Grounds:** the *merged* implementation of PR #247 ("the fault rail: typed fault propagation, policy seams & in-node fan-out fold", commit `04203fc`; repo HEAD `613ea02`) — the only guaranteed source of truth — cross-referenced to the two design specs.
+**Source specs:** `docs/designs/fault-rail-and-policy-seams-spec.md` (scenarios `S1`–`S47` referenced inline) · `docs/designs/in-node-fanout-aggregation-spec.md`.
+**Companion:** `docs/designs/fault-rail-fanout-integration-test-plan.md` (the real-broker test plan derived from this catalogue).
+
+> This document enumerates the behaviors the three features **should meet**. Each entry is tagged with its implementation status so the test plan can target what runs today and forward-declare what is deferred. Where the merged code diverges from the spec prose, the catalogue follows the **code** and flags the drift.
+
+---
+
+## 0. Legend & ground rules
+
+| Tag | Meaning |
+|---|---|
+| ✅ **Implemented** | Behavior is present in merged code (PR #247). A test can assert it today. |
+| ⏳ **Deferred** | Spec describes it; **no producer/handler in merged code.** A test would assert vapor. Belongs to a later PR (mostly the "reception PR" and the successor retry issue #222). |
+| ⚠️ **Diverges** | Implemented, but the behavior differs from the spec prose. Follow the code. |
+
+**The six deferred behaviors (do not test as if live):**
+1. ⏳ `surface_to_model` prebuilt — does not exist in any module.
+2. ⏳ `self_retry_budget` / `State.seam_budgets` / `calf.agent.self_retry_exhausted` / `details.reason="self_retry_disabled"` — none exist; self-retry is an *unbounded* `TailCall` loop.
+3. ⏳ Provider classification of `calf.model.context_window_exceeded` — the `FaultTypes` constant exists but has **no producer**; a context-window error surfaces as generic `calf.unhandled`.
+4. ⏳ Client-side `NodeFaultError` on a `kind=fault` reply — the reply dispatcher has no `x-calf-kind` branch.
+5. ⏳ `ConsumerContext.fault` / `ConsumerContext.delivery_kind` — absent; a consumer tap sees `output=None`, not the fault.
+6. ⏳ MCP `isError=True` → `calf.retry` marking — merged code passes `isError` results through **transparently/unmarked**.
+
+**Vocabulary** (see the specs' §2 / CONTEXT.md): *fault* (terminal failure carried as a typed `ErrorReport` on the same rail its success would take) · *recoverable error* (model-bound, rendered to ordinary content at origin — `ModelRetry`, MCP `isError`) · *policy seam* (`before_node`/`after_node`/`on_node_error`/`on_callee_error`) · *escalation* (unwind one frame, repeat; never wrapped) · *fault group* (`calf.fault_group`, children in `causes`; singletons flatten) · *delivery kind* (`x-calf-kind ∈ {call, return, fault}`) · *reply slot* (`Envelope.reply: ReturnMessage | FaultMessage | None`).
+
+**Observability note (load-bearing for the test plan):** today no typed fault reaches the client cleanly. The deterministic typed channels are **(a)** the broadcast mirror on a node's `publish_topic` (a `FaultMessage` envelope with `x-calf-kind=fault` + `x-calf-error-type` headers) and **(b)** in-process **seam-callback assertions/recording** (a registered seam receives the live `SeamContext`/`ErrorReport`). The client edge currently surfaces a routed fault only as a `DeserializationError`, or hangs (see §A7).
+
+---
+
+## Part A — The fault rail (error propagation)
+
+### A1. Synthesis & classification at the chokepoint
+
+| ID | Behavior | Status | Grounding / notes |
+|---|---|---|---|
+| FR-1 | A node body that returns normally publishes a `return` (no fault). | ✅ | `_publish_action` ReturnCall arm, `base.py:495-599`. |
+| FR-2 | An **uncaught non-`NodeFaultError` exception** in a body → synthesized `ErrorReport(error_type="calf.unhandled")` with the exception class in `details["calf.exception_type"]` and a clamped message; **no exception escapes to FastStream** (P1 — no silent drop). | ✅ | `_handle_delivery` `except Exception`, `base.py:1633-1669`; `_fault_from_exception` / `ErrorReport.from_exception`, `error_report.py:326-365`. `S1`. |
+| FR-3 | A **`raise NodeFaultError(...)`** anywhere (any seam, any body) converts **verbatim** — its `error_type`/`retryable`/`details` honored — and **bypasses `on_node_error`** (the mint rule). | ✅ | `except NodeFaultError as nfe` arm, `base.py:1630-1632`; `S32`. |
+| FR-4 | Minting a `NodeFaultError("calf.something", ...)` (user-supplied reserved `calf.*` type, or a `calf.*` key in `details`, or non-JSON-serializable `details`) raises `ValueError` **at construction** (fail-fast at the keyboard). Framework `calf.*` types pass via the internal factory. | ✅ | `NodeFaultError.__init__`, `exceptions.py:64-86`; `S26`. |
+| FR-5 | A `NodeFaultError` carrying an existing `ErrorReport` (receive/wrap arm) plus any of `message`/`retryable`/`details` raises `ValueError` ("mint-only"). | ✅ | `exceptions.py:58-63`. |
+| FR-6 | Context-window provider error classifies to `calf.model.context_window_exceeded`. | ⏳ | Constant declared (`error_report.py:53`); **no producer** in `calfkit/providers/`. Today such an error → `calf.unhandled`. `S13`. |
+
+### A2. Escalation & propagation identity
+
+| ID | Behavior | Status | Grounding / notes |
+|---|---|---|---|
+| FR-7 | An unhandled fault **escalates one frame at a time** (P5): pop the node's own frame, re-address, publish to the next `callback_topic`. Stateless per hop. | ✅ | `_publish_fault` pops the snapshot stack and re-stamps, `base.py:660-770`. |
+| FR-8 | **Escalation never wraps.** The same `ErrorReport` (identical `report_id`, `error_type`, `origin_*`, `frame_chain`, `causes`) travels untouched at every hop; only the addressing (`in_reply_to`/`tag` on the new `FaultMessage`) is re-stamped per ancestor. A declining ancestor is *propagation, not transformation*. | ✅ | `base.py:660-674` re-addresses the same `report`; `S3`, `S24`. |
+| FR-9 | Deep chain A→B→C; C faults, B declines (`on_callee_error` returns `None`), A handles → A's seam receives the fault with the multi-frame `frame_chain` and an `error_type` identical to C's origin type. | ✅ | `frame_chain` populated at synthesis; `S3`. |
+| FR-10 | `ErrorReport.walk()` / `find(error_type)` traverse nested fault groups so an `error_type` check matches at **any composition depth** (cycle-guarded, iterative). | ✅ | `error_report.py:209-239`; `S40`, `S46`. |
+
+### A3. The P2 rails — a fault takes its success's path
+
+| ID | Behavior | Status | Grounding / notes |
+|---|---|---|---|
+| FR-11 | A node owing a point-to-point return (`callback_topic` set) faults to that `callback_topic` (`kind=fault`, `reply=FaultMessage`). | ✅ | `_publish_fault`, `base.py:660-706`. |
+| FR-12 | A node that broadcasts also **mirrors the fault** on its `publish_topic` (`kind=fault` + `x-calf-error-type`), so any consumer can tap it. Fires even for fire-and-forget terminals. | ✅ | `_fault_response` mirror, `base.py:772-784`; `worker.py:285-286` wires the `@publisher`; `S10`. |
+| FR-13 | **Fire-and-forget** terminal fault (bottom frame `callback_topic=None`) → ERROR log + broadcast mirror only; **no callback publish**; the client is unaffected. | ✅ | `base.py:688-698`; `S10`, `S14`. |
+
+### A4. Wire-model invariants
+
+| ID | Behavior | Status | Grounding / notes |
+|---|---|---|---|
+| FR-14 | The reply is **per-delivery** (`Envelope.reply` stamped fresh or cleared each hop) — kills the stale-output-slot class. A no-reply hop clears the inbound reply rather than re-broadcasting it. | ✅ | `_no_reply_mirror` clears `envelope.reply`, `base.py:487-493`; `S22`. |
+| FR-15 | `x-calf-kind` classification is **total** (`_classify`): missing header ⇒ `call`; recognized values map through; **unknown value ⇒ `None` ⇒ ERROR-log + ignore** (`_floor_unknown_kind`). | ✅ | `base.py:1048-1068`; `S11`. |
+| FR-16 | **Kind ↔ slot-shape disagreement** (e.g. `kind=fault` with `reply=None`, or `kind=return` with a `FaultMessage`) ⇒ **stray** handling (WARNING + ignore for returns; ERROR + floor for readable faults) — **never** the node-own-failure path. A junk message on the return inbox must not fault a live invocation. | ✅ | `_stray_check`, `base.py:1070-1086`; `S17`, `S29`. |
+| FR-17 | Fault/return deliveries carry no `x-calf-route` and **structurally cannot** enter the route CoR or `'*'` — classification precedes routing. | ✅ | `_execute` routes `kind in {return,fault}` through `_aggregate` before the body; `S11`. |
+| FR-18 | Outbound fault headers = emitter headers + `x-calf-kind=fault` + `x-calf-error-type=<error_type>`; the broadcast mirror carries them too (filterable at the broker without deserialization). | ✅ | `_headers`, `base.py:478-485`; fault add at `base.py:705,783`. |
+
+### A5. `ErrorReport` totality & carriage budget
+
+| ID | Behavior | Status | Grounding / notes |
+|---|---|---|---|
+| FR-19 | `ErrorReport.build_safe(...)` and `from_exception(...)` **never raise** (the error path must not re-open the drop hole): clamping validators, defensive `str()`, last-resort scalar-only fallback. | ✅ | `error_report.py:255-365`. |
+| FR-20 | Carriage clamps: `message ≤ 2000` chars (coerce-then-clamp, never reject); `causes` depth ≤ 8 / total ≤ 64; `frame_chain` ≤ 64 (head+tail elision); `details ≤ 16 KB` serialized; elision breadcrumb under `details["calf.elided"]`. Caller-supplied `calf.*` keys in `details` are stripped. | ✅ | `error_report.py:27-35`, `_bound_details`, `285`. |
+| FR-21 | **Oversized fault** (publish hits `MessageSizeTooLargeError`) → strip to `to_minimal()` (identity only) and **retry once**; second failure floors. An oversized fault must not become a new silent-drop class. | ✅ | `_publish_fault` size arm, `base.py:718-759`. `S42`-adjacent. |
+| FR-22 | `report_id` is a stable UUID7 minted at synthesis — the dedup key across hops/mirrors. | ✅ | `error_report.py:150`. |
+| FR-23 | `FrameRef` is topology-only (`frame_id`, `target_topic`); it **excludes** payloads/overrides — faults carry no user payload by construction (leak posture). | ✅ | `error_report.py:108-119`. |
+
+### A6. Stray, stage-0, and decode-floor
+
+| ID | Behavior | Status | Grounding / notes |
+|---|---|---|---|
+| FR-24 | A **stage-0** failure (classification/context-build/stray-check raises) runs **no seams** (no context yet): on `call`-kind ingress it faults the caller where the stack is readable; on `return`/`fault`-kind it **floors only** (junk must not fault a live invocation). | ✅ | `_floor_stage0`, `base.py:1595-1606`, `796-797`; `S29`. |
+| FR-25 | A **stray return** (no pending slot) → WARNING + ignore, batch state untouched; a **stray fault** → ERROR with full `ErrorReport` JSON + broadcast mirror where `publish_topic` exists. | ✅ | `_floor_stray`; `S17`, `S33`. |
+| FR-26 | An envelope that **fails pydantic decode** never reaches a handler; the decode shim floors `calf.delivery.undecodable` and **re-raises** (suppressing would push an empty body through the `@publisher`). At nodes routing is impossible (address is inside the unreadable body) — floor-only is the ceiling. | ✅ | client `DecodeFloorMiddleware`, `client/middleware.py:35-77`; `S30`. |
+| FR-27 | At the **client** reply subscriber, an undecodable reply floors + re-raises **like a node** → the pending future is *not* failed → hangs under `reply_ttl=None`. (The spec's "fail the future" is the deferred reception PR.) | ⚠️/⏳ | `client/middleware.py`; `S30` correction. Test must use finite `reply_ttl`. |
+
+### A7. The client edge
+
+| ID | Behavior | Status | Grounding / notes |
+|---|---|---|---|
+| FR-28 | `execute(...)` / `start(...)` / `send(...)` / `connect(...)` surface; `execute` = `start` then `await handle.result(timeout)`. `reply_ttl` default `None`; finite `reply_ttl` → `ReplyExpiredError` on expiry. `send(...)` registers no future (fire-and-forget; optional `reply_to` for a *different* address). | ✅ | `client/client.py`, `client/base.py:106-115`, `reply_dispatcher.py`. |
+| FR-29 | A `kind=fault` reply routed to a **registered future** is `set_result`'d like a success; with `strict=True` the projection of an empty `FaultMessage.parts` raises **`DeserializationError`** at the caller. There is **no `x-calf-kind` branch** and **no `NodeFaultError`** at the client. | ⚠️ (current) | `reply_dispatcher.py:64-100`; `node_result.py:247-287`; `S23`/`S30` corrections. |
+| FR-30 | A `kind=fault` reply that does **not** route back to a future (fire-and-forget / floored / undecodable) leaves the future **hanging** until `reply_ttl`. | ⚠️ (current) | Test must set finite `reply_ttl` or `asyncio.wait_for`. |
+| FR-31 | Future target: the reply dispatcher branches on `x-calf-kind` — `fault` fails the future with `NodeFaultError(report)`; `return` resolves from `reply.parts`; `find()` lets the client branch on slotted reports. | ⏳ | The "reception PR". `S23`. |
+
+---
+
+## Part B — Policy seams
+
+### B1. The uniform contract (P4): *whatever a seam returns becomes the output of the thing it guards; `None` means you weren't there*
+
+| Seam | Guards | Return a value → | Return `None` → | Status |
+|---|---|---|---|---|
+| `before_node` | the node body | node output; **body never runs** (mock/cache/refusal) | body runs | ✅ |
+| `after_node` | the produced output | **replaces** the output (values only) | output kept | ✅ |
+| `on_node_error` | the node's own failure | the node output (**recovered**) | fault synthesizes & escalates | ✅ |
+| `on_callee_error` | one callee's failed result | the callee's output (**slot resolves**, values only) | unhandled → escalation (after batch closure for fan-outs) | ✅ |
+
+`SE-1` ✅ — `is None` / `is not None` everywhere (no truthiness ambiguity). `_seams.py`, `run_chain` first-non-`None` wins.
+`SE-2` ✅ — Chains: each seam accepts a single callable **or a list**; runs in registration order; constructor entries precede decorator entries; first non-`None` stops the chain. `base.py:270-311,365-387`; `S38`/chain-order trap.
+
+### B2. `before_node` firing rule
+
+| ID | Behavior | Status | Notes |
+|---|---|---|---|
+| SE-3 | `before_node` fires on **every inbound delivery on which the body would run**: ingress, and single-`Call` returns. | ✅ | `_execute` stage 3, `base.py:1461-1468`. |
+| SE-4 | In a fan-out, mid-batch sibling arrivals are slot-keeping (body doesn't run) → `before_node` does **not** fire. It fires **once at batch closure**, post-aggregation, with all results assembled — *and* it fired on the ingress delivery that opened the fan-out (two firings/invocation, one per body run). | ✅ | `_close_fanout_batch` → `_BatchClosed` → before_node; `S38`. |
+| SE-5 | A batch closing with ≥1 unhandled fault **escalates instead of running the body** — `before_node`, body, and `after_node` are all skipped. | ✅ | `_aggregate` returns `_BatchFaulted` → `_execute` returns immediately, `base.py:1447-1456`. |
+| SE-6 | A `before_node` handler that is ingress-shaped (auth/cache/mock) **must discriminate on `ctx.delivery_kind`** (and note `ctx.route is None` off-ingress); a cache short-circuit on a *continuation* delivery would replace the in-flight workflow with the cached terminal. The agent's self-retry `TailCall` arrives `kind=call` on the private inbox, so `delivery_kind=="call"` alone admits it. | ✅ (contract) | `S45`. Caveat the handler author owns. |
+
+### B3. Seam failure semantics
+
+| ID | Behavior | Status | Notes |
+|---|---|---|---|
+| SE-7 | The **mint rule** is absolute: `raise NodeFaultError(...)` in any seam/body bypasses `on_node_error` and converts verbatim (incl. inside a recovery-path `after_node`). | ✅ | `base.py:1630-1632`; recovery-path local `except NodeFaultError`; `S19`, `S32`. |
+| SE-8 | A **non-`NodeFaultError`** raise inside `before_node`/`after_node` is a node-own accident → routed to `on_node_error`, with the original inbound fault (if any) chained in `causes` via `_SeamAccidentError`. | ✅ | `_SeamAccidentError`, `base.py:171-185,1637-1640`; `S8`. |
+| SE-9 | A raise inside **`on_callee_error` is slot-scoped, never node-own**: the slot resolves *failed* carrying the raised error (a `NodeFaultError` honored verbatim; else `calf.unhandled`) chained to the inbound fault; siblings continue; closure escalates. No double reply. | ✅ | `_resolve_callee` except arm, `base.py:1013-1032`; `S31`. |
+| SE-10 | A **non-`NodeFaultError`** raise inside an `on_node_error` handler = *that handler declines* (logged, noted under `details["calf.seam_errors"]`); the chain continues; all-declined → the **original** fault escalates (no regress). A `NodeFaultError` there = mint → stop chain, convert verbatim, original chained via `causes` (`_Minted`). `CancelledError` propagates. | ✅ | `run_chain_guarded`, `_seams.py:69-117`; `S9`. |
+| SE-11 | `on_node_error` recovery value flows through `after_node` (ADK parity). A **non-`NodeFaultError`** raise during recovery processing is terminal (single-shot), chaining the original as `cause`. | ✅ | `base.py:1658-1669`; `S19`. |
+| SE-12 | A seam can never produce *nothing*: substitute / decline (`None`) / raise. (`Silent` is removed.) | ✅ | §10 of the spec. |
+
+### B4. Return-value guards (teach at coercion)
+
+| ID | Behavior | Status | Notes |
+|---|---|---|---|
+| SE-13 | A seam returning a **`bool`** → `SeamContractError` ("a bool is never a node output…"). `bool` checked **before** `int` (bool subclasses int). | ✅ | `_coerce_output`, `base.py:859-916`; `S41`. |
+| SE-14 | A seam returning the node's **`StateT`** or the **`SeamContext`** itself → `SeamContractError` ("mutate `ctx.state` in place and return `None`"). | ✅ | `S41`. |
+| SE-15 | A seam returning **`bytes`** → `SeamContractError` (no parts arm). A seam returning the route-CoR sentinel `Next` → rejected (not a seam gesture). | ✅ | `base.py:859-916`. |
+| SE-16 | `after_node` returning an **action** (Call/TailCall/ReturnCall) → `SeamContractError` ("after_node returns values, not actions") → `on_node_error`. `before_node`/`on_node_error` may return a `NodeResult` action. | ✅ | `_apply_after`, `base.py:959-976`; `S16`. |
+| SE-17 | An agent seam substitute **in output position** (`before_node` short-circuit, `on_node_error` recovery, `after_node` replacement) is validated against the agent's declared `final_output_type` at coercion — but only when that type is **schematizable** (exotic `OutputSpec` skips, lenient). An `on_callee_error` substitute (callee-output, slot position) is **exempt**. | ✅ | `S44` + PR-6 correction; `_coerce_output` output-type check. |
+
+### B5. Registration validation (startup, never mid-message)
+
+| ID | Behavior | Status | Notes |
+|---|---|---|---|
+| SE-18 | Registering any seam on an **observer (consumer)** raises `RegistryConfigError` at startup ("consumers receive faults as `ctx.fault`… seams exist only on nodes that call"). Observer check runs **first**. | ✅ | `_register_seam`, `base.py:338-363`; `S25`/§6.6. |
+| SE-19 | Wrong-**arity** seam → `RegistryConfigError` at startup (`before_node`=1 arg; others=2). Non-callable → `RegistryConfigError`. | ✅ | `_SEAM_ARITY`, `base.py:75,355-362`. |
+| SE-20 | Constructor seam params exist on `BaseNodeDef.__init__` and `Agent.__init__`. **Tool nodes (`@dataclass`) and `MCPToolbox` have no seam constructor params** — seams attach only via the instance decorator (`@node.on_callee_error`), which every node type supports via the lazy `_chains` property. | ⚠️ | `tool.py:23-28` dataclass bypasses base `__init__`; `base.py:313-326`. |
+
+### B6. `SeamContext` capability surface
+
+| ID | Behavior | Status | Notes |
+|---|---|---|---|
+| SE-21 | Seams receive `SeamContext` (capability-scoped), **not** `SessionRunContext`. `ctx.state` is the **same mutable object** the body reads — `before_node` mutate-in-place + return `None` is the input-transform channel. | ✅ | `seam_context.py:60-100`; `base.py:441`; `S18`. |
+| SE-22 | `ctx.failing_call: CalleeResult | None` is set **only during `on_callee_error`** (the transport view: `tag`/`target_topic`/`frame_id`/`fault`); cleared in `finally`. | ✅ | `base.py:1030`, `seam_context.py:91`. |
+| SE-23 | `ctx.exception: BaseException | None` is set **only during `on_node_error`** (the live in-process exception; never serialized; cleared post-recovery). | ✅ | `base.py:1648,1658`. |
+| SE-24 | `ctx.awaiting_reply` is `True` iff this node is the addressee of a reply-owing frame (the hard-vs-soft-reject discriminator). `ctx.delivery_kind ∈ {call,return,fault}`; `ctx.route` is the inbound route key (call-kind ingress only, else `None`). `ctx.callee_results` lists resolved slots in dispatch order (`[]` on ingress). | ✅ | `seam_context.py:81-93`. |
+| SE-25 | `CalleeResult` fields: `frame_id`, `tag`, `target_topic: str | None` (None for a single non-fan-out call), `parts`, `value` (auto-extracted: DataPart→TextPart→None), `fault`, `handled`. | ✅ | `seam_context.py:27-57`. |
+
+### B7. The observer surface
+
+| ID | Behavior | Status | Notes |
+|---|---|---|---|
+| SE-26 | Consumers have **no seams** and **never produce on the workflow rails** (no point-to-point publish, no auto-fault; `awaiting_reply ≡ False`). A consumer's own `consume_fn` raise floor-logs at ERROR. | ✅ | `consumer.py`; `S21`, `S28`. |
+| SE-27 | A `kind=fault` delivery reaches a consumer's body, but the fault payload is **invisible** — projects to `output=None`/`output_parts=[]`; there is **no `ctx.fault`** and **no `ctx.delivery_kind`** to read. | ⏳ (reception) | `consumer_context.py:20-101`; `S25`/`S28` corrections. |
+
+### B8. Deferred seam-adjacent behaviors
+
+| ID | Behavior | Status | Notes |
+|---|---|---|---|
+| SE-28 | `surface_to_model(max_failures, only_types, exclude_types)` prebuilt: converts a fault to a model-visible result, per-tool budget, declines on exhaustion. | ⏳ | **Does not exist.** Write the equivalent as a user-authored `on_callee_error` to exercise the slot-resolve path; do not import a prebuilt. `S12`, `S35`. |
+
+---
+
+## Part C — In-node durable fan-out aggregation
+
+### C1. Dispatch / OPEN (replica D, causal order)
+
+| ID | Behavior | Status | Notes |
+|---|---|---|---|
+| FO-1 | An agent model turn emitting **≥2 tool calls** returns a `list[Call]`; the handler recognizes it (`_is_fanout_capable and isinstance(output,list) and len≥2 and all Call`) and opens a durable batch. A **single** call (or `sequential_only_mode`) takes the plain `Call` path — never a durable batch (`FanoutOpen.expected` has `min_length=2`). | ✅ | `agent.py:464-495`, `base.py:1722-1730`, `fanout.py:52`. |
+| FO-2 | OPEN order: capture `EnvelopeSnapshot` **pre-marker-stamp** (State + current stack, node's own frame on top, no siblings pushed, + `deps`); `await store.open` writes **basestate then state** (acks awaited) **before any sibling publish**; then publish N siblings with `mark_fanout()` stamping `fanout_id = frame_id` on each sibling stack copy. | ✅ | `_handle_fanout_open`, `base.py:1132-1183`. |
+| FO-3 | The whole OPEN block is guarded: any failure (sibling publish, store write, missing store) → `abort_batch` (if resolved) + `_fanout_abort_report(REASON_DISPATCH_FAILED)` → fault to the caller. | ✅ | `base.py:1169-1182`; the §4.4 dispatch-abort arm. |
+
+### C2. Fold (replica O — durable stage-2)
+
+| ID | Behavior | Status | Notes |
+|---|---|---|---|
+| FO-4 | Per marked sibling reply: **`barrier(state); read state[X]`** for read-your-own-writes freshness; a barrier that can't confirm **blocks** (transient) or **aborts** (`status=="failed"` → `FanoutStoreUnavailableError`). | ✅ | `KtablesFanoutBatchStore._await_fresh`, `_fanout_store.py:306-314`. |
+| FO-5 | **Stray check precedes the seams** (on the fresh read): `state[X]` absent → post-closure stray (floor); slot ∉ `expected` → foreign stray (floor); slot ∈ `outcomes` → duplicate (idempotent ignore); else live → proceed. | ✅ | `classify_sibling`, `_fanout_store.py:161-181`; `S33`. |
+| FO-6 | **Stage-1 `on_callee_error` runs per sibling** during the fold: handler returns a value → `_SlotResolved(parts, handled=True)`; declines/raises → `_SlotFailed(report)`; a fault-free return skips stage 1 → `_SlotResolved(parts, handled=False)`. | ✅ | `_fold_sibling_reply`, `base.py:1223-1254`. |
+| FO-7 | **Fold is idempotent per slot frame id** (LWW on `state[X].outcomes`); producer-retry duplicates neither double-resolve nor double-close. | ✅ | `fold`, `_fanout_store.py:325-334`; §5.2. |
+| FO-8 | Not complete → no-reply mirror (`_CONSUMED`). Complete → having awaited the completing fold's ack, **self-publish the closure re-entry** on the shared `acks=all`+idempotent producer, await its ack, return `_CONSUMED`. | ✅ | `_record_and_maybe_close`; `base.py`. |
+
+### C3. Closure re-entry (replica O — one close path)
+
+| ID | Behavior | Status | Notes |
+|---|---|---|---|
+| FO-9 | The closure is a **self-published `kind=return` re-entry** with `in_reply_to = fanout_id` and **no payload** (state cleared, rebuilt from tables). Recognition is in a dedicated `_classify_fanout` (`in_reply_to == current_frame.frame_id` ⇒ reentry; a sibling's `in_reply_to` is a callee frame id ⇒ sibling). It is stray-exempt **by routing** — it passes the sealed `_stray_check` (a shape-valid return) and is then classified as a re-entry. | ✅ | `_classify_fanout`, `base.py:1114-1130`; `_publish_reentry`, `base.py:601-624`; in-node §4.3. |
+| FO-10 | **Stage-0 rebuild**: `_restore_from_snapshot` overwrites `ctx.state`/`ctx.deps`/stack from `basestate[X].snapshot` **before any seam runs**; resources re-stamped from the local bag (not snapshotted). `basestate[X]` absent → floor `calf.fanout.aborted` (`reason=basestate_missing`), never `AttributeError`. | ✅ | `_restore_from_snapshot`, `base.py:1397-1416`. |
+| FO-11 | Close guards (barriered): `state[X]` absent → **abandon** (defensive — one re-entry under ACK_FIRST); present but `outcomes ≠ expected` → **spurious** → WARN + park; complete → proceed. | ✅ | `close_batch`, `_fanout_store.py:202-231`. |
+
+### C4. Three-way close decision
+
+| ID | Behavior | Status | Notes |
+|---|---|---|---|
+| FO-12 | **Any unhandled fault → batch fails**: build the fault group, **tombstone state+basestate first**, `return _BatchFaulted(group)` (returned, never raised) → `_publish_fault` pops the fan-out frame, re-stamps for the caller, mirrors on `publish_topic`. `before_node`/body/`after_node`/`on_node_error` never run. | ✅ | `_close_fanout_batch`, `base.py:1291-1325`; `S4`, `S5`. |
+| FO-13 | **All resolved → batch succeeds**: materialize each resolved slot into `snapshot.state` (marker-aware; `_SlotFailed` never materializes), tombstone first, `_BatchClosed` → `before_node → body (resume model call) → after_node` → publish. A body raise here is the node's **own** work → `on_node_error`. | ✅ | `base.py:1291-1325`; `S6`. |
+| FO-14 | **Fault group shape:** exactly one unhandled fault **flattens** to the bare child (identity preserved; topology copied onto `details["calf.fanout_topology"]`); **2+** compose `calf.fault_group` carrying children in `causes`. Topology = `{slots:[{tag,target_topic,status}], ok, failed}` nested under `details["calf.fanout_topology"]` (⚠️ not at `details` root). Partial successes are **topology metadata only** — values never carried (leak posture). | ⚠️ | `_build_fault_group`, `base.py:1374-1395`; `S4`, `S40`. |
+
+### C5. Abort paths
+
+| ID | Behavior | Status | Notes |
+|---|---|---|---|
+| FO-15 | `calf.fanout.aborted` with `details["reason"] ∈ {dispatch_failed, store_unavailable, basestate_missing, reentry_failed}`. The caller is sourced from the **inbound delivery's pre-mutation stack snapshot**, *not* basestate (basestate is `None` in the `basestate_missing` case). | ✅ | `_fanout_abort_report`, `base.py:1327-1337`; reasons `error_report.py:65-69`. |
+| FO-16 | Mid-fold node-own terminal fault (stage-5 unrecovered, or publish failure) while a batch is open → recovery is **forbidden** mid-batch; tombstone both + escalate once. A permanent re-entry-publish failure → close-side `reentry_failed` abort. | ✅ | `_in_batch_work` arm, `base.py:1641-1647`; in-node §4.4. |
+| FO-17 | **Residual (accepted):** under a **dead store** (terminal reader death) the abort's tombstone write also fails, so each still-pending sibling independently aborts+escalates → the caller may receive up to **N** `calf.fanout.aborted` faults for one batch (a duplicate/over-delivery, not a loss; v1 holds zero in-process dedup state). | ✅ (by design) | in-node §4.4 / §13(6). |
+
+### C6. Durability & recovery
+
+| ID | Behavior | Status | Notes |
+|---|---|---|---|
+| FO-18 | Batch state **survives graceful partition movement**: the new owner reads `state[X]`/`basestate[X]` (barriered) and continues folding; the durable re-entry is processed by whoever owns the partition. Safety rests on durable-write-survives-revoke + barrier-before-read + idempotent fold — **no sweep, no rebalance listener**. | ✅ | in-node §6; kafka test `test_graceful_rebalance_continues_batch_on_new_owner`. `S43`. |
+| FO-19 | Posture: **at-most-once** (`ACK_FIRST` kept), **`max_workers=1`** pinned per-subscriber for caller-capable nodes. No duplicate side-effects ⇒ tools need not be idempotent for this design. Crashes/ungraceful kills/broker degradation are **out of scope** (operator's domain; bounded by `reply_ttl`, reclaimed by #220). | ✅ | in-node §2, §7. |
+
+### C7. Continuation & re-fan-out edges
+
+| ID | Behavior | Status | Notes |
+|---|---|---|---|
+| FO-20 | A `return`/`fault` arriving where **no batch is registered** is a **stateless continuation**, validated against the durable stack — no in-process state required. Keeps sequential agents and every mid-chain escalation hop stateless. A batch-of-one is never registered. | ✅ | `_aggregate` `None` arm, `base.py:1185-1221`; §6.7. |
+| FO-21 | After a successful fan-out closes, the agent's **next single `Call`** is **unmarked by construction** (the closure re-entry was assembled from the pre-stamp snapshot — no clearing step) → body-dispatches as an ordinary stateless continuation, not orphan-floored. | ✅ | `S47` + correction. |
+| FO-22 | **Sequential re-fan-out is safe**: close tombstones before the body runs; a resumed body re-fanning out (same frame ⇒ same `fanout_id`) opens a fresh batch over a tombstoned key; barrier-before-read reads the new registration, never the stale tombstone. | ✅ | in-node §4.3. |
+| FO-23 | A `TailCall`'s replacement frame **preserves `frame_id`/`tag`/`overrides`**, clears `payload` and `fanout_id` — the same pending call retargeted; a fresh id would orphan the caller's slot. | ✅ | `_publish_action` TailCall arm, `base.py:572-585`; `S34`. |
+
+### C8. Agent self-retry
+
+| ID | Behavior | Status | Notes |
+|---|---|---|---|
+| FO-24 | When **every** tool call in a turn is invalid (unknown tool / malformed args / validator raise → all become `RetryPromptPart` results) the agent emits a `TailCall` self-retry on its own private inbox (`kind=call`), re-prompting the model. | ✅ | `agent.py:456-460`. `S27`, `S37`. |
+| FO-25 | The self-retry loop is **bounded** by `self_retry_budget` (default 1); exhaustion → `calf.agent.self_retry_exhausted`; `self_retry_budget=0` → immediate fault `reason=self_retry_disabled`. | ⏳ | **Unimplemented.** Merged code has an **unbounded** loop, no budget, no exhaustion fault. `S37`. |
+
+---
+
+## Part D — Cross-cutting / "other" behaviors
+
+| ID | Behavior | Status | Notes |
+|---|---|---|---|
+| XC-1 | Caller-capable nodes require **`max_workers=1`**, set per-subscriber by `register_handlers` (the framework choosing the right value per node type, not policing a worker knob). The serialization is load-bearing for the fold and the seam/`State` ordering. | ✅ | in-node §2, §12(8); worker registration. |
+| XC-2 | The shared producer defaults to **`acks=all` + `enable_idempotence=True`** — hardens every rail; makes "await the ack" durable and the re-entry retry-safe. | ✅ | §13 producer posture. |
+| XC-3 | Structured logging: synthesis = ERROR (with traceback, at origin); each escalation hop = WARNING (`error_type`, origin, remaining depth); seam handling = INFO. The escalation logs carry the "why didn't my handler fire" teaching load. | ✅ | `base.py:650-657,709-716`; `_seams.py` INFO. `S9`. |
+| XC-4 | `ModelRetry` raised by a tool → caught at origin, rendered to a **`calf.retry`-marked `TextPart`** (raw message, no suffix), shipped as an **ordinary return** (not a fault). The agent's `_resolve_slot` materializes a `RetryPromptPart` (Anthropic `is_error=True` fidelity). | ✅ | `tool.py:116-121`, `payload.py:47-53`, `agent.py:131-193`; `S20`, `S36`. |
+| XC-5 | MCP **transport/session failure** → fault rail (`calf.unhandled`); **`isError=True`** result → **transparent passthrough** as an ordinary `ReturnCall` (NOT marked `calf.retry`). | ⚠️ | `mcp_toolbox.py:243-266` (B2 decision). Spec's `calf.retry`-for-MCP is deferred. |
+| XC-6 | `surface_to_model` per-tool budget tally in `State.seam_budgets` at every slot finalization (closure + the single continuation); reset on a tool's fault-free return; key = tool identity not topic. | ⏳ | **Unimplemented** (no `seam_budgets` field). `S35`. |
+| XC-7 | `reply_ttl` stays `None` by default; with the rail in place faults *arrive* instead of hanging — except where reception is deferred (FR-27/FR-30), where a finite `reply_ttl` is the liveness backstop. | ⚠️ | Until the reception PR, finite `reply_ttl` is **required** to observe routed-fault/undecodable cases without hanging. |
+
+---
+
+## Appendix — Deferred-behavior register (forward test targets)
+
+When these land, promote the tagged behaviors from ⏳ to ✅ and activate the corresponding stubbed tests (see the test plan's §Deferred).
+
+| Deferred item | Unblocks behaviors | Filed issue |
+|---|---|---|
+| Client reply-dispatcher `x-calf-kind` branch + `NodeFaultError` | FR-31; `S23` fault-half; `S30` client-half | **#250** (fault reception) |
+| `ConsumerContext.fault` / `.delivery_kind` | SE-27; `S25`, `S28` fault-tap | **#250** (fault reception) |
+| `surface_to_model` prebuilt + `State.seam_budgets` tally | SE-28, XC-6; `S12`, `S35` | **#251** (agent self-healing budgets) |
+| `self_retry_budget` + `calf.agent.self_retry_exhausted` | FO-25; `S37` exhaustion arm | **#251** (agent self-healing budgets) |
+| Provider classification `calf.model.context_window_exceeded` | FR-6; `S13` | **#193** (provider rider) |
+| MCP `isError` → `calf.retry` marking | XC-5 marked-arm | follow-up MCP PR (B2 deferral) |
+
+---
+
+## Appendix — Spec ↔ code drift (follow the code)
+
+These are the points where the *prose* of the two specs is ahead of the *merged code*. The catalogue above already follows the code; listed here so the divergence is recorded (not as an instruction to edit the specs — that's a separate call).
+
+1. `surface_to_model`, `self_retry_budget`/`seam_budgets`, the provider classifier, and the client-side `NodeFaultError` are **described as present** in the fault-rail spec body but are **deferred/absent** (the spec's own PR-6 CORRECTION banners flag most of them).
+2. The fault-group topology lives under `details["calf.fanout_topology"]`, **not** at the `details` root as the §7 prose reads.
+3. MCP `isError=True` is **transparent/unmarked** (B2), not `calf.retry`-marked.
+4. The fan-out aggregation language in the **fault-rail** spec still references the deleted v1 separate aggregator throughout §4/§6/§7/§13/§17 and scenarios #43/#46/#47; the authoritative current design is the **in-node** spec. (The fault-rail spec carries a blocking edit-checklist for this in the in-node spec's §10.)

--- a/docs/designs/fault-rail-fanout-integration-test-plan.md
+++ b/docs/designs/fault-rail-fanout-integration-test-plan.md
@@ -1,0 +1,324 @@
+# Fault Rail, Policy Seams & In-Node Fan-out — Real-Broker Integration Test Plan
+
+**Status:** Plan · **Date:** 2026-06-18
+**Targets:** the merged implementation of PR #247 (commit `04203fc`; HEAD `613ea02`).
+**Companion:** `docs/designs/fault-rail-fanout-behavior-catalogue.md` (behavior IDs `FR-*`, `SE-*`, `FO-*`, `XC-*` referenced throughout). Source specs: `fault-rail-and-policy-seams-spec.md` (scenarios `S*`), `in-node-fanout-aggregation-spec.md`.
+
+---
+
+## 1. Goals, lane, and non-duplication
+
+**Goal.** Prove the fault rail, the four policy seams, and the in-node durable fan-out fold behave correctly **over a real broker** — the lane that exercises real partitions, real consumer-group joins, real header filtering, real `KtablesFanoutBatchStore` materialization with `barrier()`, and real producer `acks=all`/idempotence. Today **every** seam, fault-escalation, auto-fault, decode-floor, oversized-fault, OPEN-abort and `calf.retry`-into-the-loop behavior is **offline-only**; this plan fills that gap.
+
+**Lane.** All tests carry `pytestmark = pytest.mark.kafka`, live under `tests/integration/`, run via `make test-kafka` / `uv run --group integration pytest -m kafka`, and use the session-scoped `kafka_bootstrap` (testcontainers Redpanda or `CALF_TEST_KAFKA_BOOTSTRAP`) + function-scoped `topic_namespace` fixtures from `tests/integration/conftest.py`. Every worker passes `extra_subscribe_kwargs={"auto_offset_reset": "earliest"}` (load-bearing — a group join otherwise races and drops the publish addressing it).
+
+**Do NOT duplicate** (already real-broker covered — `test_durable_fanout_agent_kafka.py`, `test_fanout_store_kafka.py`, `test_tool_node_roundtrip_kafka.py`, `test_mcp_roundtrip_kafka.py`): the durable fan-out happy arc + real store opening; graceful-rebalance continuation; store RYOW barrier / tombstone visibility / failed-outcome typed-fault round-trip; and all tool/MCP **happy-path** single-dispatch / fan-out / dup-call / sequential / multi-worker / multi-turn / arg-validation-to-model / include-pinning / `list_changed`.
+
+**Do NOT test vapor** (deferred — see catalogue Appendix): `surface_to_model`, `self_retry_budget`/`seam_budgets`/`calf.agent.self_retry_exhausted`, provider `calf.model.context_window_exceeded`, client-side `NodeFaultError`, `ConsumerContext.fault`, MCP-`isError`-marking. These get **skipped/xfail stubs** (§7) that flip on when their PR lands.
+
+---
+
+## 2. Observability — three channels (standardize on these)
+
+No typed fault reaches the client today (FR-29/FR-30). The plan uses three deterministic channels; **most fault/seam tests use Channel A + B together** (B asserts the in-process decision, A asserts the wire/headers).
+
+### Channel A — the broadcast-mirror fault tap (NEW shared helper)
+
+The faulting node's fault is mirrored on its `publish_topic` as an `Envelope` whose `reply` is a `FaultMessage`, with headers `x-calf-kind=fault` + `x-calf-error-type`. We add **one** reusable tap (no such helper exists in `tests/` today). Sketch — `tests/integration/_fault_tap.py`:
+
+```python
+# tests/integration/_fault_tap.py
+from __future__ import annotations
+import asyncio, uuid
+from contextlib import asynccontextmanager
+from aiokafka import AIOKafkaConsumer
+from calfkit.models.envelope import Envelope
+from calfkit.models.reply import FaultMessage, ReturnMessage
+from calfkit._protocol import HDR_KIND, HDR_ERROR_TYPE, decode_header_str
+
+class FaultTap:
+    """Raw consumer on a topic, decoding calfkit Envelopes and exposing their replies.
+
+    Subscribe BEFORE the publish under test; pass auto_offset_reset='earliest'."""
+    def __init__(self, consumer: AIOKafkaConsumer):
+        self._c = consumer
+
+    async def next_envelope(self, *, timeout: float = 30.0) -> tuple[Envelope, dict[str, str | None]]:
+        record = await asyncio.wait_for(self._c.getone(), timeout=timeout)
+        env = Envelope.model_validate_json(record.value)
+        headers = {k: decode_header_str(v) for k, v in record.headers}
+        return env, headers
+
+    async def next_fault(self, *, timeout: float = 30.0) -> tuple[FaultMessage, dict[str, str | None]]:
+        """Drain until a FaultMessage envelope appears (skips return/call mirrors)."""
+        deadline = asyncio.get_event_loop().time() + timeout
+        while asyncio.get_event_loop().time() < deadline:
+            env, headers = await self.next_envelope(timeout=max(0.1, deadline - asyncio.get_event_loop().time()))
+            if isinstance(env.reply, FaultMessage):
+                return env.reply, headers
+        raise AssertionError("no FaultMessage observed on the tapped topic")
+
+@asynccontextmanager
+async def fault_tap(bootstrap: str, topic: str):
+    consumer = AIOKafkaConsumer(
+        topic, bootstrap_servers=bootstrap,
+        auto_offset_reset="earliest", group_id=f"fault-tap-{uuid.uuid4().hex[:8]}",
+    )
+    await consumer.start()
+    try:
+        yield FaultTap(consumer)
+    finally:
+        await consumer.stop()
+```
+
+Usage: give the node-under-test a `publish_topic`, start the tap on it **before** invoking, then assert:
+
+```python
+async with fault_tap(kafka_bootstrap, agent_pub) as tap:
+    handle = await driver.start("go", agent_in)              # don't block on the (hanging) future
+    fault, headers = await tap.next_fault(timeout=30)
+    assert headers[HDR_KIND] == "fault"
+    assert headers[HDR_ERROR_TYPE] == "calf.unhandled"
+    assert fault.error.find("calf.unhandled") is not None
+```
+
+> Why a raw consumer and not a `@consumer` node: `ConsumerContext` has no `.fault` today (SE-27), so a sink node sees `output=None`. The raw tap reads `envelope.reply.error` directly — the only typed channel.
+
+### Channel B — in-callback seam assertions (in-process)
+
+Seams are developer-supplied callables that run inside the worker and receive the live `SeamContext`/`ErrorReport`. Register a seam that **records** what it saw (and optionally asserts), then assert in the test body after the roundtrip. This is the cleanest channel for seam-firing/ordering/context-content checks and **sidesteps the deferred client edge entirely**.
+
+```python
+# A recorder seam — capture-in-callback, assert-in-test-body (robust default).
+class SeamProbe:
+    def __init__(self): self.calls: list[dict] = []
+    def on_callee_error(self, ctx, fault):
+        self.calls.append({"kind": ctx.delivery_kind, "type": fault.error_type,
+                           "tag": ctx.failing_call.tag if ctx.failing_call else None,
+                           "depth": len(fault.frame_chain)})
+        return None                                    # decline → escalate (or return a value to handle)
+
+probe = SeamProbe()
+agent = Agent(..., on_callee_error=probe.on_callee_error)
+...
+async with worker:
+    handle = await driver.start("go", agent_in)
+    await asyncio.wait_for(_settle(...), timeout=30)   # wait for the probe to fire / fault to mirror
+assert probe.calls == [{"kind": "fault", "type": "calf.unhandled", "tag": "c1", "depth": 1}]
+```
+
+**Caveat (document in the helper):** a *raised* `AssertionError` inside a seam is a node-own accident — for `before_node`/`after_node` it routes to `on_node_error` → `calf.unhandled` (visible as a fault, not a test failure); for `on_callee_error` it is slot-scoped (resolves the slot failed). So **default to capture-then-assert.** Direct in-callback `assert`/`raise NodeFaultError(...)` is valid only for "must-fire / must-see-X" checks where you *want* the failure to surface as an observable fault (then assert that distinctive fault on Channel A). A handler that must *not* fire can assert by leaving its recorder empty.
+
+### Channel C — client edge (current behavior) + caplog
+
+- **Routed fault → `DeserializationError`:** `await handle.result(timeout=...)` raises `DeserializationError` (FaultMessage → empty parts → strict projection). Proves "didn't hang, didn't succeed" but carries no typed report — pair with Channel A for the `error_type`.
+- **Hang-prone cases** (fire-and-forget fault, floored fault, undecodable reply): connect the driver with a **finite `reply_ttl`** and assert `ReplyExpiredError`, or wrap in `asyncio.wait_for`.
+- **caplog (secondary):** floor/synthesis events log at ERROR (`calfkit.client.middleware`, `base.py` synthesis), escalation hops at WARNING. Over a real broker these are timing-sensitive (logged in the worker consume coroutine) — use only as a corroborating assertion, never the sole one.
+
+---
+
+## 3. Test fixtures & doubles to add
+
+### 3.1 Example fault-emitting tools (`tests/integration/_fault_tools.py`)
+
+```python
+from calfkit.nodes import agent_tool
+from calfkit.exceptions import NodeFaultError
+from calfkit._vendor.pydantic_ai import ModelRetry   # exact import per tool.py
+
+@agent_tool
+def boom(x: int) -> int:                  # FR-2: generic raise → calf.unhandled
+    raise ValueError("kaboom")
+
+@agent_tool
+def quota(x: int) -> int:                 # FR-3: deliberate verbatim fault (mint rule)
+    raise NodeFaultError("billing.quota_exceeded", message="over quota",
+                         retryable=False, details={"x": x})
+
+@agent_tool
+def needs_retry(x: int) -> int:           # XC-4: ModelRetry → calf.retry-marked return
+    raise ModelRetry("provide a positive x")
+
+@agent_tool
+def huge(n: int) -> str:                  # FR-21: oversized result to force strip-and-retry
+    return "z" * n                        # n sized > broker message.max.bytes at the fault hop
+
+@agent_tool
+def ok_a() -> str: return "a_result"      # happy siblings for fan-out mixes
+@agent_tool
+def ok_b() -> str: return "b_result"
+```
+
+A **gated** tool variant (reuse the durable-fanout suite's `_GATE` idiom) for deterministic ordering in rebalance / interleave stress tests.
+
+### 3.2 FunctionModel scripts (extend `tests/integration/_roundtrip_helpers.py`)
+
+Reuse `scripted_model([...])` (turn-1 calls, turn-2 finalize), `reactive_model(decide)`, `tool_returns`, `returns_by_call_id`, `retry_prompt_texts`. Add only if needed:
+- a **fan-out script** = `scripted_model([ToolCallPart("boom",{"x":1},tool_call_id="c1"), ToolCallPart("ok_a",{},tool_call_id="c2")])` (≥2 calls → durable batch).
+- a **retry-then-recover** reactive model: turn 1 calls `needs_retry`; on seeing the retry text, turn 2 calls `ok_a`; then finalize — proves `calf.retry` re-enters the loop (XC-4) over the wire.
+
+### 3.3 Worker helper
+
+Reuse the suites' `_worker(bootstrap, *, nodes)` (own `Client.connect`, `extra_subscribe_kwargs=_EARLIEST`). Each node-under-test gets an explicit `publish_topic` so Channel A can tap it. Tear down with `await driver.close()` + `await worker._client.close()`.
+
+---
+
+## 4. Test suites
+
+Each row: **ID** · behavior(s) covered · setup · action · assertion / channel · maps-to scenario. `A`=mirror tap, `B`=in-callback, `C`=client-edge.
+
+### Suite F — Fault escalation over the wire
+
+| ID | Covers | Setup | Action → Assert |
+|---|---|---|---|
+| F-1 | FR-2, FR-11, FR-18 | agent(`tools=[boom]`, `model=scripted([boom c1])`, `publish_topic=pub`), no seams | `driver.start`; **A**: `next_fault` → `error_type=="calf.unhandled"`, `details["calf.exception_type"]=="ValueError"`, headers `kind=fault`+`error-type`. **C**: `handle.result()` raises `DeserializationError`. |
+| F-2 | FR-3, FR-4 | agent(`tools=[quota]`), no seams | **A**: fault `error_type=="billing.quota_exceeded"`, `retryable is False`, `details["x"]==1`. Verbatim, not `calf.unhandled`. `S32`. |
+| F-3 | FR-7, FR-8, FR-9 | deep chain A→B→C as 3 agents over 3 topics; C's tool `boom`; B has no `on_callee_error` (declines) | invoke A; **A** taps A's `publish_topic` → fault `error_type` identical to C's origin, `frame_chain` length ≥ 2, same `report_id` as the C-hop mirror. **B**: a recorder `on_callee_error` on A fires once with that fault. `S3`, `S24`. |
+| F-4 | FR-12, FR-13 | fire-and-forget: `driver.send("go", agent_in)` (no reply_to) to an agent whose tool `boom`s; agent `publish_topic=pub` | **A**: fault mirrored on `pub`. **C**: no future exists (send returns a correlation id only); assert nothing hangs. `S10`, `S14`. |
+| F-5 | FR-25, FR-16 (stray) | publish a hand-built `kind=fault`/`reply=None` envelope (kind/slot disagreement) onto a live agent's return topic | **B/caplog**: WARNING stray, the open invocation untouched; the agent's reply future still resolves normally for a concurrent valid call. `S29`. |
+
+### Suite S — Policy-seam pipeline over the wire
+
+| ID | Covers | Setup | Action → Assert |
+|---|---|---|---|
+| S-1 | SE-3, B1 `before_node` | agent with `before_node` returning a substitute string on ingress | invoke; **C**: `handle.result().output` is the substitute; **B**: a body-probe tool never ran. `S` (uniform contract). |
+| S-2 | SE-21 input transform | agent `before_node` mutates `ctx.state` (rewrite prompt) + returns `None` | **B**: body sees the transformed input (recorder tool captures it). `S18`. |
+| S-3 | B1 `after_node` replace | agent `after_node` returns `"redacted"` | **C**: output is `"redacted"`. |
+| S-4 | SE-8, SE-11 | agent `before_node` raises `ValueError`; `on_node_error` returns a recovery value | **A**: no fault; **C**: output is the recovery value (flowed through `after_node`). `S8`. |
+| S-5 | SE-10 decline-escalate | tool `boom`; agent `on_node_error` *handler* raises a non-NodeFaultError (declines) | **A**: original `calf.unhandled` escalates; `details["calf.seam_errors"]` notes the handler failure. `S9`. |
+| S-6 | SE-7 mint bypass | tool `boom`; agent `on_node_error=[recover]` **and** the body raises `NodeFaultError("x.y")` | **A**: `x.y` escalates verbatim; the recovery seam never fired (recorder empty). `S32`. |
+| S-7 | SE-9 slot-scoped raise | fan-out of 2 (`boom`,`ok_a`); agent `on_callee_error` raises a `NodeFaultError("seam.reject")` on the `boom` slot | **A**: at closure the group/flattened fault carries `seam.reject` chained to the inbound fault; `ok_a` recorded ok; no double reply. `S31`. |
+| S-8 | SE-13/14/15/16 guards | agent `before_node` returns `True` / its `StateT` / `b"x"` / (separately) `after_node` returns a `Call` | each: **A**: `SeamContractError`-origin fault (`calf.unhandled`) escalates; body not silently skipped. `S41`, `S16`. |
+| S-9 | SE-18, SE-19 | register a seam on a `@consumer`; register a wrong-arity seam | worker **startup raises** `RegistryConfigError` (assert at `async with worker:` entry). `S25`. |
+| S-10 | SE-24, SE-22, SE-23 | recorder seams on all four positions | drive ingress + a callee fault; **B**: assert `delivery_kind`/`route`/`awaiting_reply`/`failing_call`/`exception` are populated exactly per position and cleared elsewhere. |
+
+### Suite R — Auto-fault, decline, fire-and-forget
+
+| ID | Covers | Setup | Action → Assert |
+|---|---|---|---|
+| R-1 | FR (auto-fault), §10 | a routed (`execute`) delivery whose only handler **declines** (all-declined) on a reply-owing node | **A**: `calf.delivery.rejected`, `details["reason"]=="all_declined"`. **C**: `DeserializationError` (didn't hang). `S15`. |
+| R-2 | schema_rejected | a routed delivery whose matching handler rejects the body schema | **A**: `calf.delivery.rejected`, `reason=="schema_rejected"`. `S39`. |
+| R-3 | fire-and-forget no-op | `send(...)` to a node whose handler declines (no reply owed) | **B/caplog**: DEBUG no-op, no fault, no publish on a callback rail. `S15`, `S28`. |
+
+### Suite D — Decode floor
+
+| ID | Covers | Setup | Action → Assert |
+|---|---|---|---|
+| D-1 | FR-26 | a raw `AIOKafkaConsumer`/producer publishes a **malformed body** (invalid JSON / wrong shape) to a live node's input topic | **caplog (ERROR, `calfkit...middleware`/node decode)**: `calf.delivery.undecodable` floored; the worker keeps consuming (a subsequent valid invocation still completes — the stronger assertion). `S30`. |
+| D-2 | FR-27 (current) | malformed body on the **client reply topic**; driver with finite `reply_ttl` | **C**: the pending future does **not** resolve from the junk; it raises `ReplyExpiredError` (documents the current hang-until-TTL behavior). Flip to `NodeFaultError(calf.delivery.undecodable)` when the reception PR lands. |
+
+### Suite O — Oversized fault strip-and-retry
+
+| ID | Covers | Setup | Action → Assert |
+|---|---|---|---|
+| O-1 | FR-21 | tool raises a `NodeFaultError` whose `details` (or a fault group whose `causes`) serialize **> the broker's `message.max.bytes`** on the fault hop; node `publish_topic=pub` | **A**: a fault still arrives, stripped to minimal (`to_minimal()` — only `report_id`/`error_type`/`message`/`retryable`/origin ids; `causes`/`details`/`frame_chain` empty). Confirms the strip-and-retry-once path against a *real* `MessageSizeTooLargeError`, not the offline `_FailThenCaptureBroker`. |
+
+> Sizing note: set a small broker/topic `max.message.bytes` on the tap/fault topic (or build a genuinely large `details` via `huge`) so the first publish trips the size limit but the minimal report fits. Document the chosen limit in the test.
+
+### Suite X — Fan-out fault paths over the wire
+
+| ID | Covers | Setup | Action → Assert |
+|---|---|---|---|
+| X-1 | FO-12, FO-14 (flatten) | agent fan-out of 3 (`boom`,`ok_a`,`ok_b`), no `on_callee_error` | real `KtablesFanoutBatchStore`; **A**: at closure a **flattened** fault (the bare `boom` `calf.unhandled`) with `details["calf.fanout_topology"].ok==2`, the two successes as `status=="ok"` slots; body never ran (recorder). `S4`. |
+| X-2 | FO-12, FO-14 (group) | fan-out of 3, **two** tools `boom` | **A**: `calf.fault_group` with 2 `causes`; `report.find("calf.unhandled")` matches at depth; `failed==2`. `S5`, `S40`. |
+| X-3 | FO-6, B1 `on_callee_error` resolve | fan-out of 3 (`boom`,`ok_a`,`ok_b`); agent `on_callee_error` returns a substitute string for `boom` | **C**: batch **completes** (`handle.result().output` is the finalized text); **B**: the model's turn-2 saw 3 results (one substituted). `S6`. |
+| X-4 | FO-3, FO-15 dispatch-abort | fan-out where a sibling **publish fails** (point a sibling at an invalid topic / inject a broker error via a wrapper) **or** the store is made unavailable at OPEN | **A**: `calf.fanout.aborted`, `details["reason"]=="dispatch_failed"` (or `store_unavailable`), exactly one fault to the caller. |
+| X-5 | FO-16 mid-fold abort | fan-out open on real store; force a node-own raise mid-fold (a seam recorder that raises on the 2nd sibling) | **A**: `calf.fanout.aborted` once; both tables tombstoned (assert via a follow-up `KafkaTable` read that `state[X]` is gone); late siblings stray-floor. |
+| X-6 | FO-20, FO-21 | a sequential agent runs single calls before & after a fan-out turn; verify the post-fan-out single `Call` is unmarked and completes (not orphan-floored) | **C**: full completion; **B**: no stray/orphan floor logged. `S47`. |
+| X-7 | FO-22 re-fan-out | model fans out, closes, then the resumed body fans out again on the same frame | real store; **C**: both batches complete; assert the second OPEN read fresh registration (no stale-tombstone hang). |
+
+### Suite M — `calf.retry` marker round-trip into a real agent loop
+
+| ID | Covers | Setup | Action → Assert |
+|---|---|---|---|
+| M-1 | XC-4 | `tools=[needs_retry, ok_a]`; **retry-then-recover** reactive model (§3.2) | **C**: completes; `retry_prompt_texts(history)` contains the rendered retry; the model's turn-2 `ok_a` result is present. Proves the `calf.retry` TextPart materialized as a `RetryPromptPart` and re-entered the loop over real Kafka. `S20`, `S36`. |
+| M-2 | XC-5 | MCP toolbox tool returning `isError=True` (extend `_mcp_roundtrip_server.py`) | **C**: the `isError` result arrives as an **ordinary** model-visible return (transparent, **not** a fault, **not** `calf.retry`-marked) — assert `tool_returns(history)` carries it and no fault mirrors. Locks the B2 passthrough. |
+
+### Suite Z — Stress / soak
+
+| ID | Covers | Setup | Action → Assert |
+|---|---|---|---|
+| Z-1 | FO-1, FO-7, fold throughput | fan-out of **large N** (e.g. 16–32 tools, mix of `ok_*`); real store | completes once; **A**: no fault; assert the model's final turn saw exactly N results; assert exactly one re-entry (spy/store read shows one tombstone). |
+| Z-2 | FO-7 idempotency under dup | fan-out of N; replay a sibling reply (duplicate `in_reply_to`) via a raw producer | batch still closes once; the duplicate is a stray (no double-resolve, no early closure). `S33`. |
+| Z-3 | concurrency / serialization | launch **M concurrent invocations** (distinct correlation ids) at one agent, each fanning out; `max_workers=1` | all complete; no cross-batch bleed (each result set matches its own correlation); proves the serial fold under load. XC-1. |
+| Z-4 | mixed success/fault batches | K concurrent fan-outs, half with a `boom` sibling | the faulting halves each escalate exactly one group/flattened fault (Channel A count == failing-batch count); the healthy halves complete. No strands, no doubles. |
+| Z-5 | rapid sequential re-fan-out | one agent doing B back-to-back fan-out turns | each closes before the next opens; no tombstone races; B completions. FO-22. |
+| Z-6 | large payload carriage | fan-out where siblings return large (but in-budget) results, plus one `huge`-driven oversized fault | healthy results carry; the oversized fault strips to minimal (O-1) without dropping. |
+
+> Stress determinism: use gated tools (`_GATE`) to control sibling arrival ordering where an assertion depends on it; otherwise rely on `_wait(predicate, timeout, what)` polling (no bare sleeps). Keep N/M/K modest (CI budget) but > the offline lane's 2–3.
+
+---
+
+## 5. Determinism & hygiene rules (every test)
+
+1. **`auto_offset_reset="earliest"`** on every worker and tap consumer.
+2. **Namespace** all topics/groups off `topic_namespace` (per-test isolation); the fan-out tables are `calf.fanout.{agent_id}.{state,basestate}` so the agent id must be namespaced too.
+3. **Subscribe the tap before the publish** under test (Channel A). Start the worker, `await` its readiness (resource phase opens the real store), then invoke.
+4. **Never block on a hang-prone future** — use `driver.start(...)` + Channel A/B, or a finite `reply_ttl`, or `asyncio.wait_for`. A test that does `await driver.execute(...)` on a path that escalates a fault will **hang** until timeout (FR-30).
+5. **No bare `sleep`** — poll with `_wait(predicate, timeout, what)`; gate ordering with `_GATE`.
+6. **Capture-then-assert** for seam probes (Channel B); reserve direct in-callback `assert`/`raise` for must-fire/must-see checks paired with a Channel-A fault assertion.
+7. **Teardown**: `await driver.close()` and `await worker._client.close()` (and `await tap...stop()` via the context manager). Drain in-flight folds before stopping a worker mid-batch.
+8. **Mark** `pytestmark = [pytest.mark.kafka]`; set `models.ALLOW_MODEL_REQUESTS = True` only if a live model is used (these tests use `FunctionModel`, so it is not needed — keep them offline-model, real-broker).
+
+---
+
+## 6. Coverage traceability (gap → suite)
+
+| Gap (offline-only today) | Behavior IDs | Suite/tests | Spec scenario |
+|---|---|---|---|
+| Body-raise escalation to a real caller + headers | FR-2, FR-11, FR-18, FR-29 | F-1 | S1 |
+| Deliberate verbatim mint over the wire | FR-3, FR-4 | F-2 | S32 |
+| Deep-chain identity-preserving escalation | FR-7..FR-10 | F-3 | S3, S24 |
+| Fire-and-forget terminal fault | FR-12, FR-13 | F-4 | S10, S14 |
+| Stray fault/return on a live node | FR-16, FR-25 | F-5 | S17, S29 |
+| Seam pipeline (all four) through a live Worker | SE-3..SE-25 | S-1..S-10 | S8, S9, S16, S18, S31, S41, S44 |
+| Registration validation at startup | SE-18, SE-19 | S-9 | S25 |
+| `calf.delivery.rejected` auto-fault | §10, FR | R-1, R-2 | S15, S39 |
+| Decode floor `calf.delivery.undecodable` | FR-26, FR-27 | D-1, D-2 | S30 |
+| Oversized-fault strip-and-retry (real size limit) | FR-21 | O-1 | S42-adj |
+| Fan-out fault group / flatten over the wire | FO-12, FO-14 | X-1, X-2 | S4, S5, S40 |
+| `on_callee_error` slot-resolve in a real fan-out | FO-6 | X-3, S-7 | S6, S31 |
+| OPEN-dispatch-abort + mid-fold abort | FO-3, FO-15, FO-16 | X-4, X-5 | — (in-node §4.4) |
+| Unmarked continuation / re-fan-out | FO-20..FO-22 | X-6, X-7 | S47 |
+| `calf.retry` round-trip into the loop | XC-4 | M-1 | S20, S36 |
+| MCP `isError` transparent passthrough | XC-5 | M-2 | — (B2) |
+| Fan-out under load / dup / concurrency | FO-1, FO-7, XC-1 | Z-1..Z-6 | S33 |
+
+---
+
+## 7. Deferred-behavior stubs (skip/xfail until the PR lands)
+
+Add these now as `@pytest.mark.skip(reason="reception PR — FR-31")` / `xfail(strict=True)` so the suite documents the target and flips on automatically:
+
+| Stub | Asserts (when live) | Unblocked by (filed issue) |
+|---|---|---|
+| `test_client_raises_node_fault_error_on_fault_reply` | `await handle.result()` raises `NodeFaultError`; `e.report.find(...)` branches | **#250** fault reception (FR-31) — `S23` |
+| `test_consumer_tap_sees_fault` | a `@consumer` on a mirror reads `ctx.fault.error_type`, `ctx.delivery_kind=="fault"` | **#250** fault reception (SE-27) — `S25`, `S28` |
+| `test_surface_to_model_bounds_then_escalates` | prebuilt resolves slots until budget, then declines → escalates | **#251** self-healing budgets (SE-28) — `S12`, `S35` |
+| `test_self_retry_budget_exhausts` | one WARNING retry, then `calf.agent.self_retry_exhausted`; `budget=0` → `reason=self_retry_disabled` | **#251** self-healing budgets (FO-25) — `S37` |
+| `test_context_window_classifies` | a provider context-window error → `calf.model.context_window_exceeded` | **#193** provider rider (FR-6) — `S13` |
+| `test_mcp_iserror_marks_calf_retry` | MCP `isError` materializes a `RetryPromptPart` (Anthropic `is_error` fidelity) | follow-up MCP PR / B2 deferral (XC-5) |
+
+> Until each lands, the corresponding **current-behavior** test in §4 (D-2 hang, F-1/X-1 `DeserializationError`, M-2 transparent passthrough) is the live assertion; the stub is the forward target.
+
+---
+
+## 8. Suggested file layout
+
+```
+tests/integration/
+  _fault_tap.py            # NEW — Channel A shared helper (§2.A)
+  _fault_tools.py          # NEW — boom/quota/needs_retry/huge/ok_* + gated variants (§3.1)
+  _roundtrip_helpers.py    # extend with fan-out + retry-then-recover scripts (§3.2)
+  test_fault_escalation_kafka.py     # Suite F
+  test_seam_pipeline_kafka.py        # Suite S
+  test_auto_fault_kafka.py           # Suite R
+  test_decode_floor_kafka.py         # Suite D
+  test_oversized_fault_kafka.py      # Suite O
+  test_fanout_faults_kafka.py        # Suite X
+  test_retry_marker_kafka.py         # Suite M
+  test_fault_stress_kafka.py         # Suite Z
+  test_deferred_reception_kafka.py   # Suite §7 stubs
+```
+
+Each module: `pytestmark = pytest.mark.kafka`; reuse `kafka_bootstrap`/`topic_namespace`, `_worker`, `_wait`, the new `_fault_tap`/`_fault_tools`. Build incrementally, TDD-style (`/test-driven-development`), one suite at a time; run `make fix && make check` before raising the PR.

--- a/tests/integration/_fault_kafka.py
+++ b/tests/integration/_fault_kafka.py
@@ -1,0 +1,39 @@
+"""Shared real-broker helpers for the fault / seam / fan-out integration suites.
+
+The fault suites are a cohesive family, so they share one Worker builder and one
+topic pre-creation helper here rather than each re-declaring them (the older roundtrip
+suites predate this module and keep their own ``_worker``/``_topics`` copies).
+"""
+
+from __future__ import annotations
+
+from aiokafka.admin import AIOKafkaAdminClient, NewTopic
+from aiokafka.errors import TopicAlreadyExistsError
+
+from calfkit.client import Client
+from calfkit.worker import Worker
+
+EARLIEST = {"auto_offset_reset": "earliest"}
+"""Mandatory for every node + tap consumer: ``earliest`` keeps a consumer-group join from
+racing (and dropping) the publish addressing it on a freshly auto-created partition."""
+
+
+def fault_worker(bootstrap: str, *, nodes: list) -> Worker:
+    """A Worker on its own broker connection, reading earliest."""
+    return Worker(Client.connect(bootstrap), nodes=nodes, extra_subscribe_kwargs=EARLIEST)
+
+
+async def ensure_topic(bootstrap: str, topic: str, *, config: dict[str, str] | None = None) -> None:
+    """Pre-create *topic* (1 partition) so a consumer has a partition to read from the
+    moment it starts — removing the auto-create metadata race for tapped / injected topics.
+
+    ``config`` sets topic-level overrides (e.g. ``{"max.message.bytes": "4096"}`` to make a
+    callback topic reject an oversized fault, exercising the strip-and-retry floor)."""
+    admin = AIOKafkaAdminClient(bootstrap_servers=bootstrap)
+    await admin.start()
+    try:
+        await admin.create_topics([NewTopic(topic, num_partitions=1, replication_factor=1, topic_configs=config)])
+    except TopicAlreadyExistsError:
+        pass
+    finally:
+        await admin.close()

--- a/tests/integration/_fault_tap.py
+++ b/tests/integration/_fault_tap.py
@@ -1,0 +1,92 @@
+"""Channel A — the broadcast-mirror fault tap for the real-broker fault tests.
+
+No typed fault reaches the client today: the reply dispatcher has no ``x-calf-kind``
+branch yet, so a routed fault is ``set_result``-ed like a success and surfaces to the
+caller as a ``DeserializationError`` (the typed ``NodeFaultError`` reception is deferred
+to #250). The deterministic *typed* channel is a node's ``publish_topic`` broadcast
+mirror: every caller-capable node that escalates (or floors) a fault returns the
+fault-bearing envelope as its handler ``Response``, and the worker's ``@publisher``
+broadcasts it on ``publish_topic`` with headers ``x-calf-kind=fault`` +
+``x-calf-error-type``. This module taps that topic with a raw ``AIOKafkaConsumer`` and
+decodes the calfkit ``Envelope`` so a test can read ``envelope.reply.error`` — a typed
+:class:`~calfkit.models.error_report.ErrorReport`.
+
+Why a raw consumer and not a ``@consumer`` node: ``ConsumerContext`` has no ``.fault``
+field yet (also deferred to #250), so a sink node projects a ``FaultMessage`` to
+``output=None`` and never sees the report. The raw tap reads the reply slot directly.
+
+Read ``earliest`` with a fresh group so the tap sees the mirror even if it joins after
+the publish. Pre-create the tapped topic (see ``_ensure_topic`` in the test module) so
+the consumer has a partition to read from the moment it starts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from aiokafka import AIOKafkaConsumer
+
+from calfkit._protocol import decode_header_str
+from calfkit.models.envelope import Envelope
+from calfkit.models.reply import FaultMessage
+
+
+class FaultTap:
+    """A live tap over one topic: decode calfkit ``Envelope``s and surface their replies."""
+
+    def __init__(self, consumer: AIOKafkaConsumer) -> None:
+        self._consumer = consumer
+
+    async def next_envelope(self, *, timeout: float = 30.0) -> tuple[Envelope, dict[str, str | None]]:
+        """The next decoded envelope on the topic, with its headers as ``str | None``."""
+        record = await asyncio.wait_for(self._consumer.getone(), timeout=timeout)
+        envelope = Envelope.model_validate_json(record.value)
+        headers = {key: decode_header_str(value) for key, value in record.headers}
+        return envelope, headers
+
+    async def next_fault(self, *, timeout: float = 30.0) -> tuple[FaultMessage, dict[str, str | None]]:
+        """Drain until a ``FaultMessage`` envelope appears.
+
+        A faulting node's ``publish_topic`` also carries its non-fault mirrors (the
+        ``kind=call`` dispatch mirror with ``reply=None``), so skip past anything whose
+        reply is not a :class:`FaultMessage`. ``timeout`` bounds the whole wait.
+        """
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + timeout
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise AssertionError("no FaultMessage observed on the tapped topic within the timeout")
+            try:
+                envelope, headers = await self.next_envelope(timeout=remaining)
+            except TimeoutError:
+                # No message before the deadline — surface the single, predictable failure
+                # mode (AssertionError) on the next loop, so callers asserting "no fault
+                # arrived" can ``pytest.raises(AssertionError)`` rather than catch a raw
+                # asyncio TimeoutError.
+                continue
+            if isinstance(envelope.reply, FaultMessage):
+                return envelope.reply, headers
+
+
+@asynccontextmanager
+async def fault_tap(bootstrap: str, topic: str) -> AsyncIterator[FaultTap]:
+    """Open a :class:`FaultTap` over *topic* for the duration of the ``with`` block.
+
+    A fresh ``group_id`` + ``auto_offset_reset="earliest"`` so the tap reads the topic
+    from the start regardless of when it joins relative to the publish under test.
+    """
+    consumer = AIOKafkaConsumer(
+        topic,
+        bootstrap_servers=bootstrap,
+        auto_offset_reset="earliest",
+        group_id=f"fault-tap-{uuid.uuid4().hex[:8]}",
+    )
+    await consumer.start()
+    try:
+        yield FaultTap(consumer)
+    finally:
+        await consumer.stop()

--- a/tests/integration/_fault_tap.py
+++ b/tests/integration/_fault_tap.py
@@ -62,11 +62,13 @@ class FaultTap:
                 raise AssertionError("no FaultMessage observed on the tapped topic within the timeout")
             try:
                 envelope, headers = await self.next_envelope(timeout=remaining)
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 # No message before the deadline — surface the single, predictable failure
                 # mode (AssertionError) on the next loop, so callers asserting "no fault
                 # arrived" can ``pytest.raises(AssertionError)`` rather than catch a raw
-                # asyncio TimeoutError.
+                # timeout. Catch ``asyncio.TimeoutError`` (what ``wait_for`` raises), NOT the
+                # builtin ``TimeoutError``: on Python <= 3.10 they are distinct classes, so
+                # ``except TimeoutError`` would miss it (it is only an alias on 3.11+).
                 continue
             if isinstance(envelope.reply, FaultMessage):
                 return envelope.reply, headers

--- a/tests/integration/_fault_tools.py
+++ b/tests/integration/_fault_tools.py
@@ -1,0 +1,101 @@
+"""Example fault-emitting tool nodes + a recorder seam for the real-broker fault tests.
+
+A tool node's topics are derived from its function name (``tool.<name>.input`` /
+``tool.<name>.output``, via ``@agent_tool``), so the names here are module-global
+addresses — keep them unique and descriptive. Each tool exercises one entry point of
+the rail:
+
+- :func:`boom` — a generic uncaught exception → the chokepoint synthesizes
+  ``calf.unhandled`` (catalogue FR-2), carrying the exception class in
+  ``details["calf.exception_type"]``.
+- :func:`quota` — a deliberate ``NodeFaultError`` minted in the tool body → carried
+  **verbatim** (the mint rule bypasses ``on_node_error``; FR-3/FR-4).
+- :func:`ok_a` / :func:`ok_b` — fault-free siblings, for mixed fan-out batches.
+
+:class:`CalleeErrorRecorder` is the Channel-B observation seam: an ``on_callee_error``
+handler that captures the live ``SeamContext`` / ``ErrorReport`` and then **declines**
+(returns ``None``) so the fault still escalates. It records rather than asserts so a
+failed assertion in the test body — not a raise inside the seam (which would itself
+become a node-own fault) — reports the failure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from calfkit._vendor.pydantic_ai.exceptions import ModelRetry
+from calfkit.exceptions import NodeFaultError
+from calfkit.models.error_report import ErrorReport
+from calfkit.models.seam_context import SeamContext
+from calfkit.nodes import agent_tool
+
+
+@agent_tool
+def boom(x: int) -> int:
+    """Raise a generic exception → synthesized as ``calf.unhandled`` at the chokepoint."""
+    raise ValueError(f"kaboom({x})")
+
+
+@agent_tool
+def needs_retry(x: int) -> int:
+    """Raise ``ModelRetry`` → a *recoverable* (model-visible) failure, NOT a fault: the
+    tool renders it at origin to a ``calf.retry``-marked ``TextPart`` that the agent
+    materializes back into a ``RetryPromptPart`` (catalogue XC-4)."""
+    raise ModelRetry("provide a positive x")
+
+
+@agent_tool
+def quota(x: int) -> int:
+    """Mint a deliberate typed fault → carried verbatim (bypasses ``on_node_error``)."""
+    raise NodeFaultError("billing.quota_exceeded", message="over quota", retryable=False, details={"x": x})
+
+
+#: A details payload large enough that the wrapping fault envelope exceeds a small
+#: per-topic ``max.message.bytes`` (but within ``build_safe``'s 16 KB details bound, so it
+#: is carried whole — not elided — until the strip-and-retry drops it at the size limit).
+_OVERSIZED_DETAIL = "x" * 8000
+
+
+@agent_tool
+def oversized_fault(x: int) -> int:
+    """Mint a fault whose ``details`` make the envelope exceed a constrained callback
+    topic's size limit — exercising the strip-to-minimal-and-retry floor (FR-21)."""
+    raise NodeFaultError("billing.oversized", message="oversized fault", details={"blob": _OVERSIZED_DETAIL})
+
+
+@agent_tool
+def ok_a() -> str:
+    """A fault-free sibling for mixed fan-out batches."""
+    return "a_result"
+
+
+@agent_tool
+def ok_b() -> str:
+    """A fault-free sibling for mixed fan-out batches."""
+    return "b_result"
+
+
+@dataclass
+class CalleeErrorRecorder:
+    """A Channel-B ``on_callee_error`` recorder: capture-in-callback, assert-in-test-body.
+
+    Records one entry per firing (the live ``delivery_kind``, the fault's ``error_type``,
+    the failing call's ``tag``, and the fault's ``frame_chain`` depth), then returns
+    ``None`` to decline — so the fault escalates exactly as if the seam were absent. A
+    raised assertion here would be a node-own accident routed to ``on_node_error``, so
+    the test asserts on :attr:`calls` *after* the roundtrip instead.
+    """
+
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def __call__(self, ctx: SeamContext[Any], fault: ErrorReport) -> None:
+        self.calls.append(
+            {
+                "delivery_kind": ctx.delivery_kind,
+                "error_type": fault.error_type,
+                "tag": ctx.failing_call.tag if ctx.failing_call is not None else None,
+                "frame_chain_len": len(fault.frame_chain),
+            }
+        )
+        return None

--- a/tests/integration/_mcp_roundtrip_server.py
+++ b/tests/integration/_mcp_roundtrip_server.py
@@ -43,6 +43,14 @@ def danger() -> str:
     return "danger-result"
 
 
+@mcp.tool()
+def domain_error() -> str:
+    """Raise a domain error → FastMCP returns a ``CallToolResult`` with ``isError=True``
+    (a model-visible failure by MCP convention). calfkit passes this through transparently
+    as an ordinary return — NOT the fault rail (the temporary PR-6 behavior)."""
+    raise ValueError("domain failure")
+
+
 def _bonus_impl() -> str:
     """The tool registered at runtime by :func:`enable_bonus`."""
     return "bonus-result"

--- a/tests/integration/_roundtrip_helpers.py
+++ b/tests/integration/_roundtrip_helpers.py
@@ -62,6 +62,21 @@ def scripted_model(tool_calls: list[ToolCallPart]) -> FunctionModel:
     return FunctionModel(_fn)
 
 
+def final_model(text: str = FINAL_OUTPUT) -> FunctionModel:
+    """A model that finalizes immediately with *text* — no tool calls, ever.
+
+    For seam tests whose body must run and produce an output (e.g. an ``after_node``
+    replacement, or a ``before_node`` recorder that declines) without dispatching any
+    tools. Distinct from ``scripted_model([])`` (which would emit an empty tool-call
+    turn, not a finalization).
+    """
+
+    def _fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[TextPart(text)])
+
+    return FunctionModel(_fn)
+
+
 def reactive_model(decide: Callable[[dict[str, object]], list[ToolCallPart] | None]) -> FunctionModel:
     """A multi-turn model driven by the tool returns seen so far.
 

--- a/tests/integration/test_auto_fault_kafka.py
+++ b/tests/integration/test_auto_fault_kafka.py
@@ -1,0 +1,100 @@
+"""Suite R — the reply-owing auto-fault over the real broker.
+
+When a reply-owing delivery's route chain finds no matching handler (and no ``run()``
+fallback), the body produces nothing — but a caller is owed an answer, so the framework
+auto-faults ``calf.delivery.rejected`` instead of stranding the caller (#201 closed by
+construction; catalogue §10). This drives that over the wire with a custom routed
+``NodeDef``: a single ``@handler("known.route")`` and no catch-all, hit with an unmatched
+route. The ``schema_rejected`` reason and the fire-and-forget no-op are covered offline
+(``tests/test_fault_pipeline.py``).
+
+Opt-in (``-m kafka`` / ``make test-kafka``); skips cleanly without Docker.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from calfkit._protocol import HDR_ERROR_TYPE
+from calfkit._registry import handler
+from calfkit.client import Client
+from calfkit.models import ReturnCall, SessionRunContext, State
+from calfkit.models.error_report import FaultTypes
+from calfkit.nodes import NodeDef
+from tests.integration._fault_kafka import ensure_topic, fault_worker
+from tests.integration._fault_tap import fault_tap
+
+pytestmark = pytest.mark.kafka
+
+
+class RoutedNode(NodeDef[State]):
+    """A node that handles exactly one route and nothing else — so any other route
+    all-declines (no matching handler, no ``run()`` fallback)."""
+
+    @handler("known.route")
+    async def on_known(self, ctx: SessionRunContext) -> ReturnCall[State]:
+        return ReturnCall(state=ctx.state, value="handled")
+
+
+class Order(BaseModel):
+    amount: int
+
+
+class SchemaNode(NodeDef[State]):
+    """A node whose single handler matches the route but pins a payload schema — a
+    matching route with a body that fails the schema declines as ``schema_rejected``
+    (distinct from ``all_declined``: a route DID match, the body did not)."""
+
+    @handler("create", schema=Order)
+    async def on_create(self, ctx: SessionRunContext, payload: Order) -> ReturnCall[State]:
+        return ReturnCall(state=ctx.state, value="created")
+
+
+async def test_reply_owing_all_declined_auto_faults(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """R-1: a reply-owing delivery on a route no handler matches auto-faults
+    ``calf.delivery.rejected`` with ``details.reason='all_declined'`` — the caller is
+    never stranded."""
+    node_in = f"{topic_namespace}.r1.input"
+    node_pub = f"{topic_namespace}.r1.mirror"
+    node = RoutedNode(node_id=f"{topic_namespace}-r1", subscribe_topics=[node_in], publish_topic=node_pub)
+    await ensure_topic(kafka_bootstrap, node_pub)
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[node])
+
+    try:
+        async with worker, fault_tap(kafka_bootstrap, node_pub) as tap:
+            # A reply is owed (start registers a future), but the route matches no handler.
+            await driver.start("go", node_in, route="unknown.route")
+
+            fault, headers = await tap.next_fault(timeout=60)
+            assert fault.error.error_type == FaultTypes.DELIVERY_REJECTED
+            assert headers[HDR_ERROR_TYPE] == FaultTypes.DELIVERY_REJECTED
+            assert fault.error.details[FaultTypes.REASON] == FaultTypes.REASON_ALL_DECLINED
+    finally:
+        await driver.close()
+        await worker._client.close()
+
+
+async def test_reply_owing_schema_rejection_auto_faults(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """R-2: a reply-owing delivery on a matching route whose body fails the handler's
+    schema auto-faults ``calf.delivery.rejected`` with ``details.reason='schema_rejected'``."""
+    node_in = f"{topic_namespace}.r2.input"
+    node_pub = f"{topic_namespace}.r2.mirror"
+    node = SchemaNode(node_id=f"{topic_namespace}-r2", subscribe_topics=[node_in], publish_topic=node_pub)
+    await ensure_topic(kafka_bootstrap, node_pub)
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[node])
+
+    try:
+        async with worker, fault_tap(kafka_bootstrap, node_pub) as tap:
+            # the route matches "create", but the body does not satisfy Order(amount: int)
+            await driver.start("go", node_in, route="create", body={"wrong": "shape"})
+
+            fault, headers = await tap.next_fault(timeout=60)
+            assert fault.error.error_type == FaultTypes.DELIVERY_REJECTED
+            assert headers[HDR_ERROR_TYPE] == FaultTypes.DELIVERY_REJECTED
+            assert fault.error.details[FaultTypes.REASON] == FaultTypes.REASON_SCHEMA_REJECTED
+    finally:
+        await driver.close()
+        await worker._client.close()

--- a/tests/integration/test_decode_floor_kafka.py
+++ b/tests/integration/test_decode_floor_kafka.py
@@ -1,0 +1,103 @@
+"""Suite D — the decode floor over the real broker.
+
+A message whose body fails to decode never reaches a handler; the broker-wide
+``DecodeFloorMiddleware`` (installed by ``Client.connect``, so every worker subscriber
+and the client reply subscriber are covered) floors a typed ``calf.delivery.undecodable``
+event at ERROR and re-raises — never a silent drop (catalogue FR-26/FR-27):
+
+* **D-1** — a malformed body to a live agent's input topic is floored; the worker keeps
+  consuming, proven by a valid invocation that completes afterwards.
+* **D-2** — a malformed body on the client's reply topic is floored and does **not**
+  resolve the pending future (typed reception deferred to #250), so a finite ``reply_ttl``
+  evicts it as ``ReplyExpiredError`` rather than resolving with garbage.
+
+Opt-in (``-m kafka`` / ``make test-kafka``); skips cleanly without Docker.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from aiokafka import AIOKafkaProducer
+
+from calfkit._vendor.pydantic_ai import models
+from calfkit._vendor.pydantic_ai.messages import ToolCallPart
+from calfkit.client import Client
+from calfkit.exceptions import ReplyExpiredError
+from calfkit.models.error_report import FaultTypes
+from calfkit.nodes import Agent
+from tests.integration._fault_kafka import ensure_topic, fault_worker
+from tests.integration._fault_tools import ok_a
+from tests.integration._roundtrip_helpers import FINAL_OUTPUT, scripted_model
+
+pytestmark = pytest.mark.kafka
+models.ALLOW_MODEL_REQUESTS = True
+
+_MW_LOGGER = "calfkit.client.middleware"
+
+
+async def test_undecodable_body_floored_and_worker_survives(kafka_bootstrap: str, topic_namespace: str, caplog: pytest.LogCaptureFixture) -> None:
+    """D-1: a malformed body on an agent's input topic floors ``calf.delivery.undecodable``
+    (ERROR) and is dropped; the worker keeps consuming and a valid invocation completes."""
+    agent_in = f"{topic_namespace}.d1.input"
+    agent = Agent(
+        f"{topic_namespace}-d1",
+        system_prompt="call ok_a",
+        subscribe_topics=agent_in,
+        model_client=scripted_model([ToolCallPart("ok_a", {}, tool_call_id="c1")]),
+        tools=[ok_a],
+        sequential_only_mode=True,
+    )
+    await ensure_topic(kafka_bootstrap, agent_in)
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent, ok_a])
+
+    try:
+        with caplog.at_level(logging.ERROR, logger=_MW_LOGGER):
+            async with worker:
+                producer = AIOKafkaProducer(bootstrap_servers=kafka_bootstrap)
+                await producer.start()
+                try:
+                    await producer.send_and_wait(agent_in, b'{"not": "a valid envelope"}')
+                finally:
+                    await producer.stop()
+
+                result = await driver.execute("go", agent_in, timeout=60)
+                assert result.output is not None and FINAL_OUTPUT in result.output
+
+        assert FaultTypes.DELIVERY_UNDECODABLE in caplog.text
+    finally:
+        await driver.close()
+        await worker._client.close()
+
+
+async def test_undecodable_reply_floors_and_does_not_resolve_the_future(
+    kafka_bootstrap: str, topic_namespace: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    """D-2: a malformed body on the client's reply topic is floored and does NOT resolve
+    the pending future (typed reception deferred, #250); a finite ``reply_ttl`` evicts it
+    as ``ReplyExpiredError`` instead of resolving the caller with garbage."""
+    reply_topic = f"{topic_namespace}.d2.reply"
+    await ensure_topic(kafka_bootstrap, reply_topic)
+    # No worker runs, so a real reply never arrives; the only thing on the reply topic is
+    # the malformed message we inject. A short reply_ttl bounds the (correct) hang.
+    driver = Client.connect(kafka_bootstrap, reply_topic=reply_topic, reply_ttl=3.0)
+
+    try:
+        with caplog.at_level(logging.ERROR, logger=_MW_LOGGER):
+            handle = await driver.start("go", f"{topic_namespace}.d2.input")
+
+            producer = AIOKafkaProducer(bootstrap_servers=kafka_bootstrap)
+            await producer.start()
+            try:
+                await producer.send_and_wait(reply_topic, b'{"garbage": true}')
+            finally:
+                await producer.stop()
+
+            with pytest.raises(ReplyExpiredError):
+                await handle.result()  # floored, never resolved → evicted by reply_ttl
+
+        assert FaultTypes.DELIVERY_UNDECODABLE in caplog.text
+    finally:
+        await driver.close()

--- a/tests/integration/test_deferred_reception_kafka.py
+++ b/tests/integration/test_deferred_reception_kafka.py
@@ -1,0 +1,69 @@
+"""Deferred-behavior stubs — the forward targets, skipped until their PR lands.
+
+These document behaviors the design specs describe but the merged code does NOT yet
+implement (see the behavior catalogue's deferred register). Each is a ``skip`` rather
+than a live test or an ``xfail``: the feature is *absent*, so a real test would error at
+the missing API, not merely fail. When the named issue lands, drop the ``skip`` and fill
+in the body (the docstring states the intended assertion).
+
+Tracked deferrals:
+* **#250** — fault reception at the client (typed ``NodeFaultError``) and on consumers
+  (``ConsumerContext.fault`` / ``.delivery_kind``).
+* **#251** — agent self-healing budgets (``surface_to_model`` + ``State.seam_budgets`` +
+  a bounded ``self_retry_budget`` with ``calf.agent.self_retry_exhausted``).
+* **#193** — provider classification of ``calf.model.context_window_exceeded``.
+* MCP ``isError=True`` → ``calf.retry`` marking (the B2 follow-up).
+
+Opt-in (``-m kafka``); all skipped, so they never need a broker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.kafka
+
+
+@pytest.mark.skip(reason="#250 fault reception: the reply dispatcher has no x-calf-kind branch yet")
+async def test_client_raises_node_fault_error_on_fault_reply() -> None:
+    """When #250 lands: a routed fault makes ``await handle.result()`` raise
+    ``NodeFaultError``, and ``e.report.find(error_type)`` branches on the slotted report —
+    replacing today's ``DeserializationError`` (see Suite F's F-1 Channel C)."""
+
+
+@pytest.mark.skip(reason="#250 fault reception: ConsumerContext has no .fault / .delivery_kind yet")
+async def test_consumer_tap_sees_typed_fault() -> None:
+    """When #250 lands: a ``@consumer`` subscribed to a fault mirror reads
+    ``ctx.fault.error_type`` and ``ctx.delivery_kind == 'fault'`` — replacing today's raw
+    ``AIOKafkaConsumer`` tap (``_fault_tap``), which exists precisely because the sink
+    surface cannot see the fault yet."""
+
+
+@pytest.mark.skip(reason="#251 self-healing budgets: surface_to_model prebuilt does not exist")
+async def test_surface_to_model_bounds_then_escalates() -> None:
+    """When #251 lands: the ``surface_to_model(max_failures=...)`` prebuilt resolves
+    failing slots as model-visible results until the per-tool budget exhausts, then
+    declines → escalates. Today the only failure-surfacing seam is a user-authored
+    ``on_callee_error`` (see Suite X's X-3), with no budget."""
+
+
+@pytest.mark.skip(reason="#251 self-healing budgets: self_retry_budget / seam_budgets do not exist")
+async def test_self_retry_budget_exhausts() -> None:
+    """When #251 lands: an all-invalid turn self-retries up to ``self_retry_budget`` (one
+    WARNING-logged turn by default), then faults ``calf.agent.self_retry_exhausted``;
+    ``self_retry_budget=0`` faults immediately with ``details.reason='self_retry_disabled'``.
+    Today the all-invalid ``TailCall`` self-retry loop is unbounded."""
+
+
+@pytest.mark.skip(reason="#193 provider rider: calf.model.context_window_exceeded has no producer")
+async def test_context_window_error_classifies() -> None:
+    """When #193 lands: a provider context-window error classifies to
+    ``calf.model.context_window_exceeded`` at the provider layer. Today such an error
+    surfaces as a generic ``calf.unhandled`` fault via the chokepoint."""
+
+
+@pytest.mark.skip(reason="B2 follow-up: MCP isError is passed through transparently/unmarked")
+async def test_mcp_iserror_marks_calf_retry() -> None:
+    """When the MCP-isError marking follow-up lands: an MCP ``isError=True`` result is
+    marked ``calf.retry`` and materializes a ``RetryPromptPart`` (Anthropic ``is_error``
+    fidelity). Today it rides the reply slot as an ordinary, unmarked return."""

--- a/tests/integration/test_fanout_faults_kafka.py
+++ b/tests/integration/test_fanout_faults_kafka.py
@@ -1,0 +1,212 @@
+"""Suite X — fan-out fault paths over the real durable store.
+
+A fan-out-capable agent (no ``sequential_only_mode``) opens a real
+``KtablesFanoutBatchStore`` and folds N sibling replies; these tests drive faulting
+siblings through that durable fold over the wire (offline-only today):
+
+* **X-1** — one unhandled sibling fault → at closure the batch fails with a *flattened*
+  fault (the bare child ``calf.unhandled``), carrying the partial-success topology under
+  ``details["calf.fanout_topology"]``; the body never resumes.
+* **X-2** — two unhandled sibling faults → a ``calf.fault_group`` with both in ``causes``.
+* **X-3** — an ``on_callee_error`` substitute resolves the faulting slot during the fold,
+  so the batch *completes* and the model sees the substitute among the results.
+
+X-1/X-2 read the escalated group on the agent's ``publish_topic`` mirror (Channel A);
+X-3 reads the finalized output at the client edge (Channel C).
+
+Opt-in (``-m kafka`` / ``make test-kafka``); skips cleanly without Docker.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from calfkit._protocol import HDR_ERROR_TYPE
+from calfkit._vendor.pydantic_ai import models
+from calfkit._vendor.pydantic_ai.messages import ToolCallPart
+from calfkit.client import Client
+from calfkit.exceptions import NodeFaultError
+from calfkit.models.error_report import ErrorReport, FaultTypes
+from calfkit.models.seam_context import SeamContext
+from calfkit.nodes import Agent
+from tests.integration._fault_kafka import ensure_topic, fault_worker
+from tests.integration._fault_tap import fault_tap
+from tests.integration._fault_tools import boom, ok_a, ok_b
+from tests.integration._roundtrip_helpers import FINAL_OUTPUT, scripted_model, tool_returns
+
+pytestmark = pytest.mark.kafka
+models.ALLOW_MODEL_REQUESTS = True
+
+
+def substitute_failed_callee(ctx: SeamContext[Any], fault: ErrorReport) -> str:
+    """An ``on_callee_error`` that resolves any failed slot with a model-visible
+    substitute (the slot-position substitute is exempt from output-type validation)."""
+    return "boom recovered"
+
+
+def reject_failed_callee(ctx: SeamContext[Any], fault: ErrorReport) -> str:
+    """An ``on_callee_error`` that mints its own fault for the failing slot — a
+    slot-scoped raise: the slot resolves failed carrying this error (the inbound fault
+    chained as a cause), siblings continue, and the batch escalates at closure."""
+    raise NodeFaultError("seam.reject", message="rejecting this slot")
+
+
+def _fanout_agent(node_id: str, *, agent_in: str, agent_pub: str, calls: list[ToolCallPart], tools: list, **seams) -> Agent:
+    """A fan-out-capable agent (durable store opens at worker start) that emits *calls* as
+    one fan-out turn, then finalizes once it has acted."""
+    return Agent(
+        node_id,
+        system_prompt="fan out the tools",
+        subscribe_topics=agent_in,
+        publish_topic=agent_pub,
+        model_client=scripted_model(calls),
+        tools=tools,
+        **seams,
+    )
+
+
+async def test_one_unhandled_sibling_flattens_to_bare_fault(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """X-1: a fan-out of 3 with one faulting sibling and no ``on_callee_error`` → the
+    batch closes failed with a *flattened* ``calf.unhandled`` fault carrying the
+    partial-success topology (``ok``/``failed`` counts); the body never resumes."""
+    agent_in = f"{topic_namespace}.x1.input"
+    agent_pub = f"{topic_namespace}.x1.mirror"
+    agent = _fanout_agent(
+        f"{topic_namespace}-x1",
+        agent_in=agent_in,
+        agent_pub=agent_pub,
+        calls=[
+            ToolCallPart("boom", {"x": 1}, tool_call_id="c1"),
+            ToolCallPart("ok_a", {}, tool_call_id="c2"),
+            ToolCallPart("ok_b", {}, tool_call_id="c3"),
+        ],
+        tools=[boom, ok_a, ok_b],
+    )
+    await ensure_topic(kafka_bootstrap, agent_pub)
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent, boom, ok_a, ok_b])
+
+    try:
+        async with worker, fault_tap(kafka_bootstrap, agent_pub) as tap:
+            await driver.start("go", agent_in)
+            fault, headers = await tap.next_fault(timeout=90)
+
+            # singleton flatten: the bare child, not a group
+            assert fault.error.error_type == FaultTypes.UNHANDLED
+            assert headers[HDR_ERROR_TYPE] == FaultTypes.UNHANDLED
+            topology = fault.error.details[FaultTypes.FANOUT_TOPOLOGY]
+            assert topology["ok"] == 2
+            assert topology["failed"] == 1
+    finally:
+        await driver.close()
+        await worker._client.close()
+
+
+async def test_two_unhandled_siblings_compose_a_fault_group(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """X-2: a fan-out with two faulting siblings → a ``calf.fault_group`` carrying both
+    in ``causes`` (``find`` matches the nested type at depth)."""
+    agent_in = f"{topic_namespace}.x2.input"
+    agent_pub = f"{topic_namespace}.x2.mirror"
+    agent = _fanout_agent(
+        f"{topic_namespace}-x2",
+        agent_in=agent_in,
+        agent_pub=agent_pub,
+        calls=[
+            ToolCallPart("boom", {"x": 1}, tool_call_id="c1"),
+            ToolCallPart("boom", {"x": 2}, tool_call_id="c2"),
+            ToolCallPart("ok_a", {}, tool_call_id="c3"),
+        ],
+        tools=[boom, ok_a],
+    )
+    await ensure_topic(kafka_bootstrap, agent_pub)
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent, boom, ok_a])
+
+    try:
+        async with worker, fault_tap(kafka_bootstrap, agent_pub) as tap:
+            await driver.start("go", agent_in)
+            fault, headers = await tap.next_fault(timeout=90)
+
+            assert fault.error.error_type == FaultTypes.FAULT_GROUP
+            assert headers[HDR_ERROR_TYPE] == FaultTypes.FAULT_GROUP
+            assert len(fault.error.causes) == 2
+            assert fault.error.find(FaultTypes.UNHANDLED) is not None  # matches at depth
+            topology = fault.error.details[FaultTypes.FANOUT_TOPOLOGY]
+            assert topology["failed"] == 2
+            assert topology["ok"] == 1
+    finally:
+        await driver.close()
+        await worker._client.close()
+
+
+async def test_on_callee_error_substitute_completes_the_batch(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """X-3: an ``on_callee_error`` substitute resolves the faulting slot during the fold,
+    so the batch completes, the model sees the substitute, and the agent finalizes."""
+    agent_in = f"{topic_namespace}.x3.input"
+    agent_pub = f"{topic_namespace}.x3.mirror"
+    agent = _fanout_agent(
+        f"{topic_namespace}-x3",
+        agent_in=agent_in,
+        agent_pub=agent_pub,
+        calls=[
+            ToolCallPart("boom", {"x": 1}, tool_call_id="c1"),
+            ToolCallPart("ok_a", {}, tool_call_id="c2"),
+            ToolCallPart("ok_b", {}, tool_call_id="c3"),
+        ],
+        tools=[boom, ok_a, ok_b],
+        on_callee_error=substitute_failed_callee,
+    )
+    await ensure_topic(kafka_bootstrap, agent_pub)
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent, boom, ok_a, ok_b])
+
+    try:
+        async with worker:
+            result = await driver.execute("go", agent_in, timeout=90)
+            assert result.output is not None and FINAL_OUTPUT in result.output
+
+            returns = tool_returns(result.message_history)
+            assert returns["boom"] == "boom recovered"  # the substitute reached the model
+            assert returns["ok_a"] == "a_result"
+            assert returns["ok_b"] == "b_result"
+    finally:
+        await driver.close()
+        await worker._client.close()
+
+
+async def test_slot_scoped_seam_raise_fails_the_slot_and_escalates_at_closure(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """S-7: an ``on_callee_error`` that *raises* is slot-scoped — the slot resolves failed
+    carrying the seam's mint (with the original fault chained), siblings continue, and the
+    batch escalates that at closure (no node-own failure, no double reply)."""
+    agent_in = f"{topic_namespace}.s7.input"
+    agent_pub = f"{topic_namespace}.s7.mirror"
+    agent = _fanout_agent(
+        f"{topic_namespace}-s7",
+        agent_in=agent_in,
+        agent_pub=agent_pub,
+        calls=[
+            ToolCallPart("boom", {"x": 1}, tool_call_id="c1"),
+            ToolCallPart("ok_a", {}, tool_call_id="c2"),
+        ],
+        tools=[boom, ok_a],
+        on_callee_error=reject_failed_callee,
+    )
+    await ensure_topic(kafka_bootstrap, agent_pub)
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent, boom, ok_a])
+
+    try:
+        async with worker, fault_tap(kafka_bootstrap, agent_pub) as tap:
+            await driver.start("go", agent_in)
+            fault, _ = await tap.next_fault(timeout=90)
+
+            assert fault.error.error_type == "seam.reject"  # the seam's slot-scoped mint
+            assert fault.error.find(FaultTypes.UNHANDLED) is not None  # original boom fault, chained
+            topology = fault.error.details[FaultTypes.FANOUT_TOPOLOGY]
+            assert topology["failed"] == 1  # the boom slot
+            assert topology["ok"] == 1  # ok_a still resolved
+    finally:
+        await driver.close()
+        await worker._client.close()

--- a/tests/integration/test_fault_escalation_kafka.py
+++ b/tests/integration/test_fault_escalation_kafka.py
@@ -1,0 +1,247 @@
+"""Suite F — fault escalation over the real broker.
+
+The real-broker counterpart to the offline ``tests/test_fault_pipeline.py``: a tool's
+terminal failure travels back through a live Worker to the caller as a typed
+``FaultMessage`` (catalogue FR-2/FR-3/FR-11/FR-12/FR-13/FR-16/FR-25), observed on three
+channels:
+
+* **Channel A** — the agent's ``publish_topic`` broadcast mirror, tapped raw
+  (``_fault_tap``): the only *typed* channel today. Asserts the ``ErrorReport`` and the
+  ``x-calf-kind=fault`` / ``x-calf-error-type`` headers.
+* **Channel B** — an ``on_callee_error`` recorder (``_fault_tools.CalleeErrorRecorder``)
+  that sees the live fault in-process, then declines so it still escalates.
+* **Channel C** — the client edge as it behaves today: a routed fault resolves the
+  pending future and surfaces as ``DeserializationError`` (the typed ``NodeFaultError``
+  reception is deferred to #250).
+
+The agents run ``sequential_only_mode=True``: every case dispatches a single tool call,
+so the fault path is identical to a fan-out-capable agent's, and the durable fan-out
+store (a separate ktables dependency, covered by Suite X) stays out of the way.
+
+Opt-in (``-m kafka`` / ``make test-kafka``); skips cleanly without Docker.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from aiokafka import AIOKafkaProducer
+
+from calfkit._protocol import HDR_ERROR_TYPE, HDR_KIND
+from calfkit._vendor.pydantic_ai import models
+from calfkit._vendor.pydantic_ai.messages import ToolCallPart
+from calfkit.client import Client
+from calfkit.exceptions import DeserializationError
+from calfkit.models import CallFrame, CallFrameStack, Envelope, SessionRunContext, State, WorkflowState
+from calfkit.models.error_report import FaultTypes
+from calfkit.nodes import Agent
+from tests.integration._fault_kafka import ensure_topic, fault_worker
+from tests.integration._fault_tap import fault_tap
+from tests.integration._fault_tools import CalleeErrorRecorder, boom, ok_a, quota
+from tests.integration._roundtrip_helpers import FINAL_OUTPUT, scripted_model
+
+# Every test needs a real broker; FunctionModel is offline but pydantic-ai still gates
+# "model requests" behind this flag (matches the other kafka-lane agent suites).
+pytestmark = pytest.mark.kafka
+models.ALLOW_MODEL_REQUESTS = True
+
+
+def _agent(node_id: str, *, agent_in: str, agent_pub: str, tool, call: ToolCallPart, **seams) -> Agent:
+    return Agent(
+        node_id,
+        system_prompt=f"call the {tool.name} tool",
+        subscribe_topics=agent_in,
+        publish_topic=agent_pub,
+        model_client=scripted_model([call]),
+        tools=[tool],
+        sequential_only_mode=True,
+        **seams,
+    )
+
+
+async def test_tool_generic_raise_escalates_unhandled_fault(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """F-1: a tool's generic exception → the agent escalates a ``calf.unhandled``
+    ``FaultMessage`` on its ``publish_topic`` mirror (typed report + filterable
+    headers), and the client's routed reply surfaces as ``DeserializationError``."""
+    agent_in = f"{topic_namespace}.f1.input"
+    agent_pub = f"{topic_namespace}.f1.mirror"
+    agent = _agent(
+        f"{topic_namespace}-f1",
+        agent_in=agent_in,
+        agent_pub=agent_pub,
+        tool=boom,
+        call=ToolCallPart("boom", {"x": 7}, tool_call_id="c1"),
+    )
+    await ensure_topic(kafka_bootstrap, agent_pub)
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent, boom])
+
+    try:
+        async with worker, fault_tap(kafka_bootstrap, agent_pub) as tap:
+            handle = await driver.start("go", agent_in)
+
+            fault, headers = await tap.next_fault(timeout=60)
+            assert headers[HDR_KIND] == "fault"
+            assert headers[HDR_ERROR_TYPE] == FaultTypes.UNHANDLED
+            assert fault.error.error_type == FaultTypes.UNHANDLED
+            assert fault.error.find(FaultTypes.UNHANDLED) is not None
+            assert fault.error.details.get(FaultTypes.EXCEPTION_TYPE) == "ValueError"
+            assert len(fault.error.frame_chain) >= 1  # the faulting hop's topology is captured
+
+            # Channel C — current client-edge behavior: a routed fault resolves the
+            # future and fails strict output projection (typed reception deferred, #250).
+            with pytest.raises(DeserializationError):
+                await handle.result(timeout=60)
+    finally:
+        await driver.close()
+        await worker._client.close()
+
+
+async def test_callee_error_seam_observes_fault_then_escalates(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """F-1b (Channel B): an ``on_callee_error`` recorder sees the live ``calf.unhandled``
+    fault (``delivery_kind=fault``, ``failing_call.tag``) and declines → the fault still
+    escalates to the agent's ``publish_topic`` mirror."""
+    recorder = CalleeErrorRecorder()
+    agent_in = f"{topic_namespace}.f1b.input"
+    agent_pub = f"{topic_namespace}.f1b.mirror"
+    agent = _agent(
+        f"{topic_namespace}-f1b",
+        agent_in=agent_in,
+        agent_pub=agent_pub,
+        tool=boom,
+        call=ToolCallPart("boom", {"x": 1}, tool_call_id="c1"),
+        on_callee_error=recorder,
+    )
+    await ensure_topic(kafka_bootstrap, agent_pub)
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent, boom])
+
+    try:
+        async with worker, fault_tap(kafka_bootstrap, agent_pub) as tap:
+            await driver.start("go", agent_in)
+            fault, _ = await tap.next_fault(timeout=60)
+            assert fault.error.error_type == FaultTypes.UNHANDLED
+    finally:
+        await driver.close()
+        await worker._client.close()
+
+    # Capture-in-callback, assert-in-test-body (the seam fired once, in the worker
+    # process, before it produced the mirror this test just observed).
+    assert len(recorder.calls) == 1
+    (call,) = recorder.calls
+    assert call["delivery_kind"] == "fault"
+    assert call["error_type"] == FaultTypes.UNHANDLED
+    assert call["tag"] == "c1"
+
+
+async def test_tool_mint_escalates_verbatim_typed_fault(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """F-2: a tool minting ``NodeFaultError`` carries the user ``error_type`` verbatim
+    (the mint rule), with ``retryable`` and ``details`` preserved end-to-end."""
+    agent_in = f"{topic_namespace}.f2.input"
+    agent_pub = f"{topic_namespace}.f2.mirror"
+    agent = _agent(
+        f"{topic_namespace}-f2",
+        agent_in=agent_in,
+        agent_pub=agent_pub,
+        tool=quota,
+        call=ToolCallPart("quota", {"x": 42}, tool_call_id="c1"),
+    )
+    await ensure_topic(kafka_bootstrap, agent_pub)
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent, quota])
+
+    try:
+        async with worker, fault_tap(kafka_bootstrap, agent_pub) as tap:
+            await driver.start("go", agent_in)
+            fault, headers = await tap.next_fault(timeout=60)
+            assert fault.error.error_type == "billing.quota_exceeded"
+            assert headers[HDR_ERROR_TYPE] == "billing.quota_exceeded"
+            assert fault.error.retryable is False
+            assert fault.error.details.get("x") == 42
+    finally:
+        await driver.close()
+        await worker._client.close()
+
+
+async def test_fire_and_forget_fault_mirrors_without_callback(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """F-4: a one-way ``send`` whose tool faults → the fault is mirrored on the agent's
+    ``publish_topic`` (the fire-and-forget terminal floors + mirrors, no callback rail);
+    ``send`` registered no future, so nothing hangs."""
+    agent_in = f"{topic_namespace}.f4.input"
+    agent_pub = f"{topic_namespace}.f4.mirror"
+    agent = _agent(
+        f"{topic_namespace}-f4",
+        agent_in=agent_in,
+        agent_pub=agent_pub,
+        tool=boom,
+        call=ToolCallPart("boom", {"x": 5}, tool_call_id="c1"),
+    )
+    await ensure_topic(kafka_bootstrap, agent_pub)
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent, boom])
+
+    try:
+        async with worker, fault_tap(kafka_bootstrap, agent_pub) as tap:
+            correlation_id = await driver.send("go", agent_in)  # one-way: returns the id, no future
+            assert isinstance(correlation_id, str)
+
+            fault, headers = await tap.next_fault(timeout=60)
+            assert headers[HDR_KIND] == "fault"
+            assert fault.error.error_type == FaultTypes.UNHANDLED
+    finally:
+        await driver.close()
+        await worker._client.close()
+
+
+async def test_stray_fault_does_not_disturb_the_live_worker(kafka_bootstrap: str, topic_namespace: str, caplog: pytest.LogCaptureFixture) -> None:
+    """F-5: a ``kind=fault`` delivery whose reply slot is empty (kind/slot disagreement)
+    injected onto a live agent's private return inbox is floored as a stray (WARNING +
+    ignore, FR-16/FR-25) — the worker keeps consuming, proven by a valid invocation that
+    completes normally afterwards."""
+    agent_in = f"{topic_namespace}.f5.input"
+    agent_pub = f"{topic_namespace}.f5.mirror"
+    agent = _agent(
+        f"{topic_namespace}-f5",
+        agent_in=agent_in,
+        agent_pub=agent_pub,
+        tool=ok_a,
+        call=ToolCallPart("ok_a", {}, tool_call_id="c1"),
+    )
+    return_topic = f"{agent.node_id}.private.return"
+    await ensure_topic(kafka_bootstrap, agent_pub)
+    await ensure_topic(kafka_bootstrap, return_topic)
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent, ok_a])
+
+    # A decodable envelope whose header says kind=fault but whose reply slot is empty —
+    # the kind↔slot disagreement the stray check catches before any seam runs.
+    stack = CallFrameStack()
+    stack.push(CallFrame(target_topic=agent_in, callback_topic="nobody.return", tag="t1"))
+    stray = Envelope(
+        internal_workflow_state=WorkflowState(call_stack=stack),
+        context=SessionRunContext(state=State(), deps={}),
+    )
+
+    try:
+        with caplog.at_level(logging.WARNING, logger="calfkit.nodes.base"):
+            async with worker:
+                producer = AIOKafkaProducer(bootstrap_servers=kafka_bootstrap)
+                await producer.start()
+                try:
+                    await producer.send_and_wait(
+                        return_topic,
+                        stray.model_dump_json().encode(),
+                        headers=[(HDR_KIND, b"fault")],
+                    )
+                finally:
+                    await producer.stop()
+
+                # The worker survived the stray: a valid invocation still completes.
+                result = await driver.execute("go", agent_in, timeout=60)
+                assert result.output is not None and FINAL_OUTPUT in result.output
+
+        assert any("stray" in record.getMessage().lower() for record in caplog.records)
+    finally:
+        await driver.close()
+        await worker._client.close()

--- a/tests/integration/test_fault_stress_kafka.py
+++ b/tests/integration/test_fault_stress_kafka.py
@@ -1,0 +1,125 @@
+"""Suite Z — fan-out stress / soak over the real durable store.
+
+Pushes the in-node durable fold past the offline lane's 2-3 siblings:
+
+* **Z-1** — a large-N fan-out (8 siblings) folds and completes; the model sees all N
+  results.
+* **Z-3** — M concurrent invocations of one fan-out agent each open their own durable
+  batch (keyed by their own ``fanout_id``); under ``max_workers=1`` they fold serially
+  and all complete with their own result set (no cross-batch bleed, no deadlock).
+* **Z-4** — a healthy and a faulting batch run concurrently in one worker: the healthy
+  one completes, the faulting one escalates — no strand, no cross-contamination.
+
+Opt-in (``-m kafka`` / ``make test-kafka``); skips cleanly without Docker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from calfkit._vendor.pydantic_ai import models
+from calfkit._vendor.pydantic_ai.messages import ToolCallPart
+from calfkit.client import Client
+from calfkit.exceptions import DeserializationError
+from calfkit.nodes import Agent
+from tests.integration._fault_kafka import fault_worker
+from tests.integration._fault_tools import boom, ok_a, ok_b
+from tests.integration._roundtrip_helpers import FINAL_OUTPUT, returns_by_call_id, scripted_model
+
+pytestmark = pytest.mark.kafka
+models.ALLOW_MODEL_REQUESTS = True
+
+
+def _fanout_agent(node_id: str, *, agent_in: str, calls: list[ToolCallPart], tools: list, **seams) -> Agent:
+    return Agent(
+        node_id,
+        system_prompt="fan out the tools",
+        subscribe_topics=agent_in,
+        model_client=scripted_model(calls),
+        tools=tools,
+        **seams,
+    )
+
+
+async def test_large_fanout_folds_and_completes(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """Z-1: an 8-sibling fan-out folds in the durable store and completes; the model's
+    resumed turn sees all 8 results (one per slot, keyed by call id)."""
+    n_each = 4
+    calls = [ToolCallPart("ok_a", {}, tool_call_id=f"a{i}") for i in range(n_each)]
+    calls += [ToolCallPart("ok_b", {}, tool_call_id=f"b{i}") for i in range(n_each)]
+    agent_in = f"{topic_namespace}.z1.input"
+    agent = _fanout_agent(f"{topic_namespace}-z1", agent_in=agent_in, calls=calls, tools=[ok_a, ok_b])
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent, ok_a, ok_b])
+
+    try:
+        async with worker:
+            result = await driver.execute("go", agent_in, timeout=120)
+            assert result.output is not None and FINAL_OUTPUT in result.output
+            by_id = returns_by_call_id(result.message_history)
+            assert len(by_id) == 2 * n_each  # every slot resolved into its own result
+    finally:
+        await driver.close()
+        await worker._client.close()
+
+
+async def test_concurrent_batches_all_complete(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """Z-3: M concurrent invocations of one fan-out agent each fold their own durable
+    batch serially (``max_workers=1``) and all complete with their own 2 results — no
+    cross-batch bleed, no deadlock under load."""
+    m = 4
+    calls = [ToolCallPart("ok_a", {}, tool_call_id="c1"), ToolCallPart("ok_b", {}, tool_call_id="c2")]
+    agent_in = f"{topic_namespace}.z3.input"
+    agent = _fanout_agent(f"{topic_namespace}-z3", agent_in=agent_in, calls=calls, tools=[ok_a, ok_b])
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent, ok_a, ok_b])
+
+    try:
+        async with worker:
+            handles = [await driver.start("go", agent_in) for _ in range(m)]
+            results = await asyncio.gather(*(handle.result(timeout=120) for handle in handles))
+        for result in results:
+            assert result.output is not None and FINAL_OUTPUT in result.output
+            assert len(returns_by_call_id(result.message_history)) == 2
+    finally:
+        await driver.close()
+        await worker._client.close()
+
+
+async def test_mixed_success_and_fault_batches_are_isolated(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """Z-4: a healthy fan-out and a faulting fan-out run concurrently in one worker — the
+    healthy batch completes, the faulting batch escalates; neither contaminates the other."""
+    healthy_in = f"{topic_namespace}.z4ok.input"
+    faulty_in = f"{topic_namespace}.z4bad.input"
+    healthy = _fanout_agent(
+        f"{topic_namespace}-z4ok",
+        agent_in=healthy_in,
+        calls=[ToolCallPart("ok_a", {}, tool_call_id="c1"), ToolCallPart("ok_b", {}, tool_call_id="c2")],
+        tools=[ok_a, ok_b],
+    )
+    faulting = _fanout_agent(
+        f"{topic_namespace}-z4bad",
+        agent_in=faulty_in,
+        calls=[ToolCallPart("boom", {"x": 1}, tool_call_id="c1"), ToolCallPart("ok_a", {}, tool_call_id="c2")],
+        tools=[boom, ok_a],
+    )
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[healthy, faulting, ok_a, ok_b, boom])
+
+    try:
+        async with worker:
+            ok_handle = await driver.start("go", healthy_in)
+            bad_handle = await driver.start("go", faulty_in)
+
+            ok_result = await ok_handle.result(timeout=120)
+            assert ok_result.output is not None and FINAL_OUTPUT in ok_result.output
+
+            # The faulting batch escalated (a routed fault surfaces today as a
+            # DeserializationError at the client edge — reception deferred, #250).
+            with pytest.raises(DeserializationError):
+                await bad_handle.result(timeout=120)
+    finally:
+        await driver.close()
+        await worker._client.close()

--- a/tests/integration/test_mcp_roundtrip_kafka.py
+++ b/tests/integration/test_mcp_roundtrip_kafka.py
@@ -198,6 +198,47 @@ async def test_single_tool_call_roundtrips_over_the_wire(kafka_bootstrap: str, t
     await agent_worker._client.close()
 
 
+async def test_mcp_iserror_result_passes_through_transparently(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """An MCP ``isError=True`` result (a domain failure by MCP convention) rides the reply
+    slot as an ordinary, model-visible return — NOT the fault rail, and NOT ``calf.retry``-
+    marked (the temporary PR-6 passthrough; catalogue XC-5). The agent sees it and
+    finalizes normally, and the error content travels back in history."""
+    agent_id = f"{topic_namespace}-mcp-iserror"
+    agent_in = f"{topic_namespace}.mcp-iserror.input"
+    cap_topic = f"{topic_namespace}.capabilities"
+    discovery = _discovery(cap_topic, kafka_bootstrap)
+
+    toolbox = MCPToolboxNode(_SERVER_NAME, connection_params=_server_params(_SERVER_SCRIPT))
+    agent = Agent(
+        agent_id,
+        system_prompt="call domain_error",
+        subscribe_topics=agent_in,
+        model_client=scripted_model([ToolCallPart("domain_error", {}, tool_call_id="call-err")]),
+        tools=[toolbox.select(include=["domain_error"])],
+    )
+
+    driver = Client.connect(kafka_bootstrap)
+    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], discovery=discovery)
+    agent_worker = _worker(kafka_bootstrap, nodes=[agent], discovery=discovery)
+
+    async with toolbox_worker:
+        await _await_capability(kafka_bootstrap, cap_topic, _SERVER_NAME, timeout=60)
+        async with agent_worker:
+            result = await driver.execute("trigger the error", agent_in, timeout=120)
+
+    # Finalized normally — the isError result was recoverable/model-visible, not a fault.
+    assert result.output is not None and FINAL_OUTPUT in result.output
+    # It arrived as an ORDINARY return (tool_returns collects ToolReturnParts only), carrying
+    # the isError result through transparently.
+    returns = tool_returns(result.message_history)
+    assert "domain_error" in returns
+    assert "isError" in _serialized(returns["domain_error"])
+
+    await driver.close()
+    await toolbox_worker._client.close()
+    await agent_worker._client.close()
+
+
 async def test_concurrent_tool_calls_roundtrip_via_fanout(kafka_bootstrap: str, topic_namespace: str) -> None:
     """Two distinct tool calls in one model turn drive the durable in-node
     fan-out path: both dispatch concurrently, execute on the real MCP server,

--- a/tests/integration/test_oversized_fault_kafka.py
+++ b/tests/integration/test_oversized_fault_kafka.py
@@ -1,0 +1,67 @@
+"""Suite O — oversized-fault strip-and-retry against a real per-topic size limit.
+
+When a fault's serialized envelope exceeds the callback topic's ``max.message.bytes``, the
+publish raises ``MessageSizeTooLargeError``; the rail strips the report to its identity
+(``to_minimal()`` — no ``causes`` / ``details`` / ``frame_chain``) and retries once, so an
+oversized fault still reaches the caller instead of becoming a new silent drop (FR-21).
+
+This drives that against a REAL broker size limit: the client's reply topic (the agent's
+callback) is created with a small ``max.message.bytes`` so a fault carrying a large
+``details`` blob trips the limit on the first publish; the minimal retry then fits. The tap
+reads the reply topic (the callback) — where the *stripped* report lands (the
+``publish_topic`` mirror, on a default-sized topic, keeps the full report).
+
+Opt-in (``-m kafka`` / ``make test-kafka``); skips cleanly without Docker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from calfkit._vendor.pydantic_ai import models
+from calfkit._vendor.pydantic_ai.messages import ToolCallPart
+from calfkit.client import Client
+from calfkit.nodes import Agent
+from tests.integration._fault_kafka import ensure_topic, fault_worker
+from tests.integration._fault_tap import fault_tap
+from tests.integration._fault_tools import oversized_fault
+from tests.integration._roundtrip_helpers import scripted_model
+
+pytestmark = pytest.mark.kafka
+models.ALLOW_MODEL_REQUESTS = True
+
+
+async def test_oversized_fault_strips_to_minimal_and_still_arrives(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """O-1: a fault too large for the callback topic is stripped to a minimal report and
+    retried, so it still reaches the caller — identity preserved, ``details``/``causes``/
+    ``frame_chain`` dropped."""
+    reply_topic = f"{topic_namespace}.o1.reply"
+    agent_in = f"{topic_namespace}.o1.input"
+    # Constrain the callback (client reply) topic so the full ~8 KB fault overflows it but
+    # the minimal report fits. (The agent's own return topic + publish mirror stay default.)
+    await ensure_topic(kafka_bootstrap, reply_topic, config={"max.message.bytes": "4096"})
+
+    agent = Agent(
+        f"{topic_namespace}-o1",
+        system_prompt="call oversized_fault",
+        subscribe_topics=agent_in,
+        model_client=scripted_model([ToolCallPart("oversized_fault", {"x": 1}, tool_call_id="c1")]),
+        tools=[oversized_fault],
+        sequential_only_mode=True,
+    )
+    driver = Client.connect(kafka_bootstrap, reply_topic=reply_topic)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent, oversized_fault])
+
+    try:
+        async with worker, fault_tap(kafka_bootstrap, reply_topic) as tap:
+            await driver.start("go", agent_in)
+
+            fault, _ = await tap.next_fault(timeout=60)
+            # identity survives; the heavy parts were stripped to fit
+            assert fault.error.error_type == "billing.oversized"
+            assert "blob" not in fault.error.details
+            assert fault.error.causes == []
+            assert fault.error.frame_chain == []
+    finally:
+        await driver.close()
+        await worker._client.close()

--- a/tests/integration/test_retry_marker_kafka.py
+++ b/tests/integration/test_retry_marker_kafka.py
@@ -1,0 +1,66 @@
+"""Suite M — the ``calf.retry`` marker round-trips into a real agent loop.
+
+A tool's ``ModelRetry`` is a *recoverable* failure, not a fault: it is rendered at origin
+to a ``calf.retry``-marked ``TextPart`` that rides the reply slot as an ordinary
+``return``, and the calling agent materializes it back into a ``RetryPromptPart`` so the
+model sees the retry and adapts (catalogue XC-4). This exercises that whole round-trip
+over a real broker — the marker surviving the wire and re-entering the agent loop.
+
+Opt-in (``-m kafka`` / ``make test-kafka``); skips cleanly without Docker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from calfkit._vendor.pydantic_ai import models
+from calfkit._vendor.pydantic_ai.messages import ToolCallPart
+from calfkit.client import Client
+from calfkit.nodes import Agent
+from tests.integration._fault_kafka import ensure_topic, fault_worker
+from tests.integration._fault_tap import fault_tap
+from tests.integration._fault_tools import needs_retry
+from tests.integration._roundtrip_helpers import FINAL_OUTPUT, retry_prompt_texts, scripted_model
+
+pytestmark = pytest.mark.kafka
+models.ALLOW_MODEL_REQUESTS = True
+
+
+async def test_model_retry_round_trips_as_calf_retry_not_a_fault(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """M-1: a tool raising ``ModelRetry`` comes back as a ``calf.retry``-marked return
+    (not a fault); the agent materializes a ``RetryPromptPart`` the model sees, then
+    finalizes — and nothing is mirrored on the fault rail."""
+    agent_in = f"{topic_namespace}.m1.input"
+    agent_pub = f"{topic_namespace}.m1.mirror"
+    agent = Agent(
+        f"{topic_namespace}-m1",
+        system_prompt="call needs_retry",
+        subscribe_topics=agent_in,
+        publish_topic=agent_pub,
+        model_client=scripted_model([ToolCallPart("needs_retry", {"x": -1}, tool_call_id="c1")]),
+        tools=[needs_retry],
+        sequential_only_mode=True,
+    )
+    await ensure_topic(kafka_bootstrap, agent_pub)
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent, needs_retry])
+
+    try:
+        async with worker, fault_tap(kafka_bootstrap, agent_pub) as tap:
+            result = await driver.execute("go", agent_in, timeout=60)
+
+            # The agentic loop resumed past the retry to a clean finalization (a return,
+            # not a fault) — the recoverable failure stayed model-visible.
+            assert result.output is not None and FINAL_OUTPUT in result.output
+
+            # The ModelRetry text crossed the wire (calf.retry marker) and materialized
+            # back into a RetryPromptPart the model saw.
+            retries = retry_prompt_texts(result.message_history)
+            assert any("positive x" in text for text in retries)
+
+            # And it never touched the fault rail: no FaultMessage on the mirror.
+            with pytest.raises(AssertionError):
+                await tap.next_fault(timeout=5)
+    finally:
+        await driver.close()
+        await worker._client.close()

--- a/tests/integration/test_seam_pipeline_kafka.py
+++ b/tests/integration/test_seam_pipeline_kafka.py
@@ -1,0 +1,234 @@
+"""Suite S — the policy-seam pipeline over the real broker.
+
+``before_node`` / ``after_node`` / ``on_node_error`` fire inside a live Worker (all
+offline-only today): a ``before_node`` substitute short-circuits the body, an
+``after_node`` replaces the produced output, a ``before_node`` accident is recovered by
+``on_node_error``, a ``NodeFaultError`` minted in a seam bypasses ``on_node_error`` and
+escalates verbatim, and a ``before_node`` recorder sees the ingress ``SeamContext``.
+
+Channels: most cases read the substituted/recovered output at the client edge (Channel
+C — a successful ``return``, no fault); the mint-bypass case taps the fault mirror
+(Channel A) and asserts the ``on_node_error`` recorder never fired (Channel B). Seam
+registration validation (rejecting a seam on a consumer / wrong arity) is a
+registration-time check covered offline (``tests/test_seam_registration.py``), so it is
+not duplicated here.
+
+Opt-in (``-m kafka`` / ``make test-kafka``); skips cleanly without Docker.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from calfkit._vendor.pydantic_ai import models
+from calfkit.client import Client
+from calfkit.exceptions import NodeFaultError
+from calfkit.models.error_report import ErrorReport, FaultTypes
+from calfkit.models.seam_context import SeamContext
+from calfkit.nodes import Agent
+from tests.integration._fault_kafka import ensure_topic, fault_worker
+from tests.integration._fault_tap import fault_tap
+from tests.integration._fault_tools import CalleeErrorRecorder
+from tests.integration._roundtrip_helpers import FINAL_OUTPUT, final_model
+
+pytestmark = pytest.mark.kafka
+models.ALLOW_MODEL_REQUESTS = True
+
+
+# ── seam handlers under test (output-position substitutes are plain str, which the
+#    agent's default str output type validates at coercion) ─────────────────────────
+
+
+def before_substitute(ctx: SeamContext[Any]) -> str:
+    """``before_node`` short-circuit: the body never runs, this becomes the output."""
+    return "substituted"
+
+
+def after_redact(ctx: SeamContext[Any], output: Any) -> str:
+    """``after_node`` replacement of whatever the body produced."""
+    return "redacted"
+
+
+def before_raise_value(ctx: SeamContext[Any]) -> None:
+    """A node-own accident in ``before_node`` → routed to ``on_node_error``."""
+    raise ValueError("before_node boom")
+
+
+def on_node_recover(ctx: SeamContext[Any], fault: ErrorReport) -> str:
+    """``on_node_error`` recovery: the value becomes the node's (recovered) output."""
+    return "recovered"
+
+
+def before_raise_mint(ctx: SeamContext[Any]) -> None:
+    """A deliberate ``NodeFaultError`` minted in a seam → bypasses ``on_node_error``."""
+    raise NodeFaultError("seam.mint", message="deliberate seam fault")
+
+
+@dataclass
+class BeforeNodeRecorder:
+    """Channel-B ``before_node`` recorder: capture the ingress ``SeamContext`` fields,
+    then return ``None`` so the body still runs."""
+
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def __call__(self, ctx: SeamContext[Any]) -> None:
+        self.calls.append(
+            {
+                "delivery_kind": ctx.delivery_kind,
+                "route": ctx.route,
+                "awaiting_reply": ctx.awaiting_reply,
+                "node_id": ctx.node_id,
+            }
+        )
+        return None
+
+
+def _agent(node_id: str, *, agent_in: str, publish_topic: str | None = None, **seams) -> Agent:
+    return Agent(
+        node_id,
+        system_prompt="respond",
+        subscribe_topics=agent_in,
+        publish_topic=publish_topic,
+        model_client=final_model(),
+        sequential_only_mode=True,
+        **seams,
+    )
+
+
+async def test_before_node_substitute_short_circuits_body(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """S-1: a ``before_node`` that returns a value becomes the output; the body (model
+    loop) never runs."""
+    agent_in = f"{topic_namespace}.s1.input"
+    agent = _agent(f"{topic_namespace}-s1", agent_in=agent_in, before_node=before_substitute)
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent])
+
+    try:
+        async with worker:
+            result = await driver.execute("go", agent_in, timeout=60)
+            assert result.output == "substituted"
+    finally:
+        await driver.close()
+        await worker._client.close()
+
+
+async def test_after_node_replaces_output(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """S-3: ``after_node`` replaces the body's produced output."""
+    agent_in = f"{topic_namespace}.s3.input"
+    agent = _agent(f"{topic_namespace}-s3", agent_in=agent_in, after_node=after_redact)
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent])
+
+    try:
+        async with worker:
+            result = await driver.execute("go", agent_in, timeout=60)
+            assert result.output == "redacted"
+    finally:
+        await driver.close()
+        await worker._client.close()
+
+
+async def test_before_node_accident_recovered_by_on_node_error(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """S-4: a non-``NodeFaultError`` raise in ``before_node`` routes to ``on_node_error``,
+    whose returned value becomes the recovered output (no fault reaches the caller)."""
+    agent_in = f"{topic_namespace}.s4.input"
+    agent = _agent(
+        f"{topic_namespace}-s4",
+        agent_in=agent_in,
+        before_node=before_raise_value,
+        on_node_error=on_node_recover,
+    )
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent])
+
+    try:
+        async with worker:
+            result = await driver.execute("go", agent_in, timeout=60)
+            assert result.output == "recovered"
+    finally:
+        await driver.close()
+        await worker._client.close()
+
+
+async def test_seam_mint_bypasses_on_node_error(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """S-6: a ``NodeFaultError`` minted in ``before_node`` bypasses ``on_node_error``
+    entirely and escalates verbatim — the recovery seam never fires."""
+    recorder = CalleeErrorRecorder()  # reused as the on_node_error handler; must NOT fire
+    agent_in = f"{topic_namespace}.s6.input"
+    agent_pub = f"{topic_namespace}.s6.mirror"
+    agent = _agent(
+        f"{topic_namespace}-s6",
+        agent_in=agent_in,
+        publish_topic=agent_pub,
+        before_node=before_raise_mint,
+        on_node_error=recorder,
+    )
+    await ensure_topic(kafka_bootstrap, agent_pub)
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent])
+
+    try:
+        async with worker, fault_tap(kafka_bootstrap, agent_pub) as tap:
+            await driver.start("go", agent_in)
+            fault, _ = await tap.next_fault(timeout=60)
+            assert fault.error.error_type == "seam.mint"
+    finally:
+        await driver.close()
+        await worker._client.close()
+
+    assert recorder.calls == []  # the mint rule bypassed on_node_error entirely
+
+
+async def test_before_node_recorder_sees_ingress_seam_context(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """S-10 (Channel B): a ``before_node`` recorder sees the ingress ``SeamContext`` —
+    ``delivery_kind=call``, ``awaiting_reply=True`` (a reply is owed), ``route=None``
+    (no inbound route header) — then declines so the body runs."""
+    recorder = BeforeNodeRecorder()
+    agent_in = f"{topic_namespace}.s10.input"
+    agent = _agent(f"{topic_namespace}-s10", agent_in=agent_in, before_node=recorder)
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent])
+
+    try:
+        async with worker:
+            result = await driver.execute("go", agent_in, timeout=60)
+            assert result.output is not None and FINAL_OUTPUT in result.output
+    finally:
+        await driver.close()
+        await worker._client.close()
+
+    assert len(recorder.calls) >= 1
+    ingress = recorder.calls[0]
+    assert ingress["delivery_kind"] == "call"
+    assert ingress["awaiting_reply"] is True
+    assert ingress["route"] is None
+
+
+@pytest.mark.parametrize("bad_value", [True, b"bytes"], ids=["bool", "bytes"])
+async def test_before_node_contract_guard_faults(kafka_bootstrap: str, topic_namespace: str, bad_value: object) -> None:
+    """S-8: a ``before_node`` returning a value that can never be a node output (a ``bool``
+    or ``bytes`` — the §6.2 coercion guards) raises ``SeamContractError``, which escalates
+    as a ``calf.unhandled`` fault rather than silently passing garbage downstream."""
+
+    def before_bad(ctx: SeamContext[Any]) -> object:
+        return bad_value
+
+    agent_in = f"{topic_namespace}.s8.input"
+    agent_pub = f"{topic_namespace}.s8.mirror"
+    agent = _agent(f"{topic_namespace}-s8", agent_in=agent_in, publish_topic=agent_pub, before_node=before_bad)
+    await ensure_topic(kafka_bootstrap, agent_pub)
+    driver = Client.connect(kafka_bootstrap)
+    worker = fault_worker(kafka_bootstrap, nodes=[agent])
+
+    try:
+        async with worker, fault_tap(kafka_bootstrap, agent_pub) as tap:
+            await driver.start("go", agent_in)
+            fault, _ = await tap.next_fault(timeout=60)
+            assert fault.error.error_type == FaultTypes.UNHANDLED
+            assert fault.error.details.get(FaultTypes.EXCEPTION_TYPE) == "SeamContractError"
+    finally:
+        await driver.close()
+        await worker._client.close()


### PR DESCRIPTION
## What

Real-broker (`kafka` lane) integration tests for the merged **fault rail, policy seams & in-node durable fan-out** (PR #247), exercising the behaviors end-to-end over a live broker (testcontainers Redpanda) with offline `FunctionModel` agents and example fault-emitting tools.

**26 real-broker tests + 6 skip stubs.** `make check` clean; existing tool-roundtrip + MCP suites stay green. **No production code changed.**

## Coverage

| Suite | Tests |
|---|---|
| **F** fault escalation | generic raise → `calf.unhandled`, Channel-B `on_callee_error` recorder, mint verbatim, fire-and-forget mirror, stray-fault survival |
| **S** policy seams | before-node substitute, after-node replace, before-raise → `on_node_error` recover, seam-mint bypass, ingress `SeamContext`, bool/bytes contract guards |
| **R** auto-fault | `all_declined` + `schema_rejected` → `calf.delivery.rejected` (custom routed `NodeDef`) |
| **D** decode floor | node-side `calf.delivery.undecodable` + survival; client undecodable reply → `ReplyExpiredError` |
| **X** fan-out faults (real durable store) | singleton flatten + topology, `calf.fault_group`, `on_callee_error` substitute completes, slot-scoped seam raise |
| **M** retry marker | `ModelRetry` → `calf.retry` round-trip (recoverable, not a fault); MCP `isError` transparent passthrough |
| **O** oversized | strip-to-minimal-and-retry against a real `max.message.bytes` limit |
| **Z** stress | N=8 fold, concurrent batches under `max_workers=1`, mixed success/fault isolation |

## Observability

No typed fault reaches the client today (reception deferred to #250), so the suite standardizes three channels:
- **A** — a raw-consumer tap on the faulting node's `publish_topic` broadcast mirror (the only *typed* fault channel: reads `Envelope.reply` as a `FaultMessage` + `x-calf-kind`/`x-calf-error-type` headers).
- **B** — in-process seam-callback recorders (capture-in-callback, assert-in-test-body).
- **C** — the client edge as it behaves today (`DeserializationError` on a routed fault; `ReplyExpiredError` via a finite `reply_ttl`).

## Deferred (skip stubs)

`test_deferred_reception_kafka.py` holds 6 documented `skip`s for behaviors the **design specs describe but the merged code does not implement** — they would error on missing API. They flip on when the named issue lands:
- **#250** — client `NodeFaultError` reception + `ConsumerContext.fault`
- **#251** — `surface_to_model` + `self_retry_budget`
- **#193** — provider `calf.model.context_window_exceeded`
- MCP-`isError` *marking* follow-up

## Docs

Includes the source-grounded **behavior catalogue** and **integration test plan** (`docs/designs/fault-rail-fanout-*.md`) the tests implement; test docstrings reference the catalogue's behavior IDs.

## Running

```
make test-kafka            # or:
uv run --group integration pytest -m kafka tests/integration/test_*_kafka.py
```
Skips cleanly without Docker.
