### PR TITLE
chore: bump ktables to >=0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "typing-extensions>=4.15.0",
     "dishka>=1.9.1",
     "mcp>=1.27.2",
-    "ktables>=0.3.0",
+    "ktables>=0.4.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## What

Bump the `ktables` dependency floor from `>=0.3.0` to `>=0.4.0` in `pyproject.toml`.

## Why

[ktables 0.4.0](https://github.com/ryan-yuuu/ktables/releases/tag/v0.4.0) adds:

- **`fetch_max_wait_ms` exposed** to tune barrier latency ([ktables#23](https://github.com/ryan-yuuu/ktables/issues/23))

## Notes

- `uv sync` resolves and installs `ktables==0.4.0` cleanly.
- `make fix` (no changes) + `make check` (lint, format, type) all pass.
- No tracked `uv.lock`, so nothing else to sync.