### PR TITLE
test: verify the agent's POV of advertised MCP tools matches the capability view

### DIFF
--- a/tests/integration/_roundtrip_helpers.py
+++ b/tests/integration/_roundtrip_helpers.py
@@ -26,6 +26,7 @@ from calfkit._vendor.pydantic_ai.messages import (
     ToolReturnPart,
 )
 from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
+from calfkit._vendor.pydantic_ai.tools import ToolDefinition
 
 #: The text the scripted model emits once it has acted. Reaching it proves the
 #: agent resumed past tool dispatch to a clean finalization.
@@ -57,6 +58,27 @@ def scripted_model(tool_calls: list[ToolCallPart]) -> FunctionModel:
     def _fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         if _has_acted(messages):
             return ModelResponse(parts=[TextPart(FINAL_OUTPUT)])
+        return ModelResponse(parts=list(tool_calls))
+
+    return FunctionModel(_fn)
+
+
+def capturing_model(pov: dict[str, ToolDefinition], tool_calls: list[ToolCallPart]) -> FunctionModel:
+    """Like :func:`scripted_model`, but first records the agent's POV of its tools.
+
+    On the acting turn it captures ``info.function_tools`` — the exact
+    :class:`ToolDefinition`\\ s the agent resolved from the Capability View and presented
+    to the model — into ``pov`` (keyed by name), *then* emits ``tool_calls``. Lets a test
+    assert that what the agent advertised to the model matches what the toolbox advertised
+    on the view (names + schemas) and call one tool drawn from that POV, rather than
+    hardcoding the available surface and assuming the agent saw it.
+    """
+
+    def _fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if _has_acted(messages):
+            return ModelResponse(parts=[TextPart(FINAL_OUTPUT)])
+        pov.clear()
+        pov.update({tool.name: tool for tool in info.function_tools})
         return ModelResponse(parts=list(tool_calls))
 
     return FunctionModel(_fn)

--- a/tests/integration/test_mcp_roundtrip_kafka.py
+++ b/tests/integration/test_mcp_roundtrip_kafka.py
@@ -38,6 +38,7 @@ import os
 import sys
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import pydantic_core
 import pytest
