### PR TITLE
feat: runtime tool discoverability

### DIFF
--- a/calfkit/__init__.py
+++ b/calfkit/__init__.py
@@ -4,7 +4,7 @@ from calfkit.client import Client, InvocationHandle, InvocationResult
 from calfkit.controlplane import ControlPlaneConfig, ControlPlaneRecord, ControlPlaneStamp, ControlPlaneView, advertises
 from calfkit.exceptions import DeserializationError, LifecycleConfigError, NodeFaultError
 from calfkit.models import ErrorReport, FaultTypes, ToolContext
-from calfkit.nodes import Agent, BaseNodeDef, ConsumerFn, ConsumerNode, NodeDef, ToolNodeDef, agent_tool, consumer
+from calfkit.nodes import Agent, BaseNodeDef, ConsumerFn, ConsumerNode, NodeDef, ToolNodeDef, Tools, agent_tool, consumer
 from calfkit.providers import AnthropicModelClient, OpenAIModelClient, OpenAIResponsesModelClient
 from calfkit.provisioning import ProvisioningConfig
 from calfkit.worker import LifecycleContext, ResourceSetupContext, ServingContext, Worker
@@ -27,6 +27,7 @@ __all__ = [
     "ConsumerNode",
     "NodeDef",
     "ToolNodeDef",
+    "Tools",
     "agent_tool",
     "consumer",
     # providers

--- a/calfkit/controlplane/advert.py
+++ b/calfkit/controlplane/advert.py
@@ -57,8 +57,8 @@ def advertises(topic: str, *, record: type[ControlPlaneRecord]) -> Callable[[_Me
     :meth:`AdvertRegistryMixin.__init_subclass__` when the owning class is built.
 
     The decorated method is a *content factory*: it takes a **bare**
-    :class:`~calfkit.controlplane.records.ControlPlaneStamp` (the three worker-stamped
-    boot/liveness fields) and returns a fully-formed ``record`` instance —
+    :class:`~calfkit.controlplane.records.ControlPlaneStamp` (the worker-stamped
+    boot/liveness/cadence/kind fields) and returns a fully-formed ``record`` instance —
     typically ``record(**stamp.model_dump(), <content>)``. Node identity is the wire
     key, never in the record value, so there is nothing for the factory to get wrong.
     Splat the stamp, never a full record: because ``ControlPlaneRecord`` *is-a*

--- a/calfkit/controlplane/publisher.py
+++ b/calfkit/controlplane/publisher.py
@@ -121,6 +121,7 @@ class ControlPlanePublisher:
             started_at=self._started_at,
             last_heartbeat_at=now,
             heartbeat_interval=self._config.heartbeat_interval,
+            node_kind=node._node_kind,  # over-pull guard basis; the worker knows each hosted node's kind
         )
         record = getattr(node, info.name)(stamp)  # opaque ControlPlaneRecord; identity is the wire key
         await writer.set(node.node_id, self._worker_id, record)

--- a/calfkit/controlplane/records.py
+++ b/calfkit/controlplane/records.py
@@ -14,13 +14,17 @@ from pydantic import AwareDatetime, BaseModel, ConfigDict
 class ControlPlaneStamp(BaseModel):
     """The worker-stamped per-instance fields, spread into every record by the publisher.
 
-    Boot time + liveness + the writer's cadence — everything the *worker* (not the node)
-    owns and stamps on each tick. Node identity (``node_id`` × ``worker_id``) is the wire
-    **key**, never duplicated here. Frozen: built fresh per tick, never mutated.
+    Boot time + liveness + the writer's cadence + the node's kind — everything the *worker*
+    stamps on each tick. Node identity (``node_id`` × ``worker_id``) is the wire **key**, never
+    duplicated here. Frozen: built fresh per tick, never mutated.
 
     ``heartbeat_interval`` is the writer's cadence, carried on the wire so any reader
     (including a config-less out-of-process one) can judge staleness against the writer's
-    interval rather than its own config (spec §9).
+    interval rather than its own config (spec §9). ``node_kind`` is the node's own
+    ``_node_kind``, stamped by the worker; it lets a reader filter by advertiser kind (a tool
+    selector must not bind a toolbox record) and observe heterogeneous-owner ``node_id``
+    collisions. It is **required** (no default): adding it is a breaking wire change, so the
+    control-plane topic is recreated on upgrade.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -28,6 +32,7 @@ class ControlPlaneStamp(BaseModel):
     started_at: AwareDatetime  # this instance's boot time -> uptime / restart detection
     last_heartbeat_at: AwareDatetime  # liveness basis; refreshed every heartbeat tick
     heartbeat_interval: float  # the writer's cadence (seconds)
+    node_kind: str  # the node's kind ("tool"/"toolbox"/"agent"/...), stamped from BaseNodeDef._node_kind
 
 
 class ControlPlaneRecord(ControlPlaneStamp):

--- a/calfkit/controlplane/view.py
+++ b/calfkit/controlplane/view.py
@@ -81,6 +81,7 @@ class ControlPlaneView(Generic[R]):
         self._reader_version: int = field.default
         self._stale_after = stale_after
         self._logged_skips: set[tuple[str, str, int]] = set()  # (node, worker, version) already warned about
+        self._logged_mixed_kinds: set[tuple[str, frozenset[str]]] = set()  # (node, kind-set) already warned about
 
     # -- collapsed, liveness-aware reads -------------------------------------
 
@@ -120,6 +121,7 @@ class ControlPlaneView(Generic[R]):
             if (now - record.last_heartbeat_at).total_seconds() > threshold:
                 continue  # stale (spec §9)
             live[worker_id] = record
+        self._warn_if_mixed_kind(node_id, live)
         return live
 
     def _log_schema_skip(self, node_id: str, worker_id: str, schema_version: int) -> None:
@@ -141,6 +143,32 @@ class ControlPlaneView(Generic[R]):
             worker_id,
             schema_version,
             self._reader_version,
+        )
+
+    def _warn_if_mixed_kind(self, node_id: str, live: dict[str, R]) -> None:
+        """Warn once per ``(node, kind-set)`` when one node_id holds live members of differing kinds (spec C1/L14).
+
+        A heterogeneous-owner collision — two advertisers of *different* ``node_kind`` sharing a
+        ``node_id`` — would flap the collapsed view between owners tick to tick. It is a facet of
+        the global ``node_id``-uniqueness contract (documented, not policed), surfaced here for
+        observability. **Cross-kind only**: same-kind/different-content collisions are invisible to
+        the view (it does not compare content) and rely on that contract alone. Dedup keeps this off
+        the read hot-path; a changed kind-set re-warns and it self-clears once the collision resolves.
+        """
+        if len(live) < 2:
+            return  # the common case (single instance) — nothing to compare
+        kinds = frozenset(record.node_kind for record in live.values())
+        if len(kinds) < 2:
+            return  # same-kind (benign replicas)
+        key = (node_id, kinds)
+        if key in self._logged_mixed_kinds:
+            return
+        self._logged_mixed_kinds.add(key)
+        logger.warning(
+            "control-plane view: node=%s has live members of differing node_kind=%s "
+            "(duplicate node_id across owner kinds; resolve the identity collision)",
+            node_id,
+            sorted(kinds),
         )
 
     # -- health passthrough (closes frozen-view blindness, spec §9) ----------

--- a/calfkit/mcp/mcp_toolbox.py
+++ b/calfkit/mcp/mcp_toolbox.py
@@ -244,4 +244,4 @@ class MCPToolbox:
             object.__setattr__(self, "include", tuple(self.include))
 
     def resolve_tools(self, view: CapabilityLookup) -> SelectorResult:
-        return resolve_capability(view, self.name, include=self.include)
+        return resolve_capability(view, self.name, include=self.include, expected_kind="toolbox")

--- a/calfkit/mcp/mcp_toolbox.py
+++ b/calfkit/mcp/mcp_toolbox.py
@@ -135,7 +135,7 @@ class MCPToolboxNode(BaseNodeDef):
 
         Reads the cached tool list — NEVER re-lists inline (this runs on the
         shared heartbeat loop). Splat the bare ``stamp`` (boot + liveness +
-        cadence); identity (``toolbox_id`` × ``worker_id``) is the wire key, not
+        cadence + kind); identity (``toolbox_id`` × ``worker_id``) is the wire key, not
         carried in the value.
         """
         if self._last_tools is None or self._tools_changed_at is None:

--- a/calfkit/models/capability.py
+++ b/calfkit/models/capability.py
@@ -1,11 +1,11 @@
 """Capability control-plane wire model (spec §3.2).
 
-A :class:`CapabilityRecord` is one MCP Toolbox instance's advertisement on the
-capability control-plane topic: dispatch topic and tool definitions, keyed on the
-wire by ``toolbox_id`` × ``worker_id`` (the control-plane instance key, held by the
-substrate — never in the value). Records are calfkit-owned models — never the
-vendored ``ToolDefinition`` — because compacted records outlive deploys, so the
-wire shape must not move when the vendored library does.
+A :class:`CapabilityRecord` is one advertiser instance's advertisement on the
+capability control-plane topic — an MCP toolbox or a function tool node: dispatch
+topic and tool definitions, keyed on the wire by ``node_id`` × ``worker_id`` (the
+control-plane instance key, held by the substrate — never in the value). Records are
+calfkit-owned models — never the vendored ``ToolDefinition`` — because compacted
+records outlive deploys, so the wire shape must not move when the vendored library does.
 
 Reader policy: tolerant (unknown fields ignored — a newer writer may add fields).
 Staleness and newer-``schema_version`` filtering are owned by the reader's
@@ -46,25 +46,25 @@ class CapabilityToolDef(BaseModel):
 
 
 class CapabilityRecord(ControlPlaneRecord):
-    """One toolbox instance's current advertisement on the capability control plane.
+    """One advertiser instance's current advertisement on the capability control plane.
 
-    A :class:`~calfkit.controlplane.ControlPlaneRecord` (identity ``toolbox_id`` ×
+    A :class:`~calfkit.controlplane.ControlPlaneRecord` (identity ``node_id`` ×
     ``worker_id`` is the wire key; the worker stamps ``started_at`` /
-    ``last_heartbeat_at`` / ``heartbeat_interval``) plus the capability content: the
-    dispatch topic and the tool list. ``content_updated_at`` advances only when
-    ``tools`` actually changes — separate from the liveness heartbeat — so liveness
+    ``last_heartbeat_at`` / ``heartbeat_interval`` / ``node_kind``) plus the capability
+    content: the dispatch topic and the tool list. ``content_updated_at`` advances only
+    when ``tools`` actually changes — separate from the liveness heartbeat — so liveness
     and content currency stay distinct. It is **advisory**: the substrate cannot
     enforce its monotonicity (the writing node owns the contract; a hand-rolled
     factory could pass ``now()``), and no production reader gates on it yet — it is
     wire surface for future ops/observability consumers.
 
-    **Precondition for the collapsed view:** all replicas of one toolbox (same
-    ``toolbox_id``) must advertise *equivalent* content. The view collapses replicas to
-    one record by most-recent heartbeat — it does not merge tool sets — so two replicas
-    with divergent tool lists would flap the agent's visible surface tick-to-tick. The
-    dispatch topic is name-derived and identical across replicas, so routing is never
-    wrong; only tool *visibility* would flap. Keep a toolbox's replicas pointed at the
-    same server / tool set.
+    **Precondition for the collapsed view:** all replicas of one advertiser (same
+    ``node_id``) must advertise *equivalent* content. The view collapses replicas to one
+    record by most-recent heartbeat — it does not merge tool sets — so two replicas with
+    divergent tool lists would flap the agent's visible surface tick-to-tick. The dispatch
+    topic is name-derived and identical across replicas, so routing is never wrong; only
+    tool *visibility* would flap. Keep an advertiser's replicas pointed at the same tool
+    set — trivially true for a function tool node (its schema is static).
 
     Inherits the base's tolerant, frozen ``model_config`` (``extra="ignore"``); the
     value object is rebuilt per heartbeat tick, never mutated.
@@ -79,8 +79,9 @@ class CapabilityRecord(ControlPlaneRecord):
 def record_to_bindings(record: CapabilityRecord) -> list[ToolBinding]:
     """Expand a record into validator-less :class:`ToolBinding`s.
 
-    Wire-crossing tools dispatch unvalidated (the schema-only carve-out): the
-    toolbox's MCP server is the argument validator of record.
+    Wire-crossing tools dispatch unvalidated (the schema-only carve-out): the advertiser
+    validates arguments on receipt — the toolbox's MCP server, or the tool node's own
+    function schema.
     """
     return [
         ToolBinding(
@@ -102,7 +103,7 @@ is published to hosted nodes."""
 
 
 class CapabilityLookup(Protocol):
-    """The minimal read surface the resolver needs: ``get(toolbox_id)``.
+    """The minimal read surface the resolver needs: ``get(target_id)``.
 
     Satisfied by a ``ControlPlaneView[CapabilityRecord]`` (production) and by a
     plain ``dict`` (tests), so the agent layer needs no ktables import. The view
@@ -110,40 +111,46 @@ class CapabilityLookup(Protocol):
     and supported.
     """
 
-    def get(self, toolbox_id: str) -> CapabilityRecord | None: ...
+    def get(self, target_id: str) -> CapabilityRecord | None: ...
 
 
 def resolve_capability(
     view: CapabilityLookup,
-    toolbox_id: str,
+    target_id: str,
     *,
     include: tuple[str, ...] | None = None,
+    expected_kind: str | None = None,
 ) -> SelectorResult:
-    """Resolve ``toolbox_id`` (optionally filtered) against the Capability View.
+    """Resolve ``target_id`` (optionally filtered) against the capability view.
 
-    Public API: this is the resolution kernel behind ``MCPToolbox`` and
-    ``MCPToolboxNode.resolve_tools``; custom ``ToolSelector`` implementations may
-    call it directly. The view owns staleness + schema-version filtering, so this
-    only maps a present record to bindings.
+    Public API: this is the resolution kernel behind ``MCPToolbox`` and ``Tools``;
+    custom ``ToolSelector`` implementations may call it directly. The view owns
+    staleness + schema-version filtering, so this only maps a present record to bindings.
 
-    Never raises on bad records: the tolerant reader admits shapes that fail
-    binding expansion (e.g. empty ``dispatch_topic``); those surface as
-    ``invalid_record`` so a poisoned advertisement cannot crash a turn.
+    ``expected_kind`` is the over-pull guard: when given, a present record whose
+    ``node_kind`` differs (e.g. a ``Tools`` selector hitting a toolbox record, or vice
+    versa) is rejected as ``wrong_kind_targets`` rather than bound.
+
+    Never raises on bad records: the tolerant reader admits shapes that fail binding
+    expansion (e.g. empty ``dispatch_topic``); those surface as ``invalid_targets`` so a
+    poisoned advertisement cannot crash a turn.
     """
-    record = view.get(toolbox_id)
+    record = view.get(target_id)
     if record is None:
-        return SelectorResult(toolbox_id=toolbox_id, missing_toolbox=True)
+        return SelectorResult(missing_targets=(target_id,))
+    if expected_kind is not None and record.node_kind != expected_kind:
+        return SelectorResult(wrong_kind_targets=(target_id,))
     try:
         bindings = record_to_bindings(record)
     except ValidationError:
         # The one tolerant-reader bad-data path: an empty dispatch_topic fails
-        # ToolBinding's min_length. A poisoned advert degrades (invalid_record),
+        # ToolBinding's min_length. A poisoned advert degrades (invalid_targets),
         # not crashes the turn. A NON-validation error here is a logic bug — let
         # it propagate (fail loud) rather than masking it as bad wire data.
-        return SelectorResult(toolbox_id=toolbox_id, invalid_record=True)
-    missing: tuple[str, ...] = ()
+        return SelectorResult(invalid_targets=(target_id,))
+    missing_tools: tuple[str, ...] = ()
     if include is not None:
         wanted = set(include)
         bindings = [b for b in bindings if b.name in wanted]
-        missing = tuple(name for name in include if name not in {b.name for b in bindings})
-    return SelectorResult(toolbox_id=toolbox_id, bindings=bindings, missing_tools=missing)
+        missing_tools = tuple(name for name in include if name not in {b.name for b in bindings})
+    return SelectorResult(bindings=tuple(bindings), missing_tools=missing_tools)

--- a/calfkit/models/capability.py
+++ b/calfkit/models/capability.py
@@ -29,7 +29,8 @@ CAPABILITY_SCHEMA_VERSION = 1
 wire changes; additive fields ride on the tolerant reader instead."""
 
 CAPABILITY_TOPIC = "calf.capabilities"
-"""The cluster-wide compacted control-plane topic toolboxes advertise to.
+"""The cluster-wide compacted control-plane topic capability advertisers advertise to —
+both MCP toolboxes and function tool nodes.
 
 A control-plane topic (not MCP-specific transport): one record schema per topic.
 Both the ``@advertises`` factory and the reader's ``ControlPlaneView`` bind to it."""

--- a/calfkit/models/tool_dispatch.py
+++ b/calfkit/models/tool_dispatch.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -70,27 +70,30 @@ class ToolProvider(Protocol):
 
 @dataclass(frozen=True)
 class SelectorResult:
-    """Outcome of resolving one MCP tool selector against the Capability View.
+    """Outcome of resolving one tool selector against the capability view.
 
-    Carries the bindings plus structured diagnostics so the agent owns the
-    warn/degrade policy in one place and tests assert on data, not log text.
+    Cardinality-neutral: a selector may resolve one target (a tool node), one target
+    with many tools (an MCP toolbox), or many targets (a ``Tools`` handle). Carries the
+    bindings plus structured diagnostics so the agent owns the warn/degrade policy in one
+    place and tests assert on data, not log text. A frozen value object — every field is
+    immutable (``bindings`` is a tuple), so equal results compare and hash equal.
 
-    Staleness and schema-version filtering are the :class:`ControlPlaneView`'s
-    job now (it hides stale/newer-schema records), so the only ways a selection
-    is ``unresolved`` are a missing toolbox, missing requested tools, or a
-    record that fails binding expansion.
+    The :class:`ControlPlaneView` owns staleness + schema-version filtering, so the only
+    ways a selection is ``unresolved`` are: an absent target, an ``include``-pinned tool
+    missing from a present record (MCP ``include`` only), a present-but-unexpandable
+    record, or a present record of the wrong node kind (the over-pull guard).
     """
 
-    toolbox_id: str
-    bindings: list[ToolBinding] = field(default_factory=list)
-    missing_toolbox: bool = False
-    missing_tools: tuple[str, ...] = ()
-    invalid_record: bool = False
+    bindings: tuple[ToolBinding, ...] = ()
+    missing_targets: tuple[str, ...] = ()  # requested identities with no live record
+    missing_tools: tuple[str, ...] = ()  # include-pinned tool names absent from a present record (MCP include only)
+    invalid_targets: tuple[str, ...] = ()  # identities whose record was present but failed binding expansion
+    wrong_kind_targets: tuple[str, ...] = ()  # identities present but of the wrong node_kind for this selector
 
     @property
     def unresolved(self) -> bool:
         """True when anything the selector asked for could not be delivered."""
-        return self.missing_toolbox or bool(self.missing_tools) or self.invalid_record
+        return bool(self.missing_targets or self.missing_tools or self.invalid_targets or self.wrong_kind_targets)
 
 
 @runtime_checkable

--- a/calfkit/models/tool_dispatch.py
+++ b/calfkit/models/tool_dispatch.py
@@ -101,12 +101,13 @@ class ToolSelector(Protocol):
     """Deferred tool declaration, resolved per turn against the Capability View.
 
     Implemented by :class:`~calfkit.mcp.mcp_toolbox.MCPToolbox` (the handle
-    agents hold, including ``select()`` results) and by the hosting
-    :class:`~calfkit.mcp.mcp_toolbox.MCPToolboxNode`, which delegates to it:
-    passing either to an agent extracts only a lookup key — no session contact,
-    no deployment. The ``view`` is a :class:`~calfkit.models.capability.CapabilityLookup`
-    (anything with ``get(toolbox_id) -> CapabilityRecord | None``), so the agent layer
-    needs no ktables import and tests can use plain dicts.
+    agents hold, including ``select()`` results) and the hosting
+    :class:`~calfkit.mcp.mcp_toolbox.MCPToolboxNode` that delegates to it, and by
+    :class:`~calfkit.nodes.tool.Tools` for function tool nodes: passing any of them
+    to an agent extracts only a lookup key — no session contact, no deployment. The
+    ``view`` is a :class:`~calfkit.models.capability.CapabilityLookup` (anything with
+    ``get(target_id) -> CapabilityRecord | None``), so the agent layer needs no
+    ktables import and tests can use plain dicts.
     """
 
     def resolve_tools(self, view: "CapabilityLookup") -> SelectorResult: ...

--- a/calfkit/nodes/__init__.py
+++ b/calfkit/nodes/__init__.py
@@ -2,7 +2,7 @@ from calfkit.nodes.agent import Agent, BaseAgentNodeDef
 from calfkit.nodes.base import BaseNodeDef
 from calfkit.nodes.consumer import ConsumerFn, ConsumerNode, consumer
 from calfkit.nodes.node import NodeDef
-from calfkit.nodes.tool import BaseToolNodeDef, ToolNodeDef, agent_tool
+from calfkit.nodes.tool import BaseToolNodeDef, ToolNodeDef, Tools, agent_tool
 
 __all__ = [
     "Agent",
@@ -13,6 +13,7 @@ __all__ = [
     "ConsumerNode",
     "NodeDef",
     "ToolNodeDef",
+    "Tools",
     "agent_tool",
     "consumer",
 ]

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -194,32 +194,32 @@ class BaseAgentNodeDef(
 
     def _maybe_resolve_selectors(self, ctx: SessionRunContext, tools_registry: dict[str, ToolBinding]) -> None:
         """Selector resolution gate: per-run overrides pin the EXACT tool
-        surface for the turn, so MCP selectors are skipped entirely when
+        surface for the turn, so selectors are skipped entirely when
         ``override_agent_tools`` is present (overrides are the exact surface;
-        MCP must not widen a turn the caller scoped away from it)."""
+        discovery must not widen a turn the caller scoped away from it)."""
         if not self._tool_selectors:
             return
         if ctx.state.overrides is not None and ctx.state.overrides.override_agent_tools is not None:
             logger.debug(
-                "agent=%s per-run tool overrides active; skipping MCP selector resolution for this turn",
+                "agent=%s per-run tool overrides active; skipping selector resolution for this turn",
                 self.name,
             )
             return
         self._resolve_selector_tools(ctx.resources, tools_registry)
 
     def _resolve_selector_tools(self, resources: Mapping[str, Any], tools_registry: dict[str, ToolBinding]) -> None:
-        """Per-turn MCP selector resolution against the Capability View.
+        """Per-turn tool-selector resolution against the capability view.
 
-        Merges AFTER static tools with collision = error-log + static wins (a
-        remote server must never silently shadow a locally defined tool). The
-        :class:`ControlPlaneView` owns staleness + schema-version filtering, so
-        an unresolved selection (missing toolbox/tools, or a poisoned record)
+        Merges AFTER static tools with collision = error-log + existing wins (a
+        discovered tool must never silently shadow a locally configured one). The
+        :class:`ControlPlaneView` owns staleness + schema-version filtering, so an
+        unresolved selection (missing target/tools, wrong kind, or a poisoned record)
         only warns and degrades — there is no strict fail path.
         """
         view = resources.get(CAPABILITY_VIEW_RESOURCE_KEY)
         if view is None:
             logger.warning(
-                "agent=%s has MCP tool selectors but no Capability View resource; running without MCP tools",
+                "agent=%s has tool selectors but no Capability View resource; running without discovered tools",
                 self.name,
             )
             return
@@ -229,7 +229,7 @@ class BaseAgentNodeDef(
         failure = getattr(view, "failure", None)
         if failure is not None or status in ("degraded", "failed"):
             logger.warning(
-                "agent=%s resolving MCP tools against a %s Capability View (failure=%r); tools may be stale",
+                "agent=%s resolving tools against a %s Capability View (failure=%r); tools may be stale",
                 self.name,
                 status,
                 failure,
@@ -238,21 +238,22 @@ class BaseAgentNodeDef(
             result: SelectorResult = selector.resolve_tools(view)
             if result.unresolved:
                 logger.warning(
-                    "agent=%s MCP selection partially unresolved (toolbox=%r missing_toolbox=%s "
-                    "missing_tools=%s invalid_record=%s); running degraded",
+                    "agent=%s tool selection partially unresolved by %r (missing_targets=%s "
+                    "missing_tools=%s invalid_targets=%s wrong_kind_targets=%s); running degraded",
                     self.name,
-                    result.toolbox_id,
-                    result.missing_toolbox,
+                    selector,
+                    result.missing_targets,
                     result.missing_tools,
-                    result.invalid_record,
+                    result.invalid_targets,
+                    result.wrong_kind_targets,
                 )
             for binding in result.bindings:
                 if binding.name in tools_registry:
                     logger.error(
-                        "agent=%s MCP tool %r from toolbox=%s collides with a locally configured tool; static wins",
+                        "agent=%s discovered tool %r from selector %r collides with an existing tool; existing wins",
                         self.name,
                         binding.name,
-                        result.toolbox_id,
+                        selector,
                     )
                     continue
                 tools_registry[binding.name] = binding

--- a/calfkit/nodes/tool.py
+++ b/calfkit/nodes/tool.py
@@ -11,8 +11,10 @@ from calfkit._registry import handler
 from calfkit._vendor.pydantic_ai import Tool
 from calfkit._vendor.pydantic_ai.exceptions import ModelRetry
 from calfkit._vendor.pydantic_ai.tools import ToolDefinition
+from calfkit.controlplane import ControlPlaneStamp, advertises
 from calfkit.models import SessionRunContext, State, ToolContext
 from calfkit.models.actions import NodeResult, ReturnCall
+from calfkit.models.capability import CAPABILITY_TOPIC, CapabilityRecord, CapabilityToolDef
 from calfkit.models.payload import retry_text_part
 from calfkit.models.tool_dispatch import ToolBinding, ToolCallRef
 from calfkit.nodes.base import BaseNodeDef
@@ -55,6 +57,31 @@ class BaseToolNodeDef(BaseNodeDef):
         ``except Exception`` catch is the safety net for those.
         """
         return self._tool.function_schema.validator.validate_python(args_dict)
+
+    @advertises(topic=CAPABILITY_TOPIC, record=CapabilityRecord)
+    def _capability_advert(self, stamp: ControlPlaneStamp) -> CapabilityRecord:
+        """Advertise this node's single tool on the shared capability plane (always-on).
+
+        Static-schema advertiser: the tool surface is fixed at construction, so the factory
+        reads ``tool_schema`` directly — no session, no cache to prime, nothing that can fail
+        at publish time. ``content_updated_at`` is the process boot time (``stamp.started_at``):
+        the content never changes, so a stable, non-``now()`` value satisfies the substrate's
+        no-``now()``-in-factory contract. ``node_kind`` rides on the stamp (the worker stamps
+        it from ``_node_kind="tool"``), so it is not set here. ``subscribe_topics[0]`` is always
+        safe: ``BaseNodeSchema`` rejects an empty list at construction.
+        """
+        return CapabilityRecord(
+            **stamp.model_dump(),
+            dispatch_topic=self.subscribe_topics[0],
+            tools=[
+                CapabilityToolDef(
+                    name=self.tool_schema.name,
+                    description=self.tool_schema.description,
+                    parameters_json_schema=self.tool_schema.parameters_json_schema,
+                )
+            ],
+            content_updated_at=stamp.started_at,
+        )
 
 
 class ToolNodeDef(BaseToolNodeDef):

--- a/calfkit/nodes/tool.py
+++ b/calfkit/nodes/tool.py
@@ -64,12 +64,20 @@ class ToolNodeDef(BaseToolNodeDef):
         func: Callable[..., Any],
         subscribe_topics: str | list[str],
         publish_topic: str,
+        *,
+        name: str | None = None,
     ) -> Self:
