### PR TITLE
feat!: migrate MCP capability plane onto the control-plane substrate

### DIFF
--- a/calfkit/exceptions.py
+++ b/calfkit/exceptions.py
@@ -179,14 +179,3 @@ class MissingTopicsError(RuntimeError):
             f"Topic provisioning was enabled but these topic(s) could not be created: {names}. "
             "Grant the client CreateTopics authorization, or pre-create the topic(s) out-of-band."
         )
-
-
-class MCPToolResolutionError(Exception):
-    """A strict MCP tool selector could not be satisfied for this turn.
-
-    Raised by the agent BEFORE the model runs when a selector declared with
-    ``strict=True`` cannot fully resolve against the Capability View (toolbox
-    missing, requested tool not advertised, malformed/newer-schema record, or
-    no view resource at all). Non-strict selectors degrade with a warning
-    instead.
-    """

--- a/calfkit/mcp/mcp_toolbox.py
+++ b/calfkit/mcp/mcp_toolbox.py
@@ -116,6 +116,12 @@ class MCPToolboxNode(BaseNodeDef):
         next worker heartbeat tick (pull). ``content_updated_at`` advances ONLY
         when the tool set actually changes — never per heartbeat — so liveness
         and content currency stay distinct (CRITICAL-3).
+
+        On the offloaded ``tools/list_changed`` path a failed ``list_tools()`` raises
+        before the cache is touched, so the previous tool list stays cached and keeps
+        being advertised as live (logged by :meth:`_on_relist_done`); it self-heals on
+        the next successful re-list. Startup is fail-loud instead — the session resource
+        aborts boot.
         """
         listing = await session.list_tools()
         tools = [CapabilityToolDef(name=tool.name, description=tool.description, parameters_json_schema=tool.inputSchema) for tool in listing.tools]
@@ -132,7 +138,13 @@ class MCPToolboxNode(BaseNodeDef):
         cadence); identity (``toolbox_id`` × ``worker_id``) is the wire key, not
         carried in the value.
         """
-        assert self._last_tools is not None and self._tools_changed_at is not None  # session resource primes the cache first
+        if self._last_tools is None or self._tools_changed_at is None:
+            # The session resource primes the cache in the resource phase, before the
+            # publisher's after_startup pulls this factory; reaching here means that
+            # ordering broke. Fail loud with a named cause (not a `-O`-stripped assert).
+            raise RuntimeError(
+                f"MCPToolboxNode {self.node_id!r}: capability factory ran before the session resource primed the tool cache (lifecycle ordering bug)"
+            )
         return CapabilityRecord(
             **stamp.model_dump(),
             dispatch_topic=self.subscribe_topics[0],

--- a/calfkit/mcp/mcp_toolbox.py
+++ b/calfkit/mcp/mcp_toolbox.py
@@ -1,30 +1,36 @@
 import asyncio
 import contextlib
 import logging
-from collections.abc import AsyncIterator, Mapping, Sequence
+from collections.abc import AsyncIterator, Sequence
 from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, ClassVar
 
 import pydantic_core
-from ktables import KafkaTableWriter
 from mcp import ClientSession
 from mcp.types import CallToolResult as MCPCallToolResult
 from mcp.types import ToolListChangedNotification
 
 from calfkit._protocol import NodeKind
 from calfkit._registry import handler
+from calfkit.controlplane import ControlPlaneStamp, advertises
 from calfkit.exceptions import LifecycleConfigError
 from calfkit.mcp.mcp_transport import StdioServerParameters, StreamableHttpParameters, http_client, stdio_client
 from calfkit.models.actions import NodeResult, ReturnCall
-from calfkit.models.capability import CapabilityRecord, CapabilityToolDef, SelectorResult, resolve_capability
+from calfkit.models.capability import (
+    CAPABILITY_TOPIC,
+    CapabilityLookup,
+    CapabilityRecord,
+    CapabilityToolDef,
+    SelectorResult,
+    resolve_capability,
+)
 from calfkit.models.session_context import SessionRunContext
 from calfkit.models.state import State
 from calfkit.models.tool_dispatch import ToolCallRef
 from calfkit.nodes.base import BaseNodeDef
-from calfkit.worker.lifecycle import ResourceSetupContext, ServingContext
-from calfkit.worker.worker_config import MCPDiscoveryConfig
+from calfkit.worker.lifecycle import ResourceSetupContext
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +55,17 @@ class MCPToolboxNode(BaseNodeDef):
         async with transport as (read_stream, write_stream):
             async with ClientSession(read_stream, write_stream, message_handler=self._mcp_message_handler) as session:
                 await session.initialize()
-                yield session
+                # Prime the tool cache before the worker's publisher pulls the
+                # advert factory (resources set up before after_startup). A list
+                # failure here aborts boot — a toolbox that cannot advertise must
+                # fail loudly.
+                await self._refresh_tools(session)
+                try:
+                    yield session
+                finally:
+                    # Cancel any in-flight tools/list_changed re-list before the
+                    # session closes, so none outlives the receive loop.
+                    await self._cancel_relist_tasks()
 
     def __init__(
         self,
@@ -59,31 +75,17 @@ class MCPToolboxNode(BaseNodeDef):
         super().__init__(node_id=name, subscribe_topics=[f"mcp_server.{name}"])
         self._connection_params = connection_params
         self._session_resource_key = f"mcp_session.{name}"
-        self._writer_resource_key = f"mcp_writer.{name}"
-        self._heartbeat_task: asyncio.Task[None] | None = None
         self._relist_tasks: set[asyncio.Task[None]] = set()
-        self._shutting_down = False
-        self._last_record: CapabilityRecord | None = None
+        # The advertised tool list, cached from the MCP session. The @advertises
+        # factory reads it; the worker-owned ControlPlanePublisher heartbeats it
+        # and tombstones on shutdown.
+        self._last_tools: list[CapabilityToolDef] | None = None
+        self._tools_changed_at: datetime | None = None
         self.resource(name=self._session_resource_key)(self._mcp_session)
-        self.resource(name=self._writer_resource_key)(self._capability_writer)
-        self.after_startup(self._publish_on_startup)
-        self.on_shutdown(self._tombstone_on_shutdown)
-
-    @property
-    def _discovery(self) -> MCPDiscoveryConfig:
-        """Control-plane config, inherited from the hosting worker.
-
-        The worker is the single config surface (``Worker(...,
-        mcp_discovery=...)``); the toolbox reads it through the ``_worker``
-        back-reference — same pattern as bootstrap derivation. Defaults apply
-        when unhosted (tests, bare construction).
-        """
-        cfg = getattr(self._worker, "_mcp_discovery", None)
-        return cfg if cfg is not None else MCPDiscoveryConfig()
 
     # -- tool selection (spec §8.4) --------------------------------------------
 
-    def resolve_tools(self, view: Mapping[str, CapabilityRecord]) -> SelectorResult:
+    def resolve_tools(self, view: CapabilityLookup) -> SelectorResult:
         """All advertised tools, resolved against the Capability View.
 
         Implements ``ToolSelector`` by delegating to this node's handle —
@@ -92,152 +94,91 @@ class MCPToolboxNode(BaseNodeDef):
         """
         return MCPToolbox(self.node_id).resolve_tools(view)
 
-    def select(self, *, include: Sequence[str] | None = None, strict: bool = False) -> "MCPToolbox":
-        """A scoped/strict selector for this toolbox's tools.
+    def select(self, *, include: Sequence[str] | None = None) -> "MCPToolbox":
+        """A scoped selector for this toolbox's tools.
 
         ``include`` pins the exact tool names the agent may see (the trust
         boundary: a server suddenly advertising new tools cannot enlarge the
-        agent's surface). ``strict=True`` fails the agent's turn when the
-        selection cannot be fully satisfied; the default degrades with a
-        warning.
+        agent's surface). An unresolved selection degrades with a warning.
         """
         return MCPToolbox(
             name=self.node_id,
             include=tuple(include) if include is not None else None,
-            strict=strict,
         )
 
-    # -- capability publishing (spec §3.3/§8.5) -------------------------------
+    # -- capability advertisement (control-plane substrate) -------------------
 
-    def _control_plane_bootstrap(self) -> str:
-        """Bootstrap servers for the capability topic, zero-config (spec §8.3).
+    async def _refresh_tools(self, session: Any) -> None:
+        """Re-list the server's tools into the cache; bump content currency on a real change.
 
-        Chain: explicit config override -> the connected client's retained URL
-        -> the broker's connection kwargs (guarded internals fallback).
+        Called at session setup and on every ``tools/list_changed``. The
+        ``@advertises`` factory reads this cache, so a change propagates at the
+        next worker heartbeat tick (pull). ``content_updated_at`` advances ONLY
+        when the tool set actually changes — never per heartbeat — so liveness
+        and content currency stay distinct (CRITICAL-3).
         """
-        if self._discovery.bootstrap_servers:
-            return self._discovery.bootstrap_servers
-        client = getattr(self._worker, "_client", None)
-        urls = getattr(client, "server_urls", None)
-        if urls:
-            return str(urls)
-        kwargs = getattr(getattr(client, "broker", None), "_connection_kwargs", None) or {}
-        servers = kwargs.get("bootstrap_servers")
-        if servers:
-            return servers if isinstance(servers, str) else ",".join(servers)
-        raise RuntimeError(
-            f"MCPToolboxNode {self.node_id!r}: cannot derive Kafka bootstrap servers for the "
-            "capability topic (no worker/client attached). Host this node via Worker, or set "
-            "MCPDiscoveryConfig(bootstrap_servers=...) explicitly."
-        )
-
-    def _provisioning_enabled(self) -> bool:
-        provisioning = getattr(getattr(self._worker, "_client", None), "_provisioning", None)
-        return bool(getattr(provisioning, "enabled", False))
-
-    async def _capability_writer(self, ctx: ResourceSetupContext) -> AsyncIterator[KafkaTableWriter[CapabilityRecord]]:
-        writer: KafkaTableWriter[CapabilityRecord] = KafkaTableWriter.json(
-            bootstrap_servers=self._control_plane_bootstrap(),
-            topic=self._discovery.topic,
-            model=CapabilityRecord,
-            ensure_topic=self._provisioning_enabled(),
-        )
-        await writer.start()
-        yield writer
-        await writer.stop()
-
-    async def _build_record(self, session: Any) -> CapabilityRecord:
         listing = await session.list_tools()
+        tools = [CapabilityToolDef(name=tool.name, description=tool.description, parameters_json_schema=tool.inputSchema) for tool in listing.tools]
+        if tools != self._last_tools:
+            self._last_tools = tools
+            self._tools_changed_at = datetime.now(tz=timezone.utc)
+
+    @advertises(topic=CAPABILITY_TOPIC, record=CapabilityRecord)
+    def _capability_record(self, stamp: ControlPlaneStamp) -> CapabilityRecord:
+        """Content factory the worker-owned publisher pulls each heartbeat tick.
+
+        Reads the cached tool list — NEVER re-lists inline (this runs on the
+        shared heartbeat loop). Splat the bare ``stamp`` (boot + liveness +
+        cadence); identity (``toolbox_id`` × ``worker_id``) is the wire key, not
+        carried in the value.
+        """
+        assert self._last_tools is not None and self._tools_changed_at is not None  # session resource primes the cache first
         return CapabilityRecord(
-            toolbox_id=self.node_id,
+            **stamp.model_dump(),
             dispatch_topic=self.subscribe_topics[0],
-            tools=[
-                CapabilityToolDef(name=tool.name, description=tool.description, parameters_json_schema=tool.inputSchema) for tool in listing.tools
-            ],
-            published_at=datetime.now(tz=timezone.utc),
+            tools=self._last_tools,
+            content_updated_at=self._tools_changed_at,
         )
-
-    async def _publish_on_startup(self, ctx: ServingContext["MCPToolboxNode"]) -> None:
-        """Connect-time advertisement + heartbeat start. Raising here aborts
-        worker startup — a toolbox that cannot advertise must fail loudly."""
-        session = ctx.resources[self._session_resource_key]
-        writer = ctx.resources[self._writer_resource_key]
-        record = await self._build_record(session)
-        self._last_record = record
-        await writer.set(self.node_id, record)
-        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop(writer), name=f"mcp-heartbeat:{self.node_id}")
-
-    async def _heartbeat_loop(self, writer: Any) -> None:
-        # Re-publish the cached record with a fresh timestamp — liveness signal
-        # only; no re-listing (tools/list_changed drives content changes).
-        while True:
-            await asyncio.sleep(self._discovery.heartbeat_interval)
-            record = self._last_record
-            if record is None:
-                continue
-            record = record.model_copy(update={"published_at": datetime.now(tz=timezone.utc)})
-            self._last_record = record
-            try:
-                await writer.set(self.node_id, record)
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                logger.exception("toolbox=%s heartbeat publish failed; will retry next interval", self.node_id)
 
     async def _handle_tools_list_changed(self, notification: ToolListChangedNotification) -> None:
-        """Server signalled a tool-list change: re-list and re-publish."""
+        """Server signalled a tool-list change: re-list into the cache.
+
+        No publish — the worker's heartbeat carries the new content at the next
+        tick (pull). A change lands within one ``heartbeat_interval``.
+        """
         session = self.resources.get(self._session_resource_key)
-        writer = self.resources.get(self._writer_resource_key)
-        if session is None or writer is None:
-            logger.warning("toolbox=%s tools/list_changed before resources ready; ignoring", self.node_id)
+        if session is None:
+            logger.warning("toolbox=%s tools/list_changed before session ready; ignoring", self.node_id)
             return
-        record = await self._build_record(session)
-        self._last_record = record
-        await writer.set(self.node_id, record)
+        await self._refresh_tools(session)
 
     def _on_relist_done(self, task: asyncio.Task[None]) -> None:
         self._relist_tasks.discard(task)
         if not task.cancelled() and task.exception() is not None:
-            logger.error("toolbox=%s tools/list_changed re-publish failed", self.node_id, exc_info=task.exception())
+            logger.error("toolbox=%s tools/list_changed re-list failed", self.node_id, exc_info=task.exception())
 
     async def _mcp_message_handler(self, message: Any) -> None:
         # ClientSession message handler; ServerNotification is a RootModel wrapper.
         inner = getattr(message, "root", message)
         if isinstance(inner, ToolListChangedNotification):
-            if self._shutting_down:
-                # The receive loop outlives on_shutdown (session closes in the
-                # resource phase): a late notification must not spawn a re-list
-                # that lands after the tombstone and resurrects the record.
-                logger.debug("toolbox=%s ignoring tools/list_changed during shutdown", self.node_id)
-                return
-            # NEVER await the re-list inline: this handler runs ON the
-            # session's receive loop, and list_tools()'s response is delivered
-            # by that same loop — awaiting here deadlocks the session,
-            # unbounded (no read timeout). Offload and track for shutdown.
+            # NEVER await the re-list inline: this handler runs ON the session's
+            # receive loop, and list_tools()'s response is delivered by that same
+            # loop — awaiting here deadlocks the session (no read timeout). Offload
+            # and track so the session resource cancels it at teardown. A late
+            # re-list only updates a cache; with no node-side writer there is
+            # nothing to resurrect (the publisher owns the tombstone).
             task = asyncio.create_task(self._handle_tools_list_changed(inner), name=f"mcp-relist:{self.node_id}")
             self._relist_tasks.add(task)
             task.add_done_callback(self._on_relist_done)
 
-    async def _tombstone_on_shutdown(self, ctx: ServingContext["MCPToolboxNode"]) -> None:
-        # Flag FIRST, synchronously (no await above this line): after it is
-        # set, _mcp_message_handler can never create a new re-list task, so
-        # the snapshot below is complete. Then cancel heartbeat AND in-flight
-        # re-lists BEFORE the tombstone: a straggler set() landing after
-        # delete() would resurrect the record.
-        self._shutting_down = True
-        tasks = [self._heartbeat_task, *self._relist_tasks]
-        self._heartbeat_task = None
+    async def _cancel_relist_tasks(self) -> None:
+        """Cancel any in-flight ``tools/list_changed`` re-lists (session teardown)."""
+        tasks = list(self._relist_tasks)
         self._relist_tasks.clear()
         for task in tasks:
-            if task is not None:
-                task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await task
-        writer = ctx.resources.get(self._writer_resource_key)
-        if writer is not None:
-            # Clean shutdown = deliberate removal (spec §6); a crash never gets
-            # here, so the record stands and goes stale instead.
-            await writer.delete(self.node_id)
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
 
     @handler("*", schema=ToolCallRef)
     async def run(self, ctx: SessionRunContext, payload: ToolCallRef) -> NodeResult[State]:  # type: ignore[override]
@@ -276,15 +217,13 @@ class MCPToolbox:
     toolbox is the cluster's MCP client; agents never speak MCP at all — they
     hold one of these.
 
-    ``include`` pins the exact tool names the agent may see; ``strict=True``
-    fails the turn when the selection cannot be fully satisfied (default
-    degrades with a warning). Frozen with value semantics: equal handles
-    compare and hash equal.
+    ``include`` pins the exact tool names the agent may see (the trust boundary);
+    an unresolved selection degrades with a warning. Frozen with value semantics:
+    equal handles compare and hash equal.
     """
 
     name: str
     include: tuple[str, ...] | None = None
-    strict: bool = False
 
     def __post_init__(self) -> None:
         if not self.name:
@@ -292,5 +231,5 @@ class MCPToolbox:
         if self.include is not None and not isinstance(self.include, tuple):
             object.__setattr__(self, "include", tuple(self.include))
 
-    def resolve_tools(self, view: Mapping[str, CapabilityRecord]) -> SelectorResult:
-        return resolve_capability(view, self.name, include=self.include, strict=self.strict)
+    def resolve_tools(self, view: CapabilityLookup) -> SelectorResult:
+        return resolve_capability(view, self.name, include=self.include)

--- a/calfkit/models/capability.py
+++ b/calfkit/models/capability.py
@@ -1,31 +1,38 @@
 """Capability control-plane wire model (spec §3.2).
 
-A :class:`CapabilityRecord` is one MCP Toolbox's advertisement on the
-capability topic: identity, dispatch topic, and tool definitions, keyed on the
-wire by ``toolbox_id``. Records are calfkit-owned models — never the vendored
-``ToolDefinition`` — because compacted records outlive deploys, so the wire
-shape must not move when the vendored library does.
+A :class:`CapabilityRecord` is one MCP Toolbox instance's advertisement on the
+capability control-plane topic: dispatch topic and tool definitions, keyed on the
+wire by ``toolbox_id`` × ``worker_id`` (the control-plane instance key, held by the
+substrate — never in the value). Records are calfkit-owned models — never the
+vendored ``ToolDefinition`` — because compacted records outlive deploys, so the
+wire shape must not move when the vendored library does.
 
-Reader policy: tolerant (unknown fields ignored — a newer writer may add
-fields), and records with a newer ``schema_version`` decode fine but must be
-*skipped with a log* by the consumer; :func:`is_unsupported_schema` is that
-policy's predicate.
+Reader policy: tolerant (unknown fields ignored — a newer writer may add fields).
+Staleness and newer-``schema_version`` filtering are owned by the reader's
+:class:`~calfkit.controlplane.ControlPlaneView` (it hides such records and logs the
+skip), so the resolver here only maps a live record to tool bindings.
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Protocol
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict
 
 from calfkit._vendor.pydantic_ai.tools import ToolDefinition
+from calfkit.controlplane import ControlPlaneRecord
 from calfkit.models.tool_dispatch import SelectorResult as SelectorResult  # re-export: resolution API lives here
 from calfkit.models.tool_dispatch import ToolBinding
 
 CAPABILITY_SCHEMA_VERSION = 1
 """The record schema major this reader understands. Bump only on breaking
 wire changes; additive fields ride on the tolerant reader instead."""
+
+CAPABILITY_TOPIC = "calf.capabilities"
+"""The cluster-wide compacted control-plane topic toolboxes advertise to.
+
+A control-plane topic (not MCP-specific transport): one record schema per topic.
+Both the ``@advertises`` factory and the reader's ``ControlPlaneView`` bind to it."""
 
 
 class CapabilityToolDef(BaseModel):
@@ -38,22 +45,24 @@ class CapabilityToolDef(BaseModel):
     parameters_json_schema: dict[str, Any]
 
 
-class CapabilityRecord(BaseModel):
-    """One toolbox's current advertisement; superseded whole by its next publish."""
+class CapabilityRecord(ControlPlaneRecord):
+    """One toolbox instance's current advertisement on the capability control plane.
 
-    model_config = ConfigDict(extra="ignore")
+    A :class:`~calfkit.controlplane.ControlPlaneRecord` (identity ``toolbox_id`` ×
+    ``worker_id`` is the wire key; the worker stamps ``started_at`` /
+    ``last_heartbeat_at`` / ``heartbeat_interval``) plus the capability content: the
+    dispatch topic and the tool list. ``content_updated_at`` advances only when
+    ``tools`` actually changes — separate from the liveness heartbeat — so a consumer
+    can tell "instance alive" from "tool list fresh" (the CRITICAL-3 split).
+
+    Inherits the base's tolerant, frozen ``model_config`` (``extra="ignore"``); the
+    value object is rebuilt per heartbeat tick, never mutated.
+    """
 
     schema_version: int = CAPABILITY_SCHEMA_VERSION
-    toolbox_id: str
     dispatch_topic: str
     tools: list[CapabilityToolDef]
-    published_at: AwareDatetime
-
-
-def is_unsupported_schema(record: CapabilityRecord) -> bool:
-    """True when ``record`` was written by a newer schema major than this
-    reader understands — the consumer must skip it and log, not act on it."""
-    return record.schema_version > CAPABILITY_SCHEMA_VERSION
+    content_updated_at: AwareDatetime
 
 
 def record_to_bindings(record: CapabilityRecord) -> list[ToolBinding]:
@@ -75,23 +84,36 @@ def record_to_bindings(record: CapabilityRecord) -> list[ToolBinding]:
     ]
 
 
-CAPABILITY_VIEW_RESOURCE_KEY = "calfkit.mcp.capability_view"
+CAPABILITY_VIEW_RESOURCE_KEY = "calfkit.controlplane.capability_view"
 """Worker resource-bag key under which the Capability View (a
-``Mapping[str, CapabilityRecord]``) is published to hosted nodes."""
+:class:`CapabilityLookup`, in practice a ``ControlPlaneView[CapabilityRecord]``)
+is published to hosted nodes."""
+
+
+class CapabilityLookup(Protocol):
+    """The minimal read surface the resolver needs: ``get(toolbox_id)``.
+
+    Satisfied by a ``ControlPlaneView[CapabilityRecord]`` (production) and by a
+    plain ``dict`` (tests), so the agent layer needs no ktables import. The view
+    already hides stale and newer-schema records, so a returned record is live
+    and supported.
+    """
+
+    def get(self, toolbox_id: str) -> CapabilityRecord | None: ...
 
 
 def resolve_capability(
-    view: Any,
+    view: CapabilityLookup,
     toolbox_id: str,
     *,
     include: tuple[str, ...] | None = None,
-    strict: bool = False,
 ) -> SelectorResult:
-    """Resolve ``toolbox_id`` (optionally filtered) against the view.
+    """Resolve ``toolbox_id`` (optionally filtered) against the Capability View.
 
     Public API: this is the resolution kernel behind ``MCPToolbox`` and
     ``MCPToolboxNode.resolve_tools``; custom ``ToolSelector`` implementations may
-    call it directly.
+    call it directly. The view owns staleness + schema-version filtering, so this
+    only maps a present record to bindings.
 
     Never raises on bad records: the tolerant reader admits shapes that fail
     binding expansion (e.g. empty ``dispatch_topic``); those surface as
@@ -99,23 +121,14 @@ def resolve_capability(
     """
     record = view.get(toolbox_id)
     if record is None:
