### PR TITLE
docs: MCP: strict Diátaxis cleanup + reference + runnable example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -341,6 +341,56 @@ Passed to the worker/node lifecycle hooks and `@resource` bodies. All three carr
 
 See [Worker lifecycle & embedding](worker-lifecycle.md) for the full lifecycle how-to.
 
+## MCP toolboxes
+
+Host an MCP server's tools as a deployable node and reference them from agents. The toolbox types are imported from `calfkit.mcp`.
+
+| Symbol | Purpose |
+| --- | --- |
+| `MCPToolboxNode` | The deployable host — one per MCP server, placed in `Worker(nodes=[...])`. |
+| `MCPToolbox` | A frozen, identity-only handle to a toolbox by name, placed in an agent's `tools=[...]`. |
+| `StdioServerParameters` | Connection params for a local stdio (subprocess) MCP server. |
+| `StreamableHttpParameters` | Connection params for a Streamable HTTP MCP server. |
+
+### `MCPToolboxNode`
+
+```python
+MCPToolboxNode(
+    name: str,
+    connection_params: StdioServerParameters | StreamableHttpParameters,
+)
+```
+
+Hosts the tools of one MCP server; `name` is the toolbox identity agents reference. `node.select(*, include: Sequence[str] | None = None) -> MCPToolbox` returns a handle to this toolbox, optionally scoped to `include` tool names.
+
+### `MCPToolbox`
+
+```python
+MCPToolbox(name: str, include: tuple[str, ...] | None = None)
+```
+
+A frozen, identity-only handle to a toolbox. `name` must match the hosting `MCPToolboxNode`. `include` pins the tool names the agent may use; `None` exposes all of the toolbox's tools. The handle carries no connection params — passing connection details, or deploying a handle as a node, raises.
+
+### Connection params
+
+| Symbol | Key fields |
+| --- | --- |
+| `StdioServerParameters` | `command: str`, `args: list[str] = []`, `env`, `cwd`, `encoding` |
+| `StreamableHttpParameters` | `url: str`, `headers`, `timeout: float = 30.0`, `auth` |
+
+### `ControlPlaneConfig`
+
+The worker's control-plane configuration (`from calfkit import ControlPlaneConfig`), used by toolbox discovery. Passed as `Worker(control_plane=ControlPlaneConfig(...))`; every field has a default. The control-plane topic name is fixed (`calf.capabilities`).
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `heartbeat_interval` | `float` | `30.0` | Seconds between a toolbox's liveness re-publishes. |
+| `stale_after` | `float \| None` | `None` | Seconds after which an un-refreshed toolbox is hidden from agents; `None` uses the built-in default. |
+| `catchup_timeout` | `float` | `30.0` | Seconds a worker waits at boot to catch up the control-plane view before serving. |
+| `bootstrap_servers` | `str \| None` | `None` | Run the control plane on a separate Kafka cluster; `None` uses the worker's broker. |
+
+See also: [How to give agents MCP tools](mcp-tool-discovery.md).
+
 ## Other public modules
 
 The top-level package re-exports the symbols above. A few public capabilities live in submodules:
@@ -348,7 +398,7 @@ The top-level package re-exports the symbols above. A few public capabilities li
 | Import from | Provides |
 | --- | --- |
 | `calfkit.models` | `ConsumerContext` — the value passed to a `@consumer` function (`output`, `correlation_id`, `deps`, `resources`) — plus the wire/state models (`State`, `Envelope`, `ToolBinding`, …). |