@@ -53,6 +54,7 @@ from calfkit.nodes import Agent
 from calfkit.worker import Worker
 from tests.integration._roundtrip_helpers import (
     FINAL_OUTPUT,
+    capturing_model,
     retry_prompt_texts,
     returns_by_call_id,
     scripted_model,
@@ -577,3 +579,72 @@ async def test_tools_list_changed_grows_the_toolset(kafka_bootstrap: str, topic_
     await toolbox_worker._client.close()
     await enable_worker._client.close()
     await bonus_worker._client.close()
+
+
+# ── Group C: the agent's point of view of its advertised tools ───────────────
+
+
+async def test_agent_pov_matches_advertised_capability_view(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """The agent's POV of its tools IS what the toolbox advertised on the Capability View.
+
+    Instead of hardcoding the available surface, this inspects what the agent actually
+    resolved from the view and handed the model (``AgentInfo.function_tools``), asserts it
+    matches the live ``CapabilityRecord`` on ``calf.capabilities`` by NAME and by SCHEMA,
+    and that a tool drawn from that POV round-trips — proving every advertised tool reaches
+    the model exactly as advertised and is callable on the turn.
+    """
+    agent_id = f"{topic_namespace}-pov-agent"
+    agent_in = f"{topic_namespace}.pov-agent.input"
+    control_plane = _control_plane(kafka_bootstrap)
+    server_name = _server_name(topic_namespace)
+
+    toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
+    pov: dict[str, Any] = {}  # name -> ToolDefinition the agent presented to the model
+    agent = Agent(
+        agent_id,
+        system_prompt="call add",
+        subscribe_topics=agent_in,
+        model_client=capturing_model(pov, [ToolCallPart("add", {"a": 2, "b": 3}, tool_call_id="call-add")]),
+        tools=[toolbox],  # NO include: the agent sees the toolbox's full advertised set
+    )
+
+    advertised: dict[str, Any] = {}  # name -> parameters_json_schema, read straight from the view record
+
+    def _capture_advertised(view: ControlPlaneView[CapabilityRecord]) -> bool:
+        record = view.get(server_name)
+        if record is None:
+            return False
+        advertised.clear()
+        advertised.update({t.name: t.parameters_json_schema for t in record.tools})
+        return True
+
+    driver = Client.connect(kafka_bootstrap)
+    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], control_plane=control_plane)
+    agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
+
+    async with toolbox_worker:
+        await _await_capability(kafka_bootstrap, server_name, timeout=60)
+        # The source of truth the agent reads: what the toolbox advertised on the view.
+        await _await_view(kafka_bootstrap, _capture_advertised, timeout=60, what=f"advertised tools for {server_name!r}")
+        async with agent_worker:
+            result = await driver.execute("add 2 and 3", agent_in, timeout=120)
+
+    # 1) the call drawn from the advertised set round-tripped to a finalized turn
+    assert result.output is not None and FINAL_OUTPUT in result.output
+    assert "5" in _serialized(tool_returns(result.message_history)["add"])
+
+    # 2) the toolbox advertised exactly the server's tool set — all advertised tools present
+    assert set(advertised) == {"add", "echo", "ping", "danger", "domain_error", "enable_bonus"}
+
+    # 3) the agent's POV == the advertised view record, by NAME and by SCHEMA. The agent
+    #    presented to the model exactly what the toolbox advertised — nothing added or dropped.
+    assert pov, "the model never captured the agent's tool POV"
+    assert set(pov) == set(advertised)
+    assert {name: td.parameters_json_schema for name, td in pov.items()} == advertised
+
+    # 4) the called tool reached the model as advertised — its schema carries its real args
+    assert {"a", "b"} <= set(pov["add"].parameters_json_schema.get("properties", {}))
+
+    await driver.close()
+    await toolbox_worker._client.close()
+    await agent_worker._client.close()


### PR DESCRIPTION
Follow-up coverage for the MCP capability → control-plane substrate migration (#260).

## The gap

The MCP roundtrip suite proved a **hardcoded** tool call round-trips the distributed loop, but no test verified — *from the model's point of view* — that the agent actually resolved the advertised tools from the Capability View and presented them **as advertised**. Every scripted model takes `(messages, info: AgentInfo)` and **ignores `info.function_tools`** — the exact `ToolDefinition` set the agent resolved and handed the model. So a test could pass even though it never checked what the agent *saw*; it just asserted a predetermined call came back.

## What this adds

- **`capturing_model(pov, tool_calls)`** (`_roundtrip_helpers.py`): a `FunctionModel` that records `info.function_tools` into `pov` (keyed by name) on its acting turn, then emits the call — so a test can read the agent's POV.
- **`test_agent_pov_matches_advertised_capability_view`** (real broker + offline FunctionModel): hosts the toolbox, reads the **live `CapabilityRecord` on `calf.capabilities`** (what the agent reads), and asserts:
  1. the called tool (drawn from the advertised set) round-trips to a finalized turn (`add → 5`);
  2. the toolbox advertised exactly the server's tool set (all advertised tools present);
  3. **the agent's POV == the advertised view record, by NAME and by SCHEMA (exact)** — the agent presents to the model precisely what the toolbox advertised, nothing added or dropped;
  4. the called tool reached the model with its real arg schema.

This is the truest end-to-end of the migration's headline claim ("the agent resolves the same bindings the toolbox advertised") — the test *sees what the agent sees* (via both the view and `info.function_tools`) and proves they agree, rather than assuming it.

## Testing

`make check` clean (lint + format + mypy). The new test + the full roundtrip suite (**10 passed**) run on real Redpanda. Branched off `main` post-#260-merge.

Refs: #260.