-        return SelectorResult(toolbox_id=toolbox_id, strict=strict, missing_toolbox=True)
-    if is_unsupported_schema(record):
-        return SelectorResult(toolbox_id=toolbox_id, strict=strict, skipped_newer_schema=True)
+        return SelectorResult(toolbox_id=toolbox_id, missing_toolbox=True)
     try:
         bindings = record_to_bindings(record)
     except Exception:
-        return SelectorResult(toolbox_id=toolbox_id, strict=strict, invalid_record=True)
+        return SelectorResult(toolbox_id=toolbox_id, invalid_record=True)
     missing: tuple[str, ...] = ()
     if include is not None:
         wanted = set(include)
         bindings = [b for b in bindings if b.name in wanted]
         missing = tuple(name for name in include if name not in {b.name for b in bindings})
-    stale = max(0.0, (datetime.now(tz=timezone.utc) - record.published_at).total_seconds())
-    return SelectorResult(
-        toolbox_id=toolbox_id,
-        strict=strict,
-        bindings=bindings,
-        missing_tools=missing,
-        stale_seconds=stale,
-    )
+    return SelectorResult(toolbox_id=toolbox_id, bindings=bindings, missing_tools=missing)

--- a/calfkit/models/capability.py
+++ b/calfkit/models/capability.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from typing import Any, Protocol
 
-from pydantic import AwareDatetime, BaseModel, ConfigDict
+from pydantic import AwareDatetime, BaseModel, ConfigDict, ValidationError
 
 from calfkit._vendor.pydantic_ai.tools import ToolDefinition
 from calfkit.controlplane import ControlPlaneRecord
@@ -52,8 +52,19 @@ class CapabilityRecord(ControlPlaneRecord):
     ``worker_id`` is the wire key; the worker stamps ``started_at`` /
     ``last_heartbeat_at`` / ``heartbeat_interval``) plus the capability content: the
     dispatch topic and the tool list. ``content_updated_at`` advances only when
-    ``tools`` actually changes — separate from the liveness heartbeat — so a consumer
-    can tell "instance alive" from "tool list fresh" (the CRITICAL-3 split).
+    ``tools`` actually changes — separate from the liveness heartbeat — so liveness
+    and content currency stay distinct. It is **advisory**: the substrate cannot
+    enforce its monotonicity (the writing node owns the contract; a hand-rolled
+    factory could pass ``now()``), and no production reader gates on it yet — it is
+    wire surface for future ops/observability consumers.
+
+    **Precondition for the collapsed view:** all replicas of one toolbox (same
+    ``toolbox_id``) must advertise *equivalent* content. The view collapses replicas to
+    one record by most-recent heartbeat — it does not merge tool sets — so two replicas
+    with divergent tool lists would flap the agent's visible surface tick-to-tick. The
+    dispatch topic is name-derived and identical across replicas, so routing is never
+    wrong; only tool *visibility* would flap. Keep a toolbox's replicas pointed at the
+    same server / tool set.
 
     Inherits the base's tolerant, frozen ``model_config`` (``extra="ignore"``); the
     value object is rebuilt per heartbeat tick, never mutated.
@@ -124,7 +135,11 @@ def resolve_capability(
         return SelectorResult(toolbox_id=toolbox_id, missing_toolbox=True)
     try:
         bindings = record_to_bindings(record)
-    except Exception:
+    except ValidationError:
+        # The one tolerant-reader bad-data path: an empty dispatch_topic fails
+        # ToolBinding's min_length. A poisoned advert degrades (invalid_record),
+        # not crashes the turn. A NON-validation error here is a logic bug — let
+        # it propagate (fail loud) rather than masking it as bad wire data.
         return SelectorResult(toolbox_id=toolbox_id, invalid_record=True)
     missing: tuple[str, ...] = ()
     if include is not None:

--- a/calfkit/models/tool_dispatch.py
+++ b/calfkit/models/tool_dispatch.py
@@ -1,6 +1,6 @@
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.json_schema import SkipJsonSchema
@@ -8,6 +8,11 @@ from typing_extensions import Self
 
 from calfkit._vendor.pydantic_ai.messages import ToolCallPart
 from calfkit._vendor.pydantic_ai.tools import ToolDefinition
+
+if TYPE_CHECKING:
+    # Type-only: the Capability View lookup the resolver consumes lives a layer up
+    # (it references CapabilityRecord). A runtime import would cycle; this does not.
+    from calfkit.models.capability import CapabilityLookup
 
 ArgsValidator = Callable[[dict[str, Any]], Any]
 """Validates LLM-emitted tool args pre-dispatch; raises ``pydantic.ValidationError`` on mismatch."""
@@ -68,22 +73,24 @@ class SelectorResult:
     """Outcome of resolving one MCP tool selector against the Capability View.
 
     Carries the bindings plus structured diagnostics so the agent owns the
-    warn/strict policy in one place and tests assert on data, not log text.
+    warn/degrade policy in one place and tests assert on data, not log text.
+
+    Staleness and schema-version filtering are the :class:`ControlPlaneView`'s
+    job now (it hides stale/newer-schema records), so the only ways a selection
+    is ``unresolved`` are a missing toolbox, missing requested tools, or a
+    record that fails binding expansion.
     """
 
     toolbox_id: str
-    strict: bool = False
     bindings: list[ToolBinding] = field(default_factory=list)
     missing_toolbox: bool = False
     missing_tools: tuple[str, ...] = ()
-    skipped_newer_schema: bool = False
     invalid_record: bool = False
-    stale_seconds: float | None = None
 
     @property
     def unresolved(self) -> bool:
         """True when anything the selector asked for could not be delivered."""
-        return self.missing_toolbox or bool(self.missing_tools) or self.skipped_newer_schema or self.invalid_record
+        return self.missing_toolbox or bool(self.missing_tools) or self.invalid_record
 
 
 @runtime_checkable
@@ -94,11 +101,12 @@ class ToolSelector(Protocol):
     agents hold, including ``select()`` results) and by the hosting
     :class:`~calfkit.mcp.mcp_toolbox.MCPToolboxNode`, which delegates to it:
     passing either to an agent extracts only a lookup key — no session contact,
-    no deployment. The ``view`` is a plain ``Mapping`` so the agent layer needs
-    no ktables import and tests can use dicts.
+    no deployment. The ``view`` is a :class:`~calfkit.models.capability.CapabilityLookup`
+    (anything with ``get(toolbox_id) -> CapabilityRecord | None``), so the agent layer
+    needs no ktables import and tests can use plain dicts.
     """
 
-    def resolve_tools(self, view: Mapping[str, Any]) -> SelectorResult: ...
+    def resolve_tools(self, view: "CapabilityLookup") -> SelectorResult: ...
 
 
 def split_tool_declarations(

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -14,7 +14,7 @@ from calfkit._vendor.pydantic_ai.output import OutputSpec
 from calfkit._vendor.pydantic_ai.settings import ModelSettings
 from calfkit._vendor.pydantic_ai.tools import DeferredToolResults
 from calfkit._vendor.pydantic_ai.toolsets.external import ExternalToolset
-from calfkit.exceptions import DeserializationError, MCPToolResolutionError, safe_exc_message
+from calfkit.exceptions import DeserializationError, safe_exc_message
 from calfkit.models import Call, DataPart, NodeResult, ReturnCall, State, TailCall, TextPart
 from calfkit.models.capability import CAPABILITY_VIEW_RESOURCE_KEY, SelectorResult
 from calfkit.models.node_result import _extract_text, extract_lenient
@@ -195,8 +195,8 @@ class BaseAgentNodeDef(
     def _maybe_resolve_selectors(self, ctx: SessionRunContext, tools_registry: dict[str, ToolBinding]) -> None:
         """Selector resolution gate: per-run overrides pin the EXACT tool
         surface for the turn, so MCP selectors are skipped entirely when
-        ``override_agent_tools`` is present (a strict selector must not be
-        able to fail a turn the caller scoped away from MCP)."""
+        ``override_agent_tools`` is present (overrides are the exact surface;
+        MCP must not widen a turn the caller scoped away from it)."""
         if not self._tool_selectors:
             return
         if ctx.state.overrides is not None and ctx.state.overrides.override_agent_tools is not None:
@@ -207,46 +207,44 @@ class BaseAgentNodeDef(
             return
         self._resolve_selector_tools(ctx.resources, tools_registry)
 
-    _STALE_LOG_AFTER_SECONDS = 90.0  # 3x the default heartbeat interval
-
     def _resolve_selector_tools(self, resources: Mapping[str, Any], tools_registry: dict[str, ToolBinding]) -> None:
-        """Per-turn MCP selector resolution against the Capability View (spec §8.4).
+        """Per-turn MCP selector resolution against the Capability View.
 
         Merges AFTER static tools with collision = error-log + static wins (a
-        remote server must never silently shadow a locally defined tool).
-        Unresolved selections warn and degrade; ``strict=True`` raises before
-        the model runs. Staleness and newer-schema records are log-only (v1).
+        remote server must never silently shadow a locally defined tool). The
+        :class:`ControlPlaneView` owns staleness + schema-version filtering, so
+        an unresolved selection (missing toolbox/tools, or a poisoned record)
+        only warns and degrades — there is no strict fail path.
         """
         view = resources.get(CAPABILITY_VIEW_RESOURCE_KEY)
         if view is None:
-            if any(getattr(sel, "strict", False) for sel in self._tool_selectors):
-                raise MCPToolResolutionError(
-                    f"agent {self.name!r} declares strict MCP tool selectors but no Capability View "
-                    f"resource ({CAPABILITY_VIEW_RESOURCE_KEY!r}) is available — is this agent hosted "
-                    "by a Worker with MCP discovery active?"
-                )
             logger.warning(
                 "agent=%s has MCP tool selectors but no Capability View resource; running without MCP tools",
                 self.name,
             )
             return
+        # CRITICAL-4 (log-only): a degraded/failed reader serves a possibly-frozen view.
+        # Surface it so the staleness is observable — but never block the turn.
+        status = getattr(view, "status", None)
+        failure = getattr(view, "failure", None)
+        if failure is not None or status in ("degraded", "failed"):
+            logger.warning(
+                "agent=%s resolving MCP tools against a %s Capability View (failure=%r); tools may be stale",
+                self.name,
+                status,
+                failure,
+            )
         for selector in self._tool_selectors:
             result: SelectorResult = selector.resolve_tools(view)
             if result.unresolved:
-                detail = (
-                    f"toolbox={result.toolbox_id!r} missing_toolbox={result.missing_toolbox} "
-                    f"missing_tools={result.missing_tools} newer_schema={result.skipped_newer_schema} "
-                    f"invalid_record={result.invalid_record}"
-                )
-                if result.strict:
-                    raise MCPToolResolutionError(f"agent {self.name!r}: strict MCP selection unresolved: {detail}")
-                logger.warning("agent=%s MCP selection partially unresolved (%s); running degraded", self.name, detail)
-            if result.stale_seconds is not None and result.stale_seconds > self._STALE_LOG_AFTER_SECONDS:
                 logger.warning(
-                    "agent=%s toolbox=%s capability record is %.0fs stale (heartbeats missing?); using last-known tools",
+                    "agent=%s MCP selection partially unresolved (toolbox=%r missing_toolbox=%s "
+                    "missing_tools=%s invalid_record=%s); running degraded",
                     self.name,
                     result.toolbox_id,
-                    result.stale_seconds,
+                    result.missing_toolbox,
+                    result.missing_tools,
+                    result.invalid_record,
                 )
             for binding in result.bindings:
                 if binding.name in tools_registry:

--- a/calfkit/worker/worker.py
+++ b/calfkit/worker/worker.py
@@ -169,11 +169,11 @@ class Worker(LifecycleHookMixin):
         self._nodes.append(node)
 
     def _maybe_register_capability_view(self) -> None:
-        """Auto-register the MCP Capability View resource (spec §8.3).
+        """Auto-register the MCP Capability View resource.
 
         Zero user wiring: iff any hosted node declares MCP tool selectors, ONE
-        worker-level ``KafkaTable[CapabilityRecord]`` resource is registered
-        (idempotent — guarded by resource-name lookup). The table lands in the
+        worker-level ``ControlPlaneView[CapabilityRecord]`` resource is registered
+        (idempotent — guarded by resource-name lookup). The view lands in the
         worker bag and reaches every node's ``ctx.resources`` via the existing
         worker-under-node merge.
         """

--- a/calfkit/worker/worker.py
+++ b/calfkit/worker/worker.py
@@ -11,7 +11,8 @@ from typing_extensions import Self
 from calfkit.client import Client
 from calfkit.controlplane.config import ControlPlaneConfig
 from calfkit.controlplane.publisher import ControlPlanePublisher, control_plane_writer_key
-from calfkit.models.capability import CAPABILITY_VIEW_RESOURCE_KEY, CapabilityRecord
+from calfkit.controlplane.view import ControlPlaneView
+from calfkit.models.capability import CAPABILITY_TOPIC, CAPABILITY_VIEW_RESOURCE_KEY, CapabilityRecord
 from calfkit.models.tool_dispatch import ToolSelector
 from calfkit.nodes import BaseNodeDef
 from calfkit.provisioning import topics_for_nodes
@@ -26,7 +27,6 @@ from calfkit.worker.lifecycle import (
     _resource_cm,
     _span_cm,
 )
-from calfkit.worker.worker_config import MCPDiscoveryConfig
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +68,6 @@ class Worker(LifecycleHookMixin):
         extra_subscribe_kwargs: dict[str, Any] = {},
         id: str | None = None,
         name: str | None = None,
-        mcp_discovery: MCPDiscoveryConfig | None = None,
         control_plane: ControlPlaneConfig | None = None,
     ):
         """Initialize a worker.
@@ -90,21 +89,18 @@ class Worker(LifecycleHookMixin):
                 Validated non-empty; a uuid7 hex is generated when ``None``.
                 Read-only after construction — mirrors ``BaseClient.emitter_id``.
             name: Display-only label; defaults to ``id``. Never put on the wire.
-            mcp_discovery: Optional tuning for MCP capability discovery
-                (topic, catch-up timeout, bootstrap override). Entirely
-                optional — the Capability View is auto-registered with
-                defaults whenever a hosted agent declares MCP tool selectors.
             control_plane: Optional tuning for the control-plane substrate
                 (heartbeat interval, staleness, catch-up timeout, bootstrap
-                override). The publisher is auto-registered with defaults
-                whenever a hosted node declares an advert (``@advertises``).
+                override). Entirely optional. The publisher is auto-registered
+                whenever a hosted node declares an advert (``@advertises``), and
+                the MCP Capability View whenever a hosted agent declares MCP tool
+                selectors — both with these defaults, zero user wiring.
         """
         if id is not None and not id.strip():
             raise ValueError("id must be a non-empty string or None")
         if name is not None and not name.strip():
             raise ValueError("name must be a non-empty string or None")
         self._client = client
-        self._mcp_discovery = mcp_discovery if mcp_discovery is not None else MCPDiscoveryConfig()
         self._control_plane = control_plane if control_plane is not None else ControlPlaneConfig()
         self._max_workers = max_workers
         self._group_id = group_id
@@ -188,34 +184,35 @@ class Worker(LifecycleHookMixin):
         self.resource(name=CAPABILITY_VIEW_RESOURCE_KEY)(self._capability_view_resource)
 
     async def _capability_view_resource(self, ctx: ResourceSetupContext["Worker"]) -> AsyncIterator[Any]:
-        """Open the Capability View for this worker's lifetime.
+        """Open the Capability View (``ControlPlaneView[CapabilityRecord]``) for this worker's lifetime.
 
-        ``KafkaTable.start()`` IS the boot gate: it replays the capability
-        topic to its start-time end offsets bounded by ``catchup_timeout``
-        (serving degraded, loudly, on expiry) — and because resource setup
-        runs before the broker serves, agents never see a half-built view.
+        ``view.start()`` IS the boot gate: the underlying grouped table replays
+        ``calf.capabilities`` to its start-time end offsets bounded by
+        ``catchup_timeout`` (serving degraded, loudly, on expiry) — and because
+        resource setup runs before the broker serves, agents never see a
+        half-built view. The view collapses the instance-keyed records to one
+        live record per toolbox and owns staleness + schema-version filtering.
         """
-        from ktables import KafkaTable  # the one ktables import outside calfkit.mcp
-
-        cfg = self._mcp_discovery
+        cfg = self._control_plane
         bootstrap = cfg.bootstrap_servers or self._derive_bootstrap_servers()
         if not bootstrap:
             raise RuntimeError(
                 "cannot derive Kafka bootstrap servers for the MCP Capability View "
-                "(client built without connect()?); set MCPDiscoveryConfig(bootstrap_servers=...)."
+                "(client built without connect()?); set ControlPlaneConfig(bootstrap_servers=...)."
             )
-        table: KafkaTable[CapabilityRecord] = KafkaTable.json(
+        view: ControlPlaneView[CapabilityRecord] = ControlPlaneView.open(
             bootstrap_servers=bootstrap,
-            topic=cfg.topic,
-            model=CapabilityRecord,
+            topic=CAPABILITY_TOPIC,
+            record_type=CapabilityRecord,
             catchup_timeout=cfg.catchup_timeout,
-            # Readers ensure only in dev/CI (spec §3.1); production topics are
-            # ops-governed and a missing topic fails setup loudly.
+            # Readers ensure only in dev/CI; production topics are ops-governed
+            # and a missing topic fails setup loudly.
             ensure_topic=self._client._provisioning.enabled,
+            stale_after=cfg.stale_after,
         )
-        await table.start()
-        yield table
-        await table.stop()
+        await view.start()
+        yield view
+        await view.stop()
 
     def _derive_bootstrap_servers(self) -> str | None:
         """The Kafka bootstrap address for this worker's client, or ``None`` if underivable.

--- a/calfkit/worker/worker_config.py
+++ b/calfkit/worker/worker_config.py
@@ -4,39 +4,6 @@ from dataclasses import dataclass
 from calfkit.nodes import BaseNodeDef
 
 
-@dataclass(frozen=True)
-class MCPDiscoveryConfig:
-    """Optional tuning for MCP capability discovery (spec §8.3).
-
-    Entirely optional — the control plane is zero-config by design: the
-    capability view and toolbox publishers derive the broker URL from the
-    client the user already connected. Every field here is an escape hatch.
-
-    Args:
-        topic: The cluster-wide compacted capability topic.
-        catchup_timeout: Bound on the worker boot gate awaiting view catch-up;
-            on expiry the worker serves degraded (loudly logged).
-        heartbeat_interval: Seconds between a toolbox's record re-publishes.
-        bootstrap_servers: Override for the control-plane Kafka cluster.
-            ``None`` (default) derives from the connected client — set only
-            for the split-cluster case (control plane on different brokers
-            than the data plane).
-    """
-
-    topic: str = "mcp.capabilities"
-    catchup_timeout: float = 30.0
-    heartbeat_interval: float = 30.0
-    bootstrap_servers: str | None = None
-
-    def __post_init__(self) -> None:
-        if self.catchup_timeout <= 0:
-            raise ValueError(f"catchup_timeout must be > 0, got {self.catchup_timeout}")
-        if self.heartbeat_interval <= 0:
-            raise ValueError(f"heartbeat_interval must be > 0, got {self.heartbeat_interval}")
-        if not self.topic:
-            raise ValueError("topic must be non-empty")
-
-
 @dataclass
 class WorkerConfig:
     node: type[BaseNodeDef]