-| `calfkit.mcp` | `MCPToolboxNode`, `MCPToolbox`, `StdioServerParameters`, `StreamableHttpParameters` — `MCPToolboxNode` hosts an MCP server's tools as a deployable node; `MCPToolbox` is the name-only handle agents put in `tools=[...]`. |
+| `calfkit.mcp` | `MCPToolboxNode`, `MCPToolbox`, `StdioServerParameters`, `StreamableHttpParameters` — see [MCP toolboxes](#mcp-toolboxes). |
 | `calfkit.provisioning` | The full topic-provisioning surface: `TopicProvisioner`, `provision_topics`, `topics_for_nodes`, `ProvisionReport`, `StartupTopicEnsurer`, `MissingTopicsError`. |
 | `calfkit.exceptions` | The complete exception set, including `ReplyExpiredError` (raised by `execute` / `start` when a `reply_ttl` elapses), `RegistryConfigError`, and `MissingTopicsError`. |
 

--- a/docs/mcp-tool-discovery.md
+++ b/docs/mcp-tool-discovery.md
@@ -5,6 +5,10 @@ server and reference it from each agent by name. Discovery is automatic and
 cross-process — no wiring, and no bring-up order. (For how it works under the
 hood, see the [design spec](designs/mcp-capability-discovery-spec.md).)
 
+A complete, runnable version of this guide — a toolbox fronting a real MCP server
+plus a separately-deployed agent that uses it by name — lives in
+[`examples/quickstart_mcp/`](../examples/quickstart_mcp/).
+
 ## Deploy a toolbox
 
 Wrap one `MCPToolboxNode` per MCP server in a worker and run it:

--- a/docs/mcp-tool-discovery.md
+++ b/docs/mcp-tool-discovery.md
@@ -33,11 +33,37 @@ change, and re-publishes periodically as a liveness heartbeat (a tool-list chang
 lands on the next heartbeat). If the MCP server is unreachable at startup, the
 worker fails to boot — fix the connection rather than running dark.
 
-## Give the tools to an agent — same or different process
+## Give the tools to an agent
 
-Pass the toolbox object in `tools=[...]`. Passing it never contacts the MCP
-session and does not deploy the toolbox; an agent in another process imports
-the same definition:
+Reference the toolbox **by name** with an `MCPToolbox` handle in `tools=[...]`.
+This is the default pattern: it works whether the agent shares a process with the
+toolbox or runs as a separate deployment, and the agent host never needs the
+toolbox's connection config — secrets stay on the toolbox host.
+
+```python
+from calfkit.mcp import MCPToolbox
+
+agent = Agent(
+    "researcher",
+    subscribe_topics="researcher.input",
+    model_client=model,
+    tools=[MCPToolbox("docs_server")],   # all of the toolbox's tools; scope with include= (below)
+)
+worker = Worker(client, nodes=[agent])   # capability view auto-registers
+```
+
+An `MCPToolbox` is a frozen, identity-only handle: it can never carry connection
+params, and deploying one fails immediately with a pointer to the hosting form.
+The agent's worker detects the declaration and maintains the local capability
+view, gated at boot so the first turn already sees it. Selections re-resolve at
+the start of every agent turn, so a toolbox that comes up later — or changes its
+tools — is picked up on the next turn. No restarts, no bring-up order.
+
+### Pass the toolbox object directly (when the agent shares the definition)
+
+If the agent's process already imports the toolbox definition — the same codebase
+— you can pass the `MCPToolboxNode` object itself instead of a name handle;
+passing it never contacts the MCP session or deploys the toolbox:
 
 ```python
 from my_service.toolboxes import docs   # shared module; deployed elsewhere
@@ -48,44 +74,22 @@ agent = Agent(
     model_client=model,
     tools=[weather_tool, docs],          # all of the toolbox's tools
 )
-worker = Worker(client, nodes=[agent])   # capability view auto-registers
 ```
 
-If the agent host doesn't import the toolbox definition — or must not hold
-its connection config at all (secrets stay on the toolbox host) — reference
-the toolbox **by name** instead:
-
-```python
-from calfkit.mcp import MCPToolbox
-
-agent = Agent(
-    "researcher",
-    subscribe_topics="researcher.input",
-    model_client=model,
-    tools=[MCPToolbox("docs_server", include=("search",))],
-)
-```
-
-An `MCPToolbox` is a frozen, identity-only handle: it can never carry connection
-params, and deploying one fails immediately with a pointer to the hosting
-form. (`MCPToolboxNode.select(...)` returns the same type.)
-
-The agent's worker detects the declaration and maintains the local capability
-view, gated at boot so the first turn already sees it. Selections re-resolve
-at the start of every agent turn, so a toolbox that comes up later — or
-changes its tools — is picked up on the next turn. No restarts, no bring-up
-order.
+Both forms resolve through the same capability view; prefer the name handle
+unless you specifically want to share the definition.
 
 ## Scope the selection
 
 ```python
-tools=[docs.select(include=["search", "fetch"])]      # only these tools
+tools=[MCPToolbox("docs_server", include=("search", "fetch"))]   # only these tools
 ```
 
 Use `include` to pin the exact tool names the agent may see — a server that
-starts advertising new tools cannot enlarge the agent's surface. An unresolved
-selection (the toolbox is offline, or a requested tool isn't advertised) logs a
-warning and the turn runs with whatever resolved.
+starts advertising new tools cannot enlarge the agent's surface. (For the object
+form, `docs.select(include=("search", "fetch"))` returns the same handle.) An
+unresolved selection (the toolbox is offline, or a requested tool isn't
+advertised) logs a warning and the turn runs with whatever resolved.
 
 If a toolbox tool name collides with a locally configured tool, the local tool
 wins and an error is logged.

--- a/docs/mcp-tool-discovery.md
+++ b/docs/mcp-tool-discovery.md
@@ -1,20 +1,18 @@
 # How to give agents MCP tools
 
-To let agents call tools served by an MCP server, deploy one `MCPToolboxNode`
-per server and give each agent a name-only `MCPToolbox` handle in `tools=[...]`
-— like a tool node. Discovery is automatic and cross-process: the toolbox advertises
-its tools on a control-plane topic, and each agent's worker keeps a local view
-of it. There is no discovery configuration in the happy path. (For why it
-works this way, see the
-[design spec](designs/mcp-capability-discovery-spec.md).)
+To let agents call tools served by an MCP server, deploy one `MCPToolboxNode` per
+server and reference it from each agent by name. Discovery is automatic and
+cross-process — no wiring, and no bring-up order. (For how it works under the
+hood, see the [design spec](designs/mcp-capability-discovery-spec.md).)
 
 ## Deploy a toolbox
 
+Wrap one `MCPToolboxNode` per MCP server in a worker and run it:
+
 ```python
-from calfkit.client.client import Client
-from calfkit.mcp.mcp_toolbox import MCPToolboxNode
-from calfkit.mcp.mcp_transport import StreamableHttpParameters
-from calfkit.worker.worker import Worker
+from calfkit.client import Client
+from calfkit.mcp import MCPToolboxNode, StreamableHttpParameters
+from calfkit.worker import Worker
 
 docs = MCPToolboxNode(
     "docs_server",
@@ -26,12 +24,10 @@ worker = Worker(client, nodes=[docs])
 await worker.run()
 ```
 
-On startup the toolbox connects to the MCP server and lists its tools; its host
-worker then advertises them on the capability control-plane topic
-(`calf.capabilities`), refreshes them whenever the server reports a tool-list
-change, and re-publishes periodically as a liveness heartbeat (a tool-list change
-lands on the next heartbeat). If the MCP server is unreachable at startup, the
-worker fails to boot — fix the connection rather than running dark.
+Connect over HTTP with `StreamableHttpParameters`, or spawn a local stdio server
+with `StdioServerParameters` (see the [reference](api.md#mcp-toolboxes)). If the
+MCP server is unreachable at startup, the toolbox fails to boot — fix the
+connection rather than running dark.
 
 ## Give the tools to an agent
 
@@ -49,21 +45,18 @@ agent = Agent(
     model_client=model,
     tools=[MCPToolbox("docs_server")],   # all of the toolbox's tools; scope with include= (below)
 )
-worker = Worker(client, nodes=[agent])   # capability view auto-registers
+worker = Worker(client, nodes=[agent])
 ```
 
-An `MCPToolbox` is a frozen, identity-only handle: it can never carry connection
-params, and deploying one fails immediately with a pointer to the hosting form.
-The agent's worker detects the declaration and maintains the local capability
-view, gated at boot so the first turn already sees it. Selections re-resolve at
-the start of every agent turn, so a toolbox that comes up later — or changes its
-tools — is picked up on the next turn. No restarts, no bring-up order.
+An `MCPToolbox` is an identity-only handle: it carries no connection config, and
+deploying one fails immediately with a pointer to the hosting form. A toolbox
+that comes up later — or changes its tools — is picked up automatically on the
+agent's next turn. No restarts, no bring-up order.
 
 ### Pass the toolbox object directly (when the agent shares the definition)
 
 If the agent's process already imports the toolbox definition — the same codebase
-— you can pass the `MCPToolboxNode` object itself instead of a name handle;
-passing it never contacts the MCP session or deploys the toolbox:
+— you can pass the `MCPToolboxNode` object itself instead of a name handle:
 
 ```python
 from my_service.toolboxes import docs   # shared module; deployed elsewhere
@@ -76,8 +69,8 @@ agent = Agent(
 )
 ```
 
-Both forms resolve through the same capability view; prefer the name handle
-unless you specifically want to share the definition.
+Both forms behave the same; prefer the name handle unless you specifically want
+to share the definition.
 
 ## Scope the selection
 
@@ -86,33 +79,26 @@ tools=[MCPToolbox("docs_server", include=("search", "fetch"))]   # only these to
 ```
 
 Use `include` to pin the exact tool names the agent may see — a server that
-starts advertising new tools cannot enlarge the agent's surface. (For the object
-form, `docs.select(include=("search", "fetch"))` returns the same handle.) An
-unresolved selection (the toolbox is offline, or a requested tool isn't
-advertised) logs a warning and the turn runs with whatever resolved.
+starts offering new tools cannot enlarge the agent's surface. (For the object
+form, `docs.select(include=("search", "fetch"))` returns the same handle.) If a
+requested tool isn't available — the toolbox is offline, or doesn't offer it —
+the turn proceeds with whatever tools are available and logs a warning.
 
 If a toolbox tool name collides with a locally configured tool, the local tool
 wins and an error is logged.
 
 ## Handle outages and topic creation
 
-- A **crashed** toolbox stops heartbeating; its advertisement goes **stale**
-  after roughly three heartbeat intervals, and the view then hides it — so
-  agents stop being offered its tools (the selection degrades) rather than
-  dispatching to a dead toolbox. A **clean shutdown** removes the advertisement
-  immediately. Either way the toolbox reappears on the next turn once it is back
-  and heartbeating.
-- With provisioning enabled (dev/CI), toolbox and agent workers both create
-  the compacted capability topic idempotently — bring up either side first.
-  In production, create the topic out-of-band (`cleanup.policy=compact`,
-  RF≥3) like any governed topic; see
-  [topic provisioning](topic-provisioning.md).
+- If a toolbox **crashes**, agents stop being offered its tools shortly after, so
+  they degrade rather than dispatch to a dead toolbox; a **clean shutdown** drops
+  them immediately. Either way the toolbox reappears automatically once it's back.
+- In dev/CI with provisioning enabled, the control-plane topic is created for you
+  — bring up either side first. In production, create it out-of-band as a
+  compacted topic (`calf.capabilities`, `cleanup.policy=compact`, RF≥3) like any
+  governed topic; see [topic provisioning](topic-provisioning.md).
 
 ## Tune it (optional)
 
-Every knob has a working default, and there is one config surface:
-`Worker(..., control_plane=ControlPlaneConfig(...))` — the boot catch-up
-timeout, the heartbeat interval, a staleness threshold, and a `bootstrap_servers`
-override for running the control plane on a separate Kafka cluster. The
-capability topic name is fixed (`calf.capabilities`). Toolboxes and agents
-inherit the config of the worker that hosts them.
+The control plane's timings and an alternate Kafka cluster are set with
+`Worker(control_plane=ControlPlaneConfig(...))` — every setting has a working
+default. See the [`ControlPlaneConfig` reference](api.md#mcp-toolboxes).

--- a/examples/quickstart_mcp/README.md
+++ b/examples/quickstart_mcp/README.md
@@ -1,0 +1,53 @@
+# MCP toolbox quickstart
+
+Give an agent tools served by an [MCP](https://modelcontextprotocol.io) server —
+deployed as its own node and used by a **separately-deployed agent that
+references it by name**. This is the end-to-end version of the
+[How to give agents MCP tools](../../docs/mcp-tool-discovery.md) guide.
+
+The toolbox here fronts the official **`fetch`** reference server, giving the
+agent one tool — `fetch` (URL → markdown) — so it can read the live web.
+
+## What's here
+
+| File | Role |
+| --- | --- |
+| `fetch_toolbox.py` | The toolbox node — spawns `uvx mcp-server-fetch` and advertises its tools on the control plane. |
+| `research_agent.py` | An agent that references the toolbox **by name** (`MCPToolbox("fetcher")`) — no shared import, no connection config. |
+| `ask.py` | Sends the agent a question that needs a web fetch. |
+
+## Prerequisites
+
+- A running [Calfkit broker](../../README.md#start-a-calfkit-broker) on `localhost:9092`.
+- The CLI extra: `pip install "calfkit[cli]"`.
+- [`uv`](https://docs.astral.sh/uv/) on your PATH — the toolbox runs the fetch
+  server with `uvx`, which fetches it on first use (no manual install).
+- An LLM API key: `export OPENAI_API_KEY=sk-...`.
+
+## Run it (three terminals)
+
+```console
+# 1) the toolbox node (spawns the MCP fetch server)
+$ calfkit run fetch_toolbox:fetcher
+
+# 2) the agent — references the toolbox by name
+$ calfkit run research_agent:agent
+
+# 3) ask it something that needs the web
+$ python ask.py
+```
+
+The agent's worker discovers the toolbox's `fetch` tool over the control plane
+and calls it to read the page. Bring the toolbox and agent up in any order —
+selections re-resolve every turn.
+
+## Offline alternative: the `time` server
+
+No network for the fetch demo? Swap the toolbox to the official `time` server
+(current time + timezone conversion) by changing one line in `fetch_toolbox.py`:
+
+```python
+connection_params=StdioServerParameters(command="uvx", args=["mcp-server-time"]),
+```
+
+then ask something like `"What time is it in Asia/Tokyo right now?"`.

--- a/examples/quickstart_mcp/ask.py
+++ b/examples/quickstart_mcp/ask.py
@@ -1,0 +1,21 @@
+"""Ask the researcher agent to read and summarize a page.
+
+Run it with:  python ask.py
+"""
+
+import asyncio
+
+from calfkit.client import Client
+
+
+async def main() -> None:
+    async with Client.connect("localhost:9092") as client:
+        result = await client.execute(
+            "Summarize https://modelcontextprotocol.io/introduction in 3 bullet points.",
+            "researcher.input",  # the topic the researcher agent subscribes to
+        )
+        print(f"Researcher: {result.output}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/quickstart_mcp/fetch_toolbox.py
+++ b/examples/quickstart_mcp/fetch_toolbox.py
@@ -1,0 +1,19 @@
+"""Deploy a toolbox node that fronts the official ``fetch`` MCP server.
+
+On startup the toolbox spawns ``uvx mcp-server-fetch`` as a subprocess (stdio),
+lists its tools, and advertises them on the capability control plane so any agent
+in the cluster can use them by name. Agents never speak MCP themselves — the
+toolbox is the cluster's MCP client.
+
+Prerequisites: a running broker, and ``uv`` on your PATH (for ``uvx``).
+
+Run it with:  calfkit run fetch_toolbox:fetcher
+"""
+
+from calfkit.mcp import MCPToolboxNode, StdioServerParameters
+
+# The toolbox node manages the MCP server's lifecycle for you (spawn + connect).
+fetcher = MCPToolboxNode(
+    "fetcher",
+    connection_params=StdioServerParameters(command="uvx", args=["mcp-server-fetch"]),
+)

--- a/examples/quickstart_mcp/research_agent.py
+++ b/examples/quickstart_mcp/research_agent.py
@@ -1,0 +1,24 @@
+"""Deploy an agent that uses the fetch toolbox — by name, in a separate process.
+
+This agent never imports the toolbox definition or its connection config; it
+references the toolbox with an identity-only ``MCPToolbox`` handle. The agent's
+worker discovers the toolbox's tools over the capability control plane and
+re-resolves them every turn, so bring-up order does not matter.
+
+Prerequisites: a running broker, and ``export OPENAI_API_KEY=sk-...``.
+
+Run it with:  calfkit run research_agent:agent
+"""
+
+from calfkit.mcp import MCPToolbox
+from calfkit.nodes import Agent
+from calfkit.providers import OpenAIResponsesModelClient
+
+agent = Agent(
+    "researcher",
+    system_prompt=("You answer questions by fetching and reading web pages with your fetch tool. Always cite the URL you read."),
+    subscribe_topics="researcher.input",
+    model_client=OpenAIResponsesModelClient(model_name="gpt-5.4-nano"),
+    # Reference the toolbox by name; `include` pins the exact tool we expect.
+    tools=[MCPToolbox("fetcher", include=("fetch",))],
+)


### PR DESCRIPTION
## Summary

Reworks calfkit's MCP docs to follow Diátaxis strictly, and adds a runnable end-to-end example.

### How-to (`docs/mcp-tool-discovery.md`)
- **Name-only handle is the default.** `MCPToolbox("...")` works whether the agent shares a process with the toolbox or is a separate deployment, and keeps connection config off the agent host — so it leads. The shared-definition object import is a smaller subsection; "Scope the selection" uses the handle form.
- **Aggressively pruned of internal wiring.** Removed the advertise / heartbeat / capability-view / staleness / re-resolve mechanics — the how-to now covers only what the user *does* and the user-facing outcomes, and delegates "how it works" to the design spec. Clean public import paths throughout.

### Reference (`docs/api.md`)
- New **"MCP toolboxes"** section: `MCPToolboxNode`, `MCPToolbox`, the stdio/HTTP connection params, and `ControlPlaneConfig` (the tuning knobs relocated out of the how-to's "Tune it"). The `calfkit.mcp` roll-up row points to it.

### Example (`examples/quickstart_mcp/`)
A runnable demonstration of the recommended pattern with a *real* MCP server:
- `fetch_toolbox.py` — a toolbox node fronting the official `fetch` server (via `uvx mcp-server-fetch`, stdio).
- `research_agent.py` — a separately-deployed agent referencing it by name.
- `ask.py` + `README.md` — the three-terminal run, with a `time`-server offline fallback.

## Run it

```console
$ calfkit run fetch_toolbox:fetcher
$ calfkit run research_agent:agent
$ python ask.py
```

## Verification
- `make check` green (lint/format/mypy, 66 files).
- Example modules import/construct; **`uvx mcp-server-fetch` launches over stdio and advertises the `fetch` tool**.
- The full cluster run (agent calling the tool) needs a live broker + `OPENAI_API_KEY`.

Docs + example only; no library code changes.