+        # The tool name (``name`` if given, else the function name) IS the node id —
+        # the capability key an agent references — and the LLM-facing tool name. No
+        # prefix: one name everywhere. ``name`` disambiguates without renaming ``func``.
+        if name is not None and not name:
+            raise ValueError("name must be non-empty when given")
         if not isinstance(subscribe_topics, (list, tuple)):
             subscribe_topics = [subscribe_topics]
-        tool = Tool(func)
+        effective = name or func.__name__
+        tool = Tool(func, name=effective)
         return cls(
-            node_id=f"tool_{func.__name__}",
+            node_id=effective,
             tool_schema=tool.tool_def,
             subscribe_topics=subscribe_topics,
             publish_topic=publish_topic,
@@ -127,10 +135,17 @@ class ToolNodeDef(BaseToolNodeDef):
         return ReturnCall[State](state=ctx.state, value=result)
 
 
-def agent_tool(func: Callable[..., Any] | Callable[..., Awaitable[Any]]) -> ToolNodeDef:
-    """Decorator to turn a function into a deployable tool node that agents can call"""
-    subscribe_topic = f"tool.{func.__name__}.input"
-    publish_topic = f"tool.{func.__name__}.output"
-    tool_node = ToolNodeDef.create_tool_node(func=func, subscribe_topics=subscribe_topic, publish_topic=publish_topic)
+def agent_tool(func: Callable[..., Any] | Callable[..., Awaitable[Any]], *, name: str | None = None) -> ToolNodeDef:
+    """Turn a function into a deployable tool node that agents can call.
 
-    return tool_node
+    Usable bare (``@agent_tool``) or as a call (``agent_tool(fn, name="x")``). The tool
+    name — ``name`` if given, else the function name — drives the node id (the capability
+    key an agent references), the LLM-facing tool name, and the ``tool.<name>.input`` /
+    ``.output`` topics, so one name is the only thing to reason about.
+    """
+    if name is not None and not name:
+        raise ValueError("name must be non-empty when given")
+    effective = name or func.__name__
+    subscribe_topic = f"tool.{effective}.input"
+    publish_topic = f"tool.{effective}.output"
+    return ToolNodeDef.create_tool_node(func=func, subscribe_topics=subscribe_topic, publish_topic=publish_topic, name=effective)

--- a/calfkit/nodes/tool.py
+++ b/calfkit/nodes/tool.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import KW_ONLY, dataclass
-from typing import Any, ClassVar
+from typing import Any, ClassVar, overload
 
 import pydantic_core
 from typing_extensions import Self
@@ -162,20 +162,37 @@ class ToolNodeDef(BaseToolNodeDef):
         return ReturnCall[State](state=ctx.state, value=result)
 
 
-def agent_tool(func: Callable[..., Any] | Callable[..., Awaitable[Any]], *, name: str | None = None) -> ToolNodeDef:
+@overload
+def agent_tool(func: Callable[..., Any] | Callable[..., Awaitable[Any]], *, name: str | None = None) -> ToolNodeDef: ...
+@overload
+def agent_tool(func: None = None, *, name: str | None = None) -> Callable[[Callable[..., Any]], ToolNodeDef]: ...
+def agent_tool(func: Callable[..., Any] | None = None, *, name: str | None = None) -> ToolNodeDef | Callable[[Callable[..., Any]], ToolNodeDef]:
     """Turn a function into a deployable tool node that agents can call.
 
-    Usable bare (``@agent_tool``) or as a call (``agent_tool(fn, name="x")``). The tool
-    name — ``name`` if given, else the function name — drives the node id (the capability
-    key an agent references), the LLM-facing tool name, and the ``tool.<name>.input`` /
-    ``.output`` topics, so one name is the only thing to reason about.
+    Usable three ways — bare (``@agent_tool``), with args (``@agent_tool(name="x")``),
+    or as a direct call (``agent_tool(fn, name="x")``). The tool name — ``name`` if given,
+    else the function name — drives the node id (the capability key an agent references),
+    the LLM-facing tool name, and the ``tool.<name>.input`` / ``.output`` topics, so one
+    name is the only thing to reason about.
+
+    When called without a function (``@agent_tool(name="x")`` or ``@agent_tool()``) it
+    returns the decorator that builds the node once applied; otherwise it builds the node
+    immediately. ``name`` is validated eagerly so ``@agent_tool(name="")`` fails at the
+    decoration site, not when the decorated function is defined.
     """
     if name is not None and not name:
         raise ValueError("name must be non-empty when given")
-    effective = name or func.__name__
-    subscribe_topic = f"tool.{effective}.input"
-    publish_topic = f"tool.{effective}.output"
-    return ToolNodeDef.create_tool_node(func=func, subscribe_topics=subscribe_topic, publish_topic=publish_topic, name=effective)
+
+    def _build(fn: Callable[..., Any]) -> ToolNodeDef:
+        effective = name or fn.__name__
+        return ToolNodeDef.create_tool_node(
+            func=fn,
+            subscribe_topics=f"tool.{effective}.input",
+            publish_topic=f"tool.{effective}.output",
+            name=effective,
+        )
+
+    return _build if func is None else _build(func)
 
 
 @dataclass(frozen=True)

--- a/calfkit/nodes/tool.py
+++ b/calfkit/nodes/tool.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import KW_ONLY, dataclass
 from typing import Any, ClassVar
 
@@ -14,9 +14,9 @@ from calfkit._vendor.pydantic_ai.tools import ToolDefinition
 from calfkit.controlplane import ControlPlaneStamp, advertises
 from calfkit.models import SessionRunContext, State, ToolContext
 from calfkit.models.actions import NodeResult, ReturnCall
-from calfkit.models.capability import CAPABILITY_TOPIC, CapabilityRecord, CapabilityToolDef
+from calfkit.models.capability import CAPABILITY_TOPIC, CapabilityLookup, CapabilityRecord, CapabilityToolDef, resolve_capability
 from calfkit.models.payload import retry_text_part
-from calfkit.models.tool_dispatch import ToolBinding, ToolCallRef
+from calfkit.models.tool_dispatch import SelectorResult, ToolBinding, ToolCallRef
 from calfkit.nodes.base import BaseNodeDef
 
 logger = logging.getLogger(__name__)
@@ -176,3 +176,54 @@ def agent_tool(func: Callable[..., Any] | Callable[..., Awaitable[Any]], *, name
     subscribe_topic = f"tool.{effective}.input"
     publish_topic = f"tool.{effective}.output"
     return ToolNodeDef.create_tool_node(func=func, subscribe_topics=subscribe_topic, publish_topic=publish_topic, name=effective)
+
+
+@dataclass(frozen=True)
+class Tools:
+    """Identity-only handle to one or more function tool nodes, resolved per agent turn.
+
+    The call-side counterpart to deployed tool nodes (mirrors :class:`~calfkit.mcp.MCPToolbox`):
+    constructible anywhere with just the tool names — no schema, no import of the tool's code.
+    Each name is a tool node's identity (its ``node_id``, which equals the LLM-facing tool name).
+    Resolution reuses :func:`~calfkit.models.capability.resolve_capability` with
+    ``expected_kind="tool"`` (the over-pull guard), so a name that resolves to a toolbox record is
+    rejected rather than absorbed. Frozen value semantics: names are order-preserving-deduped, so
+    equal handles compare and hash equal.
+
+    Accepts either ``Tools("add", "subtract")`` or ``Tools(names=[...])`` (not both). There is no
+    ``strict`` knob — an unresolved selection warns and degrades (mirrors MCP).
+    """
+
+    names: tuple[str, ...]
+
+    # ``*positional`` varargs (the common case) plus a keyword-only ``names=`` list; no name
+    # collision because the varargs param is ``positional`` while the stored field is ``names``.
+    def __init__(self, *positional: str, names: Sequence[str] | None = None) -> None:
+        if positional and names is not None:
+            raise ValueError("Tools: pass tool names positionally or via names=, not both")
+        source = positional if positional else tuple(names or ())
+        collected = tuple(dict.fromkeys(source))  # order-preserving dedupe
+        if not collected:
+            raise ValueError("Tools requires at least one tool name")
+        if any(not n for n in collected):
+            raise ValueError("Tools names must be non-empty")
+        object.__setattr__(self, "names", collected)
+
+    def resolve_tools(self, view: CapabilityLookup) -> SelectorResult:
+        """Resolve each name against the capability view and aggregate (one binding per tool node)."""
+        bindings: list[ToolBinding] = []
+        missing: list[str] = []
+        invalid: list[str] = []
+        wrong_kind: list[str] = []
+        for name in self.names:
+            result = resolve_capability(view, name, expected_kind="tool")
+            bindings.extend(result.bindings)
+            missing.extend(result.missing_targets)
+            invalid.extend(result.invalid_targets)
+            wrong_kind.extend(result.wrong_kind_targets)
+        return SelectorResult(
+            bindings=tuple(bindings),
+            missing_targets=tuple(missing),
+            invalid_targets=tuple(invalid),
+            wrong_kind_targets=tuple(wrong_kind),
+        )

--- a/docs/adr/0013-function-tool-nodes-discoverable-via-capability-plane.md
+++ b/docs/adr/0013-function-tool-nodes-discoverable-via-capability-plane.md
@@ -29,8 +29,9 @@ Three changes let the plane serve both adopters safely:
   tool-node record). It also lets the view observe (log) cross-kind `node_id` collisions.
 - A tool node's identity becomes the tool name — the `tool_` `node_id` prefix is dropped —
   so `node_id == the LLM-facing tool name == the capability key`, and an agent references a
-  node by the same name it calls. `agent_tool(func, name=...)` / `create_tool_node(..., name=...)`
-  override it (the disambiguation knob for the cluster-wide-unique identity contract).
+  node by the same name it calls. `@agent_tool(name=...)` (or `agent_tool(func, name=...)`) /
+  `create_tool_node(..., name=...)` override it (the disambiguation knob for the
+  cluster-wide-unique identity contract).
 - The `SelectorResult` / `resolve_capability` vocabulary is de-MCP'd to be
   cardinality-neutral (`missing_targets` / `invalid_targets` / `wrong_kind_targets`, tuple
   `bindings`), since `Tools` resolves N targets where `MCPToolbox` resolves one.

--- a/docs/adr/0013-function-tool-nodes-discoverable-via-capability-plane.md
+++ b/docs/adr/0013-function-tool-nodes-discoverable-via-capability-plane.md
@@ -1,0 +1,49 @@
+---
+status: accepted
+---
+
+# Function tool nodes are discoverable via the capability plane
+
+`MCPToolboxNode` advertises on the capability control plane (ADR-0012) so an agent can
+hold an identity-only `MCPToolbox` handle and discover its tools at runtime. Function tool
+nodes had no such path: an agent could only use one by importing the live `ToolNodeDef`,
+which baked the tool's JSON schema into the agent's process — even though dispatch always
+crosses Kafka. We make tool nodes a **second adopter** of the same plane. `BaseToolNodeDef`
+declares an `@advertises("calf.capabilities", CapabilityRecord)` factory (always-on; the
+schema is static, so the factory just reads it), and `Tools(*names)` is the by-name,
+deployment-free handle an agent passes in `tools=[...]` — the call-side counterpart to a
+deployed tool node, mirroring the `MCPToolbox`/`MCPToolboxNode` split (ADR-0009). It
+resolves per turn against the shared `ControlPlaneView[CapabilityRecord]`, reusing MCP's
+resolution kernel.
+
+The eager path is kept: passing a live tool node still bakes the schema in with a local
+arg validator (fail-fast before dispatch); a discovered binding has no validator, so bad
+args are dispatched and fault at the tool node, riding the rail back (ADR-0003). Two
+handles onto one node — the caller picks zero-infra-and-local-validation vs. decoupled-and-discovered.
+
+Three changes let the plane serve both adopters safely:
+
+- A worker-stamped `node_kind` on every control-plane record (`ControlPlaneStamp`) is the
+  **over-pull guard**: `resolve_capability(..., expected_kind=)` rejects a record of the
+  wrong kind, so `Tools` can never bind a multi-tool toolbox record (nor `MCPToolbox` a
+  tool-node record). It also lets the view observe (log) cross-kind `node_id` collisions.
+- A tool node's identity becomes the tool name — the `tool_` `node_id` prefix is dropped —
+  so `node_id == the LLM-facing tool name == the capability key`, and an agent references a
+  node by the same name it calls. `agent_tool(func, name=...)` / `create_tool_node(..., name=...)`
+  override it (the disambiguation knob for the cluster-wide-unique identity contract).
+- The `SelectorResult` / `resolve_capability` vocabulary is de-MCP'd to be
+  cardinality-neutral (`missing_targets` / `invalid_targets` / `wrong_kind_targets`, tuple
+  `bindings`), since `Tools` resolves N targets where `MCPToolbox` resolves one.
+
+Considered and rejected: **opt-in advertising** (an eager-only tool node that does not
+advertise) — designed and deferred, since always-on keeps the common case configuration-free
+at the cost of making `calf.capabilities` a boot dependency for any tool-node worker;
+**namespacing the capability key by owner kind** to make heterogeneous-owner collisions
+unrepresentable — rejected because it breaks the clean `node_id == tool name` identity, and
+the collision is a facet of the global `node_id`-uniqueness contract the framework already
+documents (the `node_kind` view warning makes the cross-kind case observable).
+
+Consequences, breaking (pre-1.0, no deployments): `node_kind` is a **required** field on the
+control-plane record — recreate `calf.capabilities` on upgrade — and a tool node's `node_id`
+changes from `tool_<fn>` to `<fn>`, which appears on the wire in envelope headers and fault
+origin. Full design: `docs/designs/runtime-tool-discoverability-spec.md`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,7 +35,7 @@ from calfkit import (
 | Symbol | Purpose |
 | --- | --- |
 | `Agent` | An agent node — an LLM-backed node that consumes prompts, calls tools, and publishes output. |
-| `agent_tool` | Decorator that turns a function into a deployable tool node (`agent_tool(func, name=...)` overrides its name). |
+| `agent_tool` | Decorator that turns a function into a deployable tool node (`@agent_tool(name=...)` or `agent_tool(func, name=...)` overrides its name). |
 | `Tools` | Identity-only handle that references deployed tool nodes by name; pass in `Agent(tools=[...])` to discover their schemas at runtime. |
 | `consumer` | Decorator that turns a function into a deployable consumer node (a terminal sink on a topic). |
 
@@ -175,7 +175,7 @@ def get_weather(location: str) -> str:        # -> ToolNodeDef
     ...
 ```
 
-Turns a function into a tool node. The function's parameters and type annotations become the tool's argument schema, and its docstring becomes the description shown to the calling LLM. Declare an optional first `ctx: ToolContext` parameter to receive the [context](#context-objects) — it is hidden from the LLM schema. The return value must be JSON-serializable. Sync and async functions are both supported. The tool name defaults to the function name and is the node's identity — the name the LLM calls and the name a `Tools(...)` handle references; `agent_tool(func, name="...")` overrides it. The node's topics derive from that name (`tool.<name>.input` / `tool.<name>.output`).
+Turns a function into a tool node. The function's parameters and type annotations become the tool's argument schema, and its docstring becomes the description shown to the calling LLM. Declare an optional first `ctx: ToolContext` parameter to receive the [context](#context-objects) — it is hidden from the LLM schema. The return value must be JSON-serializable. Sync and async functions are both supported. The tool name defaults to the function name and is the node's identity — the name the LLM calls and the name a `Tools(...)` handle references; `@agent_tool(name="...")` (or `agent_tool(func, name="...")`) overrides it. The node's topics derive from that name (`tool.<name>.input` / `tool.<name>.output`).
 
 ### `Tools`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -370,6 +370,7 @@ The top-level package re-exports the symbols above. A few public capabilities li
 - **[How to guard and transform node invocations](policy-seams.md)** — `before_node` / `after_node` recipes.
 - **[How to handle errors and faults](error-handling.md)** — `on_node_error` / `on_callee_error`, minting `NodeFaultError`, and inspecting an `ErrorReport`.
 - **[How to give agents MCP tools](mcp-tool-discovery.md)** — fronting an MCP server as a toolbox.
+- **[How to give agents discoverable tool nodes](tool-discovery.md)** — referencing deployed function tool nodes by name with `Tools`.
 - **[Worker lifecycle & embedding](worker-lifecycle.md)** — `Worker`, the lifecycle contexts, and `@resource`.
 - **[CLI reference](cli.md)** — the `calfkit run` and `calfkit topics` commands.
 - **[Topic provisioning](topic-provisioning.md)** — `ProvisioningConfig` and the opt-in topic-creation helper.

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,6 +6,7 @@ The full public surface is re-exported from the top-level `calfkit` package:
 from calfkit import (
     Client, InvocationHandle, InvocationResult,          # client
     Agent, agent_tool, consumer,                         # node authoring
+    Tools,                                               # reference deployed tool nodes by name
     BaseNodeDef, NodeDef, ToolNodeDef, ConsumerNode,     # node types
     ConsumerFn,                                          # node typing helpers
     ToolContext,                                         # tool-side context
@@ -34,7 +35,8 @@ from calfkit import (
 | Symbol | Purpose |
 | --- | --- |
 | `Agent` | An agent node — an LLM-backed node that consumes prompts, calls tools, and publishes output. |
-| `agent_tool` | Decorator that turns a function into a deployable tool node. |
+| `agent_tool` | Decorator that turns a function into a deployable tool node (`agent_tool(func, name=...)` overrides its name). |
+| `Tools` | Identity-only handle that references deployed tool nodes by name; pass in `Agent(tools=[...])` to discover their schemas at runtime. |
 | `consumer` | Decorator that turns a function into a deployable consumer node (a terminal sink on a topic). |
 
 ### Node types
@@ -173,7 +175,16 @@ def get_weather(location: str) -> str:        # -> ToolNodeDef
     ...
 ```
 
-Turns a function into a tool node. The function's parameters and type annotations become the tool's argument schema, and its docstring becomes the description shown to the calling LLM. Declare an optional first `ctx: ToolContext` parameter to receive the [context](#context-objects) — it is hidden from the LLM schema. The return value must be JSON-serializable. Sync and async functions are both supported. The node's topics default to `tool.<function-name>.input` and `tool.<function-name>.output`.
+Turns a function into a tool node. The function's parameters and type annotations become the tool's argument schema, and its docstring becomes the description shown to the calling LLM. Declare an optional first `ctx: ToolContext` parameter to receive the [context](#context-objects) — it is hidden from the LLM schema. The return value must be JSON-serializable. Sync and async functions are both supported. The tool name defaults to the function name and is the node's identity — the name the LLM calls and the name a `Tools(...)` handle references; `agent_tool(func, name="...")` overrides it. The node's topics derive from that name (`tool.<name>.input` / `tool.<name>.output`).
+
+### `Tools`
+
+```python
+agent = Agent("researcher", subscribe_topics="researcher.input", model_client=model,
+              tools=[Tools("add", "subtract")])    # reference tool nodes by name
+```
+
+A frozen, identity-only handle to one or more deployed tool nodes. The agent discovers each named tool's schema at runtime from the capability control plane instead of importing the tool's code — the call-side counterpart to a deployed tool node. Resolved per turn; an unresolved name warns and degrades. See [discoverable tool nodes](tool-discovery.md).
 
 ### `@consumer`
 

--- a/docs/designs/runtime-tool-discoverability-spec.md
+++ b/docs/designs/runtime-tool-discoverability-spec.md
@@ -9,7 +9,7 @@
 
 ## 1. Summary
 
-Today an agent can only use a function tool node by being handed the **live node object** (`tools=[my_tool_node]`), which bakes the tool's JSON schema into the agent's process at construction (`BaseToolNodeDef.tool_bindings`, `calfkit/nodes/tool.py:30`). That couples the agent's deployment to *importing the tool's Python code*, even though the call itself always crosses Kafka.
+Today an agent can only use a function tool node by being handed the **live node object** (`tools=[my_tool_node]`), which bakes the tool's JSON schema into the agent's process at construction (`BaseToolNodeDef.tool_bindings`, `calfkit/nodes/tool.py:32`). That couples the agent's deployment to *importing the tool's Python code*, even though the call itself always crosses Kafka.
 
 This feature adds an **identity-only handle** — `Tools(*names)` — that lets an agent reference tool nodes **by name** and discover their schemas **at runtime** from the shared capability control plane (a `ControlPlaneView[CapabilityRecord]` materialized from the compacted `calf.capabilities` topic). It is the exact mirror of how `MCPToolbox` already resolves MCP tools, applied to function tool nodes.
 
@@ -51,19 +51,19 @@ The eager path is **kept** unchanged. `Tools` is purely additive: the same tool 
 
 | Piece | Location | Role |
 |---|---|---|
-| `ControlPlaneRecord` / `ControlPlaneStamp` | `calfkit/controlplane/records.py:14,33` | Record base: identity-as-key + boot/liveness/cadence stamp + `schema_version`. **This spec adds `node_kind` to the stamp (§6.4).** |
+| `ControlPlaneRecord` / `ControlPlaneStamp` | `calfkit/controlplane/records.py:14,38` | Record base: identity-as-key + boot/liveness/cadence stamp + `schema_version`. **This spec adds `node_kind` to the stamp (§6.4).** |
 | `@advertises(topic, record=...)` | `calfkit/controlplane/advert.py:52` | Class-body marker: binds a node *type* to one topic + record schema; factory `(self, stamp) -> record`. |
 | `ControlPlanePublisher` | `calfkit/controlplane/publisher.py:42` | One per worker; fail-loud first publish, per-advert-resilient heartbeat loop, ordered tombstone. **Stamps `node_kind` (§6.4).** |
 | `ControlPlaneView[R]` | `calfkit/controlplane/view.py:64` | Read side: instance-keyed (`node_id × worker_id`) → collapsed `get(node_id)`, staleness + schema-version filtering, health passthrough. **Gains a mixed-`node_kind` warning (§6.4, C1).** |
 | `CapabilityRecord` / `CapabilityToolDef` | `calfkit/models/capability.py:48,38` | Wire content: `dispatch_topic`, `tools[name/description/json_schema]`, `content_updated_at` (+ inherited `node_kind`). |
-| `resolve_capability` / `record_to_bindings` | `calfkit/models/capability.py:116,79` | Resolution kernel: `view.get(id)` → validator-less `ToolBinding`s. **Gains `expected_kind` (§6.4).** |
-| `ToolBinding` / `ToolProvider` / `ToolSelector` / `SelectorResult` | `calfkit/models/tool_dispatch.py:21,58,96,71` | The agent's tool-type machinery. |
-| `_node_kind` | `calfkit/nodes/base.py:483` (used in `HDR_EMITTER_KIND`); `mcp_toolbox.py:41` (`"toolbox"`); `tool.py:25` (`"tool"`) | Each node type's kind. Already exists; `node_kind` on the stamp is sourced from it. |
+| `resolve_capability` / `record_to_bindings` | `calfkit/models/capability.py:117,79` | Resolution kernel: `view.get(id)` → validator-less `ToolBinding`s. **Gains `expected_kind` (§6.4).** |
+| `ToolBinding` / `ToolProvider` / `ToolSelector` / `SelectorResult` | `calfkit/models/tool_dispatch.py:21,59,100,72` | The agent's tool-type machinery. |
+| `_node_kind` | `calfkit/nodes/base.py:483` (used in `HDR_EMITTER_KIND`); `mcp_toolbox.py:41` (`"toolbox"`); `tool.py:27` (`"tool"`) | Each node type's kind. Already exists; `node_kind` on the stamp is sourced from it. |
 | Worker read-side wiring | `calfkit/worker/worker.py:171-184` | Registers ONE `ControlPlaneView[CapabilityRecord]` resource iff any hosted node has `_tool_selectors`. |
 | Worker write-side wiring | `calfkit/worker/worker.py:232-253` | Registers the publisher + one writer per topic iff any hosted node declares an `@advertises`. |
 | Agent resolution | `calfkit/nodes/agent.py:195-258` | Per turn: read the view, resolve each selector, merge bindings (collision → existing wins), warn/degrade. |
 
-MCP's flow today: `MCPToolboxNode` declares `@advertises(topic=CAPABILITY_TOPIC, record=CapabilityRecord)` (`mcp_toolbox.py:132`); the `MCPToolbox` handle (`name` + `include`, no `strict`) resolves via `resolve_capability(view, name, include=...)` (`mcp_toolbox.py:246`). `Tools` and the tool node mirror both halves.
+MCP's flow today: `MCPToolboxNode` declares `@advertises(topic=CAPABILITY_TOPIC, record=CapabilityRecord)` (`mcp_toolbox.py:132`); the `MCPToolbox` handle (`name` + `include`, no `strict`) resolves via `resolve_capability(view, name, include=...)` (`mcp_toolbox.py:247`). `Tools` and the tool node mirror both halves.
 
 ---
 
@@ -98,7 +98,7 @@ model calls add → Call(dispatch_topic="tool.add.input", body=ToolCallRef) → 
 
 ### 6.1 Tool node as advertiser (always-on)
 
-`BaseToolNodeDef` already extends `BaseNodeDef`, which carries `AdvertRegistryMixin` (`base.py:221`), and already holds `tool_schema: ToolDefinition` (`tool.py:28`) and `subscribe_topics`. The factory mirrors MCP's, reading static data instead of a cached session list. **It does not stamp `node_kind` itself** — that rides on the stamp (§6.4), so it flows in via `stamp.model_dump()`:
+`BaseToolNodeDef` already extends `BaseNodeDef`, which carries `AdvertRegistryMixin` (`base.py:221`), and already holds `tool_schema: ToolDefinition` (`tool.py:30`) and `subscribe_topics`. The factory mirrors MCP's, reading static data instead of a cached session list. **It does not stamp `node_kind` itself** — that rides on the stamp (§6.4), so it flows in via `stamp.model_dump()`:
 
 ```python
 # calfkit/nodes/tool.py — on BaseToolNodeDef
@@ -111,10 +111,9 @@ def _capability_advert(self, stamp: ControlPlaneStamp) -> CapabilityRecord:
     ``content_updated_at`` is the process boot time (``stamp.started_at``): the
     content never changes, so a stable, non-``now()`` value satisfies the
     substrate's no-``now()``-in-factory contract. ``node_kind`` rides on the
-    stamp (the worker stamps it), so it is not set here.
+    stamp (the worker stamps it), so it is not set here. ``subscribe_topics[0]``
+    is always safe: ``BaseNodeSchema`` rejects an empty list at construction.
     """
-    if not self.subscribe_topics:  # named guard: empty subscribe_topics would IndexError mid-publish
-        raise RuntimeError(f"tool node {self.node_id!r} has no subscribe_topics; cannot advertise a dispatch topic")
     return CapabilityRecord(
         **stamp.model_dump(),  # started_at, last_heartbeat_at, heartbeat_interval, node_kind, schema_version
         dispatch_topic=self.subscribe_topics[0],
@@ -131,7 +130,7 @@ def _capability_advert(self, stamp: ControlPlaneStamp) -> CapabilityRecord:
 
 Notes:
 - **Always-on.** The `@advertises` lives on the base type, so every `ToolNodeDef` advertises (L7). Consequence: a worker hosting any tool node stands up the control-plane writer + publisher at boot (fail-loud) — see §8. The opt-in alternative is fully designed in §14.1.
-- **Fail-safe at publish.** The factory reads only static fields; the one non-content read (`subscribe_topics[0]`) is guarded with a named error rather than letting an `IndexError` escape mid-publish.
+- **Fail-safe at publish.** The factory reads only static fields; the one non-content read (`subscribe_topics[0]`) is safe by construction — `BaseNodeSchema` rejects an empty `subscribe_topics` list at node construction, so no `IndexError` can escape mid-publish.
 - **`content_updated_at = stamp.started_at`.** Correct for a static schema; never moves tick-to-tick.
 - **Replicas are trivially equivalent.** `CapabilityRecord`'s collapse precondition (equivalent content across replicas) is satisfied by construction for tool nodes: the schema is derived from the same `func`, so two replicas of the same tool node advertise byte-identical content. (Two *different* functions deployed under the same `name` would violate it — but that is the identity-collision case of §8, not a replica case.)
 - **Tombstone on clean shutdown** is handled by the shared publisher (`publisher.py:75`). No tool-node-specific lifecycle code.
@@ -230,7 +229,7 @@ class Tools:
         )
 ```
 
-Both `Tools("add", "subtract")` (varargs, the common case) and `Tools(names=[...])` (pre-built list) work; mixing them raises. `Tools` satisfies the existing `ToolSelector` protocol (`tool_dispatch.py:96`), so it flows through `split_tool_declarations` into `agent._tool_selectors` with **no change to the agent's `tools=` union type**.
+Both `Tools("add", "subtract")` (varargs, the common case) and `Tools(names=[...])` (pre-built list) work; mixing them raises. `Tools` satisfies the existing `ToolSelector` protocol (`tool_dispatch.py:100`), so it flows through `split_tool_declarations` into `agent._tool_selectors` with **no change to the agent's `tools=` union type**.
 
 ### 6.4 Wire model, resolution kernel & de-MCP'd `SelectorResult`
 
@@ -272,7 +271,7 @@ class CapabilityRecord(ControlPlaneRecord):   # ControlPlaneRecord(ControlPlaneS
 
 **Wire compatibility — breaking change (accepted; pre-1.0, no deployments).** `node_kind` is **required**, like the sibling stamp fields. A `CapabilityRecord` written before this field existed will fail to decode (`model_validate_json` raises; ktables' poison-tolerance then *skips* it — `kafka_table.py`), so the compacted `calf.capabilities` topic must be **recreated/drained on upgrade**. This is a deliberate clean break rather than a compat default: a defaulted `node_kind="node"` would mask a publisher that forgot to stamp the field and would conflate "legacy/unknown" with the real base-node kind — and with no live deployments to preserve, the shim earns nothing (and a shim runs against the project's hard-breaks-over-compat stance). **No `CAPABILITY_SCHEMA_VERSION` bump** — the topic is recreated with the new shape, so `schema_version` stays `1`. `node_kind` is typed `str` (not the `NodeKind` Literal) so a future *additive* kind value from a newer writer still decodes on an older reader.
 
-**C1 — heterogeneous-owner collision (observable, documented).** Tool nodes and MCP toolboxes share the `calf.capabilities` `node_id` keyspace. A `node_id` collision between *different owners* (a tool node and a toolbox, or two unrelated tool nodes) would land them in one group as different `worker_id` members, and the collapsed `get()` (max-by-heartbeat, `view.py:90`) would flap the agent's surface between two owners tick-to-tick. This is **a facet of the existing global `node_id`-uniqueness contract** — `node_id` already must be unique cluster-wide because it drives return topics and consumer groups (`worker.py:299,309`); a collision is an already-broken deployment, and the flap is one more symptom. So it is documented, not policed (§8). For observability, the generic view logs (dedup'd, like its schema-skip warning) when one group holds members of differing `node_kind`:
+**C1 — heterogeneous-owner collision (observable, documented).** Tool nodes and MCP toolboxes share the `calf.capabilities` `node_id` keyspace. A `node_id` collision between *different owners* (a tool node and a toolbox, or two unrelated tool nodes) would land them in one group as different `worker_id` members, and the collapsed `get()` (max-by-heartbeat, `view.py:91`) would flap the agent's surface between two owners tick-to-tick. This is **a facet of the existing global `node_id`-uniqueness contract** — `node_id` already must be unique cluster-wide because it drives return topics and consumer groups (`worker.py:299,309`); a collision is an already-broken deployment, and the flap is one more symptom. So it is documented, not policed (§8). For observability, the generic view logs (dedup'd, like its schema-skip warning) when one group holds members of differing `node_kind`:
 
 ```python
 # calfkit/controlplane/view.py — inside _live_members, after collecting live members
@@ -362,19 +361,19 @@ for selector in self._tool_selectors:          # selector in scope
 - **Degrade (unchanged policy):** missing view, degraded/failed view, or `result.unresolved` → warn and continue. No raise.
 
 **Validation semantics (the eager/discovered divergence, by design):**
-- *Eager:* `ToolBinding.validator = validate_call_args` (`tool.py:41`) → the agent validates LLM args **before** dispatch; a schema mismatch is corrected locally with no Kafka hop.
+- *Eager:* `ToolBinding.validator = validate_call_args` (`tool.py:43`) → the agent validates LLM args **before** dispatch; a schema mismatch is corrected locally with no Kafka hop.
 - *Discovered:* `validator=None` → the agent dispatches unvalidated. Two distinct outcomes at the tool node:
-  - a **schema-mismatch** (`function_schema` raises `ValidationError`, `tool.py:110`) escapes to the chokepoint → `on_node_error` → fault rail → typed fault back to the agent;
-  - an in-body **`ModelRetry`** is *not* a fault — it is rendered at origin to a `calf.retry`-marked reply (`tool.py:116-121`), a model-visible recoverable, identical on both eager and discovered paths (it's body behavior, not arg validation).
+  - a **schema-mismatch** (`function_schema` raises `ValidationError`, `tool.py:145`) escapes to the chokepoint → `on_node_error` → fault rail → typed fault back to the agent;
+  - an in-body **`ModelRetry`** is *not* a fault — it is rendered at origin to a `calf.retry`-marked reply (`tool.py:151-156`), a model-visible recoverable, identical on both eager and discovered paths (it's body behavior, not arg validation).
 
 So the discovered path's *arg-validation* failure rides the rail (one Kafka hop later than the eager path's local correction); in-body retries behave identically on both paths.
 
-**`add_tools` timing caveat (carried over from MCP).** `Agent.add_tools` (`agent.py:518`) added *after* the worker's `register_handlers` has snapshotted `_tool_selectors` will **not** get a capability view (the read-side gate already ran), so its `Tools`/`MCPToolbox` selectors silently degrade to no-discovery. Declare discovery selectors at agent construction. (Pre-existing MCP constraint; `Tools` inherits it.)
+**`add_tools` timing caveat (carried over from MCP).** `Agent.add_tools` (`agent.py:519`) added *after* the worker's `register_handlers` has snapshotted `_tool_selectors` will **not** get a capability view (the read-side gate already ran), so its `Tools`/`MCPToolbox` selectors silently degrade to no-discovery. Declare discovery selectors at agent construction. (Pre-existing MCP constraint; `Tools` inherits it.)
 
 ### 6.6 Worker wiring (zero new code)
 
-- **Write side:** `_maybe_register_control_plane` (`worker.py:245`) collects `type(node)._adverts`. With `@advertises` on `BaseToolNodeDef`, every hosted tool node contributes the capability advert automatically — no new branch.
-- **Read side:** `_maybe_register_capability_view` (`worker.py:180`) registers the view iff any hosted node has `_tool_selectors`. A `Tools` selector trips the same gate. One worker-level `ControlPlaneView[CapabilityRecord]`, shared with MCP.
+- **Write side:** `_maybe_register_control_plane` (`worker.py:232`) collects `type(node)._adverts`. With `@advertises` on `BaseToolNodeDef`, every hosted tool node contributes the capability advert automatically — no new branch.
+- **Read side:** `_maybe_register_capability_view` (`worker.py:171`) registers the view iff any hosted node has `_tool_selectors`. A `Tools` selector trips the same gate. One worker-level `ControlPlaneView[CapabilityRecord]`, shared with MCP.
 
 ---
 
@@ -416,7 +415,7 @@ So the discovered path's *arg-validation* failure rides the rail (one Kafka hop 
 No wire-format break to `CapabilityRecord`/`CapabilityToolDef` content (MCP and tool nodes interoperate immediately).
 
 **Concrete migration checklist (from the blast-radius review — nothing parses the prefix, so it is mechanical):**
-- Production: `tool.py:72` (the prefix), `tool.py:130-136`/`61-77` (`name=`), `agent.py` resolution logs (SelectorResult fields), `mcp_toolbox.py:246` (`expected_kind`), substrate touch (`records.py`, `publisher.py`, `view.py`).
+- Production: `tool.py:72` (the prefix), `tool.py:130-136`/`61-77` (`name=`), `agent.py` resolution logs (SelectorResult fields), `mcp_toolbox.py:247` (`expected_kind`), substrate touch (`records.py`, `publisher.py`, `view.py`).
 - Node-id test assertions (8): `tests/test_run_loader.py:25,33,41,91,110,138`, `tests/test_run_serve.py:48,122` (all fed by `tests/provisioning_cli_nodes.py`).
 - `SelectorResult`-field assertions (~14): `tests/test_tool_selector.py` (many), `tests/test_mcp_toolbox.py:95` (`toolbox_id` equality — needs rewrite).
 - **`node_kind` required-field fallout (new).** Because `node_kind` is required, **every** test that constructs a `ControlPlaneStamp`/`ControlPlaneRecord`/`CapabilityRecord` must pass it, and the field-set assertions break: `tests/test_controlplane_records.py:49,53` (add `node_kind`); the `_stamp`/`make_stamp`/`make_record` helpers in `tests/test_controlplane_records.py`, `tests/test_controlplane_advert.py`, `tests/test_mcp_toolbox_publisher.py`, `tests/test_capability_models.py`, `tests/test_tool_selector.py`, `tests/test_mcp_toolbox.py`, `tests/test_controlplane_view.py`, `tests/test_controlplane_worker_wiring.py`, `tests/test_controlplane_publisher.py`. Resolution fixtures must set the kind the selector expects (`"tool"` for `Tools` tests, `"toolbox"` for MCP tests) or they resolve as `wrong_kind`. Add a publisher test asserting the stamp carries `node._node_kind`.
@@ -431,7 +430,7 @@ No wire-format break to `CapabilityRecord`/`CapabilityToolDef` content (MCP and 
 1. **`node_kind` on the substrate** — add required `node_kind: str` to `ControlPlaneStamp`, stamp it in the publisher from `node._node_kind`, add the view's mixed-kind warning. *Tests:* the publisher stamps `node_kind` from `node._node_kind` (`MCPToolboxNode`→`"toolbox"`, tool node→`"tool"`); the view warns once per `(node_id, frozenset(kinds))` on a cross-kind group (and does NOT warn on a same-kind group).
 2. **De-MCP `SelectorResult` + `resolve_capability`** — plural/immutable fields, `expected_kind`, `bindings` tuple, kept fail-loud comment. Update `MCPToolbox.resolve_tools` (`expected_kind="toolbox"`) and agent logs (selector-provenance). *Tests:* MCP resolution adapted; new `missing_targets`/`invalid_targets`/`wrong_kind_targets` cases.
 3. **Drop the `tool_` prefix + `name=`** on `agent_tool`/`create_tool_node` (reject empty). *Tests:* `node_id == effective`, topics derive from it, `tool_def.name == effective`, override on both entry points, empty rejected.
-4. **Tool node advertises** (`@advertises` on `BaseToolNodeDef`, guarded `subscribe_topics[0]`). *Tests:* factory builds a valid record from `tool_schema`+stamp; `content_updated_at == started_at`; worker auto-registers publisher/writer.
+4. **Tool node advertises** (`@advertises` on `BaseToolNodeDef`; `subscribe_topics[0]` is safe by `BaseNodeSchema`'s construction-time non-empty check). *Tests:* factory builds a valid record from `tool_schema`+stamp; `content_updated_at == started_at`; worker auto-registers publisher/writer.
 5. **`Tools` selector** — varargs + `names=`, dedupe, reject-mixed, reject-empty, `expected_kind="tool"`. *Tests (dict view):* single/multi name; `names=` form; dedupe; mixed-call raises; missing → `missing_targets`; toolbox key → `wrong_kind_targets`; satisfies `ToolSelector`; lands in `_tool_selectors`.
 6. **Eager/discovered parity test** (§7).
 7. **Kafka-lane roundtrip** (mirror `test_mcp_roundtrip_kafka.py`): tool node in one worker, agent with `tools=[Tools("add")]` in another; discover → dispatch `add(2,3)` → `5` returns. Plus a bad-args case asserting the fault-rail path.
@@ -440,7 +439,7 @@ No wire-format break to `CapabilityRecord`/`CapabilityToolDef` content (MCP and 
 
 ## 11. Testing strategy
 
-- **Unit** — `CapabilityLookup` is a `Protocol` satisfied by a `dict` (`capability.py:104`), so all resolution logic is broker-free.
+- **Unit** — `CapabilityLookup` is a `Protocol` satisfied by a `dict` (`capability.py:105`), so all resolution logic is broker-free.
 - **Parity** — eager vs discovered `ToolDefinition` equality (§7 guard).
 - **Scenarios** (from review) — duplicate names dedupe; `Tools(...)`/`Tools(names=...)` and the rejected mixed call; rejected empty `name=`; `Tools` + eager same tool (eager wins, validator preserved); `Tools` against `view is None` / degraded view; `wrong_kind_targets` (Tools → toolbox key); `expected_kind` for both selectors; the publisher stamps `node_kind` from `_node_kind`; cross-kind view warning fires / same-kind does not; `name=` collision (two nodes same `name`); `add_tools` post-registration degradation; replica content-equivalence; eager/discovered `ToolDefinition` parity.
 - **Worker wiring** — tool node trips write-side; `Tools` agent trips read-side.

--- a/docs/designs/runtime-tool-discoverability-spec.md
+++ b/docs/designs/runtime-tool-discoverability-spec.md
@@ -1,0 +1,497 @@
+# Runtime Tool Discoverability Spec
+
+- **Status:** Implemented (2026-06-20) on branch `feat/runtime-tool-discoverability` — built TDD per the §10 build order; review rounds 1 & 2 folded (§13); offline suite + full kafka lane green. Decision recorded in ADR-0013.
+- **Date:** 2026-06-19
+- **Depends on:** the control-plane substrate (`calfkit/controlplane/`, ADR-0010/0011) and the MCP capability plane migration (ADR-0012). This feature is a second *adopter* of the same substrate, sharing the capability plane with MCP.
+- **Relationship to prior specs:** consumes the machinery defined in `docs/designs/control-plane-substrate-spec.md` and reuses the wire model from the (now-migrated) `docs/designs/mcp-capability-discovery-spec.md`. It does **not** introduce a new control plane.
+
+---
+
+## 1. Summary
+
+Today an agent can only use a function tool node by being handed the **live node object** (`tools=[my_tool_node]`), which bakes the tool's JSON schema into the agent's process at construction (`BaseToolNodeDef.tool_bindings`, `calfkit/nodes/tool.py:30`). That couples the agent's deployment to *importing the tool's Python code*, even though the call itself always crosses Kafka.
+
+This feature adds an **identity-only handle** — `Tools(*names)` — that lets an agent reference tool nodes **by name** and discover their schemas **at runtime** from the shared capability control plane (a `ControlPlaneView[CapabilityRecord]` materialized from the compacted `calf.capabilities` topic). It is the exact mirror of how `MCPToolbox` already resolves MCP tools, applied to function tool nodes.
+
+The eager path is **kept** unchanged. `Tools` is purely additive: the same tool node can be consumed eagerly (schema baked in, local arg validation) or by reference (schema discovered, validation deferred to the node + fault rail).
+
+**Naming convention (project-wide).** A `Node` suffix marks a *deployable* host; the bare name is a *reference* to it. So `MCPToolboxNode` (deployable) ↔ `MCPToolbox` (reference), and the planned `ToolNodeDef`→`ToolNode` rename (deployable) ↔ `Tools` (reference). `Tools` is plural because a tool node is single-tool, so referencing several at once is the common case; it has no `Node` suffix because it is not deployable; and it avoids colliding with the vendored `pydantic_ai.Tool`.
+
+---
+
+## 2. Motivation
+
+- **Decouple the agent from tool code.** An agent that references `Tools("add")` needs neither the `add` function nor its module on its deployment path — only the name. The schema travels over the capability plane.
+- **Symmetry with MCP.** MCP has *no* eager path: you always hand the agent a handle (`MCPToolbox`) and the schema is discovered. Function tool nodes were the odd one out (always eager). `Tools` makes the two kinds of tools symmetric — both are "callable tools advertised on the capability plane," differing only in cardinality.
+- **Reuse, not rebuild.** The control-plane substrate, the worker-owned publisher, the capability view, the per-turn resolution loop, the staleness/schema filtering, and the wire model already shipped for MCP. A tool node becomes one more *advertiser*, and `Tools` becomes one more `ToolSelector`. The net new surface is small.
+
+---
+
+## 3. Goals / Non-goals
+
+### Goals
+1. `Tools(*names, names=...)` — a frozen, identity-only handle an agent holds to reference tool nodes by name; resolved per turn against the capability view.
+2. Tool nodes advertise their (single, static) tool to the shared `calf.capabilities` plane, **always-on**, via the substrate's `@advertises` mechanism.
+3. The discovered binding is **provably equivalent** to the eager binding for the current tool-node surface (§7).
+4. De-MCP the resolution vocabulary so it reads correctly for both a multi-tool toolbox and N single-tool nodes (`SelectorResult` plural, cardinality-neutral diagnostics).
+5. A **structural** guard against an agent absorbing the wrong kind of advertiser (e.g. `Tools` pulling a whole MCP toolbox), via a worker-stamped `node_kind` discriminator on the control-plane record.
+6. Zero new worker wiring: the feature rides the existing write-side (`@advertises` → publisher) and read-side (`_tool_selectors` → view) auto-registration.
+
+### Non-goals
+- **No `strict` mode.** Removed from MCP in ADR-0012; not added for `Tools`. Unresolved selections warn and degrade.
+- **No open-ended discovery.** An agent discovers exactly the names it declares. There is no "discover whatever tool nodes are online" mode (§14).
+- **No new control plane / topic / record type.** Tool nodes share `calf.capabilities` and `CapabilityRecord`.
+- **No protocol merge.** Collapsing `ToolProvider` + `ToolSelector` is an orthogonal refactor, out of scope (L9).
+- **No opt-in advertising in v1.** Every tool node advertises (L7). Opt-in is designed and recorded as future work (§14.1).
+- **No tool-node argument-schema fidelity beyond name/description/JSON-schema** (§7 boundary).
+
+---
+
+## 4. Background — the machinery being reused (grounded)
+
+| Piece | Location | Role |
+|---|---|---|
+| `ControlPlaneRecord` / `ControlPlaneStamp` | `calfkit/controlplane/records.py:14,33` | Record base: identity-as-key + boot/liveness/cadence stamp + `schema_version`. **This spec adds `node_kind` to the stamp (§6.4).** |
+| `@advertises(topic, record=...)` | `calfkit/controlplane/advert.py:52` | Class-body marker: binds a node *type* to one topic + record schema; factory `(self, stamp) -> record`. |
+| `ControlPlanePublisher` | `calfkit/controlplane/publisher.py:42` | One per worker; fail-loud first publish, per-advert-resilient heartbeat loop, ordered tombstone. **Stamps `node_kind` (§6.4).** |
+| `ControlPlaneView[R]` | `calfkit/controlplane/view.py:64` | Read side: instance-keyed (`node_id × worker_id`) → collapsed `get(node_id)`, staleness + schema-version filtering, health passthrough. **Gains a mixed-`node_kind` warning (§6.4, C1).** |
+| `CapabilityRecord` / `CapabilityToolDef` | `calfkit/models/capability.py:48,38` | Wire content: `dispatch_topic`, `tools[name/description/json_schema]`, `content_updated_at` (+ inherited `node_kind`). |
+| `resolve_capability` / `record_to_bindings` | `calfkit/models/capability.py:116,79` | Resolution kernel: `view.get(id)` → validator-less `ToolBinding`s. **Gains `expected_kind` (§6.4).** |
+| `ToolBinding` / `ToolProvider` / `ToolSelector` / `SelectorResult` | `calfkit/models/tool_dispatch.py:21,58,96,71` | The agent's tool-type machinery. |
+| `_node_kind` | `calfkit/nodes/base.py:483` (used in `HDR_EMITTER_KIND`); `mcp_toolbox.py:41` (`"toolbox"`); `tool.py:25` (`"tool"`) | Each node type's kind. Already exists; `node_kind` on the stamp is sourced from it. |
+| Worker read-side wiring | `calfkit/worker/worker.py:171-184` | Registers ONE `ControlPlaneView[CapabilityRecord]` resource iff any hosted node has `_tool_selectors`. |
+| Worker write-side wiring | `calfkit/worker/worker.py:232-253` | Registers the publisher + one writer per topic iff any hosted node declares an `@advertises`. |
+| Agent resolution | `calfkit/nodes/agent.py:195-258` | Per turn: read the view, resolve each selector, merge bindings (collision → existing wins), warn/degrade. |
+
+MCP's flow today: `MCPToolboxNode` declares `@advertises(topic=CAPABILITY_TOPIC, record=CapabilityRecord)` (`mcp_toolbox.py:132`); the `MCPToolbox` handle (`name` + `include`, no `strict`) resolves via `resolve_capability(view, name, include=...)` (`mcp_toolbox.py:246`). `Tools` and the tool node mirror both halves.
+
+---
+
+## 5. Design overview
+
+Four changes, all additive except the one required identity rename:
+
+1. **A `node_kind` discriminator on the control-plane stamp.** Worker-stamped from each node's `_node_kind` (so it costs no per-advertiser code). It gives the over-pull guard (§6.3) a structural basis and lets the view observe heterogeneous-owner collisions (§6.4, C1).
+2. **Tool nodes become advertisers.** `BaseToolNodeDef` declares an `@advertises` factory that publishes its single static tool to `calf.capabilities`, keyed by its `node_id`. Always-on.
+3. **Tool-node identity becomes the tool name.** Drop the `tool_` `node_id` prefix so `node_id == LLM tool name == capability key`; let `agent_tool(func, *, name=...)` and `create_tool_node(..., *, name=...)` override it.
+4. **`Tools` selector + de-MCP'd `SelectorResult`.** A new `ToolSelector` that does N independent capability lookups (one per name, `expected_kind="tool"`) and aggregates; `SelectorResult` becomes a cardinality-neutral, fully-immutable value with plural diagnostics.
+
+End-to-end flow (discovered path):
+
+```
+deploy time     tool node `add` (node_id="add", _node_kind="tool", subscribe="tool.add.input")
+                  └─ @advertises → worker publisher stamps node_kind="tool" → set("add", worker_id,
+                       CapabilityRecord{node_kind:"tool", tools:[add], dispatch_topic:"tool.add.input"})
+                                                                                  ↓ calf.capabilities (compacted)
+agent worker    ControlPlaneView[CapabilityRecord] (auto-registered: agent has a Tools selector)
+                                                                                  ↓
+agent turn      Tools("add").resolve_tools(view) → resolve_capability(view,"add",expected_kind="tool")
+                  → view.get("add") → node_kind matches → ToolBinding(tool_def=add, dispatch_topic=..., validator=None)
+                  → merged into tools_registry → advertised to the LLM
+model calls add → Call(dispatch_topic="tool.add.input", body=ToolCallRef) → tool node runs, validates, returns via reply slot
+                  (bad args → function_schema raises ValidationError → fault rail → typed fault back to the agent)
+```
+
+---
+
+## 6. Detailed design
+
+### 6.1 Tool node as advertiser (always-on)
+
+`BaseToolNodeDef` already extends `BaseNodeDef`, which carries `AdvertRegistryMixin` (`base.py:221`), and already holds `tool_schema: ToolDefinition` (`tool.py:28`) and `subscribe_topics`. The factory mirrors MCP's, reading static data instead of a cached session list. **It does not stamp `node_kind` itself** — that rides on the stamp (§6.4), so it flows in via `stamp.model_dump()`:
+
+```python
+# calfkit/nodes/tool.py — on BaseToolNodeDef
+@advertises(topic=CAPABILITY_TOPIC, record=CapabilityRecord)
+def _capability_advert(self, stamp: ControlPlaneStamp) -> CapabilityRecord:
+    """Advertise this node's single tool on the shared capability plane.
+
+    Static-schema advertiser: the tool surface is fixed at construction, so the
+    factory reads ``tool_schema`` directly (no session, no cache to prime).
+    ``content_updated_at`` is the process boot time (``stamp.started_at``): the
+    content never changes, so a stable, non-``now()`` value satisfies the
+    substrate's no-``now()``-in-factory contract. ``node_kind`` rides on the
+    stamp (the worker stamps it), so it is not set here.
+    """
+    if not self.subscribe_topics:  # named guard: empty subscribe_topics would IndexError mid-publish
+        raise RuntimeError(f"tool node {self.node_id!r} has no subscribe_topics; cannot advertise a dispatch topic")
+    return CapabilityRecord(
+        **stamp.model_dump(),  # started_at, last_heartbeat_at, heartbeat_interval, node_kind, schema_version
+        dispatch_topic=self.subscribe_topics[0],
+        tools=[
+            CapabilityToolDef(
+                name=self.tool_schema.name,
+                description=self.tool_schema.description,
+                parameters_json_schema=self.tool_schema.parameters_json_schema,
+            )
+        ],
+        content_updated_at=stamp.started_at,
+    )
+```
+
+Notes:
+- **Always-on.** The `@advertises` lives on the base type, so every `ToolNodeDef` advertises (L7). Consequence: a worker hosting any tool node stands up the control-plane writer + publisher at boot (fail-loud) — see §8. The opt-in alternative is fully designed in §14.1.
+- **Fail-safe at publish.** The factory reads only static fields; the one non-content read (`subscribe_topics[0]`) is guarded with a named error rather than letting an `IndexError` escape mid-publish.
+- **`content_updated_at = stamp.started_at`.** Correct for a static schema; never moves tick-to-tick.
+- **Replicas are trivially equivalent.** `CapabilityRecord`'s collapse precondition (equivalent content across replicas) is satisfied by construction for tool nodes: the schema is derived from the same `func`, so two replicas of the same tool node advertise byte-identical content. (Two *different* functions deployed under the same `name` would violate it — but that is the identity-collision case of §8, not a replica case.)
+- **Tombstone on clean shutdown** is handled by the shared publisher (`publisher.py:75`). No tool-node-specific lifecycle code.
+
+### 6.2 Identity & naming
+
+The capability key is the node's `node_id` (the view is `get(node_id)`). For `Tools("add")` → `view.get("add")` to resolve, the tool node's `node_id` **must equal the tool name** the user references. Today `create_tool_node` sets `node_id=f"tool_{func.__name__}"` (`tool.py:72`) while the LLM-facing tool name is `func.__name__` — they diverge.
+
+**Change `create_tool_node` / `agent_tool` so the effective tool name drives all three identities:** the `node_id`, the LLM-facing `tool_def.name`, and the topic names. The function name is the default; `name=` overrides it (the disambiguation knob for the cluster-unique-identity contract, §8). `name=` is accepted by **both** entry points; an empty `name=""` is rejected (it must not silently fall back to the function name and quietly violate the identity contract).
+
+```python
+@classmethod
+def create_tool_node(cls, func, subscribe_topics, publish_topic, *, name=None) -> Self:
+    if name is not None and not name:
+        raise ValueError("name must be non-empty when given")
+    effective = name or func.__name__
+    tool = Tool(func, name=effective)          # pydantic_ai Tool name override (tools.py:294,375)
+    return cls(
+        node_id=effective,                     # capability key == LLM tool name (== node.name property)
+        tool_schema=tool.tool_def,             # tool_def.name == effective
+        subscribe_topics=subscribe_topics,
+        publish_topic=publish_topic,
+        _tool=tool,
+    )
+
+def agent_tool(func, *, name=None) -> ToolNodeDef:
+    if name is not None and not name:
+        raise ValueError("name must be non-empty when given")
+    effective = name or func.__name__          # computed once; topics + identity share one source of truth
+    return ToolNodeDef.create_tool_node(
+        func=func, name=effective,
+        subscribe_topics=f"tool.{effective}.input",
+        publish_topic=f"tool.{effective}.output",
+    )
+```
+
+`pydantic_ai.Tool` accepts a `name` override (verified `tools.py:294`, `self.name = name or function.__name__` at `tools.py:375`), so `tool_def.name`, `node_id`, and the topics stay in lockstep. The `tool_` prefix is removed (cosmetic — one construction site, nothing parses it). `node.name`/`node.id` are read-only aliases of `node_id` (`base.py:1748-1753`), so the capability key is equivalently the node's `name`.
+
+> **Breaking change.** Dropping the `tool_` prefix changes the `node_id`, which appears on the wire in envelope headers (`HDR_EMITTER`), fault-rail origin fields, and logs. Pre-1.0, this is a clean break (§9).
+
+### 6.3 The `Tools` handle
+
+A frozen, deployment-free, identity-only handle. No connection params, no schema, no `strict`, no `include` (each name *is* an explicit selection). It dedupes names (so `Tools("add", "add") == Tools("add")`), rejects the mixed positional+keyword call, and binds only `node_kind == "tool"` records (§6.4) so it can never silently absorb a multi-tool toolbox.
+
+```python
+# calfkit/nodes/tool.py (co-located with the tool node it references; exported from `calfkit`)
+@dataclass(frozen=True)
+class Tools:
+    """Identity-only handle to one or more function tool nodes, resolved per agent
+    turn against the capability view. The call-side counterpart to a deployed tool
+    node (mirrors ``MCPToolbox``): constructible anywhere with just the tool names —
+    no schema, no import of the tool's code. Each name is a tool node's identity (its
+    ``node_id``, which equals the LLM-facing tool name). Frozen value semantics:
+    equal handles compare and hash equal; names are order-preserving-deduped.
+
+    NOTE — deliberate divergence from ``MCPToolbox``'s shape: ``MCPToolbox`` is a
+    plain frozen dataclass (declared fields + ``__post_init__``). ``Tools`` needs a
+    custom ``__init__`` to accept varargs (``Tools("add", "subtract")``), so it keeps
+    ``@dataclass(frozen=True)`` only for ``__eq__``/``__hash__``/``__repr__`` over
+    ``names``. The varargs ergonomics (L1) require this.
+    """
+
+    names: tuple[str, ...]
+
+    def __init__(self, *positional: str, names: Sequence[str] | None = None) -> None:
+        if positional and names is not None:
+            raise ValueError("pass tool names positionally or via names=, not both")
+        collected = tuple(positional) if positional else tuple(names or ())
+        collected = tuple(dict.fromkeys(collected))  # order-preserving dedupe
+        if not collected:
+            raise ValueError("Tools requires at least one tool name")
+        if any(not n for n in collected):
+            raise ValueError("Tools names must be non-empty")
+        object.__setattr__(self, "names", collected)
+
+    def resolve_tools(self, view: CapabilityLookup) -> SelectorResult:
+        bindings: list[ToolBinding] = []
+        missing: list[str] = []
+        invalid: list[str] = []
+        wrong_kind: list[str] = []
+        for name in self.names:
+            r = resolve_capability(view, name, expected_kind="tool")  # structural over-pull guard
+            bindings.extend(r.bindings)
+            missing.extend(r.missing_targets)
+            invalid.extend(r.invalid_targets)
+            wrong_kind.extend(r.wrong_kind_targets)
+        return SelectorResult(
+            bindings=tuple(bindings),
+            missing_targets=tuple(missing),
+            invalid_targets=tuple(invalid),
+            wrong_kind_targets=tuple(wrong_kind),
+        )
+```
+
+Both `Tools("add", "subtract")` (varargs, the common case) and `Tools(names=[...])` (pre-built list) work; mixing them raises. `Tools` satisfies the existing `ToolSelector` protocol (`tool_dispatch.py:96`), so it flows through `split_tool_declarations` into `agent._tool_selectors` with **no change to the agent's `tools=` union type**.
+
+### 6.4 Wire model, resolution kernel & de-MCP'd `SelectorResult`
+
+**`node_kind` on the stamp (the canonical home).** The kind discriminator is worker-stamped node metadata, exactly like `started_at`/`heartbeat_interval`, so it belongs on `ControlPlaneStamp`, not on `CapabilityRecord`. This makes it (a) generic — every control-plane record carries it, so the generic `ControlPlaneView` can use it; (b) free — it flows into every advert via `stamp.model_dump()`, so no advert factory changes; (c) identity-safe — it is a *category*, not identity, so it sits in the value alongside the other stamp metadata without violating "identity is the key, not the value."
+
+```python
+# calfkit/controlplane/records.py
+class ControlPlaneStamp(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    started_at: AwareDatetime
+    last_heartbeat_at: AwareDatetime
+    heartbeat_interval: float
+    node_kind: str            # NEW: worker-stamped node kind ("tool"/"toolbox"/"agent"/...), sourced from node._node_kind.
+                              # Required, like the sibling stamp fields (fails loud if ever unstamped). Adding it is a
+                              # BREAKING wire change: a record written before this field existed will not decode, so the
+                              # calf.capabilities topic must be recreated on upgrade. Pre-1.0, no deployments to preserve,
+                              # so no compat default (a default would mask a missing stamp and conflate legacy with "node").
+
+# calfkit/controlplane/publisher.py — _publish_one
+stamp = ControlPlaneStamp(
+    started_at=self._started_at,
+    last_heartbeat_at=now,
+    heartbeat_interval=self._config.heartbeat_interval,
+    node_kind=node._node_kind,   # the worker knows each hosted node's kind
+)
+```
+
+`CapabilityRecord` inherits `node_kind` automatically (no field added here):
+
+```python
+class CapabilityRecord(ControlPlaneRecord):   # ControlPlaneRecord(ControlPlaneStamp) → has node_kind
+    schema_version: int = CAPABILITY_SCHEMA_VERSION
+    dispatch_topic: str
+    tools: list[CapabilityToolDef]
+    content_updated_at: AwareDatetime
+```
+
+> `node_kind` (the *node* category: tool/toolbox) is distinct from `ToolDefinition.kind` (the *tool-call* category: function/unapproved). They are unrelated; adding `node_kind` has **no effect on the §7 fidelity parity**, which is purely about `ToolDefinition` fields.
+
+**Wire compatibility — breaking change (accepted; pre-1.0, no deployments).** `node_kind` is **required**, like the sibling stamp fields. A `CapabilityRecord` written before this field existed will fail to decode (`model_validate_json` raises; ktables' poison-tolerance then *skips* it — `kafka_table.py`), so the compacted `calf.capabilities` topic must be **recreated/drained on upgrade**. This is a deliberate clean break rather than a compat default: a defaulted `node_kind="node"` would mask a publisher that forgot to stamp the field and would conflate "legacy/unknown" with the real base-node kind — and with no live deployments to preserve, the shim earns nothing (and a shim runs against the project's hard-breaks-over-compat stance). **No `CAPABILITY_SCHEMA_VERSION` bump** — the topic is recreated with the new shape, so `schema_version` stays `1`. `node_kind` is typed `str` (not the `NodeKind` Literal) so a future *additive* kind value from a newer writer still decodes on an older reader.
+
+**C1 — heterogeneous-owner collision (observable, documented).** Tool nodes and MCP toolboxes share the `calf.capabilities` `node_id` keyspace. A `node_id` collision between *different owners* (a tool node and a toolbox, or two unrelated tool nodes) would land them in one group as different `worker_id` members, and the collapsed `get()` (max-by-heartbeat, `view.py:90`) would flap the agent's surface between two owners tick-to-tick. This is **a facet of the existing global `node_id`-uniqueness contract** — `node_id` already must be unique cluster-wide because it drives return topics and consumer groups (`worker.py:299,309`); a collision is an already-broken deployment, and the flap is one more symptom. So it is documented, not policed (§8). For observability, the generic view logs (dedup'd, like its schema-skip warning) when one group holds members of differing `node_kind`:
+
+```python
+# calfkit/controlplane/view.py — inside _live_members, after collecting live members
+kinds = {r.node_kind for r in live.values()}
+if len(kinds) > 1:
+    self._log_mixed_kind_once(node_id, kinds)   # dedup'd warning: duplicate node_id across owner kinds
+```
+
+**This warning is partial — cross-kind only.** It fires only when one `node_id` group holds members of *differing* `node_kind` (e.g. a tool node and a toolbox sharing a name). A **same-kind** collision — two *different* tool functions deployed under one `name`, both `node_kind="tool"` (the §6.1 replica-violation / §8 identity-collision case) — yields a single-element kind set and stays **silent**; it is covered only by the documented global `node_id`-uniqueness contract (§8) and its other symptoms (shared return topic / consumer group). Detecting same-kind/different-content collisions would require content comparison, which the collapsed view deliberately does not do. The dedup key is `(node_id, frozenset(kinds))` (mirroring `_log_schema_skip`'s `(node, worker, version)`), so a changed collision set re-warns and the warning self-clears once resolved.
+
+**`SelectorResult` — cardinality-neutral, fully immutable.** `bindings` becomes a `tuple` so the whole result is a true frozen value (a `list` in a frozen dataclass is only shallow-frozen and unhashable). `toolbox_id`/`missing_toolbox`/`invalid_record` are replaced by plural, generic fields; `wrong_kind_targets` is added for the over-pull guard:
+
+```python
+@dataclass(frozen=True)
+class SelectorResult:
+    """Outcome of resolving one ToolSelector against the capability view.
+
+    Cardinality-neutral: a selector may resolve one target (a tool node), one
+    target with many tools (an MCP toolbox), or many targets (a `Tools` handle).
+    The view owns staleness + schema-version filtering, so the unresolved cases
+    are: an absent target, an include-pinned tool missing from a present record
+    (MCP `include` only), a present-but-unexpandable record, or a present record
+    of the wrong node kind (e.g. `Tools` resolving a toolbox).
+    """
+
+    bindings: tuple[ToolBinding, ...] = ()
+    missing_targets: tuple[str, ...] = ()      # requested identities with no live record
+    missing_tools: tuple[str, ...] = ()        # MCP `include`-pinned tool names absent from a present record (MCP-only)
+    invalid_targets: tuple[str, ...] = ()      # identities whose record was present but failed binding expansion
+    wrong_kind_targets: tuple[str, ...] = ()   # identities present but of the wrong node_kind for this selector
+
+    @property
+    def unresolved(self) -> bool:
+        return bool(self.missing_targets or self.missing_tools or self.invalid_targets or self.wrong_kind_targets)
+```
+
+**`resolve_capability` — single-target kernel, `expected_kind` guard.** Param renamed `toolbox_id` → `target_id`; gains `expected_kind`. **The narrow `except ValidationError` is deliberate** (a non-validation error is a logic bug and must propagate, fail-loud) — keep that comment through the de-MCP cleanup, don't widen it to `except Exception`:
+
+```python
+def resolve_capability(view, target_id, *, include=None, expected_kind=None) -> SelectorResult:
+    record = view.get(target_id)
+    if record is None:
+        return SelectorResult(missing_targets=(target_id,))
+    if expected_kind is not None and record.node_kind != expected_kind:
+        return SelectorResult(wrong_kind_targets=(target_id,))
+    try:
+        bindings = record_to_bindings(record)
+    except ValidationError:
+        # tolerant-reader bad-data path ONLY (e.g. empty dispatch_topic fails ToolBinding min_length);
+        # a non-ValidationError here is a logic bug — let it propagate (fail loud).
+        return SelectorResult(invalid_targets=(target_id,))
+    missing_tools: tuple[str, ...] = ()
+    if include is not None:
+        wanted = set(include)
+        bindings = [b for b in bindings if b.name in wanted]
+        missing_tools = tuple(n for n in include if n not in {b.name for b in bindings})
+    return SelectorResult(bindings=tuple(bindings), missing_tools=missing_tools)
+```
+
+- `MCPToolbox.resolve_tools` → `resolve_capability(view, self.name, include=self.include, expected_kind="toolbox")` (symmetric protection: an MCP handle won't bind a tool-node record either).
+- `Tools.resolve_tools` → loop with `expected_kind="tool"`; never uses `include`; `missing_tools` always empty.
+
+The full de-MCP cleanup (L11) also generalizes the MCP-flavored docstrings in `capability.py` (module docstring, `record_to_bindings` "the toolbox's MCP server is the argument validator", `CapabilityLookup.get` param) so the kernel reads correctly for both adopters.
+
+### 6.5 Agent-side resolution
+
+`Tools` rides the existing path (`agent.py:195-258`): it lands in `_tool_selectors` via `split_tool_declarations`; per turn `_resolve_selector_tools` reads `CAPABILITY_VIEW_RESOURCE_KEY`, calls `selector.resolve_tools(view)`, and merges `result.bindings` into `tools_registry`.
+
+Required edits (these are **attribute-level**, not "pure log-text" — the old `SelectorResult` fields cease to exist, so the code won't compile until updated):
+- **Unresolved warning** now reads the plural fields (`missing_targets`, `missing_tools`, `invalid_targets`, `wrong_kind_targets`).
+- **Collision log — provenance via the selector, not the result.** The old log read `result.toolbox_id` to name the source; that field is gone (a `Tools` result aggregates N targets). Instead log the `selector` object, which is in scope in the merge loop and is *better* provenance:
+
+```python
+for selector in self._tool_selectors:          # selector in scope
+    result = selector.resolve_tools(view)
+    ...
+    for binding in result.bindings:
+        if binding.name in tools_registry:
+            logger.error("agent=%s discovered tool %r from selector %r collides with an existing tool; existing wins",
+                         self.name, binding.name, selector)
+            continue
+        tools_registry[binding.name] = binding
+```
+
+(For an `MCPToolbox` the selector repr carries `name="github"`; for `Tools` it carries the name list — strictly more informative than the old single `toolbox_id`.)
+
+- **Degrade (unchanged policy):** missing view, degraded/failed view, or `result.unresolved` → warn and continue. No raise.
+
+**Validation semantics (the eager/discovered divergence, by design):**
+- *Eager:* `ToolBinding.validator = validate_call_args` (`tool.py:41`) → the agent validates LLM args **before** dispatch; a schema mismatch is corrected locally with no Kafka hop.
+- *Discovered:* `validator=None` → the agent dispatches unvalidated. Two distinct outcomes at the tool node:
+  - a **schema-mismatch** (`function_schema` raises `ValidationError`, `tool.py:110`) escapes to the chokepoint → `on_node_error` → fault rail → typed fault back to the agent;
+  - an in-body **`ModelRetry`** is *not* a fault — it is rendered at origin to a `calf.retry`-marked reply (`tool.py:116-121`), a model-visible recoverable, identical on both eager and discovered paths (it's body behavior, not arg validation).
+
+So the discovered path's *arg-validation* failure rides the rail (one Kafka hop later than the eager path's local correction); in-body retries behave identically on both paths.
+
+**`add_tools` timing caveat (carried over from MCP).** `Agent.add_tools` (`agent.py:518`) added *after* the worker's `register_handlers` has snapshotted `_tool_selectors` will **not** get a capability view (the read-side gate already ran), so its `Tools`/`MCPToolbox` selectors silently degrade to no-discovery. Declare discovery selectors at agent construction. (Pre-existing MCP constraint; `Tools` inherits it.)
+
+### 6.6 Worker wiring (zero new code)
+
+- **Write side:** `_maybe_register_control_plane` (`worker.py:245`) collects `type(node)._adverts`. With `@advertises` on `BaseToolNodeDef`, every hosted tool node contributes the capability advert automatically — no new branch.
+- **Read side:** `_maybe_register_capability_view` (`worker.py:180`) registers the view iff any hosted node has `_tool_selectors`. A `Tools` selector trips the same gate. One worker-level `ControlPlaneView[CapabilityRecord]`, shared with MCP.
+
+---
+
+## 7. Wire model reuse & the fidelity boundary
+
+`Tools` reuses `CapabilityRecord` / `CapabilityToolDef` for tool content unchanged. For the **current** tool-node surface, the discovered `ToolBinding` is **field-for-field identical** to the eager one. `record_to_bindings` builds `ToolDefinition(name, description, parameters_json_schema)` and lets the other six fields default (`capability.py:87`); a bare `Tool(func).tool_def` carries the same defaults (verified empirically):
+
+| `ToolDefinition` field | discovered (defaulted) | eager `Tool(func).tool_def` | match |
+|---|---|---|---|
+| `strict` | `None` | `None` | ✓ |
+| `sequential` | `False` | `False` | ✓ |
+| `kind` | `'function'` | `'function'` (`requires_approval=False`) | ✓ |
+| `metadata` | `None` | `None` | ✓ |
+| `timeout` | `None` | `None` | ✓ |
+| `outer_typed_dict_key` | `None` | `None` | ✓ |
+
+> **Boundary to track.** `CapabilityToolDef` carries only name/description/JSON-schema. `Tool.__init__` *accepts* `strict`, `sequential`, `requires_approval`, `metadata`, `timeout` (`tools.py:300`), but `create_tool_node` exposes none today — which is *why* dropping them is lossless. **If the tool-node surface ever grows to expose those knobs, `CapabilityToolDef` must grow matching fields, or discovery silently drops them** (most consequentially `requires_approval` → `kind='unapproved'`, the human-in-the-loop gate). Such additions are additive (tolerant reader). A unit test asserts eager/discovered `ToolDefinition` parity so a future knob that breaks it fails loudly (§11).
+
+---
+
+## 8. Operational contract
+
+- **Identities are cluster-wide unique (existing contract).** `node_id` (= `name` = capability key) must be unique across **all** nodes cluster-wide — this was already required (it drives return topics and consumer groups, `worker.py:299,309`). Dropping the `tool_` prefix means a tool node `node_id` can now collide with an **agent** (or any node) `node_id` — e.g. an agent named `add` and a tool named `add` — where `tool_add` previously could not. A collision is a broken deployment with several symptoms; on the capability plane it manifests as a flapping tool surface (§6.4 C1), now observable via the mixed-`node_kind` warning. **Documented, not policed** (framework rule). `name=` on `agent_tool`/`create_tool_node` is the disambiguation knob.
+- **Always-on advertising ⇒ control-plane boot dependency.** Any worker hosting a tool node stands up the `calf.capabilities` writer + publisher; the first publish is fail-loud (`publisher.py:62`). The topic must exist (provisioning on, dev/CI) or be ops-provisioned (prod), and brokers must be reachable, or the worker won't boot — even if no agent ever discovers that tool. Accepted (L7); §14.1 is the escape hatch.
+- **Topic & compaction.** `calf.capabilities`, `cleanup.policy=compact`, delegated to ktables `ensure_topic` (dev/CI) or ops (prod) — same as MCP. Documented, not policed.
+- **Catch-up gating.** The view's `@resource` awaits `view.start()` during resource setup (before serving), so an agent never resolves against a half-built view. `Tools` inherits this.
+- **Staleness.** A crashed tool node's record goes stale after `3 × heartbeat_interval` and is hidden by the view; a clean shutdown tombstones immediately.
+
+---
+
+## 9. Backwards compatibility / breaking changes
+
+1. **`node_id` of tool nodes changes** (`tool_add` → `add`). On the wire (headers, fault origin) and logs. Pre-1.0 hard break.
+2. **`SelectorResult` redesign** — `toolbox_id` removed; `missing_toolbox`→`missing_targets`; `invalid_record`→`invalid_targets`; add `wrong_kind_targets`; `bindings` → `tuple`. Touches the shared MCP path. Internal types; no user-facing wire impact.
+3. **`resolve_capability(toolbox_id=...)` → `target_id`** + new `expected_kind`. Public-ish kernel; pre-1.0 rename.
+4. **`ControlPlaneStamp` gains `node_kind`** (substrate touch: `records.py`, `publisher.py`, `view.py`), **required** like the sibling stamp fields. This is a **breaking wire change**: records written before this field existed won't decode (ktables skips them), so the `calf.capabilities` topic must be recreated on upgrade. Accepted — pre-1.0, no live deployments; a compat default is explicitly rejected (it would mask a missing stamp and conflicts with the project's hard-breaks stance). No `CAPABILITY_SCHEMA_VERSION` bump (fresh topic, new shape; `schema_version` stays `1`).
+5. **`agent_tool` / `create_tool_node` gain `name=`** (additive); `agent_tool` drops the id prefix (breaking per #1).
+
+No wire-format break to `CapabilityRecord`/`CapabilityToolDef` content (MCP and tool nodes interoperate immediately).
+
+**Concrete migration checklist (from the blast-radius review — nothing parses the prefix, so it is mechanical):**
+- Production: `tool.py:72` (the prefix), `tool.py:130-136`/`61-77` (`name=`), `agent.py` resolution logs (SelectorResult fields), `mcp_toolbox.py:246` (`expected_kind`), substrate touch (`records.py`, `publisher.py`, `view.py`).
+- Node-id test assertions (8): `tests/test_run_loader.py:25,33,41,91,110,138`, `tests/test_run_serve.py:48,122` (all fed by `tests/provisioning_cli_nodes.py`).
+- `SelectorResult`-field assertions (~14): `tests/test_tool_selector.py` (many), `tests/test_mcp_toolbox.py:95` (`toolbox_id` equality — needs rewrite).
+- **`node_kind` required-field fallout (new).** Because `node_kind` is required, **every** test that constructs a `ControlPlaneStamp`/`ControlPlaneRecord`/`CapabilityRecord` must pass it, and the field-set assertions break: `tests/test_controlplane_records.py:49,53` (add `node_kind`); the `_stamp`/`make_stamp`/`make_record` helpers in `tests/test_controlplane_records.py`, `tests/test_controlplane_advert.py`, `tests/test_mcp_toolbox_publisher.py`, `tests/test_capability_models.py`, `tests/test_tool_selector.py`, `tests/test_mcp_toolbox.py`, `tests/test_controlplane_view.py`, `tests/test_controlplane_worker_wiring.py`, `tests/test_controlplane_publisher.py`. Resolution fixtures must set the kind the selector expects (`"tool"` for `Tools` tests, `"toolbox"` for MCP tests) or they resolve as `wrong_kind`. Add a publisher test asserting the stamp carries `node._node_kind`.
+- **Export:** add `Tools` to `calfkit/__init__.py.__all__` (today it exports `ToolNodeDef`, `agent_tool`, no `Tools`).
+- Docs (L11 de-MCP sweep): `capability.py` docstrings + `docs/adr/0012-*`, `docs/designs/{mcp-capability-substrate-migration-plan,capability-plane-migration-and-ops-spec,control-plane-substrate-spec,node-presence-substrate-spec,mcp-capability-discovery-spec}.md`.
+- Not affected (verified false positives): `tool_call_id`/`tool_name`/`tool_calls` metadata; `ConsumerNode` ids; `examples/deprecated/` (already-dead import path).
+
+---
+
+## 10. Build order (TDD)
+
+1. **`node_kind` on the substrate** — add required `node_kind: str` to `ControlPlaneStamp`, stamp it in the publisher from `node._node_kind`, add the view's mixed-kind warning. *Tests:* the publisher stamps `node_kind` from `node._node_kind` (`MCPToolboxNode`→`"toolbox"`, tool node→`"tool"`); the view warns once per `(node_id, frozenset(kinds))` on a cross-kind group (and does NOT warn on a same-kind group).
+2. **De-MCP `SelectorResult` + `resolve_capability`** — plural/immutable fields, `expected_kind`, `bindings` tuple, kept fail-loud comment. Update `MCPToolbox.resolve_tools` (`expected_kind="toolbox"`) and agent logs (selector-provenance). *Tests:* MCP resolution adapted; new `missing_targets`/`invalid_targets`/`wrong_kind_targets` cases.
+3. **Drop the `tool_` prefix + `name=`** on `agent_tool`/`create_tool_node` (reject empty). *Tests:* `node_id == effective`, topics derive from it, `tool_def.name == effective`, override on both entry points, empty rejected.
+4. **Tool node advertises** (`@advertises` on `BaseToolNodeDef`, guarded `subscribe_topics[0]`). *Tests:* factory builds a valid record from `tool_schema`+stamp; `content_updated_at == started_at`; worker auto-registers publisher/writer.
+5. **`Tools` selector** — varargs + `names=`, dedupe, reject-mixed, reject-empty, `expected_kind="tool"`. *Tests (dict view):* single/multi name; `names=` form; dedupe; mixed-call raises; missing → `missing_targets`; toolbox key → `wrong_kind_targets`; satisfies `ToolSelector`; lands in `_tool_selectors`.
+6. **Eager/discovered parity test** (§7).
+7. **Kafka-lane roundtrip** (mirror `test_mcp_roundtrip_kafka.py`): tool node in one worker, agent with `tools=[Tools("add")]` in another; discover → dispatch `add(2,3)` → `5` returns. Plus a bad-args case asserting the fault-rail path.
+
+---
+
+## 11. Testing strategy
+
+- **Unit** — `CapabilityLookup` is a `Protocol` satisfied by a `dict` (`capability.py:104`), so all resolution logic is broker-free.
+- **Parity** — eager vs discovered `ToolDefinition` equality (§7 guard).
+- **Scenarios** (from review) — duplicate names dedupe; `Tools(...)`/`Tools(names=...)` and the rejected mixed call; rejected empty `name=`; `Tools` + eager same tool (eager wins, validator preserved); `Tools` against `view is None` / degraded view; `wrong_kind_targets` (Tools → toolbox key); `expected_kind` for both selectors; the publisher stamps `node_kind` from `_node_kind`; cross-kind view warning fires / same-kind does not; `name=` collision (two nodes same `name`); `add_tools` post-registration degradation; replica content-equivalence; eager/discovered `ToolDefinition` parity.
+- **Worker wiring** — tool node trips write-side; `Tools` agent trips read-side.
+- **Kafka lane** — full roundtrip + fault path (`kafka` marker, in CI).
+- **Coverage** — 100% on new code (`/pytest-coverage`).
+
+---
+
+## 12. Locked decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| L1 | Plural `Tools(*names, names=...)`, dedupe, reject mixed call. | Tool nodes are single-tool; a plural handle restores MCP-like conciseness and is one type. |
+| L2 | Identity = the tool name (no `tool_` prefix); `node_id == tool name == capability key`. `name=` (non-empty) on `agent_tool` + `create_tool_node`. | One name everywhere; required for `Tools(name)` to resolve. |
+| L3 | No `strict`; warn-and-degrade. | Mirrors MCP (ADR-0012 D5). |
+| L4 | Keep both eager and discovered paths. | Eager = zero-infra + local validation; discovered = decoupled + fault-rail. Two handles, one node. |
+| L5 | `Tools` and `MCPToolbox` separate types, shared `resolve_capability` kernel; each binds only its own `node_kind` (`expected_kind`). | Distinct mental models; structural over-pull guard. |
+| L6 | Share `calf.capabilities` / `CapabilityRecord`; no new topic/record/view. | `CapabilityRecord` covers all needs (§7); one view aggregates both. |
+| L7 | Always-on advertising in v1. | Simplest; consistent with MCP. Cost: boot dependency (§8). Opt-in is the designed escape hatch (§14.1). |
+| L8 | `content_updated_at = stamp.started_at` for tool nodes. | Static schema ⇒ stable, non-`now()`. |
+| L9 | Keep the trio (`ToolBinding`/`ToolProvider`/`ToolSelector`); `Tools` is a third `ToolSelector`. No protocol merge. | Slots in cleanly; merge is a separate optional refactor (§14.2). |
+| L10 | Handle name `Tools`; deployable `ToolNode` (planned rename of `ToolNodeDef`). | Project convention: `Node` suffix = deployable, bare = reference. Rules out `ToolNodes` (Node suffix). Avoids vendored `Tool` collision. |
+| L11 | Full de-MCP vocabulary cleanup (`SelectorResult` fields, `resolve_capability(target_id=)`, MCP-flavored docstrings — including docstring *bodies*, e.g. `capability.py:84` "the toolbox's MCP server is the argument validator"). | Makes the shared plane read correctly for both adopters. |
+| L12 | `Tools` in `calfkit/nodes/tool.py`, exported from `calfkit`; no `.ref()` convenience. | Co-located; `.ref()` low-value (`Tools` takes names directly). |
+| L13 | Required `node_kind: str` discriminator on `ControlPlaneStamp` (worker-stamped from `_node_kind`); breaking wire change (recreate `calf.capabilities`), no compat default. | Canonical home for worker-stamped node metadata; powers the over-pull guard (L5) and C1 observability; free via the stamp. Required (not defaulted) matches the sibling stamp fields and fails loud on a missing stamp; pre-1.0 hard break, no deployments to preserve. |
+| L14 | C1 (heterogeneous-owner collision): document + tie to the existing global `node_id`-uniqueness contract, **plus** a dedup'd **cross-kind** mixed-`node_kind` view warning for observability (same-kind collisions stay silent — covered by the contract). | A facet of an already-required contract; namespacing the key would break L2/L6. |
+
+---
+
+## 13. Review status
+
+- **Round 1 (2026-06-19): complete, folded in.** Four lenses (correctness/runtime, architecture, gaps/blast-radius, type-design), all source-grounded. No CRITICAL architecture breaks. Verified: `Tool(func, name=)` works; §7 parity holds empirically; frozen-dataclass-custom-`__init__` is sound; `@advertises` MRO collection + topic-uniqueness OK; worker triggers fire. Folded: C1→L14 (`node_kind` + mixed-kind warning), structural over-pull guard (`expected_kind`/`wrong_kind_targets`), name dedupe, `SelectorResult.bindings`→tuple, collision-log-via-selector, reject mixed/empty, validation-taxonomy precision, `add_tools` caveat, identity-collision note, replica-equivalence note, `subscribe_topics[0]` guard, fail-loud comment retention, blast-radius checklist (§9), test scenarios (§11).
+- **Round 2 (2026-06-19): complete, folded in.** Three lenses (wire/schema-evolution, regression/C1-completeness, consistency/gaps), source-grounded; all converged on one CRITICAL — adding `node_kind` to an existing wire model means pre-change records lacking it fail `model_validate_json`, and ktables' poison-tolerance skips them (orphaning the node from the view). Verified empirically. **Resolution (Ryan): accept the breaking change** — `node_kind` is **required** (no compat default); the `calf.capabilities` topic is recreated on upgrade (pre-1.0, no deployments; a default shim was explicitly rejected as it would mask a missing stamp and conflicts with the hard-breaks stance). Also folded: C1 partial-coverage honesty (cross-kind only; same-kind silent) + dedup key `(node_id, frozenset(kinds))`; blast-radius extended to every stamp/record construction site + field-set assertions + the `calfkit` export; §10/§11 wording. No redesign — the `node_kind`-on-stamp architecture is sound. All four round-1 fixes re-verified with no regression.
+- **Round 3: pending.** A light confirm pass over the round-2 edits (the default, the `wrong_kind_targets` transient semantics, the blast-radius additions) to declare convergence before implementation.
+
+---
+
+## 14. Future extensions (explicitly deferred)
+
+### 14.1 Opt-in advertising (designed; deferred per L7)
+When the always-on boot dependency (§8) becomes a problem, opt-in is cheap because the substrate models advertising at the **type** level. Express it as a type distinction, not an instance flag:
+
+```
+BaseToolNodeDef           # eager machinery only — NO advert
+ └─ ToolNodeDef           # run handler + create_tool_node — NO advert (eager-only default)
+     └─ DiscoverableToolNodeDef   # adds the @advertises factory — advertises
+
+def agent_tool(func, *, name=None, discoverable=False):
+    cls = DiscoverableToolNodeDef if discoverable else ToolNodeDef
+    ...
+```
+A plain `ToolNodeDef` has empty `_adverts` → contributes nothing → eager-only deployments stay zero-infra. No substrate/worker change. Rejected alternative: an instance-flag gate in the worker (injects instance-level opt-out into a type-level substrate, applying globally for one use case).
+
+### 14.2 Other deferred items
+- **Extended `CapabilityToolDef` fidelity** — carry `requires_approval`/`strict`/`sequential`/`timeout`/`metadata` if the tool-node surface grows (§7). Additive.
+- **Open-ended discovery** — an agent that discovers tool nodes it did not pre-name (needs a new view-registration trigger, e.g. a `discover=True` agent flag). Out of scope (§3).
+- **Protocol merge** — collapse `ToolProvider` + `ToolSelector` (L9).
+- **Multi-tool tool nodes** — `CapabilityRecord.tools` is already a list; a future multi-tool node would advertise N entries and `Tools` would need an `include` filter, converging with `MCPToolbox`. (The `expected_kind="tool"` guard already admits it — it filters by kind, not count.)

--- a/docs/designs/runtime-tool-discoverability-spec.md
+++ b/docs/designs/runtime-tool-discoverability-spec.md
@@ -140,7 +140,7 @@ Notes:
 
 The capability key is the node's `node_id` (the view is `get(node_id)`). For `Tools("add")` → `view.get("add")` to resolve, the tool node's `node_id` **must equal the tool name** the user references. Today `create_tool_node` sets `node_id=f"tool_{func.__name__}"` (`tool.py:72`) while the LLM-facing tool name is `func.__name__` — they diverge.
 
-**Change `create_tool_node` / `agent_tool` so the effective tool name drives all three identities:** the `node_id`, the LLM-facing `tool_def.name`, and the topic names. The function name is the default; `name=` overrides it (the disambiguation knob for the cluster-unique-identity contract, §8). `name=` is accepted by **both** entry points; an empty `name=""` is rejected (it must not silently fall back to the function name and quietly violate the identity contract).
+**Change `create_tool_node` / `agent_tool` so the effective tool name drives all three identities:** the `node_id`, the LLM-facing `tool_def.name`, and the topic names. The function name is the default; `name=` overrides it (the disambiguation knob for the cluster-unique-identity contract, §8). `name=` is accepted by **both** entry points; an empty `name=""` is rejected (it must not silently fall back to the function name and quietly violate the identity contract). `agent_tool` is usable three ways — bare (`@agent_tool`), with args (`@agent_tool(name=...)`), or as a direct call (`agent_tool(fn, name=...)`) — via the standard optional-argument decorator pattern (`func=None` → return the builder; else build now).
 
 ```python
 @classmethod
@@ -157,15 +157,19 @@ def create_tool_node(cls, func, subscribe_topics, publish_topic, *, name=None) -
         _tool=tool,
     )
 
-def agent_tool(func, *, name=None) -> ToolNodeDef:
+def agent_tool(func=None, *, name=None) -> ToolNodeDef:   # bare / with-args / call (overloaded)
     if name is not None and not name:
         raise ValueError("name must be non-empty when given")
-    effective = name or func.__name__          # computed once; topics + identity share one source of truth
-    return ToolNodeDef.create_tool_node(
-        func=func, name=effective,
-        subscribe_topics=f"tool.{effective}.input",
-        publish_topic=f"tool.{effective}.output",
-    )
+
+    def _build(fn):
+        effective = name or fn.__name__        # computed once; topics + identity share one source of truth
+        return ToolNodeDef.create_tool_node(
+            func=fn, name=effective,
+            subscribe_topics=f"tool.{effective}.input",
+            publish_topic=f"tool.{effective}.output",
+        )
+
+    return _build if func is None else _build(func)       # (name=…) → return decorator; else build now
 ```
 
 `pydantic_ai.Tool` accepts a `name` override (verified `tools.py:294`, `self.name = name or function.__name__` at `tools.py:375`), so `tool_def.name`, `node_id`, and the topics stay in lockstep. The `tool_` prefix is removed (cosmetic — one construction site, nothing parses it). `node.name`/`node.id` are read-only aliases of `node_id` (`base.py:1748-1753`), so the capability key is equivalently the node's `name`.

--- a/docs/tool-discovery.md
+++ b/docs/tool-discovery.md
@@ -51,11 +51,12 @@ plane (gated at boot, so the first turn already sees it) and resolves each name 
 the start of every turn, so a tool node that comes up later — or runs in another
 process — is picked up on the next turn. No restarts, no bring-up order.
 
-The alternative, passing the live node (`tools=[add]`), bakes the schema into the
-agent's process and validates arguments locally *before* dispatch. A discovered
-`Tools` binding has no local validator: bad arguments are dispatched and the tool
-node rejects them on receipt (the failure travels back as a typed fault). Same
-node, two handles — choose per deployment.
+**Which handle?** Reach for `Tools(...)` when you want the agent's deployment
+decoupled from the tool's code — the schema travels over the plane. Pass the live
+node (`tools=[add]`) when you'd rather bake the schema in and validate arguments
+locally *before* dispatch, at the cost of importing the tool. Same node, either
+handle. (A discovered binding defers argument validation to the tool node; see the
+[design spec](designs/runtime-tool-discoverability-spec.md) for the full trade-off.)
 
 ## Names are cluster-wide identities
 

--- a/docs/tool-discovery.md
+++ b/docs/tool-discovery.md
@@ -64,12 +64,12 @@ unique across the cluster (like MCP toolbox names). Override the name without
 renaming the function — the disambiguation knob:
 
 ```python
+@agent_tool(name="issues_search")   # the tool name, not the function name "search"
 def search(query: str) -> list[str]:
     """Search the issue tracker."""
     ...
 
 
-issues_search = agent_tool(search, name="issues_search")   # not just "search"
 # ... then reference it: tools=[Tools("issues_search")]
 ```
 

--- a/docs/tool-discovery.md
+++ b/docs/tool-discovery.md
@@ -1,0 +1,96 @@
+# How to give agents discoverable tool nodes
+
+A function tool node (`@agent_tool`) can be given to an agent two ways. Pass the
+live node in `tools=[...]` and the agent bakes its schema in at construction (the
+**eager** path). Or reference it **by name** with a `Tools(...)` handle and the
+agent discovers its schema at runtime from the capability control plane (the
+**discovered** path) — so the agent's deployment never imports the tool's code.
+This mirrors how MCP toolboxes work (see [MCP tool discovery](mcp-tool-discovery.md));
+the two share one plane. (For why it works this way, see the
+[design spec](designs/runtime-tool-discoverability-spec.md).)
+
+## Deploy a tool node
+
+```python
+from calfkit import Client, Worker, agent_tool
+
+
+@agent_tool
+def add(a: int, b: int) -> int:
+    """Add two integers."""
+    return a + b
+
+
+client = Client.connect("kafka:9092")
+worker = Worker(client, nodes=[add])   # the tool node advertises automatically
+await worker.run()
+```
+
+A deployed tool node advertises its single tool on the capability control-plane
+topic (`calf.capabilities`) automatically: its host worker publishes the schema
+and re-publishes periodically as a liveness heartbeat. The tool name is the
+node's identity — both the name the LLM calls and the name an agent references.
+
+## Reference it by name
+
+```python
+from calfkit import Agent, Tools
+
+agent = Agent(
+    "researcher",
+    subscribe_topics="researcher.input",
+    model_client=model,
+    tools=[Tools("add", "subtract")],   # by name only — no import, no schema
+)
+worker = Worker(client, nodes=[agent])  # the capability view auto-registers
+```
+
+`Tools` is a frozen, identity-only handle — just the tool names (`Tools("add", "subtract")`
+or `Tools(names=[...])`). The agent's worker keeps a local view of the capability
+plane (gated at boot, so the first turn already sees it) and resolves each name at
+the start of every turn, so a tool node that comes up later — or runs in another
+process — is picked up on the next turn. No restarts, no bring-up order.
+
+The alternative, passing the live node (`tools=[add]`), bakes the schema into the
+agent's process and validates arguments locally *before* dispatch. A discovered
+`Tools` binding has no local validator: bad arguments are dispatched and the tool
+node rejects them on receipt (the failure travels back as a typed fault). Same
+node, two handles — choose per deployment.
+
+## Names are cluster-wide identities
+
+A tool node's name is its key on the shared capability topic, so names must be
+unique across the cluster (like MCP toolbox names). Override the name without
+renaming the function — the disambiguation knob:
+
+```python
+def search(query: str) -> list[str]:
+    """Search the issue tracker."""
+    ...
+
+
+issues_search = agent_tool(search, name="issues_search")   # not just "search"
+# ... then reference it: tools=[Tools("issues_search")]
+```
+
+`Tools` binds only tool-node records, so `Tools("github")` pointed at a multi-tool
+MCP toolbox (or any non-tool-node record) resolves nothing rather than absorbing
+the whole toolbox. If a discovered tool name collides with a tool the agent
+already has, the existing one wins and an error is logged.
+
+## Outages and topic creation
+
+Same as the MCP plane: a crashed tool node's advertisement goes **stale** after
+roughly three heartbeat intervals and the view hides it (the selection degrades);
+a clean shutdown removes it immediately; it reappears on the next turn once it is
+back. With provisioning enabled (dev/CI) either worker creates the compacted
+`calf.capabilities` topic idempotently; in production create it out-of-band
+(`cleanup.policy=compact`, RF≥3). See [topic provisioning](topic-provisioning.md).
+
+## Tune it (optional)
+
+One config surface, shared with the MCP plane:
+`Worker(..., control_plane=ControlPlaneConfig(...))` — the boot catch-up timeout,
+heartbeat interval, staleness threshold, and a `bootstrap_servers` override for
+running the control plane on a separate Kafka cluster. The capability topic name
+is fixed (`calf.capabilities`).

--- a/tests/integration/test_lifecycle_resources_kafka.py
+++ b/tests/integration/test_lifecycle_resources_kafka.py
@@ -1,0 +1,107 @@
+"""Real-broker (``kafka`` lane) lifecycle test: resources reach the Agent ``run``
+and an ``agent_tool``.
+
+This moved out of the offline ``tests/test_lifecycle_e2e.py`` because hosting a
+function tool node now stands up a REAL ``calf.capabilities`` control-plane writer
+at worker boot (always-on advertising — the tool node's ``@advertises``). That
+writer opens its own aiokafka producer, which the in-memory ``TestKafkaBroker``
+does NOT intercept, so the worker can only boot against a reachable broker.
+
+The agent->tool round trip itself still runs over ``TestKafkaBroker``; the real
+broker is needed solely so the control-plane writer/publisher can start (and
+auto-create ``calf.capabilities``, same as the other capability-lane suites).
+
+Opt-in (``-m kafka`` / ``make test-kafka``); skips cleanly without Docker. Run with
+``uv run --group integration pytest tests/integration/test_lifecycle_resources_kafka.py -m kafka``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from faststream.kafka import TestKafkaBroker
+
+from calfkit._vendor.pydantic_ai import models
+from calfkit._vendor.pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart, ToolReturnPart
+from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
+from calfkit.client import Client
+from calfkit.models.session_context import SessionRunContext
+from calfkit.models.tool_context import ToolContext
+from calfkit.nodes import Agent, agent_tool
+from calfkit.worker import Worker
+
+# Every test here needs a real broker. FunctionModel is offline, but pydantic-ai still
+# gates "model requests" behind this flag (matches the other kafka-lane agent suites).
+pytestmark = pytest.mark.kafka
+models.ALLOW_MODEL_REQUESTS = True
+
+
+def _tool_then_text(captured: dict[str, Any]) -> FunctionModel:
+    """A FunctionModel that calls ``read_resource`` once, then emits text."""
+
+    def _fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        last = messages[-1]
+        if any(isinstance(p, ToolReturnPart) for p in getattr(last, "parts", [])):
+            return ModelResponse(parts=[TextPart("done")])
+        return ModelResponse(parts=[ToolCallPart(tool_name="read_resource", args={})])
+
+    return FunctionModel(_fn)
+
+
+async def test_resources_reach_agent_run_and_agent_tool(kafka_bootstrap: str) -> None:
+    """The Agent's ``run`` reads ``ctx.resources`` (via prepare_context) and an
+    ``agent_tool`` reads ``ctx.resources`` (via the ToolContext) — two of the
+    four surfaces, exercised through a real agent->tool round trip.
+
+    In the ``kafka`` lane because hosting the tool node stands up a real
+    control-plane writer at boot (always-on advertising), so the worker needs a
+    reachable broker even though the round trip itself runs over ``TestKafkaBroker``.
+    """
+    tool_saw: dict[str, Any] = {}
+
+    def read_resource(ctx: ToolContext) -> str:
+        tool_saw["db"] = ctx.resources["db"]
+        return "ok"
+
+    tool = agent_tool(read_resource)
+    tool_sentinel = object()
+    tool.resources["db"] = tool_sentinel
+
+    # A custom agent subclass so we can also assert the *agent's* ctx.resources
+    # surface (prepare_context stamping) on the same run.
+    agent_saw: dict[str, Any] = {}
+
+    class _ResAgent(Agent[str]):
+        async def run(self, ctx: SessionRunContext) -> Any:
+            agent_saw["db"] = ctx.resources.get("db")
+            return await super().run(ctx)
+
+    agent: _ResAgent = _ResAgent(
+        "res_agent",
+        system_prompt="x",
+        subscribe_topics="res_agent.in",
+        publish_topic="res_agent.out",
+        model_client=_tool_then_text(tool_saw),  # type: ignore[arg-type]
+        tools=[tool],
+    )
+    agent_sentinel = object()
+    agent.resources["db"] = agent_sentinel
+
+    # A real bootstrap so the always-on control-plane writer can start; the round
+    # trip itself is still simulated in-memory by TestKafkaBroker below.
+    worker = Worker(Client.connect(kafka_bootstrap))
+    worker.add_nodes(agent, tool)
+    broker = worker._client.broker
+    client = worker._client
+
+    async with TestKafkaBroker(broker):
+        await worker.start()
+        result = await client.execute("hi", "res_agent.in", timeout=5)
+        await worker.stop()
+
+    assert result.output == "done"
+    # agent_tool surface: the tool read its node's resources.
+    assert tool_saw["db"] is tool_sentinel
+    # Agent run surface: the agent read its own node's resources.
+    assert agent_saw["db"] is agent_sentinel

--- a/tests/integration/test_tool_discovery_kafka.py
+++ b/tests/integration/test_tool_discovery_kafka.py
@@ -1,0 +1,251 @@
+"""Real-broker (``kafka`` lane) end-to-end runtime tool DISCOVERY roundtrip.
+
+The discovered-path counterpart to ``test_tool_node_roundtrip_kafka.py`` (eager) and the
+tool-node analogue of ``test_mcp_roundtrip_kafka.py``: a tool node is DEPLOYED in one
+worker (where it advertises its ``CapabilityRecord`` on ``calf.capabilities``), and an
+agent in another worker references it by name via a ``Tools(...)`` handle — discovering
+its schema at runtime from the capability view, then dispatching the call over Kafka:
+
+    the tool node advertises -> the agent's view catch-up includes it
+      -> the model emits a tool call
+      -> the agent resolves ``Tools(name)`` from the view (validator=None: schema-only)
+      -> dispatches a ToolCallRef over Kafka to the tool node's topic
+      -> the tool node runs the Python function
+      -> the return value comes back over Kafka
+      -> the agent re-enters the model loop and finalizes.
+
+The bad-args case is the discovered-binding contrast with the eager path
+(``test_invalid_tool_node_args_rejected_before_dispatch``): a discovered binding has NO
+validator, so the agent does NOT reject schema-invalid args locally — it dispatches them,
+the tool node raises on receipt, and the chokepoint escalates a typed ``calf.unhandled``
+``FaultMessage`` on the agent's ``publish_topic`` mirror (observed via the fault tap; typed
+client reception is deferred to #250).
+
+Opt-in (``-m kafka`` / ``make test-kafka``); skips cleanly without Docker. Run with
+``uv run --group integration pytest tests/integration/test_tool_discovery_kafka.py -m kafka``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from calfkit._protocol import HDR_ERROR_TYPE, HDR_KIND
+from calfkit._vendor.pydantic_ai import models
+from calfkit._vendor.pydantic_ai.messages import ToolCallPart
+from calfkit.client import Client
+from calfkit.controlplane import ControlPlaneConfig, ControlPlaneView
+from calfkit.models.capability import CAPABILITY_TOPIC, CapabilityRecord
+from calfkit.models.error_report import FaultTypes
+from calfkit.nodes import Agent, ToolNodeDef, Tools, agent_tool
+from calfkit.worker import Worker
+from tests.integration._fault_kafka import ensure_topic
+from tests.integration._fault_tap import fault_tap
+from tests.integration._roundtrip_helpers import FINAL_OUTPUT, capturing_model, scripted_model, tool_returns
+
+# Every test here needs a real broker. FunctionModel is offline, but pydantic-ai still
+# gates "model requests" behind this flag (matches the other kafka-lane agent suites).
+pytestmark = pytest.mark.kafka
+models.ALLOW_MODEL_REQUESTS = True
+
+_EARLIEST = {"auto_offset_reset": "earliest"}
+
+
+def _control_plane(bootstrap: str) -> ControlPlaneConfig:
+    return ControlPlaneConfig(heartbeat_interval=5.0, bootstrap_servers=bootstrap)
+
+
+def _worker(bootstrap: str, *, nodes: list, control_plane: ControlPlaneConfig) -> Worker:
+    """A Worker on its own broker connection, control plane on, reading earliest.
+
+    The tool worker needs the control plane to advertise; the agent worker needs it to
+    materialize the capability view it resolves ``Tools`` against.
+    """
+    return Worker(Client.connect(bootstrap), nodes=nodes, control_plane=control_plane, extra_subscribe_kwargs=_EARLIEST)
+
+
+def _add_tool(name: str) -> ToolNodeDef:
+    """A per-test, uniquely-named ``add`` tool node (the node_id IS the capability key on
+    the shared ``calf.capabilities`` topic, so it must be unique across tests)."""
+
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    return agent_tool(add, name=name)
+
+
+async def _wait(predicate: Callable[[], bool], *, timeout: float, what: str) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.1)
+    raise AssertionError(f"timed out after {timeout}s waiting for: {what}")
+
+
+async def _await_view(bootstrap: str, predicate: Callable[[ControlPlaneView[CapabilityRecord]], bool], *, timeout: float, what: str) -> None:
+    """Open a transient capability view, wait for ``predicate`` over it, then close it."""
+    view: ControlPlaneView[CapabilityRecord] = ControlPlaneView.open(
+        bootstrap_servers=bootstrap, topic=CAPABILITY_TOPIC, record_type=CapabilityRecord, ensure_topic=False
+    )
+    try:
+        await view.start()
+        await _wait(lambda: predicate(view), timeout=timeout, what=what)
+    finally:
+        await view.stop()
+
+
+async def _await_capability(bootstrap: str, node_id: str, *, timeout: float) -> None:
+    """Block until the tool node's CapabilityRecord is live on ``calf.capabilities``, so the
+    agent's view catch-up includes it and ``Tools(name)`` resolves on the turn."""
+    await _await_view(bootstrap, lambda v: v.get(node_id) is not None, timeout=timeout, what=f"capability record {node_id!r}")
+
+
+async def test_discovered_tool_node_roundtrips_over_the_wire(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """A tool node deployed in one worker is discovered by name from another: the agent
+    holds only ``Tools(name)`` (no schema baked in), resolves it from the view, dispatches
+    ``add(2, 3)``, and ``5`` travels all the way back into the agent's history."""
+    tool_name = f"{topic_namespace}-add"
+    agent_id = f"{topic_namespace}-disc-agent"
+    agent_in = f"{topic_namespace}.disc-agent.input"
+    control_plane = _control_plane(kafka_bootstrap)
+
+    tool = _add_tool(tool_name)
+    agent = Agent(
+        agent_id,
+        system_prompt="add two numbers",
+        subscribe_topics=agent_in,
+        model_client=scripted_model([ToolCallPart(tool_name, {"a": 2, "b": 3}, tool_call_id="c1")]),
+        tools=[Tools(tool_name)],  # by name only — schema discovered at runtime
+    )
+
+    driver = Client.connect(kafka_bootstrap)
+    tool_worker = _worker(kafka_bootstrap, nodes=[tool], control_plane=control_plane)
+    agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
+
+    async with tool_worker:
+        await _await_capability(kafka_bootstrap, tool_name, timeout=60)
+        async with agent_worker:
+            result = await driver.execute("add 2 and 3", agent_in, timeout=120)
+
+    assert result.output is not None and FINAL_OUTPUT in result.output
+    assert tool_returns(result.message_history)[tool_name] == 5
+
+    await driver.close()
+    await tool_worker._client.close()
+    await agent_worker._client.close()
+
+
+async def test_model_pov_matches_the_advertised_tool(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """The model's POV of its tools IS what the tool node advertised on the view.
+
+    The agent holds only ``Tools(name)`` — no schema baked in. Rather than assuming the
+    surface, the model captures what the agent actually resolved from the capability view
+    and handed it (``AgentInfo.function_tools``); the test asserts that POV matches the live
+    ``CapabilityRecord`` on ``calf.capabilities`` by NAME and by SCHEMA, and that the tool
+    drawn from that POV round-trips — proving the model sees the *advertised* tool at runtime,
+    not a schema the test hardcoded.
+    """
+    tool_name = f"{topic_namespace}-add"
+    agent_id = f"{topic_namespace}-pov-agent"
+    agent_in = f"{topic_namespace}.pov-agent.input"
+    control_plane = _control_plane(kafka_bootstrap)
+
+    tool = _add_tool(tool_name)
+    pov: dict[str, Any] = {}  # name -> ToolDefinition the agent resolved from the view and presented to the model
+    agent = Agent(
+        agent_id,
+        system_prompt="add two numbers",
+        subscribe_topics=agent_in,
+        model_client=capturing_model(pov, [ToolCallPart(tool_name, {"a": 2, "b": 3}, tool_call_id="c1")]),
+        tools=[Tools(tool_name)],  # by name only — the schema must come from the view
+    )
+
+    advertised: dict[str, Any] = {}  # name -> parameters_json_schema, read straight from the view record
+
+    def _capture_advertised(view: ControlPlaneView[CapabilityRecord]) -> bool:
+        record = view.get(tool_name)
+        if record is None:
+            return False
+        advertised.clear()
+        advertised.update({t.name: t.parameters_json_schema for t in record.tools})
+        return True
+
+    driver = Client.connect(kafka_bootstrap)
+    tool_worker = _worker(kafka_bootstrap, nodes=[tool], control_plane=control_plane)
+    agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
+
+    async with tool_worker:
+        await _await_capability(kafka_bootstrap, tool_name, timeout=60)
+        # The source of truth the agent reads: what the tool node advertised on the view.
+        await _await_view(kafka_bootstrap, _capture_advertised, timeout=60, what=f"advertised tools for {tool_name!r}")
+        async with agent_worker:
+            result = await driver.execute("add 2 and 3", agent_in, timeout=120)
+
+    # 1) the call drawn from the advertised tool round-tripped to a finalized turn
+    assert result.output is not None and FINAL_OUTPUT in result.output
+    assert tool_returns(result.message_history)[tool_name] == 5
+
+    # 2) the tool node advertised exactly its one tool
+    assert set(advertised) == {tool_name}
+
+    # 3) the model's POV == the advertised view record, by NAME and SCHEMA — the agent presented
+    #    to the model exactly what the tool node advertised, discovered at runtime (nothing baked in)
+    assert pov, "the model never captured the agent's tool POV"
+    assert set(pov) == set(advertised)
+    assert {name: td.parameters_json_schema for name, td in pov.items()} == advertised
+
+    # 4) the discovered tool reached the model with its real args
+    assert {"a", "b"} <= set(pov[tool_name].parameters_json_schema.get("properties", {}))
+
+    await driver.close()
+    await tool_worker._client.close()
+    await agent_worker._client.close()
+
+
+async def test_discovered_bad_args_escalate_unhandled_fault(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """A discovered binding carries NO validator (schema-only), so the agent dispatches
+    schema-invalid args instead of rejecting them locally (the eager path's contrast): the
+    tool node raises on receipt and the chokepoint escalates a typed ``calf.unhandled``
+    ``FaultMessage`` on the agent's ``publish_topic`` mirror."""
+    tool_name = f"{topic_namespace}-add"
+    agent_id = f"{topic_namespace}-disc-fault"
+    agent_in = f"{topic_namespace}.disc-fault.input"
+    agent_pub = f"{topic_namespace}.disc-fault.mirror"
+    control_plane = _control_plane(kafka_bootstrap)
+
+    tool = _add_tool(tool_name)
+    agent = Agent(
+        agent_id,
+        system_prompt="add with bad args",
+        subscribe_topics=agent_in,
+        publish_topic=agent_pub,
+        model_client=scripted_model([ToolCallPart(tool_name, {"a": "not-an-int", "b": 3}, tool_call_id="c1")]),
+        tools=[Tools(tool_name)],
+        sequential_only_mode=True,  # single dispatch; keep the durable fan-out store out of the fault path
+    )
+    await ensure_topic(kafka_bootstrap, agent_pub)
+
+    driver = Client.connect(kafka_bootstrap)
+    tool_worker = _worker(kafka_bootstrap, nodes=[tool], control_plane=control_plane)
+    agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
+
+    async with tool_worker:
+        await _await_capability(kafka_bootstrap, tool_name, timeout=60)
+        async with agent_worker, fault_tap(kafka_bootstrap, agent_pub) as tap:
+            await driver.start("add with bad args", agent_in)  # reply owed; the discovered binding dispatches the bad args
+
+            fault, headers = await tap.next_fault(timeout=60)
+            # The bad args reached the tool node (the discovered binding did NOT validate
+            # locally), and its raise escalated as a typed unhandled fault.
+            assert headers[HDR_KIND] == "fault"
+            assert headers[HDR_ERROR_TYPE] == FaultTypes.UNHANDLED
+            assert fault.error.error_type == FaultTypes.UNHANDLED
+            assert fault.error.details.get(FaultTypes.EXCEPTION_TYPE) is not None  # the tool's exception class
+
+    await driver.close()
+    await tool_worker._client.close()
+    await agent_worker._client.close()

--- a/tests/test_capability_models.py
+++ b/tests/test_capability_models.py
@@ -32,6 +32,7 @@ def make_record(**overrides: Any) -> CapabilityRecord:
         started_at=now,
         last_heartbeat_at=now,
         heartbeat_interval=30.0,
+        node_kind="toolbox",
         dispatch_topic="mcp_server.docs_server",
         tools=[
             CapabilityToolDef(

--- a/tests/test_controlplane_advert.py
+++ b/tests/test_controlplane_advert.py
@@ -23,7 +23,7 @@ class _Rec2(ControlPlaneRecord):
 
 def _stamp() -> ControlPlaneStamp:
     ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    return ControlPlaneStamp(started_at=ts, last_heartbeat_at=ts, heartbeat_interval=30.0)
+    return ControlPlaneStamp(started_at=ts, last_heartbeat_at=ts, heartbeat_interval=30.0, node_kind="node")
 
 
 # -- decorator ---------------------------------------------------------------

--- a/tests/test_controlplane_publisher.py
+++ b/tests/test_controlplane_publisher.py
@@ -26,8 +26,14 @@ class _CapRec(ControlPlaneRecord):
 class _Node:
     """A node stand-in exposing a fixed factory method named ``make_record``."""
 
-    def __init__(self, node_id: str, factory: Callable[[ControlPlaneStamp], ControlPlaneRecord]) -> None:
+    def __init__(
+        self,
+        node_id: str,
+        factory: Callable[[ControlPlaneStamp], ControlPlaneRecord],
+        node_kind: str = "node",
+    ) -> None:
         self.node_id = node_id
+        self._node_kind = node_kind
         self._factory = factory
 
     def make_record(self, identity: ControlPlaneStamp) -> ControlPlaneRecord:
@@ -101,6 +107,20 @@ async def test_start_publishes_each_advert_once_with_identity() -> None:
         assert (group, member) == ("n1", "wkr")  # identity is the wire key
         assert record.heartbeat_interval == 3600.0  # stamped from config
         assert record.started_at == pub._started_at
+    finally:
+        await pub.stop(ctx)
+
+
+async def test_start_stamps_node_kind_from_node() -> None:
+    # The worker stamps node_kind from the node's _node_kind — the over-pull guard's basis.
+    writer = _Writer()
+    node = _Node("n1", _rec_factory("x"), node_kind="tool")
+    pub = ControlPlanePublisher(worker_id="wkr", adverts=[(node, _advert("t"))], config=ControlPlaneConfig(heartbeat_interval=3600.0))
+    ctx = _Ctx({_key("t"): writer})
+    await pub.start(ctx)
+    try:
+        _, _, record = writer.sets[0]
+        assert record.node_kind == "tool"
     finally:
         await pub.stop(ctx)
 

--- a/tests/test_controlplane_records.py
+++ b/tests/test_controlplane_records.py
@@ -20,6 +20,7 @@ def _stamp(**overrides: object) -> ControlPlaneStamp:
         started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
         last_heartbeat_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
         heartbeat_interval=30.0,
+        node_kind="node",
     )
     base.update(overrides)
     return ControlPlaneStamp(**base)  # type: ignore[arg-type]
@@ -46,11 +47,26 @@ def test_identity_is_not_carried_in_the_value() -> None:
 def test_record_is_a_stamp_plus_schema_version() -> None:
     """Tidy structural form: the record extends the stamp, so worker fields are declared once."""
     assert issubclass(ControlPlaneRecord, ControlPlaneStamp)
-    assert set(ControlPlaneRecord.model_fields) == {"started_at", "last_heartbeat_at", "heartbeat_interval", "schema_version"}
+    assert set(ControlPlaneRecord.model_fields) == {"started_at", "last_heartbeat_at", "heartbeat_interval", "node_kind", "schema_version"}
 
 
 def test_stamp_carries_only_worker_owned_fields() -> None:
-    assert set(ControlPlaneStamp.model_fields) == {"started_at", "last_heartbeat_at", "heartbeat_interval"}
+    assert set(ControlPlaneStamp.model_fields) == {"started_at", "last_heartbeat_at", "heartbeat_interval", "node_kind"}
+
+
+def test_stamp_carries_node_kind() -> None:
+    """node_kind is worker-stamped onto every record (over-pull guard + mixed-kind observability)."""
+    assert _stamp(node_kind="agent").node_kind == "agent"
+
+
+def test_node_kind_is_required() -> None:
+    """node_kind has no default (a breaking wire change) — a stamp without it does not decode."""
+    with pytest.raises(ValidationError):
+        ControlPlaneStamp(  # type: ignore[call-arg]
+            started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            last_heartbeat_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            heartbeat_interval=30.0,
+        )
 
 
 def test_tolerant_reader_ignores_unknown_fields() -> None:

--- a/tests/test_controlplane_view.py
+++ b/tests/test_controlplane_view.py
@@ -14,13 +14,22 @@ class _Rec(ControlPlaneRecord):
     content: str
 
 
-def _rec(worker_id: str, *, age_s: float = 0.0, hb: float = 30.0, schema_version: int = 1, content: str | None = None) -> _Rec:
+def _rec(
+    worker_id: str,
+    *,
+    age_s: float = 0.0,
+    hb: float = 30.0,
+    schema_version: int = 1,
+    content: str | None = None,
+    node_kind: str = "node",
+) -> _Rec:
     now = datetime.now(tz=timezone.utc)
     return _Rec(
         schema_version=schema_version,
         started_at=now,
         last_heartbeat_at=now - timedelta(seconds=age_s),
         heartbeat_interval=hb,
+        node_kind=node_kind,
         content=content if content is not None else worker_id,  # default content = the instance label (identity is the key)
     )
 
@@ -164,6 +173,28 @@ def test_schema_skip_dedup_is_per_member_not_per_node(caplog: pytest.LogCaptureF
     skip_logs = [r for r in caplog.records if "schema" in r.getMessage().lower() and r.levelname == "WARNING"]
     assert len(skip_logs) == 2  # one per distinct member, deduped across reads
     assert {"w1", "w2"} == {w for w in ("w1", "w2") if any(w in r.getMessage() for r in skip_logs)}
+
+
+def test_mixed_kind_group_warns_once(caplog: pytest.LogCaptureFixture) -> None:
+    # A node_id group holding members of DIFFERENT node_kind is a heterogeneous-owner
+    # collision (spec C1/L14): observable, dedup'd. Cross-kind only.
+    v = _view({"add": {"w1": _rec("w1", node_kind="tool"), "w2": _rec("w2", node_kind="toolbox")}})
+    with caplog.at_level("WARNING"):
+        v.get("add")
+        v.get("add")  # second read must NOT re-log the same (node, kind-set)
+    mixed = [r for r in caplog.records if "node_kind" in r.getMessage() and r.levelname == "WARNING"]
+    assert len(mixed) == 1
+    msg = mixed[0].getMessage()
+    assert "add" in msg and "tool" in msg and "toolbox" in msg
+
+
+def test_same_kind_group_does_not_warn(caplog: pytest.LogCaptureFixture) -> None:
+    # Same-kind members (the benign replica case) must NOT trip the cross-kind warning.
+    v = _view({"add": {"w1": _rec("w1", node_kind="tool"), "w2": _rec("w2", node_kind="tool")}})
+    with caplog.at_level("WARNING"):
+        v.get("add")
+    mixed = [r for r in caplog.records if "node_kind" in r.getMessage() and r.levelname == "WARNING"]
+    assert mixed == []
 
 
 def test_collapse_filters_stale_before_tiebreak() -> None:

--- a/tests/test_fire_and_forget.py
+++ b/tests/test_fire_and_forget.py
@@ -286,7 +286,7 @@ async def test_send_tool_overrides_only_builds_overrides(container):
     overrides carry the tool list and a None model_settings. A ToolProvider
     (here a ToolNodeDef) is normalized into its ToolBindings, same as
     ``Agent(tools=...)``."""
-    tool = ping  # a ToolProvider (ToolNodeDef); a named fn yields a topic-safe node_id (a lambda's "tool_<lambda>" is rejected)
+    tool = ping  # a ToolProvider (ToolNodeDef); a named fn yields a topic-safe node_id (a lambda's "<lambda>" is rejected)
     client = container.get(Client)
     client._send = AsyncMock(return_value="cid")
 

--- a/tests/test_lifecycle_e2e.py
+++ b/tests/test_lifecycle_e2e.py
@@ -9,9 +9,10 @@ calls out:
 * a ``@resource`` (and a callback-shape resource) opened at boot reaches a live
   handler as ``ctx.resources[...]`` and is closed (key popped from the bag) on
   stop;
-* ``resources`` reach all four read surfaces (Agent ``run`` / custom
-  ``BaseNodeDef`` ``ctx.resources``, ``agent_tool`` ``ctx.resources``, and the
-  consumer ``result.resources``);
+* ``resources`` reach the custom ``BaseNodeDef`` ``ctx.resources`` and the
+  consumer ``result.resources`` surfaces here; the Agent ``run`` and
+  ``agent_tool`` surfaces need a real broker (the always-on control-plane
+  writer), so they live in ``tests/integration/test_lifecycle_resources_kafka.py``;
 * when an owner mixes ``@resource`` and resource-phase callbacks on the same
   key, the ``@resource`` brackets win (callbacks ignored, warning logged), and a
   duplicate ``@resource`` name on one owner raises ``LifecycleConfigError`` at
@@ -20,8 +21,7 @@ calls out:
 * an ``after_startup`` failure stops the broker, and a double ``start()`` raises.
 
 We avoid the LLM by driving deterministic node handlers directly over the
-broker (mirroring ``tests/test_consumer.py``'s hand-built envelope pattern) and
-a ``FunctionModel``-backed agent for the tool surface.
+broker (mirroring ``tests/test_consumer.py``'s hand-built envelope pattern).
 """
 
 from __future__ import annotations
@@ -33,8 +33,6 @@ import pytest
 from faststream.kafka import TestKafkaBroker
 
 from calfkit._protocol import HDR_EMITTER, HDR_EMITTER_KIND
-from calfkit._vendor.pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart, ToolReturnPart
-from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
 from calfkit.client import Client, InvocationResult
 from calfkit.exceptions import LifecycleConfigError
 from calfkit.models import ReturnCall
@@ -48,8 +46,7 @@ from calfkit.models.session_context import (
     WorkflowState,
 )
 from calfkit.models.state import State
-from calfkit.models.tool_context import ToolContext
-from calfkit.nodes import Agent, agent_tool, consumer
+from calfkit.nodes import consumer
 from calfkit.nodes.base import BaseNodeDef
 from calfkit.worker import ServingContext, Worker
 
@@ -181,7 +178,8 @@ async def test_callback_resource_reaches_handler_then_closes_on_stop() -> None:
 
 
 # ---------------------------------------------------------------------------
-# resources reach ALL FOUR surfaces
+# resources reach the in-process surfaces (custom BaseNodeDef + consumer); the
+# Agent-run + agent_tool surfaces need a real broker -> the kafka lane
 # ---------------------------------------------------------------------------
 
 
@@ -224,69 +222,6 @@ async def test_resources_reach_consumer_result() -> None:
 
     assert received, "consumer never ran"
     assert received[-1].resources["db"] is sentinel
-
-
-def _tool_then_text(captured: dict[str, Any]) -> FunctionModel:
-    """A FunctionModel that calls ``read_resource`` once, then emits text."""
-
-    def _fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
-        last = messages[-1]
-        if any(isinstance(p, ToolReturnPart) for p in getattr(last, "parts", [])):
-            return ModelResponse(parts=[TextPart("done")])
-        return ModelResponse(parts=[ToolCallPart(tool_name="read_resource", args={})])
-
-    return FunctionModel(_fn)
-
-
-async def test_resources_reach_agent_run_and_agent_tool() -> None:
-    """The Agent's ``run`` reads ``ctx.resources`` (via prepare_context) and an
-    ``agent_tool`` reads ``ctx.resources`` (via the ToolContext) — two of the
-    four surfaces, exercised through a real agent->tool round trip over Kafka."""
-    tool_saw: dict[str, Any] = {}
-
-    def read_resource(ctx: ToolContext) -> str:
-        tool_saw["db"] = ctx.resources["db"]
-        return "ok"
-
-    tool = agent_tool(read_resource)
-    tool_sentinel = object()
-    tool.resources["db"] = tool_sentinel
-
-    # A custom agent subclass so we can also assert the *agent's* ctx.resources
-    # surface (prepare_context stamping) on the same run.
-    agent_saw: dict[str, Any] = {}
-
-    class _ResAgent(Agent[str]):
-        async def run(self, ctx: SessionRunContext) -> Any:
-            agent_saw["db"] = ctx.resources.get("db")
-            return await super().run(ctx)
-
-    agent: _ResAgent = _ResAgent(
-        "res_agent",
-        system_prompt="x",
-        subscribe_topics="res_agent.in",
-        publish_topic="res_agent.out",
-        model_client=_tool_then_text(tool_saw),  # type: ignore[arg-type]
-        tools=[tool],
-    )
-    agent_sentinel = object()
-    agent.resources["db"] = agent_sentinel
-
-    worker = _make_worker()
-    worker.add_nodes(agent, tool)
-    broker = worker._client.broker
-    client = worker._client
-
-    async with TestKafkaBroker(broker):
-        await worker.start()
-        result = await client.execute("hi", "res_agent.in", timeout=5)
-        await worker.stop()
-
-    assert result.output == "done"
-    # agent_tool surface: the tool read its node's resources.
-    assert tool_saw["db"] is tool_sentinel
-    # Agent run surface: the agent read its own node's resources.
-    assert agent_saw["db"] is agent_sentinel
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_toolbox.py
+++ b/tests/test_mcp_toolbox.py
@@ -93,7 +93,7 @@ class TestMintingAndParity:
         via_toolbox = make_toolbox().resolve_tools(view)
         via_ref = MCPToolbox("github").resolve_tools(view)
         assert [b.name for b in via_toolbox.bindings] == [b.name for b in via_ref.bindings]
-        assert via_toolbox.toolbox_id == via_ref.toolbox_id
+        assert via_toolbox == via_ref  # identical SelectorResult (frozen value): toolbox and ref resolve the same
 
     def test_scoped_selector_is_gone(self) -> None:
         import calfkit.mcp.mcp_toolbox as mod

--- a/tests/test_mcp_toolbox.py
+++ b/tests/test_mcp_toolbox.py
@@ -24,6 +24,7 @@ def make_record(toolbox_id: str = "github", tool_names: tuple[str, ...] = ("sear
         started_at=now,
         last_heartbeat_at=now,
         heartbeat_interval=30.0,
+        node_kind="toolbox",
         dispatch_topic=f"mcp_server.{toolbox_id}",
         tools=[CapabilityToolDef(name=n, parameters_json_schema={"type": "object", "properties": {}}) for n in tool_names],
         content_updated_at=now,

--- a/tests/test_mcp_toolbox_publisher.py
+++ b/tests/test_mcp_toolbox_publisher.py
@@ -52,7 +52,7 @@ def make_toolbox() -> Any:
 
 def make_stamp(*, hb: float = 30.0) -> ControlPlaneStamp:
     now = datetime.now(tz=timezone.utc)
-    return ControlPlaneStamp(started_at=now, last_heartbeat_at=now, heartbeat_interval=hb)
+    return ControlPlaneStamp(started_at=now, last_heartbeat_at=now, heartbeat_interval=hb, node_kind="toolbox")
 
 
 class TestAdvertDeclaration:

--- a/tests/test_run_loader.py
+++ b/tests/test_run_loader.py
@@ -22,7 +22,7 @@ def test_resolve_specs_single_node() -> None:
 
     objs = resolve_specs([f"{_FIXTURE}:single"])
     assert len(objs) == 1
-    assert objs[0].node_id == "tool_echo"
+    assert objs[0].node_id == "echo"
 
 
 def test_resolve_specs_expands_iterable_attr() -> None:
@@ -30,7 +30,7 @@ def test_resolve_specs_expands_iterable_attr() -> None:
     from calfkit.cli._loader import resolve_specs
 
     objs = resolve_specs([f"{_FIXTURE}:nodes"])
-    assert [o.node_id for o in objs] == ["tool_alpha", "tool_beta"]
+    assert [o.node_id for o in objs] == ["alpha", "beta"]
 
 
 def test_resolve_specs_multiple_specs_concatenate_in_order() -> None:
@@ -38,7 +38,7 @@ def test_resolve_specs_multiple_specs_concatenate_in_order() -> None:
     from calfkit.cli._loader import resolve_specs
 
     objs = resolve_specs([f"{_FIXTURE}:single", f"{_FIXTURE}:nodes"])
-    assert [o.node_id for o in objs] == ["tool_echo", "tool_alpha", "tool_beta"]
+    assert [o.node_id for o in objs] == ["echo", "alpha", "beta"]
 
 
 def test_resolve_specs_bad_spec_exits_2() -> None:
@@ -88,7 +88,7 @@ def test_resolve_specs_app_dir_enables_nested_dotted_import(tmp_path: object, mo
             sys.modules.pop(name, None)
 
     assert len(objs) == 1
-    assert objs[0].node_id == "tool_my_tool"
+    assert objs[0].node_id == "my_tool"
 
 
 def test_validate_nodes_rejects_non_node_exits_2() -> None:
@@ -107,7 +107,7 @@ def test_dedupe_by_node_id_drops_repeats_preserving_order() -> None:
 
     objs = resolve_specs([f"{_FIXTURE}:single", f"{_FIXTURE}:single", f"{_FIXTURE}:nodes"])
     deduped = dedupe_by_node_id(objs)
-    assert [o.node_id for o in deduped] == ["tool_echo", "tool_alpha", "tool_beta"]
+    assert [o.node_id for o in deduped] == ["echo", "alpha", "beta"]
 
 
 def test_resolve_specs_later_bad_spec_exits_2() -> None:
@@ -135,7 +135,7 @@ def test_load_nodes_resolves_validates_and_dedupes() -> None:
     from calfkit.cli._loader import load_nodes
 
     nodes = load_nodes([f"{_FIXTURE}:single", f"{_FIXTURE}:single", f"{_FIXTURE}:nodes"])
-    assert [n.node_id for n in nodes] == ["tool_echo", "tool_alpha", "tool_beta"]
+    assert [n.node_id for n in nodes] == ["echo", "alpha", "beta"]
 
 
 def test_load_nodes_empty_resolution_exits_2() -> None:

--- a/tests/test_run_serve.py
+++ b/tests/test_run_serve.py
@@ -45,7 +45,7 @@ def test_serve_resolves_nodes_and_runs_worker(captured: dict) -> None:
 
     serve([f"{_FIXTURE}:nodes"], host=None, provision=False, group_id=None, env_file=None, app_dir=".")
 
-    assert [n.node_id for n in captured["nodes"]] == ["tool_alpha", "tool_beta"]
+    assert [n.node_id for n in captured["nodes"]] == ["alpha", "beta"]
     assert captured["ran"] is True
 
 
@@ -119,7 +119,7 @@ def test_serve_prints_banner_with_node_details(captured: dict, capsys: pytest.Ca
     monkeypatch.delenv("CALF_HOST_URL", raising=False)
     serve([f"{_FIXTURE}:single"], host=None, provision=False, group_id=None, env_file=None, app_dir=".")
     out = capsys.readouterr().out
-    assert "tool_echo" in out
+    assert "echo" in out
     assert "[tool]" in out
     assert "echo.in" in out  # subscribe topic
     assert "echo.out" in out  # publish topic

--- a/tests/test_tool_binding.py
+++ b/tests/test_tool_binding.py
@@ -148,6 +148,59 @@ class TestToolNodeDefProvidesBindings:
         assert isinstance(node, ToolProvider)
 
 
+class TestToolNodeIdentity:
+    """The tool name drives node_id (the capability key), the LLM tool name, and topics.
+
+    No `tool_` prefix: `node_id == tool name`, so an agent can reference the node by the
+    same name it calls. `name=` overrides all three without renaming the function.
+    """
+
+    def test_agent_tool_node_id_is_the_function_name(self) -> None:
+        from calfkit.nodes.tool import agent_tool
+
+        def get_weather(city: str) -> str:
+            return city
+
+        node = agent_tool(get_weather)
+        assert node.node_id == "get_weather"  # no tool_ prefix
+        assert node.tool_schema.name == "get_weather"  # capability key == LLM tool name
+        assert node.subscribe_topics == ["tool.get_weather.input"]
+        assert node.publish_topic == "tool.get_weather.output"
+
+    def test_agent_tool_name_override_drives_all_three_identities(self) -> None:
+        from calfkit.nodes.tool import agent_tool
+
+        def get_weather(city: str) -> str:
+            return city
+
+        node = agent_tool(get_weather, name="weather")
+        assert node.node_id == "weather"
+        assert node.tool_schema.name == "weather"
+        assert node.subscribe_topics == ["tool.weather.input"]
+        assert node.publish_topic == "tool.weather.output"
+
+    def test_create_tool_node_name_override(self) -> None:
+        from calfkit.nodes.tool import ToolNodeDef
+
+        def fn(x: int) -> int:
+            return x
+
+        node = ToolNodeDef.create_tool_node(func=fn, subscribe_topics="t.in", publish_topic="t.out", name="renamed")
+        assert node.node_id == "renamed"
+        assert node.tool_schema.name == "renamed"
+
+    def test_empty_name_is_rejected(self) -> None:
+        from calfkit.nodes.tool import ToolNodeDef, agent_tool
+
+        def fn(x: int) -> int:
+            return x
+
+        with pytest.raises(ValueError, match="name"):
+            agent_tool(fn, name="")
+        with pytest.raises(ValueError, match="name"):
+            ToolNodeDef.create_tool_node(func=fn, subscribe_topics="t.in", publish_topic="t.out", name="")
+
+
 from calfkit.providers.pydantic_ai.model_client import PydanticModelClient  # noqa: E402
 
 

--- a/tests/test_tool_binding.py
+++ b/tests/test_tool_binding.py
@@ -179,6 +179,30 @@ class TestToolNodeIdentity:
         assert node.subscribe_topics == ["tool.weather.input"]
         assert node.publish_topic == "tool.weather.output"
 
+    def test_agent_tool_decorator_with_args_drives_all_three_identities(self) -> None:
+        from calfkit.nodes.tool import ToolNodeDef, agent_tool
+
+        @agent_tool(name="weather")
+        def get_weather(city: str) -> str:
+            return city
+
+        assert isinstance(get_weather, ToolNodeDef)  # the decorator replaces the function with the node
+        assert get_weather.node_id == "weather"
+        assert get_weather.tool_schema.name == "weather"
+        assert get_weather.subscribe_topics == ["tool.weather.input"]
+        assert get_weather.publish_topic == "tool.weather.output"
+
+    def test_agent_tool_decorator_empty_parens_uses_function_name(self) -> None:
+        from calfkit.nodes.tool import agent_tool
+
+        @agent_tool()
+        def get_weather(city: str) -> str:
+            return city
+
+        assert get_weather.node_id == "get_weather"
+        assert get_weather.tool_schema.name == "get_weather"
+        assert get_weather.subscribe_topics == ["tool.get_weather.input"]
+
     def test_create_tool_node_name_override(self) -> None:
         from calfkit.nodes.tool import ToolNodeDef
 
@@ -197,6 +221,8 @@ class TestToolNodeIdentity:
 
         with pytest.raises(ValueError, match="name"):
             agent_tool(fn, name="")
+        with pytest.raises(ValueError, match="name"):
+            agent_tool(name="")  # decorator-with-args form rejects eagerly, before decorating
         with pytest.raises(ValueError, match="name"):
             ToolNodeDef.create_tool_node(func=fn, subscribe_topics="t.in", publish_topic="t.out", name="")
 

--- a/tests/test_tool_node_advert.py
+++ b/tests/test_tool_node_advert.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 from calfkit.client.client import Client
 from calfkit.controlplane import ControlPlaneStamp
 from calfkit.controlplane.publisher import control_plane_writer_key
-from calfkit.models.capability import CAPABILITY_TOPIC, CapabilityRecord
+from calfkit.models.capability import CAPABILITY_TOPIC, CapabilityRecord, record_to_bindings
 from calfkit.nodes.tool import ToolNodeDef, agent_tool
 from calfkit.worker.worker import Worker
 
@@ -84,3 +84,22 @@ class TestWorkerAutoRegistration:
         names = [name for name, _ in worker._resource_cms()]
         assert control_plane_writer_key(CAPABILITY_TOPIC) in names
         assert worker._control_plane_publisher is not None
+
+
+class TestEagerDiscoveredParity:
+    """§7 fidelity boundary: the ToolDefinition an agent sees is identical whether the tool
+    node is consumed eagerly (a live node passed in ``tools=``) or discovered (a ``Tools``
+    handle). The only intended difference is the validation locus. A future ``Tool`` knob
+    that breaks this parity must fail loudly here.
+    """
+
+    def test_eager_and_discovered_tool_def_are_identical(self) -> None:
+        node = make_node("add")
+        eager = node.tool_bindings()[0]  # live path: schema baked in, with a local validator
+        discovered = record_to_bindings(node._capability_advert(make_stamp()))[0]  # discovered path
+        # Same ToolDefinition — name, description, JSON schema, and every defaulted field.
+        assert discovered.tool_def == eager.tool_def
+        # The only difference is the validation locus: eager validates locally; the discovered
+        # binding has no validator (the tool node validates on receipt; bad args -> fault rail).
+        assert eager.validator is not None
+        assert discovered.validator is None

--- a/tests/test_tool_node_advert.py
+++ b/tests/test_tool_node_advert.py
@@ -1,0 +1,86 @@
+"""A function tool node advertises its single tool on the capability control plane.
+
+Like ``MCPToolboxNode``, a tool node is a content contributor: it declares one
+``@advertises`` factory that the worker-owned ``ControlPlanePublisher`` pulls each
+heartbeat tick. Unlike MCP, its schema is static (no session, no cache), so the factory
+reads ``tool_schema`` directly and ``content_updated_at`` is the process boot time.
+The heartbeat loop + tombstone live in the substrate's publisher (tested in
+``test_controlplane_publisher.py``), so they are not re-tested here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from calfkit.client.client import Client
+from calfkit.controlplane import ControlPlaneStamp
+from calfkit.controlplane.publisher import control_plane_writer_key
+from calfkit.models.capability import CAPABILITY_TOPIC, CapabilityRecord
+from calfkit.nodes.tool import ToolNodeDef, agent_tool
+from calfkit.worker.worker import Worker
+
+
+def make_node(name: str = "add") -> ToolNodeDef:
+    def add(a: int, b: int) -> int:
+        """Add two integers."""
+        return a + b
+
+    return agent_tool(add, name=name)
+
+
+def make_stamp(*, node_kind: str = "tool") -> ControlPlaneStamp:
+    now = datetime.now(tz=timezone.utc)
+    return ControlPlaneStamp(started_at=now, last_heartbeat_at=now, heartbeat_interval=30.0, node_kind=node_kind)
+
+
+class TestAdvertDeclaration:
+    def test_declares_one_capability_advert(self) -> None:
+        adverts = type(make_node())._adverts
+        assert CAPABILITY_TOPIC in adverts
+        assert adverts[CAPABILITY_TOPIC].record is CapabilityRecord
+
+    def test_advert_factory_is_a_bound_method(self) -> None:
+        factories = make_node().control_plane_adverts()
+        assert CAPABILITY_TOPIC in factories
+        assert callable(factories[CAPABILITY_TOPIC])
+
+
+class TestCapabilityFactory:
+    def test_factory_builds_one_tool_record_from_schema_and_stamp(self) -> None:
+        node = make_node("add")
+        stamp = make_stamp()
+        record = node._capability_advert(stamp)
+        assert isinstance(record, CapabilityRecord)
+        # the worker-stamped fields ride through verbatim
+        assert record.started_at == stamp.started_at
+        assert record.last_heartbeat_at == stamp.last_heartbeat_at
+        assert record.heartbeat_interval == 30.0
+        assert record.node_kind == "tool"
+        # content: exactly one tool; dispatch = the node's public inbox
+        assert record.dispatch_topic == "tool.add.input"
+        assert [t.name for t in record.tools] == ["add"]
+        assert record.tools[0].description == "Add two integers."
+        assert record.tools[0].parameters_json_schema == node.tool_schema.parameters_json_schema
+
+    def test_content_updated_at_is_the_boot_time(self) -> None:
+        # Static schema: content currency == process boot time, stable across ticks.
+        node = make_node()
+        stamp = make_stamp()
+        assert node._capability_advert(stamp).content_updated_at == stamp.started_at
+
+    def test_node_kind_rides_the_stamp(self) -> None:
+        # The factory never sets node_kind itself; it rides on the worker stamp, so the
+        # advertised record carries whatever kind the worker stamped (a tool node -> "tool").
+        record = make_node()._capability_advert(make_stamp(node_kind="tool"))
+        assert record.node_kind == "tool"
+
+
+class TestWorkerAutoRegistration:
+    def test_hosted_tool_node_registers_the_control_plane(self) -> None:
+        # Deploying a tool node trips the worker's @advertises auto-wiring: the publisher
+        # and the calf.capabilities writer are registered with zero user config.
+        worker = Worker(Client.connect("kafka:9092"), nodes=[make_node()])
+        worker._maybe_register_control_plane()
+        names = [name for name, _ in worker._resource_cms()]
+        assert control_plane_writer_key(CAPABILITY_TOPIC) in names
+        assert worker._control_plane_publisher is not None

--- a/tests/test_tool_selector.py
+++ b/tests/test_tool_selector.py
@@ -38,6 +38,7 @@ def make_record(**overrides: Any) -> CapabilityRecord:
         started_at=now,
         last_heartbeat_at=now,
         heartbeat_interval=30.0,
+        node_kind="toolbox",
         dispatch_topic="mcp_server.docs_server",
         tools=[CapabilityToolDef(name=n, parameters_json_schema={"type": "object", "properties": {}}) for n in ("search", "fetch")],
         content_updated_at=now,

--- a/tests/test_tool_selector.py
+++ b/tests/test_tool_selector.py
@@ -69,16 +69,17 @@ class TestResolveTools:
         view = {"docs_server": make_record()}
         result = toolbox.resolve_tools(view)
         assert isinstance(result, SelectorResult)
+        assert isinstance(result.bindings, tuple)  # frozen value: immutable binding sequence
         assert [b.name for b in result.bindings] == ["search", "fetch"]
         assert all(isinstance(b, ToolBinding) and b.validator is None for b in result.bindings)
         assert all(b.dispatch_topic == "mcp_server.docs_server" for b in result.bindings)
-        assert not result.missing_toolbox and not result.missing_tools
+        assert not result.unresolved
 
-    def test_missing_toolbox_diagnostic(self) -> None:
+    def test_missing_target_diagnostic(self) -> None:
         result = make_toolbox().resolve_tools({})
-        assert result.missing_toolbox
-        assert result.bindings == []
-        assert result.toolbox_id == "docs_server"
+        assert result.missing_targets == ("docs_server",)
+        assert result.bindings == ()
+        assert result.unresolved
 
     def test_include_filter_and_missing_tools(self) -> None:
         toolbox = make_toolbox()
@@ -94,11 +95,11 @@ class TestResolveTools:
 
     def test_malformed_record_is_skipped_with_diagnostic(self) -> None:
         # Tolerant reader admits an empty dispatch_topic; binding expansion
-        # must not crash the turn — it surfaces as invalid_record instead.
+        # must not crash the turn — it surfaces as invalid_targets instead.
         record = make_record(dispatch_topic="")
         result = make_toolbox().resolve_tools({"docs_server": record})
-        assert result.invalid_record
-        assert result.bindings == []
+        assert result.invalid_targets == ("docs_server",)
+        assert result.bindings == ()
 
     # -- view-owned filtering (D6): the resolver never sees stale/newer-schema records --
 
@@ -107,22 +108,30 @@ class TestResolveTools:
         # resolver reports missing_toolbox (no advisory "use last-known" path).
         view = make_view(make_record(last_heartbeat_at=datetime.now(tz=timezone.utc) - timedelta(seconds=100)))
         result = make_toolbox().resolve_tools(view)
-        assert result.missing_toolbox
-        assert result.bindings == []
+        assert result.missing_targets == ("docs_server",)
+        assert result.bindings == ()
 
     def test_newer_schema_hidden_by_view(self) -> None:
         # A record from a newer schema major is filtered (and logged) by the view;
         # the resolver just sees None -> missing_toolbox.
         view = make_view(make_record(schema_version=2))
         result = make_toolbox().resolve_tools(view)
-        assert result.missing_toolbox
-        assert result.bindings == []
+        assert result.missing_targets == ("docs_server",)
+        assert result.bindings == ()
 
     def test_live_record_resolves_through_view(self) -> None:
         view = make_view(make_record())
         result = make_toolbox().resolve_tools(view)
         assert [b.name for b in result.bindings] == ["search", "fetch"]
-        assert not result.missing_toolbox
+        assert not result.unresolved
+
+    def test_wrong_kind_record_is_rejected(self) -> None:
+        # Over-pull guard: an MCP toolbox handle must not bind a record of a
+        # different node_kind (e.g. a function tool node sharing the name).
+        result = make_toolbox().resolve_tools({"docs_server": make_record(node_kind="tool")})
+        assert result.wrong_kind_targets == ("docs_server",)
+        assert result.bindings == ()
+        assert result.unresolved
 
 
 class TestSplitToolDeclarations:
@@ -244,6 +253,9 @@ class TestNoStrictSurface:
         assert "strict" not in fields
         assert "stale_seconds" not in fields
         assert "skipped_newer_schema" not in fields
+        # cardinality-neutral, de-MCP'd diagnostics (no singular toolbox_id)
+        assert "toolbox_id" not in fields
+        assert {"bindings", "missing_targets", "missing_tools", "invalid_targets", "wrong_kind_targets"} <= fields
 
     def test_resolution_error_is_gone(self) -> None:
         import calfkit.exceptions as exc

--- a/tests/test_tool_selector.py
+++ b/tests/test_tool_selector.py
@@ -105,7 +105,7 @@ class TestResolveTools:
 
     def test_stale_record_hidden_by_view(self) -> None:
         # age 100s > 3*30 = 90 threshold -> the view collapses it to None, so the
-        # resolver reports missing_toolbox (no advisory "use last-known" path).
+        # resolver reports missing_targets (no advisory "use last-known" path).
         view = make_view(make_record(last_heartbeat_at=datetime.now(tz=timezone.utc) - timedelta(seconds=100)))
         result = make_toolbox().resolve_tools(view)
         assert result.missing_targets == ("docs_server",)
@@ -113,7 +113,7 @@ class TestResolveTools:
 
     def test_newer_schema_hidden_by_view(self) -> None:
         # A record from a newer schema major is filtered (and logged) by the view;
-        # the resolver just sees None -> missing_toolbox.
+        # the resolver just sees None -> missing_targets.
         view = make_view(make_record(schema_version=2))
         result = make_toolbox().resolve_tools(view)
         assert result.missing_targets == ("docs_server",)

--- a/tests/test_tools_selector.py
+++ b/tests/test_tools_selector.py
@@ -1,0 +1,171 @@
+"""``Tools`` — the identity-only handle to one or more function tool nodes.
+
+The call-side counterpart to a deployed tool node (mirrors ``MCPToolbox``): an agent
+holds ``Tools("add", "subtract")`` and the schemas are discovered per turn from the
+shared capability view. Resolution reuses ``resolve_capability`` with
+``expected_kind="tool"`` (the over-pull guard), so ``Tools`` can never bind a toolbox
+record. The ``strict`` flag is intentionally absent (mirrors MCP).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from calfkit.controlplane import ControlPlaneView
+from calfkit.models.capability import CAPABILITY_VIEW_RESOURCE_KEY, CapabilityRecord, CapabilityToolDef, SelectorResult
+from calfkit.models.tool_dispatch import ToolBinding, ToolSelector, split_tool_declarations
+from calfkit.nodes.tool import Tools
+from tests.test_controlplane_view import _FakeTable  # the substrate's dict-backed GroupedTableReader fake
+
+
+def make_tool_record(name: str = "add", *, dispatch: str | None = None, **overrides: Any) -> CapabilityRecord:
+    now = datetime.now(tz=timezone.utc)
+    defaults: dict[str, Any] = dict(
+        started_at=now,
+        last_heartbeat_at=now,
+        heartbeat_interval=30.0,
+        node_kind="tool",
+        dispatch_topic=dispatch or f"tool.{name}.input",
+        tools=[CapabilityToolDef(name=name, parameters_json_schema={"type": "object", "properties": {}})],
+        content_updated_at=now,
+    )
+    defaults.update(overrides)
+    return CapabilityRecord(**defaults)
+
+
+def make_agent(*tools: Any) -> Any:
+    from calfkit.nodes.agent import Agent
+    from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
+
+    class FakeModel(PydanticModelClient):
+        @property
+        def model_name(self) -> str:
+            return "fake"
+
+        @property
+        def system(self) -> str:
+            return "fake"
+
+        async def request(self, *args: object, **kwargs: object) -> object:
+            raise NotImplementedError
+
+    return Agent("a", subscribe_topics="a.in", model_client=FakeModel(), tools=list(tools))
+
+
+class TestToolsConstruction:
+    def test_varargs(self) -> None:
+        assert Tools("add", "subtract").names == ("add", "subtract")
+
+    def test_names_kwarg(self) -> None:
+        assert Tools(names=["add", "subtract"]).names == ("add", "subtract")
+
+    def test_order_preserving_dedupe(self) -> None:
+        assert Tools("add", "subtract", "add").names == ("add", "subtract")
+        assert Tools("add") == Tools("add", "add")  # dedupe gives clean value semantics
+
+    def test_rejects_mixed_positional_and_kwarg(self) -> None:
+        with pytest.raises(ValueError, match="positionally or via names="):
+            Tools("a", names=["b"])
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(ValueError, match="at least one"):
+            Tools()
+        with pytest.raises(ValueError, match="at least one"):
+            Tools(names=[])
+
+    def test_rejects_empty_name_string(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            Tools("add", "")
+
+    def test_frozen_and_hashable_value_semantics(self) -> None:
+        t = Tools("add", "subtract")
+        with pytest.raises(Exception):
+            t.names = ("x",)  # type: ignore[misc]
+        assert len({Tools("add"), Tools("add")}) == 1
+
+
+class TestToolsIsASelector:
+    def test_satisfies_tool_selector(self) -> None:
+        assert isinstance(Tools("add"), ToolSelector)
+
+    def test_splits_as_a_selector(self) -> None:
+        bindings, selectors = split_tool_declarations([Tools("add")])
+        assert bindings == [] and selectors == [Tools("add")]
+
+    def test_agent_ctor_sets_aside_the_selector(self) -> None:
+        agent = make_agent(Tools("add"))
+        assert agent.tools == []  # not expanded at construction
+        assert agent._tool_selectors == [Tools("add")]  # trips the worker's read-side view gate
+
+
+class TestToolsResolveTools:
+    def test_resolves_single_name_to_one_validatorless_binding(self) -> None:
+        result = Tools("add").resolve_tools({"add": make_tool_record("add")})
+        assert isinstance(result, SelectorResult)
+        assert [b.name for b in result.bindings] == ["add"]
+        assert result.bindings[0].dispatch_topic == "tool.add.input"
+        assert result.bindings[0].validator is None  # discovered = schema-only (node validates on receipt)
+        assert not result.unresolved
+
+    def test_resolves_multiple_names(self) -> None:
+        view = {"add": make_tool_record("add"), "sub": make_tool_record("sub")}
+        result = Tools("add", "sub").resolve_tools(view)
+        assert [b.name for b in result.bindings] == ["add", "sub"]
+        assert not result.unresolved
+
+    def test_missing_name_is_a_missing_target_and_others_still_resolve(self) -> None:
+        result = Tools("add", "ghost").resolve_tools({"add": make_tool_record("add")})
+        assert [b.name for b in result.bindings] == ["add"]
+        assert result.missing_targets == ("ghost",)
+        assert result.unresolved
+
+    def test_toolbox_record_is_rejected_as_wrong_kind(self) -> None:
+        # The over-pull guard: Tools references single-tool nodes; a toolbox record at that
+        # key is rejected, so Tools can never silently absorb a whole multi-tool MCP toolbox.
+        result = Tools("github").resolve_tools({"github": make_tool_record("github", node_kind="toolbox")})
+        assert result.bindings == ()
+        assert result.wrong_kind_targets == ("github",)
+        assert result.unresolved
+
+    def test_resolves_through_a_real_control_plane_view(self) -> None:
+        view = ControlPlaneView(_FakeTable({"add": {"w1": make_tool_record("add")}}), CapabilityRecord)
+        result = Tools("add").resolve_tools(view)
+        assert [b.name for b in result.bindings] == ["add"]
+        assert not result.unresolved
+
+
+class TestToolsThroughAgent:
+    def test_resolution_merges_discovered_bindings_into_the_registry(self) -> None:
+        agent = make_agent(Tools("add", "sub"))
+        registry: dict[str, ToolBinding] = {}
+        view = {"add": make_tool_record("add"), "sub": make_tool_record("sub")}
+        agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: view}, registry)
+        assert sorted(registry) == ["add", "sub"]
+        assert all(registry[n].validator is None for n in registry)  # discovered = schema-only
+
+    def test_eager_static_tool_wins_on_collision(self, caplog: pytest.LogCaptureFixture) -> None:
+        # Tools + an eager tool of the same name: the eager (locally validated) binding wins.
+        from calfkit._vendor.pydantic_ai.tools import ToolDefinition
+
+        agent = make_agent(Tools("add"))
+        static = ToolBinding(tool_def=ToolDefinition(name="add"), dispatch_topic="static.add.input", validator=lambda a: a)
+        registry = {"add": static}
+        with caplog.at_level("ERROR"):
+            agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: {"add": make_tool_record("add")}}, registry)
+        assert registry["add"] is static  # existing (eager) wins; discovered never shadows it
+        assert registry["add"].validator is not None  # local fail-fast validation preserved
+        assert any("add" in r.message for r in caplog.records)
+
+
+class TestToolsExport:
+    def test_importable_from_calfkit_and_nodes(self) -> None:
+        import calfkit
+        from calfkit import Tools as TopLevel
+        from calfkit.nodes import Tools as FromNodes
+        from calfkit.nodes.tool import Tools as FromModule
+
+        assert TopLevel is FromModule is FromNodes
+        assert "Tools" in calfkit.__all__


### PR DESCRIPTION
## What

Agents can now reference function tool nodes **by name** and discover their schemas at runtime from the shared `calf.capabilities` control plane — the mirror of how `MCPToolbox` works, applied to `@agent_tool` nodes. A deployed tool node advertises its single tool automatically; an agent holds an identity-only `Tools(*names)` handle (no import of the tool's code, no baked-in schema):

```python
@agent_tool
def add(a: int, b: int) -> int: ...

# in another process / deployment — by name only:
agent = Agent("researcher", subscribe_topics="...", model_client=model, tools=[Tools("add")])
```

The eager path is kept unchanged: passing a live tool node (`tools=[add]`) still bakes the schema in with local arg validation. Two handles onto one node — choose zero-infra + local validation, or decoupled + runtime discovery.

Design: `docs/designs/runtime-tool-discoverability-spec.md` (ADR-0013). Converged through 2 adversarial review rounds before implementation.

## How (commit by commit)

1. **`node_kind` on the control-plane substrate** — worker-stamped on every record; powers the over-pull guard + cross-kind `node_id`-collision observability.
2. **De-MCP `SelectorResult` / `resolve_capability`** — cardinality-neutral (`missing_targets` / `invalid_targets` / `wrong_kind_targets`, tuple `bindings`); `expected_kind` over-pull guard; `MCPToolbox` passes `expected_kind="toolbox"`.
3. **Tool-node identity = the tool name** — drop the `tool_` `node_id` prefix; `agent_tool` / `create_tool_node` gain `name=`.
4. **Tool nodes advertise** — `@advertises` on `BaseToolNodeDef` (always-on).
5. **`Tools` handle** — by-name selector; resolves with `expected_kind="tool"`; exported from `calfkit`.
6. **Eager/discovered parity test** — locks the §7 fidelity boundary (a future `Tool` knob that breaks it fails loudly).
7. **Kafka-lane roundtrip** — real-broker discover → dispatch → return; agent-POV (the model sees the *advertised* schema); discovered-binding bad-args fault path.
8. **Docs + ADR-0013 + spec.**

## Breaking changes (pre-1.0, no deployments)

- `node_kind` is a **required** field on the control-plane record → recreate `calf.capabilities` on upgrade.
- A tool node's `node_id` changes `tool_<fn>` → `<fn>` (it appears on the wire in envelope headers / fault origin).
- `SelectorResult` fields + `resolve_capability(target_id=, expected_kind=)` renamed (internal resolution API; **no** wire-format change to `CapabilityRecord`, so MCP and tool nodes interoperate on the topic).

## Testing

- **Offline suite: 3180 passed, 6 skipped** — TDD throughout (a failing test first for every change).
- **Full kafka lane (real Redpanda): 63 passed, 6 skipped** — incl. 3 new discovery roundtrips (happy path; agent-POV-matches-advertised-schema; discovered bad-args → `calf.unhandled` fault on the agent mirror) **and** every pre-existing MCP / tool-node / substrate / fault test, confirming always-on advertising doesn't break tool-node-hosting workers.
- `make check` clean (lint + format + type); **100% coverage on new code**.

## Deferred (designed, not built)

Opt-in advertising (an eager-only tool node that doesn't advertise, to keep eager-only deployments off the control plane) — spec §14.1.