--- a/docs/adr/0012-mcp-capability-plane-on-control-plane-substrate.md
+++ b/docs/adr/0012-mcp-capability-plane-on-control-plane-substrate.md
@@ -1,0 +1,70 @@
+---
+status: accepted
+---
+
+# The MCP capability plane is built on the control-plane substrate
+
+The shipped MCP capability plane was hand-rolled: `MCPToolboxNode` owned a flat
+`KafkaTableWriter` keyed by `toolbox_id`, its own heartbeat loop, and its own
+tombstone; the worker read a flat `KafkaTable`; config lived in
+`MCPDiscoveryConfig`; and selectors carried a `strict` flag. That plane carried
+three confirmed defects — CRITICAL-1 (a replica's clean tombstone blanks a node
+still alive on another worker, because the key is flat), CRITICAL-3 (a single
+`published_at` re-stamped every heartbeat masks whether the *tool list* is fresh),
+and CRITICAL-4 (the agent never reads the table's `status`/`failure`, so a
+degraded reader silently serves a frozen view). We migrate the plane onto the
+generic control-plane substrate (ADR-0010, ADR-0011), which exists precisely to
+fix these once for every plane.
+
+We therefore make the capability plane an **adopter** of the substrate. The
+toolbox keeps only the MCP-specific part — a cached tool list refreshed at
+session setup and on every `tools/list_changed` — and exposes it through one
+`@advertises("calf.capabilities", CapabilityRecord)` factory; the worker-owned
+`ControlPlanePublisher` heartbeats and tombstones it (instance-keyed by
+`node_id × worker_id`, ADR-0010/0011), and the worker reads a
+`ControlPlaneView[CapabilityRecord]` that collapses the instances to one live
+record per toolbox. `CapabilityRecord` becomes a `ControlPlaneRecord` subclass:
+identity leaves the value (it is the wire key), and `published_at` splits into the
+inherited `last_heartbeat_at` (liveness, stamped every tick) and a node-tracked
+`content_updated_at` (advanced only on a real tool change) — which is the CRITICAL-3
+fix expressed in the schema.
+
+Because this is a clean wire break (the grouped composite key is incompatible with
+the old flat topic) and we are pre-1.0, we take it whole rather than shimming:
+topic `mcp.capabilities` → `calf.capabilities`; `MCPDiscoveryConfig` folded into the
+substrate's `ControlPlaneConfig` (the topic is now fixed in the decorator, not
+configurable); resource key `calfkit.mcp.capability_view` →
+`calfkit.controlplane.capability_view`.
+
+Two behavioural decisions follow, and both simplify the read path:
+
+- **Staleness is hard-filtered, not advisory.** The collapsed view hides a stale
+  toolbox (`get()` returns `None`), so an all-stale selection resolves as
+  `missing_toolbox` and the agent degrades — rather than the old "use last-known
+  tools + log" path. The view owns *both* staleness and schema-version filtering,
+  so `SelectorResult` drops `stale_seconds` and `skipped_newer_schema`, and the
+  resolver shrinks to "is it here, and does it have the tools I asked for".
+  CRITICAL-4 becomes **log-only**: the agent warns when `view.status` is
+  `degraded`/`failed`, and never raises on reader health.
+
+- **The `strict` selector flag is removed** (along with `MCPToolResolutionError`).
+  Its only effect was failing a turn before the model ran when a selection could
+  not fully resolve. Under hard-filter staleness that would fire on a transient
+  heartbeat gap, turning a blip into a hard failure; and `include` already carries
+  the real trust boundary (it pins which tool names an agent may see). So an
+  unresolved selection now *always* warns and degrades.
+
+Considered and rejected: **keeping the per-node writer/heartbeat/tombstone** (the
+whole point of the substrate is to centralise the resurrection-safe ordering once);
+**a one-release dual-read shim** for the topic rename (pre-1.0, a clean cut is
+cheaper than carrying two codecs); **preserving `strict`/advisory staleness**
+(they fight the collapsed view and add surface for a knob `include` already
+covers).
+
+Consequences: the agent read path is a near-drop-in — `resolve_capability` still
+only calls `view.get(toolbox_id)`. Tool-list changes now propagate by **pull**
+(ADR-0011): a `tools/list_changed` updates the cache and lands at the next
+heartbeat tick (≤ `heartbeat_interval`), not instantly; an immediate `publish_now()`
+push is left as a future additive extension. The capability plane is now one of
+several substrate adopters, so agent discovery and the operator-ACL/reconfig planes
+reuse the same machinery rather than re-deriving transport.

--- a/docs/designs/capability-plane-migration-and-ops-spec.md
+++ b/docs/designs/capability-plane-migration-and-ops-spec.md
@@ -1,6 +1,6 @@
 # Capability-Plane Migration & Ops CLI
 
-- **Status:** Draft (design)
+- **Status:** SUPERSEDED for the capability migration by [`mcp-capability-substrate-migration-plan.md`](./mcp-capability-substrate-migration-plan.md) + ADR-0012 (implemented 2026-06-19). ⚠️ The reader API sketched here (`view.instances()`/`is_online()`, `node_id`/`worker_id` carried in the record value) **diverged from the shipped substrate**, which collapses to `get()` and keeps identity as the wire key only. The `calfkit nodes` ops CLI (§5) remains future work.
 - **Date:** 2026-06-16
 - **Builds on:** [Node Presence Control Plane — Substrate & Shared Primitive](./node-presence-substrate-spec.md)
 - **Scope:** (1) the shared `ControlPlaneRecord` base + record schemas; (2) migrating the shipped MCP capability plane onto the shared primitive (fixing CRITICAL-1/3/4); (3) the `calfkit nodes` ops view. These ship together in Phase 1, on top of the substrate.

--- a/docs/designs/control-plane-substrate-spec.md
+++ b/docs/designs/control-plane-substrate-spec.md
@@ -202,7 +202,7 @@ class ControlPlaneConfig:
 
 The knobs split by side: `heartbeat_interval` is the publisher's (and is stamped on records, so it reaches readers); `stale_after` and `catchup_timeout` are the view's; `bootstrap_servers` applies to whichever side opens a table. A reader in a different process than the writer needs **no** agreement on `heartbeat_interval` — it arrives on the record (the C1 decision).
 
-`ControlPlaneConfig` is introduced *alongside* the still-live `MCPDiscoveryConfig` (which keeps serving the un-migrated capability plane). That temporary duplication is intentional and collapses when the capability migration PR folds `MCPDiscoveryConfig` into `ControlPlaneConfig`.
+`ControlPlaneConfig` was introduced *alongside* the then-still-live `MCPDiscoveryConfig`. That temporary duplication has since **collapsed**: the capability migration (ADR-0012) deleted `MCPDiscoveryConfig` and folded it into `ControlPlaneConfig`.
 
 ## 12. Naming
 

--- a/docs/designs/mcp-capability-discovery-spec.md
+++ b/docs/designs/mcp-capability-discovery-spec.md
@@ -1,6 +1,6 @@
 # MCP Capability Discovery — Design Spec
 
-**Status:** converged design, pre-implementation (grilling session 2026-06-09)
+**Status:** IMPLEMENTED, then migrated onto the control-plane substrate (2026-06-19). ⚠️ The §3.3/§8.5 node-owned writer + heartbeat + tombstone, the flat `mcp.capabilities` topic, `MCPDiscoveryConfig`, and the `strict` selector flag are **superseded** — see ADR-0012 and [`mcp-capability-substrate-migration-plan.md`](./mcp-capability-substrate-migration-plan.md). What still holds: the wire model (`CapabilityRecord`/`CapabilityToolDef`), the `include` trust boundary, and per-turn agent resolution. The plane is now instance-keyed on `calf.capabilities` and read through a `ControlPlaneView`.
 **Depends on:** the `ToolBinding`/`ToolProvider` contract on `feat/mcp_bridge_v2` (`calfkit/models/tool_dispatch.py`)
 
 ## 1. Problem

--- a/docs/designs/mcp-capability-substrate-migration-plan.md
+++ b/docs/designs/mcp-capability-substrate-migration-plan.md
@@ -1,0 +1,296 @@
+# MCP Capability Plane → Control-Plane Substrate: Migration Plan
+
+**Status:** IMPLEMENTED + verified (2026-06-19) · **Branch:** `feat/mcp-capability-on-substrate` (off `main` @ `c77e2ec`) · ADR-0012
+
+> Built TDD across the five units below. `make check` clean (lint + format + mypy, 66 source files); offline suite **3141 passed**; full kafka lane **59 passed / 6 pre-existing skips** on real Redpanda (incl. the parity + CRITICAL-3 capability tests and all 9 adapted MCP-roundtrip e2e tests). Decisions D1–D6 are recorded in ADR-0012.
+
+This plan migrates the shipped, hand-rolled MCP capability discoverability
+(`calfkit/mcp/mcp_toolbox.py` + `Worker._capability_view_resource`) onto the
+generic **control-plane substrate** shipped in PR #256 (`calfkit/controlplane/`).
+It is grounded in the **actually shipped** substrate API, not the older
+`capability-plane-migration-and-ops-spec.md` / `node-presence-substrate-spec.md`,
+which predate the substrate and describe an API that diverged (see §2).
+
+---
+
+## 1. Goal, non-goals, locked decisions
+
+### Goal
+Replace the toolbox's per-node ktable writer + heartbeat loop + tombstone and the
+worker's flat `KafkaTable` reader with the substrate's `@advertises` factory +
+worker-owned `ControlPlanePublisher` + `ControlPlaneView[CapabilityRecord]`,
+fixing the three confirmed defects (CRITICAL-1/3/4) and deleting the duplicated
+lifecycle machinery. The **agent-side selector API stays a near drop-in**.
+
+### Non-goals (explicitly out of this PR)
+- `PresenceRecord` / `calf.presence` plane — separate adopter.
+- `calfkit nodes` ops CLI — separate.
+- Removing the unused `Worker.name` — separate cleanup.
+- A `publish_now()` push path — deferred (see decision D1).
+
+### Locked decisions (confirmed with Ryan, 2026-06-19)
+- **D1 — Propagation: pull-only for v1.** `tools/list_changed` updates the cached
+  record; it lands at the next heartbeat tick (≤ `heartbeat_interval`, default 30 s).
+  No `publish_now()`. Accepted latency regression vs. today's immediate re-publish.
+- **D2 — Staleness: hard-filter.** A stale toolbox is invisible (`view.get()` → `None`)
+  → `missing_toolbox` → degrade. No advisory "use last-known + warn" path. The old
+  `stale_seconds` / `_STALE_LOG_AFTER_SECONDS` logic is removed.
+- **D3 — Bundle the de-MCP renames.** It is already a clean wire break, so in the
+  same PR: topic `mcp.capabilities` → `calf.capabilities`; fold `MCPDiscoveryConfig`
+  into `ControlPlaneConfig` (delete the former); resource key
+  `calfkit.mcp.capability_view` → `calfkit.controlplane.capability_view`.
+- **D4 — Clean cut, one PR.** Pre-1.0 hard break; no dual-read shim. New worktree
+  (this one); comprehensive plan (this doc) before any code.
+- **D5 — Remove `strict` entirely.** The MCP-selector `strict` flag is deleted: from
+  `MCPToolboxNode.select()`, the `MCPToolbox` handle, `resolve_capability`, and
+  `SelectorResult`. Its only behavioral footprint was two raise sites in `agent.py`;
+  both go, so an unresolved selection **always** warns + degrades. `MCPToolResolutionError`
+  (raised only by those sites) is deleted too. `include` remains as the trust boundary
+  (it pins which tool names an agent may see). Technically orthogonal, but folded in
+  because D2 changes `strict`'s behavior and the migration already rewrites every file it lives in.
+- **D6 — The view owns filtering; CRITICAL-4 is log-only.** The `ControlPlaneView`
+  is the single owner of **both** staleness and schema-version filtering (it already
+  does both, and logs each). So `SelectorResult` drops `stale_seconds` **and**
+  `skipped_newer_schema`, and `resolve_capability` drops its `is_unsupported_schema`
+  branch. The agent's CRITICAL-4 fix is **observation only**: `logger.warning` when
+  `view.status` is `degraded`/`failed` or `view.failure` is set — it **never raises**
+  on view health.
+
+---
+
+## 2. Reconciling the stale specs with what shipped
+
+⚠️ Anyone implementing from `capability-plane-migration-and-ops-spec.md` or
+`node-presence-substrate-spec.md` will write the **wrong** code. The shipped
+substrate diverged:
+
+| Old spec says | Shipped substrate reality |
+|---|---|
+| `ControlPlaneRecord` carries `node_id`/`worker_id` in the value | Identity is the **wire key only**, never in the value (`records.py:33-49` docstring is explicit) |
+| Read API: `view.instances(node_id, include_stale=False)`, `is_online()` | Shipped view has **`get()` / `online_nodes()` / `snapshot()`** only; it **collapses to one record per node**, no per-instance access, no `include_stale` |
+| `PresenceRecord` + `calf.presence` ship here | Neither shipped — substrate is pure machinery |
+| Staleness is annotate-or-filter (two surfaces) | `get()` **always hard-filters** stale; one surface |
+
+Net effect: the shipped collapsed `get()` view is actually **closer** to a drop-in,
+because today's `resolve_capability` already calls `view.get(toolbox_id)`.
+
+**Action:** these two specs must be marked superseded/reconciled by this plan in §10.
+
+---
+
+## 3. The three defects this migration closes (and how)
+
+| Defect (confirmed live on `main`) | Root cause today | Fix via substrate |
+|---|---|---|
+| **CRITICAL-1 — replica flap** | Flat key = `toolbox_id`. Two workers hosting the same toolbox clobber each other's heartbeats (LWW); one's clean-shutdown `delete(toolbox_id)` blanks the toolbox cluster-wide while the other is alive. | Instance-keying (`group=node_id`, `member=worker_id`) → single-writer-per-key; one replica's tombstone only removes its own member; the view collapses survivors. |
+| **CRITICAL-3 — heartbeat masks content staleness** | Single `published_at`, re-stamped every tick → can't distinguish "alive" from "tools fresh". | Split: `last_heartbeat_at` (worker stamps every tick) vs. node-tracked `content_updated_at` (bumped only on real tool change). |
+| **CRITICAL-4 — frozen-view blindness** | Agent reads the table but never checks `status`/`failure`; a degraded/failed reader silently serves a frozen snapshot. | View **exposes** `status`/`failure`/`is_caught_up`; **agent is edited to log a warning when degraded/failed** (D6 — observe only, never raise). The swap alone does not close this — see §6.4. |
+
+---
+
+## 4. Current → target, at a glance
+
+| Concern | Today (`main`) | Target |
+|---|---|---|
+| Record | `CapabilityRecord(BaseModel)`: `schema_version, toolbox_id, dispatch_topic, tools, published_at` | `CapabilityRecord(ControlPlaneRecord)`: inherits `started_at, last_heartbeat_at, heartbeat_interval, schema_version`; drops `toolbox_id` (now wire key); replaces `published_at` with `content_updated_at` |
+| Write | Node owns flat `KafkaTableWriter` + `_heartbeat_loop` + `_tombstone_on_shutdown` | **Delete all of it.** One `@advertises("calf.capabilities", CapabilityRecord)` factory; worker-owned publisher heartbeats + tombstones |
+| First list | `list_tools()` in `_publish_on_startup` (`after_startup`) | `list_tools()` in `_mcp_session` **resource setup** (runs before any `after_startup`), caches `_last_tools` + `_tools_changed_at` |
+| `tools/list_changed` | re-list + **immediate** `writer.set` | re-list → update cache; propagates at next tick (pull, D1) |
+| Read | flat `KafkaTable.json(...)` under `calfkit.mcp.capability_view` | `ControlPlaneView.open(topic="calf.capabilities", record_type=CapabilityRecord, ...)` under `calfkit.controlplane.capability_view` |
+| Selector call site | `resolve_capability(view, id)` → `view.get(id)` | **unchanged** — `ControlPlaneView.get()` is a structural drop-in for the flat `.get()` |
+| `strict` flag | `select(strict=…)` → 2 raise sites in `agent.py` | **deleted** (D5); unresolved always warns + degrades; `MCPToolResolutionError` deleted |
+| Staleness | advisory log (`stale_seconds`) | view hard-filters (D2/D6); `stale_seconds` dropped from `SelectorResult`; agent stale log removed |
+| Schema filter | `is_unsupported_schema` in `resolve_capability` | view filters + logs newer-schema (D6); `skipped_newer_schema` dropped from `SelectorResult`; resolver branch removed |
+| CRITICAL-4 | not checked | agent **logs** when `view.status`/`view.failure` signal degraded/failed (D6 — never raises) |
+| Config | `MCPDiscoveryConfig` (`Worker(mcp_discovery=...)`) | `ControlPlaneConfig` (`Worker(control_plane=...)`); `MCPDiscoveryConfig` deleted |
+
+**Verified facts that make this safe:**
+- `record.toolbox_id` (the value field) is **read nowhere** — only `SelectorResult.toolbox_id` is. Dropping it from the value is safe (`grep` across `calfkit/` confirms).
+- `record.published_at` is read in **exactly one place** (`resolve_capability`'s `stale_seconds`), which D2 removes.
+- Lifecycle phase order guarantees **resources set up before `after_startup`** (`worker/lifecycle.py:103`), so listing tools in the session resource populates the cache before the publisher's `start()` calls the factory.
+- `GroupedKafkaTable` / `GroupedKafkaTableWriter` are present in pinned `ktables>=0.3.0` (verified at import).
+
+---
+
+## 5. The clean part vs. the friction (honest scoping)
+
+**Genuinely clean (near drop-in):** the read/resolution path. `resolve_capability`
+only calls `view.get(toolbox_id)`; `ControlPlaneView.get()` returns one collapsed
+record. `MCPToolbox`, `record_to_bindings`, and the `ToolSelector` protocol shape are
+untouched in behavior (`select()` loses only its `strict` param, D5).
+
+**Real friction (must be handled, not hand-waved):**
+1. **Pull latency (D1):** tool changes lag ≤ `heartbeat_interval`. Accepted.
+2. **Staleness semantics change (D2):** stale toolbox disappears instead of being
+   used-with-warning. Accepted; the 90 s default window (`3 × 30 s`) makes flapping unlikely.
+3. **CRITICAL-4 needs an agent code edit** (§6.4) — log-only (D6), not auto-fixed by the swap.
+4. **`ControlPlaneView` is not a `Mapping`.** Works at runtime (duck-typed `.get`);
+   the `Mapping[str, Any]` annotation on `ToolSelector.resolve_tools` /
+   `resolve_capability` becomes a lie. Introduce a tiny `CapabilityLookup` protocol
+   (`get(node_id) -> CapabilityRecord | None`) and retype both sides.
+5. **Factory must read cached state only.** It runs on the shared heartbeat loop;
+   any I/O (e.g. `session.list_tools()`) there would block every other advert and
+   re-rot CRITICAL-3. Contract: return `self._last_tools` + `self._tools_changed_at`,
+   never `now()`. Enforced by a focused test, not by the substrate.
+
+---
+
+## 6. Detailed change list (per file)
+
+### 6.1 `calfkit/models/capability.py`
+- **`CapabilityRecord(BaseModel)` → `CapabilityRecord(ControlPlaneRecord)`.**
+  - Remove `toolbox_id` (wire key now) and `published_at`.
+  - Add `content_updated_at: AwareDatetime`.
+  - Keep `dispatch_topic`, `tools`, `schema_version: int = CAPABILITY_SCHEMA_VERSION`.
+  - `CAPABILITY_SCHEMA_VERSION = 1` — fresh topic, fresh schema lineage (recommend 1, not 2; old `mcp.capabilities` is abandoned and unreadable by the new codec anyway).
+  - Inherits `frozen=True` from the base — fine (the node no longer mutates a cached record; the factory builds fresh each tick).
+- **New constants:**
+  - `CAPABILITY_TOPIC = "calf.capabilities"` (the `@advertises` topic + the view topic).
+  - `CAPABILITY_VIEW_RESOURCE_KEY = "calfkit.controlplane.capability_view"` (re-namespaced, D3).
+- **`resolve_capability`** simplifies to "is it here, and does it have the tools I asked for" (the view owns staleness + schema filtering, D6):
+  - `view.get(toolbox_id)` → `None` → `missing_toolbox` (now also covers stale & newer-schema, since the view filters and logs both).
+  - record → `record_to_bindings` → `invalid_record` on expansion failure; `include` filter → `missing_tools`.
+  - **Remove** the `strict` param (D5), the `is_unsupported_schema`/`skipped_newer_schema` branch (D6), and the `stale_seconds` computation (D2/D6; `published_at` is gone).
+  - Retype `view` param: `CapabilityLookup` (new protocol) instead of `Any`/`Mapping`.
+- **`is_unsupported_schema`:** delete — its only caller (`resolve_capability`) is gone, and the view's `schema_version > reader_version` check (`view.py:116`) is now the single owner. (The module docstring's "skipped with a log by the consumer" line must be updated to point at the view.)
+- **`CapabilityLookup` protocol (new):** `def get(self, node_id: str) -> CapabilityRecord | None: ...` — satisfied by `ControlPlaneView[CapabilityRecord]` and by a plain dict (test strategy).
+
+### 6.2 `calfkit/models/tool_dispatch.py`
+- `ToolSelector.resolve_tools(view: Mapping[str, Any])` → `view: CapabilityLookup`
+  (recommend the protocol for type honesty; structural `Any` is the fallback).
+- `SelectorResult`: drop **`strict`** (D5), **`stale_seconds`** (D2/D6), and
+  **`skipped_newer_schema`** (D6). Keep `toolbox_id`, `bindings`, `missing_toolbox`,
+  `missing_tools`, `invalid_record`. `unresolved` becomes
+  `missing_toolbox or bool(missing_tools) or invalid_record`.
+
+### 6.3 `calfkit/mcp/mcp_toolbox.py` (`MCPToolboxNode`)
+**Delete:**
+- `_capability_writer` resource + `_writer_resource_key`.
+- `_publish_on_startup` + its `self.after_startup(...)` registration.
+- `_heartbeat_loop`.
+- `_tombstone_on_shutdown` + its `self.on_shutdown(...)` registration.
+- `_last_record`, `_shutting_down` (no node-side writes remain → no resurrection risk to guard; that is now the worker publisher's job).
+- `_discovery` property, `_control_plane_bootstrap`, `_provisioning_enabled` (bootstrap/provisioning now worker-owned for the writer).
+
+**Add / change:**
+- State: `self._last_tools: list[CapabilityToolDef] | None = None`, `self._tools_changed_at: AwareDatetime | None = None`.
+- `_mcp_session` resource: after `session.initialize()`, `await self._refresh_tools(session)` to populate the cache **before** yielding (fail-loud here = abort boot, same as today).
+- `_refresh_tools(session)`: `listing = await session.list_tools()`; set `_last_tools = [...]`; set `_tools_changed_at = now()` (this is a genuine content-change moment — startup or `tools/list_changed` — so `now()` is correct **here**, never in the factory).
+- `@advertises(topic=CAPABILITY_TOPIC, record=CapabilityRecord)` factory:
+  ```python
+  @advertises(topic=CAPABILITY_TOPIC, record=CapabilityRecord)
+  def _capability_record(self, stamp: ControlPlaneStamp) -> CapabilityRecord:
+      assert self._last_tools is not None and self._tools_changed_at is not None  # session resource populates first
+      return CapabilityRecord(
+          **stamp.model_dump(),
+          dispatch_topic=self.subscribe_topics[0],
+          tools=self._last_tools,
+          content_updated_at=self._tools_changed_at,
+      )
+  ```
+- `_handle_tools_list_changed`: re-list via `_refresh_tools` (updates cache + bumps `content_updated_at`); **no `writer.set`** (pull, D1).
+- `_mcp_message_handler` / `_relist_tasks`: keep the deadlock-avoiding offload + task tracking, but only to **cancel cleanly at session teardown** — drop the `_shutting_down`/tombstone-resurrection logic.
+- `resolve_tools(view)` retyped to `CapabilityLookup`; behavior unchanged.
+- `select(*, include=None)`: **drop the `strict` param** (D5). The `MCPToolbox` handle
+  loses its `strict` field too; `MCPToolbox(name, include=…)` and the `resolve_capability`
+  call shed `strict`. `include` (the trust boundary) is unchanged.
+
+### 6.4 `calfkit/nodes/agent.py`
+- `_resolve_selector_tools`:
+  - **CRITICAL-4 (D6, log-only):** after fetching `view`, `logger.warning(...)` when
+    `view.status` is `degraded`/`failed` or `view.failure` is set (today this is totally
+    silent). **Never raises** on view health — purely observational.
+  - **Delete the `strict` raise path (D5):** the no-view branch (`agent.py:222-227`) now
+    always `logger.warning` + degrades (no `MCPToolResolutionError`); the
+    `result.strict and result.unresolved` raise (`agent.py:241-242`) is removed — an
+    unresolved selection always warns + degrades.
+  - **Remove** the `stale_seconds` warning block + `_STALE_LOG_AFTER_SECONDS` (D2/D6;
+    the view hard-filters, so a returned record is never stale; `content_updated_at` is a
+    "last changed" timestamp, **not** a staleness signal — a stable toolbox legitimately
+    never changes, so warning on its age would be a false alarm).
+- `_maybe_resolve_selectors`: the override-skip comment ("a strict selector must not be
+  able to fail a turn") loses its `strict` rationale; the skip itself stays (overrides
+  still pin the exact tool surface).
+- `import` updates: drop `MCPToolResolutionError`; `CAPABILITY_VIEW_RESOURCE_KEY` still
+  imported from `models.capability` (now the re-namespaced value).
+
+### 6.8 `calfkit/exceptions.py`
+- **Delete `MCPToolResolutionError`** — raised only by the two `strict` sites in
+  `agent.py` (`grep` confirms no other raiser), so it is dead after D5. Drop it from any
+  `__all__`/exports.
+
+### 6.5 `calfkit/worker/worker.py`
+- `_capability_view_resource`: swap `KafkaTable.json(...)` → `ControlPlaneView.open(bootstrap_servers, topic=CAPABILITY_TOPIC, record_type=CapabilityRecord, catchup_timeout, ensure_topic, stale_after)`; `await view.start()` (boot gate preserved) / `yield` / `await view.stop()`. Read config from `self._control_plane` (was `self._mcp_discovery`).
+- `_maybe_register_capability_view`: trigger unchanged (any node with `_tool_selectors`); only the resource body and key change. The **writer** is already auto-wired by the shipped `_maybe_register_control_plane` (triggered by `@advertises`) — independent trigger, no change needed there.
+- `__init__`: remove the `mcp_discovery` param + `self._mcp_discovery`; keep `control_plane: ControlPlaneConfig`.
+- Imports/exports: drop `MCPDiscoveryConfig`.
+
+### 6.6 `calfkit/worker/worker_config.py`
+- **Delete `MCPDiscoveryConfig`** (D3 fold). All four fields are covered by
+  `ControlPlaneConfig` (`heartbeat_interval`, `catchup_timeout`, `stale_after`,
+  `bootstrap_servers`); `topic` moves to the `@advertises` decorator constant.
+
+### 6.7 Top-level exports (`calfkit/__init__.py`, `calfkit/mcp/__init__.py`)
+- Remove `MCPDiscoveryConfig` from public exports; ensure `ControlPlaneConfig` is
+  exported (it is, via the substrate PR). Confirm `MCPToolbox`/`MCPToolboxNode` exports unchanged.
+
+---
+
+## 7. TDD test plan
+
+**Offline (dict-backed fakes, no broker) — write tests first:**
+1. `CapabilityRecord` is a `ControlPlaneRecord` subclass; `schema_version` default present (else `ControlPlaneView` ctor raises `RegistryConfigError`); tolerant reader ignores extras; round-trips.
+2. `_capability_record` factory: splatting the stamp populates `started_at`/`last_heartbeat_at`/`heartbeat_interval`; returns cached tools + `content_updated_at`.
+3. **CRITICAL-3 split:** two factory calls with different `last_heartbeat_at` but unchanged tools → identical `content_updated_at`; after `_refresh_tools` → `content_updated_at` advances. (This is the "never `now()` in the factory" guard.)
+4. `_refresh_tools` populates the cache from a fake session; `tools/list_changed` offloads a re-list that updates the cache (no write).
+5. `resolve_capability` over a `ControlPlaneView` backed by a dict `GroupedTableReader` fake:
+   - live record → bindings; **stale** record → `view.get()` None → `missing_toolbox` (D2); `include` filter → `missing_tools`; empty `dispatch_topic` → `invalid_record`.
+6. **CRITICAL-4 (log-only, D6):** agent resolution with a fake view whose `status`/`failure` signal degraded/failed → warning emitted; **assert the turn still proceeds** (no raise).
+7. Worker wiring: hosting an `MCPToolboxNode` registers a `calf.capabilities` writer (`_maybe_register_control_plane`); hosting an agent-with-selectors registers the `ControlPlaneView` resource under the new key; node layer stays **ktables-free at import**.
+8. `MCPToolboxNode` no longer registers `_capability_writer`/capability `after_startup`/`on_shutdown` (assert only the session resource + the advert remain).
+9. **`strict` removed (D5):** unresolved selection (missing toolbox / missing tools) → warns + degrades, **never raises**; no-view → warns + degrades. (`MCPToolResolutionError` no longer importable.) Replaces the old strict-raise tests in `test_tool_selector.py` / `test_mcp_toolbox.py`.
+
+**Kafka lane (real Redpanda, mirrors the substrate's lane):**
+1. **Parity:** toolbox worker up → record on `calf.capabilities`; agent worker up → catch-up gate passes → resolves the same tools as pre-migration.
+2. **CRITICAL-1 replica regression:** two workers host the same toolbox name; one shuts down cleanly; the survivor's record keeps the toolbox resolvable.
+3. **Pull propagation (D1):** change the server's tools → within ≤ `heartbeat_interval` the view reflects the new set.
+4. **Tombstone:** clean shutdown removes the `(toolbox, worker)` instance key; sole instance → toolbox offline → agent degrades (warns, no raise).
+5. **CRITICAL-4 loud failure:** view over an unreachable broker fails loud at `start()` (already asserted by the substrate lane; re-assert at the capability layer).
+
+ktables' own semantics (catch-up gate, LWW, tombstones, grouped codec) are **not**
+re-tested here — only the calfkit policy layers.
+
+---
+
+## 8. Build order (ordered commits, one PR)
+
+1. **Record + constants + resolver + `strict`/filter removal** (§6.1, §6.2): new `CapabilityRecord`, `CapabilityLookup`, simplified `resolve_capability`, slimmed `SelectorResult` (drop `strict`/`stale_seconds`/`skipped_newer_schema`) + offline tests 1, 5.
+2. **Toolbox write side** (§6.3) → `@advertises` + `_refresh_tools`; delete writer/heartbeat/tombstone; drop `select(strict=…)` + offline tests 2, 3, 4, 8.
+3. **Worker reader + config fold** (§6.5, §6.6, §6.7) + offline test 7.
+4. **Agent CRITICAL-4 (log-only) + strict-raise & stale-log removal** (§6.4) + delete `MCPToolResolutionError` (§6.8) + offline tests 6, 9.
+5. **Kafka-lane integration** (§7) — tests 1–5.
+6. **Docs + ADRs + `make fix && make check`** (§10).
+
+Each step is red→green→refactor. `make check` must stay clean (lint+format+type) at every commit boundary.
+
+---
+
+## 9. Risks & open questions
+
+- **Resolved:** the failed-view policy is log-only (D6); `strict` is removed (D5);
+  `stale_seconds` and `skipped_newer_schema` are both dropped (the view owns filtering, D6).
+- **Public-API break beyond the wire:** D5 removes the `strict` kwarg from
+  `MCPToolboxNode.select()` / `MCPToolbox` and deletes `MCPToolResolutionError`. Pre-1.0,
+  acceptable; ensure no example/doc/README still passes `strict=` or catches the exception.
+- **Coordination with other live worktrees:** `feat/run-handler-unification` (folds `run()` into `@handler` — MCP already uses `@handler("*")`, low risk) and `test/mcp-roundtrip-e2e` touch MCP; rebase order matters. `calf-sdk-ktables-0.3.0` is moot — `main` already pins `ktables>=0.3.0`.
+- **Partition count for `calf.capabilities`:** recommend 1 (total order per key is free at this cardinality).
+- **`started_at` semantics:** now the worker's serving-start (shared by all this worker's records), vs. today's per-toolbox connect time. Acceptable; document.
+
+## 10. Docs & ADRs (PR final steps)
+
+- **Update** `docs/designs/mcp-capability-discovery-spec.md` to describe the substrate-backed plane (writer = `@advertises` factory; reader = `ControlPlaneView`; pull-only; hard-filter).
+- **Reconcile / supersede** `capability-plane-migration-and-ops-spec.md` and the
+  presence-spec API mismatches called out in §2 (point them at this plan + the shipped substrate).
+- **ADRs:** confirm ADR-0010 / ADR-0011 flip proposed→accepted (the substrate PR may already track this). Evaluate a short ADR (or amend the migration spec) recording the locked decisions: **pull-only propagation** (D1), **hard-filter staleness** (D2), **`calf.capabilities` rename + `MCPDiscoveryConfig` fold** (D3), **`strict` removal** (D5), **view-owned filtering + log-only CRITICAL-4** (D6).
+- **CONTEXT.md:** ensure the capability-plane vocabulary matches (topic name, "content currency" vs "liveness").
+- **Prune** stale comments referencing `mcp.capabilities` / `published_at` / `MCPDiscoveryConfig`.

--- a/docs/designs/node-presence-substrate-spec.md
+++ b/docs/designs/node-presence-substrate-spec.md
@@ -1,6 +1,6 @@
 # Node Presence Control Plane — Substrate & Shared Primitive
 
-- **Status:** Draft (design)
+- **Status:** Motivation only. ⚠️ The substrate shipped as PR #256 with a **different (collapsed `get()`-based) API** than sketched here; the authoritative design is [`control-plane-substrate-spec.md`](./control-plane-substrate-spec.md). The presence plane (`PresenceRecord`/`calf.presence`) and the `calfkit nodes` CLI are **not built**.
 - **Date:** 2026-06-16
 - **Scope:** The foundational presence substrate and the reusable control-plane primitive it is built on. This is the base layer; two follow-on specs build on it:
   - [Capability-Plane Migration & Ops CLI](./capability-plane-migration-and-ops-spec.md)

--- a/docs/mcp-tool-discovery.md
+++ b/docs/mcp-tool-discovery.md
@@ -26,11 +26,12 @@ worker = Worker(client, nodes=[docs])
 await worker.run()
 ```
 
-On startup the toolbox connects to the MCP server, lists its tools, and
-advertises them on the capability topic (default `mcp.capabilities`). It
-re-advertises whenever the server reports a tool-list change and as a
-periodic heartbeat. If the MCP server is unreachable at startup, the worker
-fails to boot — fix the connection rather than running dark.
+On startup the toolbox connects to the MCP server and lists its tools; its host
+worker then advertises them on the capability control-plane topic
+(`calf.capabilities`), refreshes them whenever the server reports a tool-list
+change, and re-publishes periodically as a liveness heartbeat (a tool-list change
+lands on the next heartbeat). If the MCP server is unreachable at startup, the
+worker fails to boot — fix the connection rather than running dark.
 
 ## Give the tools to an agent — same or different process
 
@@ -75,26 +76,28 @@ at the start of every agent turn, so a toolbox that comes up later — or
 changes its tools — is picked up on the next turn. No restarts, no bring-up
 order.
 
-## Scope or require the selection
+## Scope the selection
 
 ```python
 tools=[docs.select(include=["search", "fetch"])]      # only these tools
-tools=[docs.select(include=["search"], strict=True)]  # fail the turn if unavailable
 ```
 
 Use `include` to pin the exact tool names the agent may see — a server that
-starts advertising new tools cannot enlarge the agent's surface. By default an
-unresolved selection logs a warning and the turn runs with whatever resolved;
-use `strict=True` to raise before the model runs instead.
+starts advertising new tools cannot enlarge the agent's surface. An unresolved
+selection (the toolbox is offline, or a requested tool isn't advertised) logs a
+warning and the turn runs with whatever resolved.
 
 If a toolbox tool name collides with a locally configured tool, the local tool
 wins and an error is logged.
 
 ## Handle outages and topic creation
 
-- A **crashed** toolbox keeps its advertisement: agents keep their last-known
-  tools and calls fail visibly. A **clean shutdown** removes the
-  advertisement until the toolbox restarts.
+- A **crashed** toolbox stops heartbeating; its advertisement goes **stale**
+  after roughly three heartbeat intervals, and the view then hides it — so
+  agents stop being offered its tools (the selection degrades) rather than
+  dispatching to a dead toolbox. A **clean shutdown** removes the advertisement
+  immediately. Either way the toolbox reappears on the next turn once it is back
+  and heartbeating.
 - With provisioning enabled (dev/CI), toolbox and agent workers both create
   the compacted capability topic idempotently — bring up either side first.
   In production, create the topic out-of-band (`cleanup.policy=compact`,
@@ -104,7 +107,8 @@ wins and an error is logged.
 ## Tune it (optional)
 
 Every knob has a working default, and there is one config surface:
-`Worker(..., mcp_discovery=MCPDiscoveryConfig(...))` — the topic name, the
-boot catch-up timeout, the heartbeat interval, and a `bootstrap_servers`
-override for running the capability topic on a separate Kafka cluster.
-Toolboxes inherit the config of the worker that hosts them.
+`Worker(..., control_plane=ControlPlaneConfig(...))` — the boot catch-up
+timeout, the heartbeat interval, a staleness threshold, and a `bootstrap_servers`
+override for running the control plane on a separate Kafka cluster. The
+capability topic name is fixed (`calf.capabilities`). Toolboxes and agents
+inherit the config of the worker that hosts them.

--- a/tests/integration/test_mcp_roundtrip_kafka.py
+++ b/tests/integration/test_mcp_roundtrip_kafka.py
@@ -42,16 +42,15 @@ from pathlib import Path
 import pydantic_core
 import pytest
 from aiokafka.admin import AIOKafkaAdminClient
-from ktables import KafkaTable
 
 from calfkit._vendor.pydantic_ai import models
 from calfkit._vendor.pydantic_ai.messages import ToolCallPart
 from calfkit.client import Client
+from calfkit.controlplane import ControlPlaneConfig, ControlPlaneView
 from calfkit.mcp import MCPToolboxNode, StdioServerParameters
-from calfkit.models.capability import CapabilityRecord
+from calfkit.models.capability import CAPABILITY_TOPIC, CapabilityRecord
 from calfkit.nodes import Agent
 from calfkit.worker import Worker
-from calfkit.worker.worker_config import MCPDiscoveryConfig
 from tests.integration._roundtrip_helpers import (
     FINAL_OUTPUT,
     retry_prompt_texts,
@@ -91,17 +90,22 @@ def _server_params(script: Path) -> StdioServerParameters:
     return StdioServerParameters(command=sys.executable, args=[str(script)], env=dict(os.environ))
 
 
-def _discovery(cap_topic: str, bootstrap: str) -> MCPDiscoveryConfig:
-    return MCPDiscoveryConfig(topic=cap_topic, heartbeat_interval=5.0, bootstrap_servers=bootstrap)
+def _control_plane(bootstrap: str) -> ControlPlaneConfig:
+    return ControlPlaneConfig(heartbeat_interval=5.0, bootstrap_servers=bootstrap)
 
 
-def _worker(bootstrap: str, *, nodes: list, discovery: MCPDiscoveryConfig) -> Worker:
-    """A Worker on its own broker connection, MCP discovery on, reading earliest.
+def _server_name(topic_namespace: str, base: str = _SERVER_NAME) -> str:
+    """A per-test-unique toolbox id on the fixed ``calf.capabilities`` topic."""
+    return f"{topic_namespace}.{base}"
+
+
+def _worker(bootstrap: str, *, nodes: list, control_plane: ControlPlaneConfig) -> Worker:
+    """A Worker on its own broker connection, control plane on, reading earliest.
 
     ``earliest`` is mandatory so a node's consumer-group join never races (and
     drops) the publish addressing it on a freshly-auto-created partition.
     """
-    return Worker(Client.connect(bootstrap), nodes=nodes, mcp_discovery=discovery, extra_subscribe_kwargs=_EARLIEST)
+    return Worker(Client.connect(bootstrap), nodes=nodes, control_plane=control_plane, extra_subscribe_kwargs=_EARLIEST)
 
 
 # ── polling utilities (no bare sleeps) ───────────────────────────────────────
@@ -116,27 +120,37 @@ async def _wait(predicate: Callable[[], bool], *, timeout: float, what: str) -> 
     raise AssertionError(f"timed out after {timeout}s waiting for: {what}")
 
 
-async def _await_capability(bootstrap: str, topic: str, toolbox_id: str, *, timeout: float) -> None:
-    """Block until the toolbox's CapabilityRecord is visible on ``topic``.
+async def _await_capability(bootstrap: str, toolbox_id: str, *, timeout: float) -> None:
+    """Block until the toolbox's CapabilityRecord is live on ``calf.capabilities``.
 
     Starting the agent worker only after the record exists makes the agent's
     Capability View catch-up include it, so the binding resolves on the turn.
     """
-    table: KafkaTable[CapabilityRecord] = KafkaTable.json(bootstrap_servers=bootstrap, topic=topic, model=CapabilityRecord, ensure_topic=False)
-    async with table:
-        await _wait(lambda: toolbox_id in table, timeout=timeout, what=f"capability record {toolbox_id!r}")
+    view: ControlPlaneView[CapabilityRecord] = ControlPlaneView.open(
+        bootstrap_servers=bootstrap, topic=CAPABILITY_TOPIC, record_type=CapabilityRecord, ensure_topic=False
+    )
+    await view.start()
+    try:
+        await _wait(lambda: view.get(toolbox_id) is not None, timeout=timeout, what=f"capability record {toolbox_id!r}")
+    finally:
+        await view.stop()
 
 
-async def _await_tool_in_record(bootstrap: str, topic: str, toolbox_id: str, tool: str, *, timeout: float) -> None:
-    """Block until ``toolbox_id``'s record advertises ``tool`` (re-list landed)."""
-    table: KafkaTable[CapabilityRecord] = KafkaTable.json(bootstrap_servers=bootstrap, topic=topic, model=CapabilityRecord, ensure_topic=False)
+async def _await_tool_in_record(bootstrap: str, toolbox_id: str, tool: str, *, timeout: float) -> None:
+    """Block until ``toolbox_id``'s live record advertises ``tool`` (re-list landed)."""
+    view: ControlPlaneView[CapabilityRecord] = ControlPlaneView.open(
+        bootstrap_servers=bootstrap, topic=CAPABILITY_TOPIC, record_type=CapabilityRecord, ensure_topic=False
+    )
+    await view.start()
 
     def _present() -> bool:
-        record = table.get(toolbox_id)
+        record = view.get(toolbox_id)
         return record is not None and any(t.name == tool for t in record.tools)
 
-    async with table:
+    try:
         await _wait(_present, timeout=timeout, what=f"tool {tool!r} in record {toolbox_id!r}")
+    finally:
+        await view.stop()
 
 
 async def _topics(bootstrap: str) -> set[str]:
@@ -167,10 +181,9 @@ async def test_single_tool_call_roundtrips_over_the_wire(kafka_bootstrap: str, t
     value travels all the way back into the agent's history."""
     agent_id = f"{topic_namespace}-mcp-agent"
     agent_in = f"{topic_namespace}.mcp-agent.input"
-    cap_topic = f"{topic_namespace}.capabilities"
-    discovery = _discovery(cap_topic, kafka_bootstrap)
+    control_plane = _control_plane(kafka_bootstrap)
 
-    toolbox = MCPToolboxNode(_SERVER_NAME, connection_params=_server_params(_SERVER_SCRIPT))
+    toolbox = MCPToolboxNode(_server_name(topic_namespace), connection_params=_server_params(_SERVER_SCRIPT))
     agent = Agent(
         agent_id,
         system_prompt="call the add tool",
@@ -180,11 +193,11 @@ async def test_single_tool_call_roundtrips_over_the_wire(kafka_bootstrap: str, t
     )
 
     driver = Client.connect(kafka_bootstrap)
-    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], discovery=discovery)
-    agent_worker = _worker(kafka_bootstrap, nodes=[agent], discovery=discovery)
+    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], control_plane=control_plane)
+    agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
 
     async with toolbox_worker:
-        await _await_capability(kafka_bootstrap, cap_topic, _SERVER_NAME, timeout=60)
+        await _await_capability(kafka_bootstrap, _server_name(topic_namespace), timeout=60)
         async with agent_worker:
             result = await driver.execute("add 2 and 3", agent_in, timeout=120)
 
@@ -205,10 +218,9 @@ async def test_mcp_iserror_result_passes_through_transparently(kafka_bootstrap: 
     finalizes normally, and the error content travels back in history."""
     agent_id = f"{topic_namespace}-mcp-iserror"
     agent_in = f"{topic_namespace}.mcp-iserror.input"
-    cap_topic = f"{topic_namespace}.capabilities"
-    discovery = _discovery(cap_topic, kafka_bootstrap)
+    control_plane = _control_plane(kafka_bootstrap)
 
-    toolbox = MCPToolboxNode(_SERVER_NAME, connection_params=_server_params(_SERVER_SCRIPT))
+    toolbox = MCPToolboxNode(_server_name(topic_namespace), connection_params=_server_params(_SERVER_SCRIPT))
     agent = Agent(
         agent_id,
         system_prompt="call domain_error",
@@ -218,11 +230,11 @@ async def test_mcp_iserror_result_passes_through_transparently(kafka_bootstrap: 
     )
 
     driver = Client.connect(kafka_bootstrap)
-    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], discovery=discovery)
-    agent_worker = _worker(kafka_bootstrap, nodes=[agent], discovery=discovery)
+    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], control_plane=control_plane)
+    agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
 
     async with toolbox_worker:
-        await _await_capability(kafka_bootstrap, cap_topic, _SERVER_NAME, timeout=60)
+        await _await_capability(kafka_bootstrap, _server_name(topic_namespace), timeout=60)
         async with agent_worker:
             result = await driver.execute("trigger the error", agent_in, timeout=120)
 
@@ -245,10 +257,9 @@ async def test_concurrent_tool_calls_roundtrip_via_fanout(kafka_bootstrap: str, 
     and each result lands back in its own slot."""
     agent_id = f"{topic_namespace}-mcp-fanout-agent"
     agent_in = f"{topic_namespace}.mcp-fanout-agent.input"
-    cap_topic = f"{topic_namespace}.capabilities"
-    discovery = _discovery(cap_topic, kafka_bootstrap)
+    control_plane = _control_plane(kafka_bootstrap)
 
-    toolbox = MCPToolboxNode(_SERVER_NAME, connection_params=_server_params(_SERVER_SCRIPT))
+    toolbox = MCPToolboxNode(_server_name(topic_namespace), connection_params=_server_params(_SERVER_SCRIPT))
     agent = Agent(
         agent_id,
         system_prompt="call both tools",
@@ -264,11 +275,11 @@ async def test_concurrent_tool_calls_roundtrip_via_fanout(kafka_bootstrap: str, 
     assert agent._is_fanout_capable
 
     driver = Client.connect(kafka_bootstrap)
-    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], discovery=discovery)
-    agent_worker = _worker(kafka_bootstrap, nodes=[agent], discovery=discovery)
+    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], control_plane=control_plane)
+    agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
 
     async with toolbox_worker:
-        await _await_capability(kafka_bootstrap, cap_topic, _SERVER_NAME, timeout=60)
+        await _await_capability(kafka_bootstrap, _server_name(topic_namespace), timeout=60)
         async with agent_worker:
             topics = await _topics(kafka_bootstrap)
             assert f"calf.fanout.{agent_id}.state" in topics
@@ -294,10 +305,9 @@ async def test_duplicate_tool_concurrent_slots_route_by_call_id(kafka_bootstrap:
     tool_call_id (not tool name), so both results return to their own slot."""
     agent_id = f"{topic_namespace}-dup-agent"
     agent_in = f"{topic_namespace}.dup-agent.input"
-    cap_topic = f"{topic_namespace}.capabilities"
-    discovery = _discovery(cap_topic, kafka_bootstrap)
+    control_plane = _control_plane(kafka_bootstrap)
 
-    toolbox = MCPToolboxNode(_SERVER_NAME, connection_params=_server_params(_SERVER_SCRIPT))
+    toolbox = MCPToolboxNode(_server_name(topic_namespace), connection_params=_server_params(_SERVER_SCRIPT))
     agent = Agent(
         agent_id,
         system_prompt="add two pairs",
@@ -312,11 +322,11 @@ async def test_duplicate_tool_concurrent_slots_route_by_call_id(kafka_bootstrap:
     )
 
     driver = Client.connect(kafka_bootstrap)
-    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], discovery=discovery)
-    agent_worker = _worker(kafka_bootstrap, nodes=[agent], discovery=discovery)
+    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], control_plane=control_plane)
+    agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
 
     async with toolbox_worker:
-        await _await_capability(kafka_bootstrap, cap_topic, _SERVER_NAME, timeout=60)
+        await _await_capability(kafka_bootstrap, _server_name(topic_namespace), timeout=60)
         async with agent_worker:
             result = await driver.execute("add 2+3 and 10+20", agent_in, timeout=120)
 
@@ -337,10 +347,9 @@ async def test_sequential_mode_dispatches_without_fanout(kafka_bootstrap: str, t
     results still round-trip."""
     agent_id = f"{topic_namespace}-seq-agent"
     agent_in = f"{topic_namespace}.seq-agent.input"
-    cap_topic = f"{topic_namespace}.capabilities"
-    discovery = _discovery(cap_topic, kafka_bootstrap)
+    control_plane = _control_plane(kafka_bootstrap)
 
-    toolbox = MCPToolboxNode(_SERVER_NAME, connection_params=_server_params(_SERVER_SCRIPT))
+    toolbox = MCPToolboxNode(_server_name(topic_namespace), connection_params=_server_params(_SERVER_SCRIPT))
     agent = Agent(
         agent_id,
         system_prompt="call both tools sequentially",
@@ -357,11 +366,11 @@ async def test_sequential_mode_dispatches_without_fanout(kafka_bootstrap: str, t
     assert not agent._is_fanout_capable
 
     driver = Client.connect(kafka_bootstrap)
-    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], discovery=discovery)
-    agent_worker = _worker(kafka_bootstrap, nodes=[agent], discovery=discovery)
+    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], control_plane=control_plane)
+    agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
 
     async with toolbox_worker:
-        await _await_capability(kafka_bootstrap, cap_topic, _SERVER_NAME, timeout=60)
+        await _await_capability(kafka_bootstrap, _server_name(topic_namespace), timeout=60)
         async with agent_worker:
             result = await driver.execute("add then echo", agent_in, timeout=120)
             topics = await _topics(kafka_bootstrap)
@@ -384,11 +393,10 @@ async def test_two_mcp_servers_route_each_call_to_its_server(kafka_bootstrap: st
     to the correct toolbox topic: ``add`` resolves on server A, ``mul`` on B."""
     agent_id = f"{topic_namespace}-multi-server-agent"
     agent_in = f"{topic_namespace}.multi-server-agent.input"
-    cap_topic = f"{topic_namespace}.capabilities"
-    discovery = _discovery(cap_topic, kafka_bootstrap)
+    control_plane = _control_plane(kafka_bootstrap)
 
-    box_a = MCPToolboxNode(_SERVER_NAME, connection_params=_server_params(_SERVER_SCRIPT))
-    box_b = MCPToolboxNode(_SERVER_B_NAME, connection_params=_server_params(_SERVER_B_SCRIPT))
+    box_a = MCPToolboxNode(_server_name(topic_namespace), connection_params=_server_params(_SERVER_SCRIPT))
+    box_b = MCPToolboxNode(_server_name(topic_namespace, _SERVER_B_NAME), connection_params=_server_params(_SERVER_B_SCRIPT))
     agent = Agent(
         agent_id,
         system_prompt="use a tool from each server",
@@ -405,12 +413,12 @@ async def test_two_mcp_servers_route_each_call_to_its_server(kafka_bootstrap: st
     driver = Client.connect(kafka_bootstrap)
     # Both toolboxes hosted in one worker (the agent reads the shared view either
     # way); each opens its own MCP session and publishes its own record.
-    toolbox_worker = _worker(kafka_bootstrap, nodes=[box_a, box_b], discovery=discovery)
-    agent_worker = _worker(kafka_bootstrap, nodes=[agent], discovery=discovery)
+    toolbox_worker = _worker(kafka_bootstrap, nodes=[box_a, box_b], control_plane=control_plane)
+    agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
 
     async with toolbox_worker:
-        await _await_capability(kafka_bootstrap, cap_topic, _SERVER_NAME, timeout=60)
-        await _await_capability(kafka_bootstrap, cap_topic, _SERVER_B_NAME, timeout=60)
+        await _await_capability(kafka_bootstrap, _server_name(topic_namespace), timeout=60)
+        await _await_capability(kafka_bootstrap, _server_name(topic_namespace, _SERVER_B_NAME), timeout=60)
         async with agent_worker:
             result = await driver.execute("add 2+3 and mul 4*5", agent_in, timeout=120)
 
@@ -431,10 +439,9 @@ async def test_two_agents_share_one_toolbox_replies_route_per_caller(kafka_boots
     a1_in = f"{topic_namespace}.agent-1.input"
     a2_id = f"{topic_namespace}-agent-2"
     a2_in = f"{topic_namespace}.agent-2.input"
-    cap_topic = f"{topic_namespace}.capabilities"
-    discovery = _discovery(cap_topic, kafka_bootstrap)
+    control_plane = _control_plane(kafka_bootstrap)
 
-    toolbox = MCPToolboxNode(_SERVER_NAME, connection_params=_server_params(_SERVER_SCRIPT))
+    toolbox = MCPToolboxNode(_server_name(topic_namespace), connection_params=_server_params(_SERVER_SCRIPT))
     agent1 = Agent(
         a1_id,
         system_prompt="add",
@@ -451,11 +458,11 @@ async def test_two_agents_share_one_toolbox_replies_route_per_caller(kafka_boots
     )
 
     driver = Client.connect(kafka_bootstrap)
-    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], discovery=discovery)
-    agent_worker = _worker(kafka_bootstrap, nodes=[agent1, agent2], discovery=discovery)
+    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], control_plane=control_plane)
+    agent_worker = _worker(kafka_bootstrap, nodes=[agent1, agent2], control_plane=control_plane)
 
     async with toolbox_worker:
-        await _await_capability(kafka_bootstrap, cap_topic, _SERVER_NAME, timeout=60)
+        await _await_capability(kafka_bootstrap, _server_name(topic_namespace), timeout=60)
         async with agent_worker:
             h1 = await driver.start("agent 1 add 2+3", a1_in)
             h2 = await driver.start("agent 2 add 10+20", a2_in)
@@ -482,10 +489,9 @@ async def test_include_pinning_blocks_unselected_tool(kafka_bootstrap: str, topi
     — the agent answers the model with an unknown-tool retry and finalizes."""
     agent_id = f"{topic_namespace}-pin-agent"
     agent_in = f"{topic_namespace}.pin-agent.input"
-    cap_topic = f"{topic_namespace}.capabilities"
-    discovery = _discovery(cap_topic, kafka_bootstrap)
+    control_plane = _control_plane(kafka_bootstrap)
 
-    toolbox = MCPToolboxNode(_SERVER_NAME, connection_params=_server_params(_SERVER_SCRIPT))
+    toolbox = MCPToolboxNode(_server_name(topic_namespace), connection_params=_server_params(_SERVER_SCRIPT))
     agent = Agent(
         agent_id,
         system_prompt="try to call danger",
@@ -495,11 +501,11 @@ async def test_include_pinning_blocks_unselected_tool(kafka_bootstrap: str, topi
     )
 
     driver = Client.connect(kafka_bootstrap)
-    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], discovery=discovery)
-    agent_worker = _worker(kafka_bootstrap, nodes=[agent], discovery=discovery)
+    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], control_plane=control_plane)
+    agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
 
     async with toolbox_worker:
-        await _await_capability(kafka_bootstrap, cap_topic, _SERVER_NAME, timeout=60)
+        await _await_capability(kafka_bootstrap, _server_name(topic_namespace), timeout=60)
         async with agent_worker:
             result = await driver.execute("call danger", agent_in, timeout=120)
 
@@ -523,10 +529,9 @@ async def test_tools_list_changed_grows_the_toolset(kafka_bootstrap: str, topic_
     enable_in = f"{topic_namespace}.enable-agent.input"
     bonus_id = f"{topic_namespace}-bonus-agent"
     bonus_in = f"{topic_namespace}.bonus-agent.input"
-    cap_topic = f"{topic_namespace}.capabilities"
-    discovery = _discovery(cap_topic, kafka_bootstrap)
+    control_plane = _control_plane(kafka_bootstrap)
 
-    toolbox = MCPToolboxNode(_SERVER_NAME, connection_params=_server_params(_SERVER_SCRIPT))
+    toolbox = MCPToolboxNode(_server_name(topic_namespace), connection_params=_server_params(_SERVER_SCRIPT))
     enable_agent = Agent(
         enable_id,
         system_prompt="enable the bonus tool",
@@ -543,12 +548,12 @@ async def test_tools_list_changed_grows_the_toolset(kafka_bootstrap: str, topic_
     )
 
     driver = Client.connect(kafka_bootstrap)
-    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], discovery=discovery)
-    enable_worker = _worker(kafka_bootstrap, nodes=[enable_agent], discovery=discovery)
-    bonus_worker = _worker(kafka_bootstrap, nodes=[bonus_agent], discovery=discovery)
+    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], control_plane=control_plane)
+    enable_worker = _worker(kafka_bootstrap, nodes=[enable_agent], control_plane=control_plane)
+    bonus_worker = _worker(kafka_bootstrap, nodes=[bonus_agent], control_plane=control_plane)
 
     async with toolbox_worker:
-        await _await_capability(kafka_bootstrap, cap_topic, _SERVER_NAME, timeout=60)
+        await _await_capability(kafka_bootstrap, _server_name(topic_namespace), timeout=60)
 
         # 1) Trigger the runtime tool registration + list_changed notification.
         async with enable_worker:
@@ -557,7 +562,7 @@ async def test_tools_list_changed_grows_the_toolset(kafka_bootstrap: str, topic_
         assert "enabled" in _serialized(tool_returns(r1.message_history)["enable_bonus"])
 
         # 2) The toolbox re-listed and re-published; wait for the grown record.
-        await _await_tool_in_record(kafka_bootstrap, cap_topic, _SERVER_NAME, "bonus", timeout=60)
+        await _await_tool_in_record(kafka_bootstrap, _server_name(topic_namespace), "bonus", timeout=60)
 
         # 3) A fresh agent's view catch-up now includes 'bonus' deterministically.
         async with bonus_worker:

--- a/tests/integration/test_mcp_roundtrip_kafka.py
+++ b/tests/integration/test_mcp_roundtrip_kafka.py
@@ -120,37 +120,38 @@ async def _wait(predicate: Callable[[], bool], *, timeout: float, what: str) -> 
     raise AssertionError(f"timed out after {timeout}s waiting for: {what}")
 
 
+async def _await_view(bootstrap: str, predicate: Callable[[ControlPlaneView[CapabilityRecord]], bool], *, timeout: float, what: str) -> None:
+    """Open a transient capability view, wait for ``predicate`` over it, then close it.
+
+    ``start()`` is inside the ``try`` so a failed open never leaks the view.
+    """
+    view: ControlPlaneView[CapabilityRecord] = ControlPlaneView.open(
+        bootstrap_servers=bootstrap, topic=CAPABILITY_TOPIC, record_type=CapabilityRecord, ensure_topic=False
+    )
+    try:
+        await view.start()
+        await _wait(lambda: predicate(view), timeout=timeout, what=what)
+    finally:
+        await view.stop()
+
+
 async def _await_capability(bootstrap: str, toolbox_id: str, *, timeout: float) -> None:
     """Block until the toolbox's CapabilityRecord is live on ``calf.capabilities``.
 
     Starting the agent worker only after the record exists makes the agent's
     Capability View catch-up include it, so the binding resolves on the turn.
     """
-    view: ControlPlaneView[CapabilityRecord] = ControlPlaneView.open(
-        bootstrap_servers=bootstrap, topic=CAPABILITY_TOPIC, record_type=CapabilityRecord, ensure_topic=False
-    )
-    await view.start()
-    try:
-        await _wait(lambda: view.get(toolbox_id) is not None, timeout=timeout, what=f"capability record {toolbox_id!r}")
-    finally:
-        await view.stop()
+    await _await_view(bootstrap, lambda v: v.get(toolbox_id) is not None, timeout=timeout, what=f"capability record {toolbox_id!r}")
 
 
 async def _await_tool_in_record(bootstrap: str, toolbox_id: str, tool: str, *, timeout: float) -> None:
     """Block until ``toolbox_id``'s live record advertises ``tool`` (re-list landed)."""
-    view: ControlPlaneView[CapabilityRecord] = ControlPlaneView.open(
-        bootstrap_servers=bootstrap, topic=CAPABILITY_TOPIC, record_type=CapabilityRecord, ensure_topic=False
-    )
-    await view.start()
 
-    def _present() -> bool:
-        record = view.get(toolbox_id)
+    def _present(v: ControlPlaneView[CapabilityRecord]) -> bool:
+        record = v.get(toolbox_id)
         return record is not None and any(t.name == tool for t in record.tools)
 
-    try:
-        await _wait(_present, timeout=timeout, what=f"tool {tool!r} in record {toolbox_id!r}")
-    finally:
-        await view.stop()
+    await _await_view(bootstrap, _present, timeout=timeout, what=f"tool {tool!r} in record {toolbox_id!r}")
 
 
 async def _topics(bootstrap: str) -> set[str]:
@@ -412,7 +413,8 @@ async def test_two_mcp_servers_route_each_call_to_its_server(kafka_bootstrap: st
 
     driver = Client.connect(kafka_bootstrap)
     # Both toolboxes hosted in one worker (the agent reads the shared view either
-    # way); each opens its own MCP session and publishes its own record.
+    # way); each opens its own MCP session, and the shared worker publisher advertises
+    # one record per toolbox.
     toolbox_worker = _worker(kafka_bootstrap, nodes=[box_a, box_b], control_plane=control_plane)
     agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
 
@@ -522,9 +524,10 @@ async def test_include_pinning_blocks_unselected_tool(kafka_bootstrap: str, topi
 
 async def test_tools_list_changed_grows_the_toolset(kafka_bootstrap: str, topic_namespace: str) -> None:
     """Dynamic discovery: a tool registers a NEW tool at runtime and emits
-    ``notifications/tools/list_changed``; the toolbox re-lists and re-publishes,
-    and a fresh agent (whose view catch-up includes the grown record) can call
-    the new tool end-to-end."""
+    ``notifications/tools/list_changed``; the toolbox re-lists into its cache and the
+    worker's heartbeat carries the grown record on the next tick (pull), and a fresh
+    agent (whose view catch-up includes the grown record) can call the new tool
+    end-to-end."""
     enable_id = f"{topic_namespace}-enable-agent"
     enable_in = f"{topic_namespace}.enable-agent.input"
     bonus_id = f"{topic_namespace}-bonus-agent"
@@ -561,7 +564,7 @@ async def test_tools_list_changed_grows_the_toolset(kafka_bootstrap: str, topic_
         assert r1.output is not None and FINAL_OUTPUT in r1.output
         assert "enabled" in _serialized(tool_returns(r1.message_history)["enable_bonus"])
 
-        # 2) The toolbox re-listed and re-published; wait for the grown record.
+        # 2) The toolbox re-listed into its cache; the next heartbeat carried the grown record — wait for it.
         await _await_tool_in_record(kafka_bootstrap, _server_name(topic_namespace), "bonus", timeout=60)
 
         # 3) A fresh agent's view catch-up now includes 'bonus' deterministically.

--- a/tests/integration/test_mcp_toolbox_capability.py
+++ b/tests/integration/test_mcp_toolbox_capability.py
@@ -1,178 +1,172 @@
-"""Integration: MCPToolboxNode publishes real CapabilityRecords a KafkaTable can read.
+"""Integration (kafka lane): MCPToolboxNode advertises on the control-plane substrate.
 
-Real Kafka writer + reader (ktables) against a live broker supplied by the
-``kafka_bootstrap`` fixture (testcontainers-managed Redpanda, or an external
-broker via ``CALF_TEST_KAFKA_BOOTSTRAP``). The MCP session stays fake (no MCP
-server needed: the session surface used by publishing is just ``list_tools``).
+A real worker-auto-wired ``GroupedKafkaTableWriter`` + a ``ControlPlaneView`` read
+back the toolbox's ``CapabilityRecord``s; an agent resolves the same bindings
+(parity), and the liveness/content split survives the wire (CRITICAL-3). The
+generic publisher mechanics — heartbeat, tombstone, replica-keying, loud-fail —
+are proven in ``test_controlplane_substrate_kafka.py``; this asserts the
+MCP-specific wiring on top.
+
+The MCP session stays fake (no MCP server needed: publishing only uses
+``list_tools``). Broker from the ``kafka_bootstrap`` fixture; isolation via a
+unique toolbox name on the fixed ``calf.capabilities`` topic.
 """
 
 from __future__ import annotations
 
 import asyncio
 import uuid
+from collections.abc import Awaitable, Callable
+from types import SimpleNamespace
 
 import pytest
-from aiokafka.admin import AIOKafkaAdminClient
-from ktables import KafkaTable
 from mcp.types import ListToolsResult, Tool
 
+from calfkit.client.client import Client
+from calfkit.controlplane import ControlPlaneConfig, ControlPlaneView
+from calfkit.controlplane.publisher import control_plane_writer_key
 from calfkit.mcp.mcp_toolbox import MCPToolboxNode
 from calfkit.mcp.mcp_transport import StreamableHttpParameters
-from calfkit.models.capability import CapabilityRecord
-from calfkit.worker.lifecycle import ServingContext
-from calfkit.worker.worker_config import MCPDiscoveryConfig
+from calfkit.models.capability import CAPABILITY_TOPIC, CAPABILITY_VIEW_RESOURCE_KEY, CapabilityRecord
+from calfkit.nodes.agent import Agent
+from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
+from calfkit.provisioning import ProvisioningConfig
+from calfkit.worker.worker import Worker
 
 # Every test here needs a real broker.
 pytestmark = pytest.mark.kafka
 
 
 class FakeSession:
+    def __init__(self, tool_names: tuple[str, ...] = ("search",)) -> None:
+        self._tool_names = tool_names
+
     async def list_tools(self) -> ListToolsResult:
-        return ListToolsResult(tools=[Tool(name="search", description="Search", inputSchema={"type": "object", "properties": {}})])
+        return ListToolsResult(tools=[Tool(name=n, description=n, inputSchema={"type": "object", "properties": {}}) for n in self._tool_names])
 
 
-@pytest.fixture
-async def capability_topic(kafka_bootstrap: str):
-    # Broker availability is guaranteed by ``kafka_bootstrap`` (the lane skips
-    # cleanly when no broker is available), so a connect failure here is a real
-    # error, not a reason to skip.
-    admin = AIOKafkaAdminClient(bootstrap_servers=kafka_bootstrap)
-    await admin.start()
-    name = f"calf.test.capabilities.{uuid.uuid4().hex[:8]}"
+class FakeModel(PydanticModelClient):
+    @property
+    def model_name(self) -> str:
+        return "fake"
+
+    @property
+    def system(self) -> str:
+        return "fake"
+
+    async def request(self, *args: object, **kwargs: object) -> object:
+        raise NotImplementedError
+
+
+async def _poll(refresh: Callable[[], Awaitable[object]], predicate: Callable[[], bool], *, tries: int = 300, delay: float = 0.02) -> bool:
+    for _ in range(tries):
+        await refresh()
+        if predicate():
+            return True
+        await asyncio.sleep(delay)
+    return predicate()
+
+
+async def _host_toolbox(bootstrap: str, toolbox: MCPToolboxNode, *, heartbeat: float = 0.05):
+    """Host the toolbox in a worker, enter its auto-wired control-plane writer
+    resource, and start the worker-owned publisher (no broker serving loop)."""
+    client = Client.connect(bootstrap, provisioning=ProvisioningConfig(enabled=True))
+    worker = Worker(client, nodes=[toolbox], control_plane=ControlPlaneConfig(heartbeat_interval=heartbeat, bootstrap_servers=bootstrap))
+    worker._maybe_register_control_plane()
+    key = control_plane_writer_key(CAPABILITY_TOPIC)
+    [(_, genfn)] = [(n, g) for n, g in worker._resource_cms() if n == key]
+    writer_gen = genfn(None)  # type: ignore[arg-type]
+    writer = await anext(writer_gen)  # ensure_topic=True (provisioning) creates calf.capabilities compacted
+    pub = worker._control_plane_publisher
+    assert pub is not None
+    ctx = SimpleNamespace(resources={key: writer})
+    await pub.start(ctx)
+    return pub, ctx, writer_gen
+
+
+async def _open_view(bootstrap: str) -> ControlPlaneView[CapabilityRecord]:
+    view: ControlPlaneView[CapabilityRecord] = ControlPlaneView.open(
+        bootstrap_servers=bootstrap, topic=CAPABILITY_TOPIC, record_type=CapabilityRecord, ensure_topic=False
+    )
+    await view.start()
+    return view
+
+
+async def test_capability_parity_toolbox_to_agent(kafka_bootstrap: str) -> None:
+    """A hosted toolbox advertises its tools; a ControlPlaneView reads them and an
+    agent resolves the same bindings; clean shutdown tombstones and the next turn
+    degrades (the migration's 'no loss of behaviour for tool selectors' claim)."""
+    name = f"docs-{uuid.uuid4().hex[:8]}"
+    toolbox = MCPToolboxNode(name, connection_params=StreamableHttpParameters(url="http://unused.local/mcp"))
+    await toolbox._refresh_tools(FakeSession(("search",)))  # prime cache (no real MCP server)
+    agent = Agent("researcher", subscribe_topics="researcher.in", model_client=FakeModel(), tools=[toolbox.select(include=["search"])])
+
+    pub, ctx, writer_gen = await _host_toolbox(kafka_bootstrap, toolbox)
+    view = await _open_view(kafka_bootstrap)
     try:
-        yield name
-    finally:
-        try:
-            await admin.delete_topics([name])
-        finally:
-            await admin.close()
+        assert await _poll(view.barrier, lambda: view.get(name) is not None)
+        record = view.get(name)
+        assert record is not None
+        assert [t.name for t in record.tools] == ["search"]
+        assert record.dispatch_topic == f"mcp_server.{name}"
 
-
-async def test_publish_heartbeat_and_tombstone_roundtrip(capability_topic: str, kafka_bootstrap: str) -> None:
-    toolbox = MCPToolboxNode(
-        "docs_server",
-        connection_params=StreamableHttpParameters(url="http://unused.local/mcp"),
-    )
-    # Config flows from the hosting worker; stub it (no Worker in this test).
-    from types import SimpleNamespace
-
-    toolbox._worker = SimpleNamespace(
-        _mcp_discovery=MCPDiscoveryConfig(topic=capability_topic, heartbeat_interval=0.05, bootstrap_servers=kafka_bootstrap),
-        _client=None,
-    )
-
-    # Resource phase: enter the writer bracket for real (creates the topic).
-    writer_gen = toolbox._capability_writer(None)  # type: ignore[arg-type]
-    writer = await anext(writer_gen)
-    toolbox.resources[toolbox._writer_resource_key] = writer
-    toolbox.resources[toolbox._session_resource_key] = FakeSession()
-    ctx = ServingContext(toolbox, toolbox.resources, broker=None)  # type: ignore[arg-type]
-
-    table: KafkaTable[CapabilityRecord] = KafkaTable.json(
-        bootstrap_servers=kafka_bootstrap, topic=capability_topic, model=CapabilityRecord, ensure_topic=False
-    )
-    async with table:
-        try:
-            # Connect-time publish lands in the view.
-            await toolbox._publish_on_startup(ctx)
-            for _ in range(200):
-                if "docs_server" in table:
-                    break
-                await asyncio.sleep(0.01)
-            record = table["docs_server"]
-            assert record.toolbox_id == "docs_server"
-            assert [t.name for t in record.tools] == ["search"]
-
-            # Heartbeat advances published_at in the view.
-            first_seen = record.published_at
-            for _ in range(200):
-                current = table.get("docs_server")
-                if current is not None and current.published_at > first_seen:
-                    break
-                await asyncio.sleep(0.01)
-            current = table["docs_server"]
-            assert current.published_at > first_seen
-        finally:
-            # Clean shutdown: heartbeat stops, tombstone removes the key.
-            await toolbox._tombstone_on_shutdown(ctx)
-        for _ in range(200):
-            if "docs_server" not in table:
-                break
-            await asyncio.sleep(0.01)
-        assert "docs_server" not in table
-
-    with pytest.raises(StopAsyncIteration):
-        await anext(writer_gen)  # close the writer bracket
-
-
-async def test_end_to_end_toolbox_to_agent_resolution(capability_topic: str, kafka_bootstrap: str) -> None:
-    """Spec §8.7: toolbox publishes -> worker view catches up -> agent turn
-    resolves bindings -> clean shutdown tombstones -> next turn degrades."""
-    from calfkit.client.client import Client
-    from calfkit.models.capability import CAPABILITY_VIEW_RESOURCE_KEY
-    from calfkit.nodes.agent import Agent
-    from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
-    from calfkit.worker.worker import Worker
-    from calfkit.worker.worker_config import MCPDiscoveryConfig
-
-    class FakeModel(PydanticModelClient):
-        @property
-        def model_name(self) -> str:
-            return "fake"
-
-        @property
-        def system(self) -> str:
-            return "fake"
-
-        async def request(self, *args: object, **kwargs: object) -> object:
-            raise NotImplementedError
-
-    discovery = MCPDiscoveryConfig(topic=capability_topic, heartbeat_interval=5.0, bootstrap_servers=kafka_bootstrap)
-
-    # Toolbox side (as if hosted in another worker): real writer, real publish.
-    from types import SimpleNamespace
-
-    toolbox = MCPToolboxNode("docs_server", connection_params=StreamableHttpParameters(url="http://unused.local/mcp"))
-    toolbox._worker = SimpleNamespace(_mcp_discovery=discovery, _client=None)
-    writer_gen = toolbox._capability_writer(None)  # type: ignore[arg-type]
-    writer = await anext(writer_gen)
-    toolbox.resources[toolbox._writer_resource_key] = writer
-    toolbox.resources[toolbox._session_resource_key] = FakeSession()
-    toolbox_ctx = ServingContext(toolbox, toolbox.resources, broker=None)  # type: ignore[arg-type]
-    await toolbox._publish_on_startup(toolbox_ctx)
-
-    # Agent side: a separate process in production — here a Worker whose
-    # auto-registered view resource we enter for real.
-    agent = Agent(
-        "researcher",
-        subscribe_topics="researcher.in",
-        model_client=FakeModel(),
-        tools=[toolbox.select(include=["search"])],
-    )
-    client = Client.connect(kafka_bootstrap)
-    worker = Worker(client, nodes=[agent], mcp_discovery=discovery)
-    worker._maybe_register_capability_view()
-    [(name, genfn)] = [(n, g) for n, g in worker._resource_cms() if n == CAPABILITY_VIEW_RESOURCE_KEY]
-    view_gen = genfn(None)  # type: ignore[arg-type]
-    table = await anext(view_gen)
-    try:
-        # Catch-up gate already passed inside start(); the record is visible.
         registry: dict = {}
-        agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: table, **agent._effective_resources()}, registry)
+        agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: view}, registry)
         assert sorted(registry) == ["search"]
-        assert registry["search"].dispatch_topic == "mcp_server.docs_server"
+        assert registry["search"].dispatch_topic == f"mcp_server.{name}"
 
-        # Clean shutdown tombstones; the next turn degrades (warns, empty).
-        await toolbox._tombstone_on_shutdown(toolbox_ctx)
-        for _ in range(200):
-            if "docs_server" not in table:
-                break
-            await asyncio.sleep(0.01)
+        # clean shutdown tombstones the instance; the next turn degrades (empty)
+        await pub.stop(ctx)
+        assert await _poll(view.barrier, lambda: view.get(name) is None)
         registry2: dict = {}
-        agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: table, **agent._effective_resources()}, registry2)
+        agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: view}, registry2)
         assert registry2 == {}
     finally:
+        if pub._task is not None:
+            await pub.stop(ctx)
+        await view.stop()
         with pytest.raises(StopAsyncIteration):
-            await anext(view_gen)
+            await anext(writer_gen)
+
+
+async def test_liveness_content_split_through_the_wire(kafka_bootstrap: str) -> None:
+    """CRITICAL-3: across real heartbeats, last_heartbeat_at advances while
+    content_updated_at stays fixed; a re-list (tool change) advances content."""
+    name = f"docs-{uuid.uuid4().hex[:8]}"
+    toolbox = MCPToolboxNode(name, connection_params=StreamableHttpParameters(url="http://unused.local/mcp"))
+    await toolbox._refresh_tools(FakeSession(("search",)))
+
+    pub, ctx, writer_gen = await _host_toolbox(kafka_bootstrap, toolbox)
+    view = await _open_view(kafka_bootstrap)
+    try:
+        assert await _poll(view.barrier, lambda: view.get(name) is not None)
+        r1 = view.get(name)
+        assert r1 is not None
+
+        def _liveness_advanced() -> bool:
+            r = view.get(name)
+            return r is not None and r.last_heartbeat_at > r1.last_heartbeat_at
+
+        assert await _poll(view.barrier, _liveness_advanced)
+        r2 = view.get(name)
+        assert r2 is not None
+        assert r2.last_heartbeat_at > r1.last_heartbeat_at  # liveness moved
+        assert r2.content_updated_at == r1.content_updated_at  # content did NOT
+
+        # a real tool-set change advances content_updated_at (pull: lands within a heartbeat)
+        await toolbox._refresh_tools(FakeSession(("search", "fetch")))
+
+        def _content_changed() -> bool:
+            r = view.get(name)
+            return r is not None and [t.name for t in r.tools] == ["search", "fetch"]
+
+        assert await _poll(view.barrier, _content_changed)
+        r3 = view.get(name)
+        assert r3 is not None
+        assert r3.content_updated_at > r1.content_updated_at
+    finally:
+        if pub._task is not None:
+            await pub.stop(ctx)
+        await view.stop()
         with pytest.raises(StopAsyncIteration):
             await anext(writer_gen)

--- a/tests/test_capability_models.py
+++ b/tests/test_capability_models.py
@@ -1,30 +1,37 @@
-"""PR A: capability wire model, discovery config, and server_urls retention.
+"""Capability wire model (migrated onto the control-plane substrate).
 
-Spec: docs/designs/mcp-capability-discovery-spec.md §3.2 (wire format),
-§8.3 (zero-config bootstrap derivation, MCPDiscoveryConfig defaults).
+The capability record is now a :class:`ControlPlaneRecord` subclass: identity
+(``toolbox_id`` × ``worker_id``) is the wire key, never in the value; liveness
+(``last_heartbeat_at``) is split from content currency (``content_updated_at``).
+See ``docs/designs/mcp-capability-substrate-migration-plan.md``.
 """
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
+from pydantic_core import PydanticUndefined
 
 from calfkit.client.client import Client
+from calfkit.controlplane import ControlPlaneRecord
 from calfkit.models.capability import (
     CAPABILITY_SCHEMA_VERSION,
+    CAPABILITY_TOPIC,
     CapabilityRecord,
     CapabilityToolDef,
-    is_unsupported_schema,
     record_to_bindings,
 )
 from calfkit.models.tool_dispatch import ToolBinding
-from calfkit.worker.worker_config import MCPDiscoveryConfig
 
 
-def make_record(**overrides) -> CapabilityRecord:
-    defaults = dict(
-        toolbox_id="docs_server",
+def make_record(**overrides: Any) -> CapabilityRecord:
+    now = datetime.now(tz=timezone.utc)
+    defaults: dict[str, Any] = dict(
+        started_at=now,
+        last_heartbeat_at=now,
+        heartbeat_interval=30.0,
         dispatch_topic="mcp_server.docs_server",
         tools=[
             CapabilityToolDef(
@@ -34,13 +41,40 @@ def make_record(**overrides) -> CapabilityRecord:
             ),
             CapabilityToolDef(name="fetch", parameters_json_schema={"type": "object", "properties": {}}),
         ],
-        published_at=datetime.now(tz=timezone.utc),
+        content_updated_at=now,
     )
     defaults.update(overrides)
     return CapabilityRecord(**defaults)
 
 
 class TestCapabilityRecordWireFormat:
+    def test_is_a_control_plane_record(self) -> None:
+        # The migration's foundation: capability records carry the substrate's
+        # identity/liveness base (started_at, last_heartbeat_at, heartbeat_interval).
+        assert issubclass(CapabilityRecord, ControlPlaneRecord)
+        record = make_record()
+        assert record.heartbeat_interval == 30.0
+        assert record.last_heartbeat_at is not None
+        assert record.started_at is not None
+
+    def test_schema_version_has_a_concrete_default(self) -> None:
+        # Load-bearing: ControlPlaneView derives its reader version from this
+        # default and rejects a record type that lacks one.
+        default = CapabilityRecord.model_fields["schema_version"].default
+        assert default is not PydanticUndefined
+        assert default == CAPABILITY_SCHEMA_VERSION == 1
+
+    def test_identity_is_not_carried_in_the_value(self) -> None:
+        # toolbox_id is the wire key now, never a field on the record value.
+        assert "toolbox_id" not in CapabilityRecord.model_fields
+
+    def test_liveness_and_content_currency_are_separate_fields(self) -> None:
+        # CRITICAL-3 fix: a heartbeat refreshes last_heartbeat_at without
+        # touching content_updated_at, so the two facts are distinguishable.
+        assert "last_heartbeat_at" in CapabilityRecord.model_fields
+        assert "content_updated_at" in CapabilityRecord.model_fields
+        assert "published_at" not in CapabilityRecord.model_fields
+
     def test_round_trips_through_json(self) -> None:
         record = make_record()
         restored = CapabilityRecord.model_validate_json(record.model_dump_json())
@@ -53,18 +87,16 @@ class TestCapabilityRecordWireFormat:
         payload = make_record().model_dump_json()
         widened = payload[:-1] + ', "future_field": {"x": 1}}'
         restored = CapabilityRecord.model_validate_json(widened)
-        assert restored.toolbox_id == "docs_server"
+        assert restored.dispatch_topic == "mcp_server.docs_server"
 
     def test_description_is_optional(self) -> None:
         record = make_record()
         assert record.tools[1].description is None
 
-    def test_newer_major_schema_is_detected_not_rejected(self) -> None:
-        # Decoding succeeds (ktables applies any valid JSON); the POLICY of
-        # skipping newer-major records lives with the caller via this helper.
-        newer = make_record(schema_version=CAPABILITY_SCHEMA_VERSION + 1)
-        assert is_unsupported_schema(newer)
-        assert not is_unsupported_schema(make_record())
+
+class TestCapabilityConstants:
+    def test_topic_is_the_renamed_control_plane_topic(self) -> None:
+        assert CAPABILITY_TOPIC == "calf.capabilities"
 
 
 class TestRecordToBindings:
@@ -81,21 +113,6 @@ class TestRecordToBindings:
         [search, _] = record_to_bindings(make_record())
         assert search.tool_def.description == "Search the docs"
         assert search.tool_def.parameters_json_schema == {"type": "object", "properties": {"q": {"type": "string"}}}
-
-
-class TestMCPDiscoveryConfig:
-    def test_defaults_match_spec(self) -> None:
-        cfg = MCPDiscoveryConfig()
-        assert cfg.topic == "mcp.capabilities"
-        assert cfg.catchup_timeout == 30.0
-        assert cfg.heartbeat_interval == 30.0
-        assert cfg.bootstrap_servers is None  # None = derive from the client
-
-    def test_rejects_non_positive_intervals(self) -> None:
-        with pytest.raises(ValueError):
-            MCPDiscoveryConfig(catchup_timeout=0)
-        with pytest.raises(ValueError):
-            MCPDiscoveryConfig(heartbeat_interval=-1)
 
 
 class TestClientServerUrlsRetention:

--- a/tests/test_mcp_toolbox.py
+++ b/tests/test_mcp_toolbox.py
@@ -19,11 +19,14 @@ from calfkit.models.tool_dispatch import ToolSelector, split_tool_declarations
 
 
 def make_record(toolbox_id: str = "github", tool_names: tuple[str, ...] = ("search", "create_issue")) -> CapabilityRecord:
+    now = datetime.now(tz=timezone.utc)
     return CapabilityRecord(
-        toolbox_id=toolbox_id,
+        started_at=now,
+        last_heartbeat_at=now,
+        heartbeat_interval=30.0,
         dispatch_topic=f"mcp_server.{toolbox_id}",
         tools=[CapabilityToolDef(name=n, parameters_json_schema={"type": "object", "properties": {}}) for n in tool_names],
-        published_at=datetime.now(tz=timezone.utc),
+        content_updated_at=now,
     )
 
 
@@ -43,15 +46,13 @@ class TestDirectConstruction:
         ref = MCPToolbox("github")
         result = ref.resolve_tools({"github": make_record()})
         assert [b.name for b in result.bindings] == ["search", "create_issue"]
-        assert not result.strict
 
-    def test_include_and_strict_kwargs(self) -> None:
+    def test_include_kwarg_filters(self) -> None:
         from calfkit.mcp import MCPToolbox
 
-        ref = MCPToolbox("github", include=("search",), strict=True)
+        ref = MCPToolbox("github", include=("search",))
         result = ref.resolve_tools({"github": make_record()})
         assert [b.name for b in result.bindings] == ["search"]
-        assert result.strict
 
     def test_include_accepts_any_sequence_normalized_to_tuple(self) -> None:
         from calfkit.mcp import MCPToolbox
@@ -64,7 +65,7 @@ class TestDirectConstruction:
 
         ref = MCPToolbox("github", include=("search",))
         with pytest.raises(Exception):
-            ref.strict = True  # type: ignore[misc]
+            ref.include = ("other",)  # type: ignore[misc]
         assert len({ref, MCPToolbox("github", include=("search",))}) == 1  # value semantics
 
     def test_satisfies_tool_selector_and_splits_as_selector(self) -> None:
@@ -80,9 +81,9 @@ class TestMintingAndParity:
     def test_select_returns_the_public_ref_type(self) -> None:
         from calfkit.mcp import MCPToolbox
 
-        ref = make_toolbox().select(include=["search"], strict=True)
+        ref = make_toolbox().select(include=["search"])
         assert isinstance(ref, MCPToolbox)
-        assert ref.name == "github" and ref.include == ("search",) and ref.strict
+        assert ref.name == "github" and ref.include == ("search",)
 
     def test_toolbox_resolution_delegates_to_its_ref(self) -> None:
         from calfkit.mcp import MCPToolbox

--- a/tests/test_mcp_toolbox_publisher.py
+++ b/tests/test_mcp_toolbox_publisher.py
@@ -134,6 +134,23 @@ class TestCapabilityFactory:
         assert after.content_updated_at > before
         assert [t.name for t in after.tools] == ["new_tool"]
 
+    async def test_factory_fails_loud_if_cache_not_primed(self) -> None:
+        # The session resource primes the cache before the publisher pulls the factory.
+        # If that ordering ever breaks, fail loud with a NAMED cause (not a -O-stripped
+        # assert, and not a half-built record).
+        toolbox = make_toolbox()  # never refreshed
+        with pytest.raises(RuntimeError, match="primed the tool cache"):
+            toolbox._capability_record(make_stamp())
+
+    async def test_empty_tool_list_is_a_valid_advertisement(self) -> None:
+        # A server advertising zero tools is valid: the cache is [] (distinct from the
+        # uninitialized None), and the factory builds a record with an empty tool list.
+        toolbox = make_toolbox()
+        await toolbox._refresh_tools(FakeSession([]))
+        assert toolbox._last_tools == []  # [] != None — primed, just empty
+        record = toolbox._capability_record(make_stamp())
+        assert record.tools == []
+
 
 class TestListChanged:
     async def test_list_changed_updates_cache_via_offloaded_relist(self) -> None:

--- a/tests/test_mcp_toolbox_publisher.py
+++ b/tests/test_mcp_toolbox_publisher.py
@@ -1,45 +1,32 @@
-"""PR B: MCPToolboxNode advertises its tools on the capability control plane.
+"""MCPToolboxNode advertises its tools on the capability control plane.
 
-Spec §3.3/§8.5: publish on connect (after_startup), re-publish on
-``tools/list_changed`` and as a heartbeat, tombstone on clean shutdown
-(on_shutdown — runs before resource teardown, so the writer is still live).
+Post-migration the node is a pure *content contributor*: it declares one
+``@advertises`` factory that the worker-owned ``ControlPlanePublisher`` pulls
+each heartbeat tick. The heartbeat loop + resurrection-safe tombstone now live
+in the substrate's publisher (tested in ``test_controlplane_publisher.py``), so
+they are not re-tested here.
 
-Tests drive the node's lifecycle hooks directly with fakes seeded into the
-node's own resource bag (worker hooks pass ``ServingContext(owner,
-owner.resources, broker)`` — verified against worker.py), so no broker is
-needed; the real KafkaTableWriter is exercised by the integration test only.
+The node caches the tool list — refreshed at session setup and on every
+``tools/list_changed`` — and the factory reads that cache (never re-lists inline;
+``content_updated_at`` advances only on a real tool change, never per heartbeat).
 """
 
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
 from typing import Any
 
 import pytest
 from mcp.types import ListToolsResult, Tool, ToolListChangedNotification
 
-from calfkit.models.capability import CapabilityRecord
-from calfkit.worker.lifecycle import ServingContext
-from calfkit.worker.worker_config import MCPDiscoveryConfig
+from calfkit.controlplane import ControlPlaneStamp
+from calfkit.models.capability import CAPABILITY_TOPIC, CapabilityRecord
 
 mcp_toolbox = pytest.importorskip("calfkit.mcp.mcp_toolbox")
 MCPToolboxNode = mcp_toolbox.MCPToolboxNode
 
 from calfkit.mcp.mcp_transport import StreamableHttpParameters  # noqa: E402
-
-
-class FakeWriter:
-    """Records set/delete calls; quacks like KafkaTableWriter."""
-
-    def __init__(self) -> None:
-        self.sets: list[tuple[str, CapabilityRecord]] = []
-        self.deletes: list[str] = []
-
-    async def set(self, key: str, value: CapabilityRecord) -> None:
-        self.sets.append((key, value))
-
-    async def delete(self, key: str) -> None:
-        self.deletes.append(key)
 
 
 class FakeSession:
@@ -59,210 +46,141 @@ def make_tools() -> list[Tool]:
     ]
 
 
-def make_toolbox(discovery: MCPDiscoveryConfig | None = None) -> Any:
-    toolbox = MCPToolboxNode(
-        "docs_server",
-        connection_params=StreamableHttpParameters(url="http://unused.local/mcp"),
-    )
-    if discovery is not None:
-        # Config flows from the hosting worker (the single config surface);
-        # tests stand in for it with a stub.
-        from types import SimpleNamespace
-
-        toolbox._worker = SimpleNamespace(_mcp_discovery=discovery, _client=None)
-    return toolbox
+def make_toolbox() -> Any:
+    return MCPToolboxNode("docs_server", connection_params=StreamableHttpParameters(url="http://unused.local/mcp"))
 
 
-def seed(toolbox: Any, session: FakeSession | None = None, writer: FakeWriter | None = None) -> tuple[FakeSession, FakeWriter]:
-    session = session or FakeSession(make_tools())
-    writer = writer or FakeWriter()
-    toolbox.resources[toolbox._session_resource_key] = session
-    toolbox.resources[toolbox._writer_resource_key] = writer
-    return session, writer
+def make_stamp(*, hb: float = 30.0) -> ControlPlaneStamp:
+    now = datetime.now(tz=timezone.utc)
+    return ControlPlaneStamp(started_at=now, last_heartbeat_at=now, heartbeat_interval=hb)
 
 
-def serving_ctx(toolbox: Any) -> ServingContext[Any]:
-    return ServingContext(toolbox, toolbox.resources, broker=None)  # type: ignore[arg-type]
+class TestAdvertDeclaration:
+    def test_declares_one_capability_advert(self) -> None:
+        adverts = type(make_toolbox())._adverts
+        assert CAPABILITY_TOPIC in adverts
+        assert adverts[CAPABILITY_TOPIC].record is CapabilityRecord
 
+    def test_advert_factory_is_a_bound_method(self) -> None:
+        toolbox = make_toolbox()
+        factories = toolbox.control_plane_adverts()
+        assert CAPABILITY_TOPIC in factories
+        assert callable(factories[CAPABILITY_TOPIC])
 
-async def fire(toolbox: Any, phase: str) -> None:
-    for hook in toolbox._hooks_for(phase):
-        result = hook(serving_ctx(toolbox))
-        if asyncio.iscoroutine(result):
-            await result
-
-
-class TestWriterResource:
-    def test_writer_resource_registered_alongside_session(self) -> None:
+    def test_node_no_longer_owns_writer_heartbeat_or_tombstone(self) -> None:
+        # The publisher (worker-owned) does heartbeats + tombstones now; the node
+        # only keeps its MCP session resource and contributes content.
         toolbox = make_toolbox()
         names = [name for name, _ in toolbox._resource_cms()]
         assert toolbox._session_resource_key in names
-        assert toolbox._writer_resource_key in names
+        assert not any("writer" in n for n in names)
+        assert not hasattr(toolbox, "_writer_resource_key")
+        assert not hasattr(toolbox, "_heartbeat_task")
+        assert list(toolbox._hooks_for("after_startup")) == []
+        assert list(toolbox._hooks_for("on_shutdown")) == []
 
 
-class TestPublishOnStartup:
-    async def test_publishes_record_keyed_by_node_id(self) -> None:
+class TestCapabilityFactory:
+    async def test_factory_builds_record_from_stamp_and_cache(self) -> None:
         toolbox = make_toolbox()
-        session, writer = seed(toolbox)
-        await fire(toolbox, "after_startup")
-        await fire(toolbox, "on_shutdown")  # cancel heartbeat for clean teardown
-
-        [(key, record)] = writer.sets[:1]
-        assert key == "docs_server"
+        await toolbox._refresh_tools(FakeSession(make_tools()))
+        stamp = make_stamp(hb=45.0)
+        record = toolbox._capability_record(stamp)
         assert isinstance(record, CapabilityRecord)
-        assert record.toolbox_id == "docs_server"
+        # the worker-stamped fields ride through verbatim
+        assert record.started_at == stamp.started_at
+        assert record.last_heartbeat_at == stamp.last_heartbeat_at
+        assert record.heartbeat_interval == 45.0
+        # content
         assert record.dispatch_topic == "mcp_server.docs_server"
         assert [t.name for t in record.tools] == ["search", "fetch"]
         assert record.tools[0].parameters_json_schema == {"type": "object", "properties": {"q": {"type": "string"}}}
         assert record.tools[1].description is None
-        assert record.published_at.tzinfo is not None
 
-
-class TestHeartbeat:
-    async def test_heartbeat_republishes_with_fresh_timestamp(self) -> None:
-        toolbox = make_toolbox(discovery=MCPDiscoveryConfig(heartbeat_interval=0.02))
-        session, writer = seed(toolbox)
-        await fire(toolbox, "after_startup")
-        try:
-            await asyncio.sleep(0.09)
-        finally:
-            await fire(toolbox, "on_shutdown")
-
-        assert len(writer.sets) >= 3  # initial + >=2 heartbeats
-        first, last = writer.sets[0][1], writer.sets[-1][1]
-        assert last.published_at > first.published_at
-        # Heartbeats re-publish the cached tool list — no re-listing.
-        assert session.list_tools_calls == 1
-
-    async def test_heartbeat_stops_on_shutdown(self) -> None:
-        toolbox = make_toolbox(discovery=MCPDiscoveryConfig(heartbeat_interval=0.02))
-        _, writer = seed(toolbox)
-        await fire(toolbox, "after_startup")
-        await fire(toolbox, "on_shutdown")
-        count = len(writer.sets)
-        await asyncio.sleep(0.06)
-        assert len(writer.sets) == count  # nothing published after shutdown
-
-
-class TestTombstoneOnShutdown:
-    async def test_shutdown_deletes_record(self) -> None:
+    async def test_factory_reads_cache_without_listing(self) -> None:
+        # The factory runs on the shared heartbeat loop: it must never do I/O.
         toolbox = make_toolbox()
-        _, writer = seed(toolbox)
-        await fire(toolbox, "after_startup")
-        await fire(toolbox, "on_shutdown")
-        assert writer.deletes == ["docs_server"]
+        session = FakeSession(make_tools())
+        await toolbox._refresh_tools(session)
+        assert session.list_tools_calls == 1
+        toolbox._capability_record(make_stamp())
+        toolbox._capability_record(make_stamp())
+        assert session.list_tools_calls == 1  # factory never re-lists
 
+    async def test_content_updated_at_stable_across_heartbeats(self) -> None:
+        # CRITICAL-3: a new heartbeat stamp must NOT move content_updated_at.
+        toolbox = make_toolbox()
+        await toolbox._refresh_tools(FakeSession(make_tools()))
+        r1 = toolbox._capability_record(make_stamp())
+        r2 = toolbox._capability_record(make_stamp())
+        assert r1.content_updated_at == r2.content_updated_at
 
-class ReceiveLoopFakeSession(FakeSession):
-    """Deadlock-faithful: list_tools() cannot complete until the message
-    handler has RETURNED — exactly the real ClientSession receive-loop
-    coupling. An implementation that awaits the re-list inline hangs here."""
+    async def test_content_updated_at_advances_only_on_real_change(self) -> None:
+        toolbox = make_toolbox()
+        session = FakeSession(make_tools())
+        await toolbox._refresh_tools(session)
+        before = toolbox._capability_record(make_stamp()).content_updated_at
 
-    def __init__(self, tools: list[Tool]) -> None:
-        super().__init__(tools)
-        self.handler_returned = asyncio.Event()
+        # A redundant re-list (identical tools) must NOT advance content currency.
+        await asyncio.sleep(0.005)
+        await toolbox._refresh_tools(session)
+        assert toolbox._capability_record(make_stamp()).content_updated_at == before
 
-    async def list_tools(self) -> ListToolsResult:
-        await self.handler_returned.wait()
-        return await super().list_tools()
+        # A genuine tool-set change advances it.
+        await asyncio.sleep(0.005)
+        session._tools = [Tool(name="new_tool", inputSchema={"type": "object", "properties": {}})]
+        await toolbox._refresh_tools(session)
+        after = toolbox._capability_record(make_stamp())
+        assert after.content_updated_at > before
+        assert [t.name for t in after.tools] == ["new_tool"]
 
 
 class TestListChanged:
-    async def test_handler_never_blocks_the_receive_loop(self) -> None:
+    async def test_list_changed_updates_cache_via_offloaded_relist(self) -> None:
         toolbox = make_toolbox()
-        session = ReceiveLoopFakeSession(make_tools())
-        _, writer = seed(toolbox, session=session)
-        notification = ToolListChangedNotification(method="notifications/tools/list_changed")
-
-        # Must return promptly even though list_tools() is gated on our return
-        # — inline awaiting would deadlock (and trip this timeout).
-        await asyncio.wait_for(toolbox._mcp_message_handler(notification), timeout=1.0)
-        session.handler_returned.set()
-        for _ in range(100):
-            if writer.sets:
-                break
-            await asyncio.sleep(0.01)
-        assert writer.sets and writer.sets[-1][0] == "docs_server"
-        await fire(toolbox, "on_shutdown")
-
-    async def test_shutdown_cancels_inflight_relist_so_tombstone_is_final(self) -> None:
-        toolbox = make_toolbox()
-        session = ReceiveLoopFakeSession(make_tools())
-        _, writer = seed(toolbox, session=session)
-        notification = ToolListChangedNotification(method="notifications/tools/list_changed")
-
-        await toolbox._mcp_message_handler(notification)  # re-list now parked
-        await fire(toolbox, "on_shutdown")  # cancels it, then tombstones
-        session.handler_returned.set()  # unpark (too late)
-        await asyncio.sleep(0.05)
-
-        assert writer.deletes == ["docs_server"]
-        assert writer.sets == []  # the cancelled re-list never resurrected the record
-
-    async def test_notification_during_tombstone_awaits_cannot_resurrect(self) -> None:
-        # The session receive loop is still alive while the tombstone awaits
-        # (slow broker round-trip): a notification arriving in that window
-        # must be dropped, not spawn a fresh re-list that lands after delete.
-        class SlowDeleteWriter(FakeWriter):
-            def __init__(self) -> None:
-                super().__init__()
-                self.delete_started = asyncio.Event()
-                self.release_delete = asyncio.Event()
-
-            async def delete(self, key: str) -> None:
-                self.delete_started.set()
-                await self.release_delete.wait()
-                await super().delete(key)
-
-        toolbox = make_toolbox()
-        session = ReceiveLoopFakeSession(make_tools())
-        writer = SlowDeleteWriter()
-        seed(toolbox, session=session, writer=writer)
-        session.handler_returned.set()  # any re-list would complete immediately
-
-        shutdown = asyncio.create_task(fire(toolbox, "on_shutdown"))
-        await asyncio.wait_for(writer.delete_started.wait(), timeout=1.0)
-        # Mid-tombstone notification: must be ignored under the shutdown flag.
-        await toolbox._mcp_message_handler(ToolListChangedNotification(method="notifications/tools/list_changed"))
-        writer.release_delete.set()
-        await shutdown
-        await asyncio.sleep(0.05)
-
-        assert writer.deletes == ["docs_server"]
-        assert writer.sets == []  # nothing resurrected the tombstone
-
-    async def test_list_changed_notification_republishes_fresh_listing(self) -> None:
-        toolbox = make_toolbox()
-        session, writer = seed(toolbox)
-        await fire(toolbox, "after_startup")
-        baseline = len(writer.sets)
+        session = FakeSession(make_tools())
+        toolbox.resources[toolbox._session_resource_key] = session
+        await toolbox._refresh_tools(session)  # prime as session setup would
 
         session._tools = [Tool(name="new_tool", inputSchema={"type": "object", "properties": {}})]
-        await toolbox._handle_tools_list_changed(ToolListChangedNotification(method="notifications/tools/list_changed"))
-        await fire(toolbox, "on_shutdown")
+        await toolbox._mcp_message_handler(ToolListChangedNotification(method="notifications/tools/list_changed"))
+        for _ in range(100):
+            if toolbox._last_tools and toolbox._last_tools[0].name == "new_tool":
+                break
+            await asyncio.sleep(0.01)
+        assert [t.name for t in toolbox._last_tools] == ["new_tool"]  # cache updated, no publish
+        await toolbox._cancel_relist_tasks()
 
-        assert len(writer.sets) == baseline + 1
-        assert [t.name for t in writer.sets[-1][1].tools] == ["new_tool"]
-        assert session.list_tools_calls == 2  # re-listed, not cached
+    async def test_handler_never_blocks_the_receive_loop(self) -> None:
+        # Deadlock-faithful: list_tools() cannot complete until the handler has
+        # RETURNED (the real ClientSession receive-loop coupling). An inline await
+        # would hang and trip this timeout.
+        class ReceiveLoopFakeSession(FakeSession):
+            def __init__(self, tools: list[Tool]) -> None:
+                super().__init__(tools)
+                self.handler_returned = asyncio.Event()
 
-
-class TestBootstrapDerivation:
-    def test_explicit_config_override_wins(self) -> None:
-        toolbox = make_toolbox(discovery=MCPDiscoveryConfig(bootstrap_servers="cp-kafka:9092"))
-        assert toolbox._control_plane_bootstrap() == "cp-kafka:9092"
-
-    def test_derives_from_workers_client(self) -> None:
-        class StubClient:
-            server_urls = "kafka-a:9092,kafka-b:9092"
-
-        class StubWorker:
-            _client = StubClient()
+            async def list_tools(self) -> ListToolsResult:
+                await self.handler_returned.wait()
+                return await super().list_tools()
 
         toolbox = make_toolbox()
-        toolbox._worker = StubWorker()  # type: ignore[assignment]
-        assert toolbox._control_plane_bootstrap() == "kafka-a:9092,kafka-b:9092"
+        session = ReceiveLoopFakeSession(make_tools())
+        toolbox.resources[toolbox._session_resource_key] = session
 
-    def test_unreachable_raises_actionable_error(self) -> None:
-        toolbox = make_toolbox()  # no worker, no override
-        with pytest.raises(RuntimeError, match="bootstrap_servers"):
-            toolbox._control_plane_bootstrap()
+        await asyncio.wait_for(
+            toolbox._mcp_message_handler(ToolListChangedNotification(method="notifications/tools/list_changed")),
+            timeout=1.0,
+        )
+        session.handler_returned.set()
+        for _ in range(100):
+            if session.list_tools_calls:
+                break
+            await asyncio.sleep(0.01)
+        assert session.list_tools_calls == 1
+        await toolbox._cancel_relist_tasks()
+
+    async def test_relist_before_session_ready_is_ignored(self) -> None:
+        toolbox = make_toolbox()  # no session seeded
+        await toolbox._handle_tools_list_changed(ToolListChangedNotification(method="notifications/tools/list_changed"))
+        assert toolbox._last_tools is None  # nothing to cache, no crash

--- a/tests/test_tool_selector.py
+++ b/tests/test_tool_selector.py
@@ -1,9 +1,11 @@
-"""PR C: ToolSelector protocol, MCPToolboxNode-as-selector, and agent resolution.
+"""ToolSelector protocol, MCPToolboxNode-as-selector, and agent resolution.
 
-Spec §8.4: the toolbox instance is passed to agents like a tool node
-(``tools=[docs]``); resolution happens per turn against the Capability View,
-typed as a plain ``Mapping[str, CapabilityRecord]`` — these tests use plain
-dicts as the view (the agent layer never imports ktables).
+The toolbox instance is passed to agents like a tool node (``tools=[docs]``);
+resolution happens per turn against the Capability View. Post-migration the view
+is a :class:`ControlPlaneView` that owns staleness + schema-version filtering, so
+the resolver simplifies to "is it here, and does it have the tools I asked for".
+The ``strict`` flag and the ``stale_seconds`` / ``skipped_newer_schema``
+diagnostics are gone (D5/D6); unresolved selections always warn + degrade.
 """
 
 from __future__ import annotations
@@ -13,32 +15,41 @@ from typing import Any
 
 import pytest
 
-from calfkit.exceptions import MCPToolResolutionError
+from calfkit.controlplane import ControlPlaneView
 from calfkit.mcp.mcp_toolbox import MCPToolboxNode
 from calfkit.mcp.mcp_transport import StreamableHttpParameters
 from calfkit.models.capability import (
-    CAPABILITY_SCHEMA_VERSION,
     CAPABILITY_VIEW_RESOURCE_KEY,
     CapabilityRecord,
     CapabilityToolDef,
     SelectorResult,
 )
 from calfkit.models.tool_dispatch import ToolBinding, ToolProvider, ToolSelector, split_tool_declarations
+from tests.test_controlplane_view import _FakeTable  # the substrate's dict-backed GroupedTableReader fake
 
 
 def make_toolbox(name: str = "docs_server") -> MCPToolboxNode:
     return MCPToolboxNode(name, connection_params=StreamableHttpParameters(url="http://unused.local/mcp"))
 
 
-def make_record(toolbox_id: str = "docs_server", *, tool_names: tuple[str, ...] = ("search", "fetch"), **overrides: Any) -> CapabilityRecord:
+def make_record(**overrides: Any) -> CapabilityRecord:
+    now = datetime.now(tz=timezone.utc)
     defaults: dict[str, Any] = dict(
-        toolbox_id=toolbox_id,
-        dispatch_topic=f"mcp_server.{toolbox_id}",
-        tools=[CapabilityToolDef(name=n, parameters_json_schema={"type": "object", "properties": {}}) for n in tool_names],
-        published_at=datetime.now(tz=timezone.utc),
+        started_at=now,
+        last_heartbeat_at=now,
+        heartbeat_interval=30.0,
+        dispatch_topic="mcp_server.docs_server",
+        tools=[CapabilityToolDef(name=n, parameters_json_schema={"type": "object", "properties": {}}) for n in ("search", "fetch")],
+        content_updated_at=now,
     )
     defaults.update(overrides)
     return CapabilityRecord(**defaults)
+
+
+def make_view(record: CapabilityRecord | None = None, **table_kwargs: Any) -> ControlPlaneView[CapabilityRecord]:
+    """A real ControlPlaneView over a one-instance dict-backed fake, keyed docs_server×w1."""
+    data: dict[str, dict[str, CapabilityRecord]] = {"docs_server": {"w1": record}} if record is not None else {}
+    return ControlPlaneView(_FakeTable(data, **table_kwargs), CapabilityRecord)
 
 
 class TestToolboxIsNoLongerAProvider:
@@ -61,7 +72,6 @@ class TestResolveTools:
         assert all(isinstance(b, ToolBinding) and b.validator is None for b in result.bindings)
         assert all(b.dispatch_topic == "mcp_server.docs_server" for b in result.bindings)
         assert not result.missing_toolbox and not result.missing_tools
-        assert not result.strict
 
     def test_missing_toolbox_diagnostic(self) -> None:
         result = make_toolbox().resolve_tools({})
@@ -76,33 +86,42 @@ class TestResolveTools:
         assert [b.name for b in result.bindings] == ["search"]
         assert result.missing_tools == ("nonexistent",)
 
-    def test_strict_flag_propagates(self) -> None:
-        selector = make_toolbox().select(strict=True)
-        assert selector.resolve_tools({}).strict is True
-
     def test_scoped_selector_is_frozen(self) -> None:
         selector = make_toolbox().select(include=["search"])
         with pytest.raises(Exception):
-            selector.strict = True  # type: ignore[misc]
-
-    def test_newer_schema_is_skipped_with_diagnostic(self) -> None:
-        record = make_record(schema_version=CAPABILITY_SCHEMA_VERSION + 1)
-        result = make_toolbox().resolve_tools({"docs_server": record})
-        assert result.skipped_newer_schema
-        assert result.bindings == []
+            selector.include = ("other",)  # type: ignore[misc]
 
     def test_malformed_record_is_skipped_with_diagnostic(self) -> None:
         # Tolerant reader admits an empty dispatch_topic; binding expansion
-        # must not crash the turn (spec §8.4 guard).
+        # must not crash the turn — it surfaces as invalid_record instead.
         record = make_record(dispatch_topic="")
         result = make_toolbox().resolve_tools({"docs_server": record})
         assert result.invalid_record
         assert result.bindings == []
 
-    def test_stale_seconds_reflects_record_age(self) -> None:
-        old = make_record(published_at=datetime.now(tz=timezone.utc) - timedelta(seconds=120))
-        result = make_toolbox().resolve_tools({"docs_server": old})
-        assert result.stale_seconds is not None and 119 < result.stale_seconds < 130
+    # -- view-owned filtering (D6): the resolver never sees stale/newer-schema records --
+
+    def test_stale_record_hidden_by_view(self) -> None:
+        # age 100s > 3*30 = 90 threshold -> the view collapses it to None, so the
+        # resolver reports missing_toolbox (no advisory "use last-known" path).
+        view = make_view(make_record(last_heartbeat_at=datetime.now(tz=timezone.utc) - timedelta(seconds=100)))
+        result = make_toolbox().resolve_tools(view)
+        assert result.missing_toolbox
+        assert result.bindings == []
+
+    def test_newer_schema_hidden_by_view(self) -> None:
+        # A record from a newer schema major is filtered (and logged) by the view;
+        # the resolver just sees None -> missing_toolbox.
+        view = make_view(make_record(schema_version=2))
+        result = make_toolbox().resolve_tools(view)
+        assert result.missing_toolbox
+        assert result.bindings == []
+
+    def test_live_record_resolves_through_view(self) -> None:
+        view = make_view(make_record())
+        result = make_toolbox().resolve_tools(view)
+        assert [b.name for b in result.bindings] == ["search", "fetch"]
+        assert not result.missing_toolbox
 
 
 class TestSplitToolDeclarations:
@@ -127,14 +146,10 @@ class TestSplitToolDeclarations:
 
 
 class TestAgentResolution:
-    """Drives the agent's per-turn selector resolution against a plain dict."""
+    """Drives the agent's per-turn selector resolution."""
 
     def make_agent(self, *tools: Any):
         from calfkit.nodes.agent import Agent
-
-        class _FakeModel:
-            pass
-
         from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
 
         class FakeModel(PydanticModelClient):
@@ -184,20 +199,55 @@ class TestAgentResolution:
         assert registry == {}
         assert any("capability" in r.message.lower() for r in caplog.records)
 
-    def test_missing_view_with_strict_raises(self) -> None:
-        agent = self.make_agent(make_toolbox().select(strict=True))
-        with pytest.raises(MCPToolResolutionError):
-            agent._resolve_selector_tools({}, {})
-
-    def test_unresolved_toolbox_warns_or_raises(self, caplog: pytest.LogCaptureFixture) -> None:
-        lenient = self.make_agent(make_toolbox())
+    def test_unresolved_toolbox_warns_and_degrades(self, caplog: pytest.LogCaptureFixture) -> None:
+        # No strict path: an unresolved toolbox always warns + degrades, never raises.
+        agent = self.make_agent(make_toolbox())
+        registry: dict[str, ToolBinding] = {}
         with caplog.at_level("WARNING"):
-            lenient._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: {}}, {})
+            agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: {}}, registry)
+        assert registry == {}
         assert any("docs_server" in r.message for r in caplog.records)
 
-        strict = self.make_agent(make_toolbox().select(strict=True))
-        with pytest.raises(MCPToolResolutionError, match="docs_server"):
-            strict._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: {}}, {})
+    def test_degraded_view_logs_warning_but_proceeds(self, caplog: pytest.LogCaptureFixture) -> None:
+        # CRITICAL-4 (D6, log-only): a degraded reader is surfaced via a warning,
+        # but resolution still proceeds against whatever the view serves.
+        agent = self.make_agent(make_toolbox())
+        registry: dict[str, ToolBinding] = {}
+        view = make_view(make_record(), status="degraded")
+        with caplog.at_level("WARNING"):
+            agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: view}, registry)
+        assert sorted(registry) == ["fetch", "search"]  # turn proceeds
+        assert any("degraded" in r.message.lower() for r in caplog.records)
+
+    def test_failed_view_logs_warning_but_proceeds(self, caplog: pytest.LogCaptureFixture) -> None:
+        agent = self.make_agent(make_toolbox())
+        registry: dict[str, ToolBinding] = {}
+        view = make_view(make_record(), status="failed", failure=RuntimeError("reader died"))
+        with caplog.at_level("WARNING"):
+            agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: view}, registry)
+        assert any("failed" in r.message.lower() or "reader died" in r.message for r in caplog.records)
+
+
+class TestNoStrictSurface:
+    """D5: the strict knob and its exception are gone from the public surface."""
+
+    def test_select_has_no_strict_parameter(self) -> None:
+        import inspect
+
+        params = inspect.signature(MCPToolboxNode.select).parameters
+        assert "strict" not in params
+        assert "include" in params
+
+    def test_selector_result_has_no_strict_or_filtering_diagnostics(self) -> None:
+        fields = set(SelectorResult.__dataclass_fields__)
+        assert "strict" not in fields
+        assert "stale_seconds" not in fields
+        assert "skipped_newer_schema" not in fields
+
+    def test_resolution_error_is_gone(self) -> None:
+        import calfkit.exceptions as exc
+
+        assert not hasattr(exc, "MCPToolResolutionError")
 
 
 class TestOverridesSuppressSelectors:
@@ -213,16 +263,18 @@ class TestOverridesSuppressSelectors:
         ctx = _make_ctx(state)
         return ctx
 
-    def test_overridden_turn_skips_selectors_even_strict(self) -> None:
+    def test_overridden_turn_skips_selector_resolution(self) -> None:
         from calfkit._vendor.pydantic_ai.tools import ToolDefinition
 
-        agent = TestAgentResolution().make_agent(make_toolbox().select(strict=True))
+        agent = TestAgentResolution().make_agent(make_toolbox())
         override = ToolBinding(tool_def=ToolDefinition(name="pinned"), dispatch_topic="pinned.topic")
         registry = {"pinned": override}
-        # No Capability View anywhere: a strict selector would raise — but the
+        ctx = self._ctx(overrides=[override])
+        # A view IS present and would resolve docs_server's tools — but the
         # override gate must short-circuit before resolution.
-        agent._maybe_resolve_selectors(self._ctx(overrides=[override]), registry)
-        assert list(registry) == ["pinned"]
+        ctx._resources = {CAPABILITY_VIEW_RESOURCE_KEY: {"docs_server": make_record()}}
+        agent._maybe_resolve_selectors(ctx, registry)
+        assert list(registry) == ["pinned"]  # search/fetch NOT merged
 
     def test_non_overridden_turn_resolves(self) -> None:
         agent = TestAgentResolution().make_agent(make_toolbox())

--- a/tests/test_worker_capability_view.py
+++ b/tests/test_worker_capability_view.py
@@ -1,9 +1,10 @@
-"""PR C: the worker auto-registers the Capability View when agents need it.
+"""The worker auto-registers the Capability View when agents need it.
 
-Spec §8.3: one KafkaTable per worker, registered as a worker-level resource
-iff any hosted node declares MCP tool selectors; zero user wiring. These
-tests cover registration mechanics only — the table itself is ktables'
-responsibility, and the live path is the integration test.
+One ``ControlPlaneView[CapabilityRecord]`` per worker, registered as a
+worker-level resource iff any hosted node declares MCP tool selectors; zero user
+wiring. These tests cover registration + open mechanics only — the view's
+collapse/staleness/schema filtering is the substrate's responsibility
+(``test_controlplane_view.py``), and the live path is the integration test.
 """
 
 from __future__ import annotations
@@ -11,12 +12,12 @@ from __future__ import annotations
 import pytest
 
 from calfkit.client.client import Client
+from calfkit.controlplane import ControlPlaneConfig
 from calfkit.mcp.mcp_toolbox import MCPToolboxNode
 from calfkit.mcp.mcp_transport import StreamableHttpParameters
-from calfkit.models.capability import CAPABILITY_VIEW_RESOURCE_KEY
+from calfkit.models.capability import CAPABILITY_TOPIC, CAPABILITY_VIEW_RESOURCE_KEY, CapabilityRecord
 from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
 from calfkit.worker.worker import Worker
-from calfkit.worker.worker_config import MCPDiscoveryConfig
 
 
 class FakeModel(PydanticModelClient):
@@ -48,54 +49,44 @@ def worker_resource_names(worker: Worker) -> list[str]:
 
 class TestCapabilityViewRegistration:
     def test_registered_when_an_agent_declares_selectors(self) -> None:
-        client = Client.connect("kafka:9092")
-        worker = Worker(client, nodes=[make_agent(make_toolbox())])
+        worker = Worker(Client.connect("kafka:9092"), nodes=[make_agent(make_toolbox())])
         worker._maybe_register_capability_view()
         assert CAPABILITY_VIEW_RESOURCE_KEY in worker_resource_names(worker)
 
     def test_not_registered_without_selectors(self) -> None:
-        client = Client.connect("kafka:9092")
-        worker = Worker(client, nodes=[make_agent()])
+        worker = Worker(Client.connect("kafka:9092"), nodes=[make_agent()])
         worker._maybe_register_capability_view()
         assert CAPABILITY_VIEW_RESOURCE_KEY not in worker_resource_names(worker)
 
     def test_idempotent_on_repeat_calls(self) -> None:
-        client = Client.connect("kafka:9092")
-        worker = Worker(client, nodes=[make_agent(make_toolbox())])
+        worker = Worker(Client.connect("kafka:9092"), nodes=[make_agent(make_toolbox())])
         worker._maybe_register_capability_view()
         worker._maybe_register_capability_view()  # must not raise duplicate-name
         assert worker_resource_names(worker).count(CAPABILITY_VIEW_RESOURCE_KEY) == 1
 
     def test_scoped_selectors_also_trigger_registration(self) -> None:
-        client = Client.connect("kafka:9092")
-        worker = Worker(client, nodes=[make_agent(make_toolbox().select(include=["search"]))])
+        worker = Worker(Client.connect("kafka:9092"), nodes=[make_agent(make_toolbox().select(include=["search"]))])
         worker._maybe_register_capability_view()
         assert CAPABILITY_VIEW_RESOURCE_KEY in worker_resource_names(worker)
 
-    def test_discovery_config_accepted_on_worker(self) -> None:
-        client = Client.connect("kafka:9092")
-        worker = Worker(client, mcp_discovery=MCPDiscoveryConfig(topic="custom.capabilities"))
-        assert worker._mcp_discovery.topic == "custom.capabilities"
-
-    def test_defaults_when_config_omitted(self) -> None:
-        client = Client.connect("kafka:9092")
-        worker = Worker(client)
-        assert worker._mcp_discovery == MCPDiscoveryConfig()
+    def test_control_plane_config_defaults_when_omitted(self) -> None:
+        worker = Worker(Client.connect("kafka:9092"))
+        assert worker._control_plane == ControlPlaneConfig()
 
 
-class FakeKafkaTable:
-    """Stands in for ktables.KafkaTable; records construction and lifecycle."""
+class FakeGroupedTable:
+    """Stands in for ktables.GroupedKafkaTable; records construction and lifecycle."""
 
-    instances: list[FakeKafkaTable] = []
+    instances: list[FakeGroupedTable] = []
 
     def __init__(self, **kwargs: object) -> None:
         self.kwargs = kwargs
         self.started = False
         self.stopped = False
-        FakeKafkaTable.instances.append(self)
+        FakeGroupedTable.instances.append(self)
 
     @classmethod
-    def json(cls, *, model: object, **kwargs: object) -> FakeKafkaTable:
+    def json(cls, *, model: object, **kwargs: object) -> FakeGroupedTable:
         return cls(model=model, **kwargs)
 
     async def start(self) -> None:
@@ -106,16 +97,16 @@ class FakeKafkaTable:
 
 
 @pytest.fixture
-def fake_table(monkeypatch: pytest.MonkeyPatch) -> type[FakeKafkaTable]:
-    FakeKafkaTable.instances = []
-    monkeypatch.setattr("ktables.KafkaTable", FakeKafkaTable)
-    return FakeKafkaTable
+def fake_table(monkeypatch: pytest.MonkeyPatch) -> type[FakeGroupedTable]:
+    FakeGroupedTable.instances = []
+    monkeypatch.setattr("ktables.GroupedKafkaTable", FakeGroupedTable)
+    return FakeGroupedTable
 
 
 async def drive(worker: Worker):
     gen = worker._capability_view_resource(None)  # type: ignore[arg-type]
-    table = await anext(gen)
-    return gen, table
+    view = await anext(gen)
+    return gen, view
 
 
 async def close(gen) -> None:
@@ -124,71 +115,51 @@ async def close(gen) -> None:
 
 
 class TestCapabilityViewResource:
-    async def test_opens_table_with_config_and_lifecycle(self, fake_table: type[FakeKafkaTable]) -> None:
-        client = Client.connect("kafka:9092")
-        worker = Worker(client, mcp_discovery=MCPDiscoveryConfig(topic="custom.caps", catchup_timeout=7.0))
-        gen, table = await drive(worker)
+    async def test_opens_view_over_calf_capabilities_with_lifecycle(self, fake_table: type[FakeGroupedTable]) -> None:
+        worker = Worker(Client.connect("kafka:9092"), control_plane=ControlPlaneConfig(catchup_timeout=7.0))
+        gen, view = await drive(worker)
+        table = fake_table.instances[0]
         assert table.started and not table.stopped
-        assert table.kwargs["topic"] == "custom.caps"
+        assert table.kwargs["topic"] == CAPABILITY_TOPIC == "calf.capabilities"  # de-MCP rename
+        assert table.kwargs["model"] is CapabilityRecord
         assert table.kwargs["catchup_timeout"] == 7.0
         assert table.kwargs["ensure_topic"] is False  # provisioning disabled by default
         await close(gen)
         assert table.stopped
 
-    async def test_bootstrap_explicit_override_wins(self, fake_table: type[FakeKafkaTable]) -> None:
-        client = Client.connect("kafka:9092")
-        worker = Worker(client, mcp_discovery=MCPDiscoveryConfig(bootstrap_servers="cp-kafka:9092"))
-        gen, table = await drive(worker)
-        assert table.kwargs["bootstrap_servers"] == "cp-kafka:9092"
+    async def test_bootstrap_explicit_override_wins(self, fake_table: type[FakeGroupedTable]) -> None:
+        worker = Worker(Client.connect("kafka:9092"), control_plane=ControlPlaneConfig(bootstrap_servers="cp-kafka:9092"))
+        gen, _ = await drive(worker)
+        assert fake_table.instances[0].kwargs["bootstrap_servers"] == "cp-kafka:9092"
         await close(gen)
 
-    async def test_bootstrap_derives_from_client(self, fake_table: type[FakeKafkaTable]) -> None:
-        client = Client.connect(["kafka-a:9092", "kafka-b:9092"])
-        worker = Worker(client)
-        gen, table = await drive(worker)
-        assert table.kwargs["bootstrap_servers"] == "kafka-a:9092,kafka-b:9092"
+    async def test_bootstrap_derives_from_client(self, fake_table: type[FakeGroupedTable]) -> None:
+        worker = Worker(Client.connect(["kafka-a:9092", "kafka-b:9092"]))
+        gen, _ = await drive(worker)
+        assert fake_table.instances[0].kwargs["bootstrap_servers"] == "kafka-a:9092,kafka-b:9092"
         await close(gen)
 
-    async def test_bootstrap_falls_back_to_broker_kwargs_list(self, fake_table: type[FakeKafkaTable]) -> None:
-        client = Client.connect("kafka:9092")
-        client._server_urls = None  # hand-built-client scenario
-        worker = Worker(client)
-        gen, table = await drive(worker)
-        assert table.kwargs["bootstrap_servers"] == "kafka:9092"  # joined from broker kwargs
-        await close(gen)
-
-    async def test_bootstrap_falls_back_to_broker_kwargs_str(self, fake_table: type[FakeKafkaTable]) -> None:
-        client = Client.connect("kafka:9092")
-        client._server_urls = None
-        client.broker._connection_kwargs = {"bootstrap_servers": "raw-str:9092"}
-        worker = Worker(client)
-        gen, table = await drive(worker)
-        assert table.kwargs["bootstrap_servers"] == "raw-str:9092"
-        await close(gen)
-
-    async def test_underivable_bootstrap_raises_actionable_error(self, fake_table: type[FakeKafkaTable]) -> None:
+    async def test_underivable_bootstrap_raises_actionable_error(self, fake_table: type[FakeGroupedTable]) -> None:
         client = Client.connect("kafka:9092")
         client._server_urls = None
         client.broker._connection_kwargs = {}
         worker = Worker(client)
-        with pytest.raises(RuntimeError, match="bootstrap_servers"):
+        with pytest.raises(RuntimeError, match="ControlPlaneConfig"):
             await drive(worker)
         assert fake_table.instances == []  # failed before construction
 
-    async def test_ensure_topic_follows_provisioning(self, fake_table: type[FakeKafkaTable]) -> None:
+    async def test_ensure_topic_follows_provisioning(self, fake_table: type[FakeGroupedTable]) -> None:
         from calfkit.provisioning import ProvisioningConfig
 
-        client = Client.connect("kafka:9092", provisioning=ProvisioningConfig(enabled=True))
-        worker = Worker(client)
-        gen, table = await drive(worker)
-        assert table.kwargs["ensure_topic"] is True
+        worker = Worker(Client.connect("kafka:9092", provisioning=ProvisioningConfig(enabled=True)))
+        gen, _ = await drive(worker)
+        assert fake_table.instances[0].kwargs["ensure_topic"] is True
         await close(gen)
 
 
 class TestRegisterHandlersIdempotency:
     def test_second_call_is_a_guarded_no_op(self) -> None:
-        client = Client.connect("kafka:9092")
-        worker = Worker(client)  # zero nodes: registration is broker-free
+        worker = Worker(Client.connect("kafka:9092"))  # zero nodes: registration is broker-free
         worker.register_handlers()
         assert worker._prepared
         worker.register_handlers()  # exercises the already-prepared early return

--- a/tests/test_worker_capability_view.py
+++ b/tests/test_worker_capability_view.py
@@ -74,6 +74,32 @@ class TestCapabilityViewRegistration:
         assert worker._control_plane == ControlPlaneConfig()
 
 
+class TestControlPlaneWriterRegistration:
+    """The writer side: hosting an advertising toolbox auto-wires the publisher + writer."""
+
+    def test_hosting_a_toolbox_registers_the_capability_writer_and_publisher(self) -> None:
+        from calfkit.controlplane.publisher import control_plane_writer_key
+        from calfkit.models.capability import CAPABILITY_TOPIC
+
+        worker = Worker(Client.connect("kafka:9092"), nodes=[make_toolbox()])
+        worker._maybe_register_control_plane()
+        assert control_plane_writer_key(CAPABILITY_TOPIC) in worker_resource_names(worker)
+        publisher = worker._control_plane_publisher
+        assert publisher is not None
+        assert CAPABILITY_TOPIC in [info.topic for _, info in publisher._adverts]
+
+    def test_agent_only_worker_registers_no_capability_writer(self) -> None:
+        from calfkit.controlplane.publisher import control_plane_writer_key
+        from calfkit.models.capability import CAPABILITY_TOPIC
+
+        # An agent declares a tool selector but advertises nothing — only the toolbox
+        # (host) advertises. A worker hosting just the agent wires no control-plane writer.
+        worker = Worker(Client.connect("kafka:9092"), nodes=[make_agent(make_toolbox())])
+        worker._maybe_register_control_plane()
+        assert control_plane_writer_key(CAPABILITY_TOPIC) not in worker_resource_names(worker)
+        assert worker._control_plane_publisher is None
+
+
 class FakeGroupedTable:
     """Stands in for ktables.GroupedKafkaTable; records construction and lifecycle."""
 


### PR DESCRIPTION
Migrates the hand-rolled MCP capability plane onto the generic **control-plane substrate** (#256, ADR-0010/0011), fixing the three confirmed defects and deleting the duplicated machinery. Built TDD; net **−131 LOC**.

**Design:** [`mcp-capability-substrate-migration-plan.md`](docs/designs/mcp-capability-substrate-migration-plan.md) · **ADR-0012** (this PR's decisions).

## Why

The shipped plane carried three defects the substrate exists to fix once for every plane:
- **CRITICAL-1** — flat `toolbox_id` key: a replica's clean tombstone blanks a node still alive on another worker.
- **CRITICAL-3** — one re-stamped `published_at` masks whether the *tool list* is fresh.
- **CRITICAL-4** — the agent never reads the table's `status`/`failure`, so a degraded reader silently serves a frozen view.

## What changed

- **Record** — `CapabilityRecord` is now a `ControlPlaneRecord`: identity (`toolbox_id × worker_id`) is the wire key only; `published_at` splits into inherited `last_heartbeat_at` (liveness) + node-tracked `content_updated_at` (content currency) — CRITICAL-3 fixed in the schema.
- **Write side** — `MCPToolboxNode` drops its writer/heartbeat/tombstone; exposes one `@advertises("calf.capabilities", CapabilityRecord)` factory over a tool cache refreshed at session setup + on `tools/list_changed`. The worker-owned `ControlPlanePublisher` heartbeats + tombstones it **instance-keyed** (CRITICAL-1 fixed).
- **Read side** — the worker opens a `ControlPlaneView[CapabilityRecord]` (collapsed `get()`); it owns staleness + schema-version filtering, so `resolve_capability` shrinks to `view.get()` + bindings and `SelectorResult` drops `stale_seconds`/`skipped_newer_schema`. CRITICAL-4 is **log-only** (warn on degraded/failed, never raise).

## ⚠️ Breaking changes (pre-1.0 clean cut, no shim)

- topic `mcp.capabilities` → `calf.capabilities` (grouped composite key; wire-incompatible).
- `MCPDiscoveryConfig` **deleted**, folded into `ControlPlaneConfig`; `Worker(mcp_discovery=…)` → `Worker(control_plane=…)`. Topic is now fixed in the decorator.
- resource key `calfkit.mcp.capability_view` → `calfkit.controlplane.capability_view`.
- the MCP-selector **`strict` flag** and **`MCPToolResolutionError`** are removed; an unresolved selection always warns + degrades (`include` remains the trust boundary).
- propagation is now **pull** (ADR-0011): a `tools/list_changed` lands at the next heartbeat (≤ `heartbeat_interval`), not instantly.

## Testing

- `make fix` + **`make check` clean** — lint, format, mypy (66 files).
- **Offline: 3141 passed.**
- **Full kafka lane on real Redpanda: 59 passed / 6 pre-existing skips** — incl. new parity + CRITICAL-3 capability integration tests and **all 9 adapted MCP-roundtrip e2e tests** (real MCP subprocesses + full distributed loop; isolated by per-test-unique toolbox names on the fixed topic).

## Docs

ADR-0012; migration plan; three predecessor specs banner'd (their `instances()`/identity-in-value sketch diverged from the shipped collapsed-`get()` substrate); user-facing `docs/mcp-tool-discovery.md` corrected.