### PR TITLE
feat: namespace MCP tool names by their toolbox node 

### DIFF
--- a/calfkit/mcp/mcp_toolbox.py
+++ b/calfkit/mcp/mcp_toolbox.py
@@ -209,11 +209,18 @@ class MCPToolboxNode(BaseNodeDef):
             )
             raise RuntimeError(f"no live MCP session for server {self.node_id!r}")
 
+        # Strip this toolbox's own ``<node_id>__`` prefix to recover the BARE server-side tool
+        # name (ADR-0018, C6). Exact-prefix ``removeprefix``, NOT ``split("__")`` — a server tool
+        # name (``a__b``) or a toolbox name (``my__server``) may legitimately contain ``__``;
+        # ``removeprefix`` of the exact ``<node_id>__`` round-trips and is a no-op on an already-bare
+        # name. The namespace is the agent's cluster-side projection; it never crosses to the server,
+        # and the strip is local here so the agent's dispatch path stays generic.
+        server_tool_name = payload.name.removeprefix(f"{self.node_id}__")
         # A transport error escapes to the chokepoint (on_node_error → fault). The B1 eager wire-safety
         # check (pydantic_core.to_json) likewise raises HERE on a non-wire-safe result, not mid-publish.
         # ``isError=True`` results pass through TRANSPARENTLY (B2): the MCPCallToolResult rides the reply
         # slot as an ordinary successful return — the agent/model sees it exactly as today.
-        tool_result: MCPCallToolResult = await session.call_tool(name=payload.name, arguments=payload.args)
+        tool_result: MCPCallToolResult = await session.call_tool(name=server_tool_name, arguments=payload.args)
         pydantic_core.to_json(tool_result)
         return ReturnCall[State](state=ctx.state, value=tool_result)
 

--- a/calfkit/models/capability.py
+++ b/calfkit/models/capability.py
@@ -175,7 +175,7 @@ def resolve_capability(
         wanted = set(include)
         prefix = _namespace_prefix(record.node_kind, target_id)
         tagged = [(b.name.removeprefix(prefix), b) for b in bindings]
-        present_bare = {bare for bare, _ in tagged}  # all bare names advertised
+        present_bare = {bare for bare, _ in tagged}  # bare names this record advertises
         bindings = [b for bare, b in tagged if bare in wanted]
         missing_tools = tuple(n for n in include if n not in present_bare)
     return SelectorResult(bindings=tuple(bindings), missing_tools=missing_tools)

--- a/calfkit/models/capability.py
+++ b/calfkit/models/capability.py
@@ -77,17 +77,36 @@ class CapabilityRecord(ControlPlaneRecord):
     content_updated_at: AwareDatetime
 
 
-def record_to_bindings(record: CapabilityRecord) -> list[ToolBinding]:
+def _namespace_prefix(node_kind: str, name: str) -> str:
+    """LLM-facing tool-name prefix for a capability record.
+
+    Toolbox tools are namespaced ``<name>__`` so the cluster tool namespace is
+    collision-free (ADR-0018); function tool-node names stay bare to preserve the
+    ``node_id == tool name == capability key`` identity (ADR-0013). This is a
+    read-time projection: the wire record's ``CapabilityToolDef.name`` stays bare
+    (so re-advertising re-projects; no ``schema_version`` bump), and dispatch strips
+    it back in ``MCPToolboxNode.run``.
+    """
+    return f"{name}__" if node_kind == "toolbox" else ""
+
+
+def record_to_bindings(record: CapabilityRecord, *, name: str) -> list[ToolBinding]:
     """Expand a record into validator-less :class:`ToolBinding`s.
 
     Wire-crossing tools dispatch unvalidated (the schema-only carve-out): the advertiser
     validates arguments on receipt — the toolbox's MCP server, or the tool node's own
     function schema.
+
+    ``name`` is the advertiser's identity (its ``node_id`` / capability key — the
+    control-plane wire key, never a field in the record value), supplied by the caller.
+    Toolbox tools are namespaced ``<name>__<tool>`` for the LLM; tool-node names stay
+    bare. See :func:`_namespace_prefix`.
     """
+    prefix = _namespace_prefix(record.node_kind, name)
     return [
         ToolBinding(
             tool_def=ToolDefinition(
-                name=tool.name,
+                name=f"{prefix}{tool.name}",
                 description=tool.description,
                 parameters_json_schema=tool.parameters_json_schema,
             ),
@@ -142,7 +161,7 @@ def resolve_capability(
     if expected_kind is not None and record.node_kind != expected_kind:
         return SelectorResult(wrong_kind_targets=(target_id,))
     try:
-        bindings = record_to_bindings(record)
+        bindings = record_to_bindings(record, name=target_id)
     except ValidationError:
         # The one tolerant-reader bad-data path: an empty dispatch_topic fails
         # ToolBinding's min_length. A poisoned advert degrades (invalid_targets),
@@ -151,7 +170,12 @@ def resolve_capability(
         return SelectorResult(invalid_targets=(target_id,))
     missing_tools: tuple[str, ...] = ()
     if include is not None:
+        # ``include`` pins BARE server-side tool names (C5): a dev knows the tool as
+        # `search`, not `github__search`. Strip the toolbox namespace prefix to compare.
         wanted = set(include)
-        bindings = [b for b in bindings if b.name in wanted]
-        missing_tools = tuple(name for name in include if name not in {b.name for b in bindings})
+        prefix = _namespace_prefix(record.node_kind, target_id)
+        tagged = [(b.name.removeprefix(prefix), b) for b in bindings]
+        present_bare = {bare for bare, _ in tagged}  # all bare names advertised
+        bindings = [b for bare, b in tagged if bare in wanted]
+        missing_tools = tuple(n for n in include if n not in present_bare)
     return SelectorResult(bindings=tuple(bindings), missing_tools=missing_tools)

--- a/docs/adr/0018-mcp-tool-names-namespaced-by-server.md
+++ b/docs/adr/0018-mcp-tool-names-namespaced-by-server.md
@@ -42,15 +42,20 @@ on its own, independent of any tool-discovery work, and lands first in its own P
   `dispatch_topic`, or any server-reported value.
 - **Separator & name validity.** `:` is not a valid tool-name character for major providers
   (OpenAI and Anthropic restrict tool names to roughly `[a-zA-Z0-9_-]`), so the separator is
-  `__` (double underscore), the common MCP-client convention. The provider charset was
-  confirmed at implementation against the vendored sanitizer
-  (`calfkit/_vendor/pydantic_ai/_output.py`, `[^a-zA-Z0-9-_]`). **Length and charset are
-  document-only (no runtime enforcement):** `{toolbox_name}__{tool_name}` must fit the
-  provider tool-name limit (Anthropic 128, OpenAI 64) and stay within the charset. The
-  toolbox name is a deployment identity, so the framework documents the constraint rather
-  than policing it — a violation surfaces as a provider 400 at turn time, exactly as a bad
-  *bare* name already would. Concatenation never truncates (truncation would create new
-  collisions); deployers keep toolbox and tool names short and charset-safe.
+  `__` (double underscore), the common MCP-client convention (e.g. Claude Code surfaces MCP
+  tools as `mcp__<server>__<tool>`). The provider charset was confirmed at implementation
+  against the vendored sanitizer (`calfkit/_vendor/pydantic_ai/_output.py`, `[^a-zA-Z0-9-_]` —
+  set-equivalent to `[a-zA-Z0-9_-]` above). **Length and charset are document-only (no runtime
+  enforcement):** `{toolbox_name}__{tool_name}` must fit the provider tool-name limit
+  (Anthropic 128, OpenAI 64) and stay within the charset. The toolbox name is a deployment
+  identity, so the framework documents the constraint rather than policing it — a violation
+  surfaces as a provider 400 at turn time, exactly as a bad *bare* name already would.
+  Concatenation never truncates (truncation would create new collisions); deployers keep
+  toolbox and tool names short and charset-safe. Keep toolbox names **`__`-free**, too: a
+  toolbox name containing `__` can reintroduce cross-toolbox ambiguity (toolbox `a` + tool
+  `b__c` and toolbox `a__b` + tool `c` both project to `a__b__c`) — a clash that is loud (the
+  agent's registry-merge logs an error) and dispatch-safe (each node strips its own
+  `<node_id>__`), but the losing tool drops for that turn.
 - **Toolbox-scoped, not in the shared kernel.** The record→`ToolDefinition` expansion
   (`record_to_bindings`, `calfkit/models/capability.py`) is **shared** by MCP toolboxes and
   function tool nodes. Namespacing must apply **only to `node_kind == "toolbox"` records** —

--- a/docs/adr/0018-mcp-tool-names-namespaced-by-server.md
+++ b/docs/adr/0018-mcp-tool-names-namespaced-by-server.md
@@ -1,0 +1,85 @@
+---
+status: accepted
+---
+
+# MCP tool names are namespaced by their toolbox node
+
+Function tool node names are globally unique by the `node_id` contract, but MCP tool names
+live inside a toolbox and are governed by the MCP server, not by that contract. Today an
+`MCPToolbox` advertises each tool to the LLM under its **bare** server-side name
+(`record_to_bindings` builds `ToolDefinition(name=tool.name, ...)`), so a toolbox tool
+`search` can collide with a tool node `search`, and two toolboxes can both expose `search`.
+We **namespace** the LLM-facing name as:
+
+```
+<toolbox_node_name>__<tool_name>          e.g.  github__search
+```
+
+where **`<toolbox_node_name>` is the calfkit `MCPToolboxNode`'s `node_id`** — the `name` you
+construct the toolbox with (`MCPToolbox("github")` / `MCPToolboxNode("github", ...)`), which
+is also the capability key and the `mcp_server.<name>` topic suffix. It is **not** the MCP
+server's own protocol-level name (`serverInfo.name`); calfkit never reads that for naming.
+`<tool_name>` is the bare server-side tool name. The bare server-side name is still what is
+sent to the MCP server on dispatch (the prefix is stripped first).
+
+This makes the cluster's tool namespace **collision-free**: tool-node names (bare, e.g.
+`add`) and MCP tool names (`github__search`) are disjoint, and two toolboxes can no longer
+clash (`github__search` vs `jira__search`). That is the property that lets an `MCPToolbox`
+sit alongside a function-tool discover/named surface without any cross-plane name collision
+(see ADR-0014).
+
+This is a **prerequisite, isolated change** to the MCP surface — it improves named MCP use
+on its own, independent of any tool-discovery work, and lands first in its own PR.
+
+## Notes
+
+- **The prefix is the toolbox node's `node_id`.** Both the expansion (prefix) and the
+  dispatch (strip) key on `MCPToolboxNode.node_id` (== the toolbox's construction `name`),
+  not on anything fetched from the MCP server. At expansion the resolver supplies it
+  (`resolve_capability`'s `target_id`, which *is* the toolbox's `node_id` / capability key);
+  at dispatch the node uses its own `self.node_id`. The two are the same string, which is why
+  the strip round-trips exactly. Do not derive the prefix from `serverInfo.name`, the
+  `dispatch_topic`, or any server-reported value.
+- **Separator & name validity.** `:` is not a valid tool-name character for major providers
+  (OpenAI and Anthropic restrict tool names to roughly `[a-zA-Z0-9_-]`), so the separator is
+  `__` (double underscore), the common MCP-client convention. The provider charset was
+  confirmed at implementation against the vendored sanitizer
+  (`calfkit/_vendor/pydantic_ai/_output.py`, `[^a-zA-Z0-9-_]`). **Length and charset are
+  document-only (no runtime enforcement):** `{toolbox_name}__{tool_name}` must fit the
+  provider tool-name limit (Anthropic 128, OpenAI 64) and stay within the charset. The
+  toolbox name is a deployment identity, so the framework documents the constraint rather
+  than policing it — a violation surfaces as a provider 400 at turn time, exactly as a bad
+  *bare* name already would. Concatenation never truncates (truncation would create new
+  collisions); deployers keep toolbox and tool names short and charset-safe.
+- **Toolbox-scoped, not in the shared kernel.** The record→`ToolDefinition` expansion
+  (`record_to_bindings`, `calfkit/models/capability.py`) is **shared** by MCP toolboxes and
+  function tool nodes. Namespacing must apply **only to `node_kind == "toolbox"` records** —
+  applying it unconditionally in the shared kernel would prefix tool-node names too and break
+  the `node_id == tool name == capability key` identity (ADR-0013). The implementation factors
+  the rule into one `_namespace_prefix(node_kind, name)` helper (returns `f"{name}__"` only
+  for toolbox records, `""` otherwise), used both by `record_to_bindings` and by
+  `resolve_capability`'s `include` filter — so the prefix is guarded on
+  `record.node_kind == "toolbox"`, never applied blanket.
+- **Dispatch de-prefixing.** The MCP server only knows the bare tool name, so the namespaced
+  name is stripped back before `session.call_tool(...)`. The `MCPToolboxNode` strips its own
+  prefix on receipt via `payload.name.removeprefix(f"{self.node_id}__")` — **not** a generic
+  `split("__")`, which would corrupt a server-side tool name that legitimately contains `__`.
+  Stripping exactly the node's own `<self.node_id>__` keeps the agent's dispatch path generic
+  (it never understands the namespacing) and is robust to embedded separators.
+- **`include` stays bare (the trust boundary).** `MCPToolbox(name, include=...)` pins tool
+  names by their **bare** server-side name (a dev knows the tool as `search`, not
+  `github__search`); the resolver strips the prefix before comparing, and the
+  `missing_tools` diagnostic is reported bare. Namespacing is purely the LLM-facing
+  projection — no user-facing API takes a namespaced name.
+
+## Consequences
+
+- **Breaking change to the LLM-facing MCP tool surface** (`search` → `github__search`). Any
+  agent prompt or wiring relying on the bare name changes. Pre-1.0, no deployments to
+  preserve — a clean break (consistent with the project's hard-breaks-over-compat stance).
+- **No control-plane / wire-record change — a read-time projection.** The capability record
+  still carries the **bare** server-side tool names; namespacing is a read-time projection
+  applied when expanding a record into the LLM-facing `ToolDefinition` (`_namespace_prefix`
+  in `record_to_bindings`), and undone on dispatch. The compacted `calf.capabilities` topic
+  is untouched and there is **no `schema_version` bump** — re-advertising re-projects from
+  bare.

--- a/docs/api.md
+++ b/docs/api.md
@@ -380,7 +380,7 @@ Hosts the tools of one MCP server; `name` is the toolbox identity agents referen
 MCPToolbox(name: str, include: tuple[str, ...] | None = None)
 ```
 
-A frozen, identity-only handle to a toolbox. `name` must match the hosting `MCPToolboxNode`. `include` pins the tool names the agent may use; `None` exposes all of the toolbox's tools. The handle carries no connection params — passing connection details, or deploying a handle as a node, raises.
+A frozen, identity-only handle to a toolbox. `name` must match the hosting `MCPToolboxNode`. `include` pins the tool names the agent may use **by their bare server-side name** (`search`, not `docs_server__search`); `None` exposes all of the toolbox's tools. The LLM-facing name of each tool is namespaced `<name>__<tool>` (e.g. `docs_server__search`) and stripped back to the bare name before dispatch to the MCP server (ADR-0018); the combined name must fit the provider's tool-name charset (`[a-zA-Z0-9_-]`) and length limit. The handle carries no connection params — passing connection details, or deploying a handle as a node, raises.
 
 ### Connection params
 

--- a/docs/designs/runtime-tool-discoverability-spec.md
+++ b/docs/designs/runtime-tool-discoverability-spec.md
@@ -318,7 +318,7 @@ def resolve_capability(view, target_id, *, include=None, expected_kind=None) -> 
     if expected_kind is not None and record.node_kind != expected_kind:
         return SelectorResult(wrong_kind_targets=(target_id,))
     try:
-        bindings = record_to_bindings(record)
+        bindings = record_to_bindings(record, name=target_id)  # name: namespaces toolbox tools (ADR-0018)
     except ValidationError:
         # tolerant-reader bad-data path ONLY (e.g. empty dispatch_topic fails ToolBinding min_length);
         # a non-ValidationError here is a logic bug — let it propagate (fail loud).

--- a/docs/mcp-tool-discovery.md
+++ b/docs/mcp-tool-discovery.md
@@ -107,9 +107,9 @@ model receives, and an over-long or out-of-charset name is rejected by the
 provider at the turn.
 
 Because MCP names are namespaced, a toolbox tool (`docs_server__search`) won't
-collide with a locally configured function tool (`search`). In the rare case a
-namespaced name does coincide with a local tool, the local tool wins and an error
-is logged.
+collide with a locally configured function tool (`search`). A collision would
+require a local tool named literally `docs_server__search`; in that rare case the
+local tool wins and an error is logged.
 
 ## Handle outages and topic creation
 

--- a/docs/mcp-tool-discovery.md
+++ b/docs/mcp-tool-discovery.md
@@ -79,7 +79,7 @@ to share the definition.
 ## Scope the selection
 
 ```python
-tools=[MCPToolbox("docs_server", include=("search", "fetch"))]   # only these tools
+tools=[MCPToolbox("docs_server", include=("search", "fetch"))]   # only these tools, by BARE name
 ```
 
 Use `include` to pin the exact tool names the agent may see — a server that
@@ -88,8 +88,28 @@ form, `docs.select(include=("search", "fetch"))` returns the same handle.) If a
 requested tool isn't available — the toolbox is offline, or doesn't offer it —
 the turn proceeds with whatever tools are available and logs a warning.
 
-If a toolbox tool name collides with a locally configured tool, the local tool
-wins and an error is logged.
+`include` names are the **bare** server-side tool names (`search`, not
+`docs_server__search`) — see below.
+
+## Tool names: bare in your code, namespaced for the model
+
+The model is shown each MCP tool under a **namespaced** name,
+`<toolbox_name>__<tool>` (e.g. `docs_server__search`), so tools from different
+toolboxes — and from your function tool nodes — never collide. You never type
+that form: calfkit applies it only on the model-facing surface and strips it back
+to the bare name before the call reaches the MCP server. Everywhere in your code —
+`include=(...)`, and any tool name you mention to the model in a system prompt —
+use the **bare** server-side name.
+
+Keep toolbox and tool names within the provider's tool-name charset
+(`[a-zA-Z0-9_-]`) and length limit: the combined `<toolbox>__<tool>` is what the
+model receives, and an over-long or out-of-charset name is rejected by the
+provider at the turn.
+
+Because MCP names are namespaced, a toolbox tool (`docs_server__search`) won't
+collide with a locally configured function tool (`search`). In the rare case a
+namespaced name does coincide with a local tool, the local tool wins and an error
+is logged.
 
 ## Handle outages and topic creation
 

--- a/tests/integration/test_mcp_roundtrip_kafka.py
+++ b/tests/integration/test_mcp_roundtrip_kafka.py
@@ -79,6 +79,17 @@ _SERVER_B_NAME = "roundtrip_server_b"
 _EARLIEST = {"auto_offset_reset": "earliest"}
 
 
+def _ns(node_id: str, tool: str) -> str:
+    """The LLM-facing namespaced tool name (ADR-0018): ``<toolbox_node_id>__<tool>``.
+
+    ``node_id`` is the toolbox's construction name — here the per-test-unique
+    ``_server_name(topic_namespace)`` — NOT the bare server base. The model is
+    advertised this namespaced name and emits it; the toolbox strips the prefix
+    before calling the MCP server (which only ever sees the bare ``tool``).
+    """
+    return f"{node_id}__{tool}"
+
+
 # ── builders ─────────────────────────────────────────────────────────────────
 
 
@@ -185,14 +196,15 @@ async def test_single_tool_call_roundtrips_over_the_wire(kafka_bootstrap: str, t
     agent_id = f"{topic_namespace}-mcp-agent"
     agent_in = f"{topic_namespace}.mcp-agent.input"
     control_plane = _control_plane(kafka_bootstrap)
+    server_name = _server_name(topic_namespace)
 
-    toolbox = MCPToolboxNode(_server_name(topic_namespace), connection_params=_server_params(_SERVER_SCRIPT))
+    toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
     agent = Agent(
         agent_id,
         system_prompt="call the add tool",
         subscribe_topics=agent_in,
-        model_client=scripted_model([ToolCallPart("add", {"a": 2, "b": 3}, tool_call_id="call-add")]),
-        tools=[toolbox.select(include=_TOOLS)],
+        model_client=scripted_model([ToolCallPart(_ns(server_name, "add"), {"a": 2, "b": 3}, tool_call_id="call-add")]),
+        tools=[toolbox.select(include=_TOOLS)],  # include uses BARE names (C5)
     )
 
     driver = Client.connect(kafka_bootstrap)
@@ -200,14 +212,14 @@ async def test_single_tool_call_roundtrips_over_the_wire(kafka_bootstrap: str, t
     agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
 
     async with toolbox_worker:
-        await _await_capability(kafka_bootstrap, _server_name(topic_namespace), timeout=60)
+        await _await_capability(kafka_bootstrap, server_name, timeout=60)
         async with agent_worker:
             result = await driver.execute("add 2 and 3", agent_in, timeout=120)
 
     assert result.output is not None and FINAL_OUTPUT in result.output
-    returns = tool_returns(result.message_history)
-    assert "add" in returns
-    assert "5" in _serialized(returns["add"])
+    returns = tool_returns(result.message_history)  # keyed by the model-facing (namespaced) name
+    assert _ns(server_name, "add") in returns
+    assert "5" in _serialized(returns[_ns(server_name, "add")])
 
     await driver.close()
     await toolbox_worker._client.close()
@@ -222,14 +234,15 @@ async def test_mcp_iserror_result_passes_through_transparently(kafka_bootstrap: 
     agent_id = f"{topic_namespace}-mcp-iserror"
     agent_in = f"{topic_namespace}.mcp-iserror.input"
     control_plane = _control_plane(kafka_bootstrap)
+    server_name = _server_name(topic_namespace)
 
-    toolbox = MCPToolboxNode(_server_name(topic_namespace), connection_params=_server_params(_SERVER_SCRIPT))
+    toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
     agent = Agent(
         agent_id,
         system_prompt="call domain_error",
         subscribe_topics=agent_in,
-        model_client=scripted_model([ToolCallPart("domain_error", {}, tool_call_id="call-err")]),
-        tools=[toolbox.select(include=["domain_error"])],
+        model_client=scripted_model([ToolCallPart(_ns(server_name, "domain_error"), {}, tool_call_id="call-err")]),
+        tools=[toolbox.select(include=["domain_error"])],  # include = BARE (C5)
     )
 
     driver = Client.connect(kafka_bootstrap)
@@ -237,7 +250,7 @@ async def test_mcp_iserror_result_passes_through_transparently(kafka_bootstrap: 
     agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
 
     async with toolbox_worker:
-        await _await_capability(kafka_bootstrap, _server_name(topic_namespace), timeout=60)
+        await _await_capability(kafka_bootstrap, server_name, timeout=60)
         async with agent_worker:
             result = await driver.execute("trigger the error", agent_in, timeout=120)
 
@@ -246,8 +259,8 @@ async def test_mcp_iserror_result_passes_through_transparently(kafka_bootstrap: 
     # It arrived as an ORDINARY return (tool_returns collects ToolReturnParts only), carrying
     # the isError result through transparently.
     returns = tool_returns(result.message_history)
-    assert "domain_error" in returns
-    assert "isError" in _serialized(returns["domain_error"])
+    assert _ns(server_name, "domain_error") in returns
+    assert "isError" in _serialized(returns[_ns(server_name, "domain_error")])
 
     await driver.close()
     await toolbox_worker._client.close()
@@ -261,16 +274,17 @@ async def test_concurrent_tool_calls_roundtrip_via_fanout(kafka_bootstrap: str, 
     agent_id = f"{topic_namespace}-mcp-fanout-agent"
     agent_in = f"{topic_namespace}.mcp-fanout-agent.input"
     control_plane = _control_plane(kafka_bootstrap)
+    server_name = _server_name(topic_namespace)
 
-    toolbox = MCPToolboxNode(_server_name(topic_namespace), connection_params=_server_params(_SERVER_SCRIPT))
+    toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
     agent = Agent(
         agent_id,
         system_prompt="call both tools",
         subscribe_topics=agent_in,
         model_client=scripted_model(
             [
-                ToolCallPart("add", {"a": 2, "b": 3}, tool_call_id="call-add"),
-                ToolCallPart("echo", {"text": "hi"}, tool_call_id="call-echo"),
+                ToolCallPart(_ns(server_name, "add"), {"a": 2, "b": 3}, tool_call_id="call-add"),
+                ToolCallPart(_ns(server_name, "echo"), {"text": "hi"}, tool_call_id="call-echo"),
             ]
         ),
         tools=[toolbox.select(include=_TOOLS)],
@@ -282,7 +296,7 @@ async def test_concurrent_tool_calls_roundtrip_via_fanout(kafka_bootstrap: str, 
     agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
 
     async with toolbox_worker:
-        await _await_capability(kafka_bootstrap, _server_name(topic_namespace), timeout=60)
+        await _await_capability(kafka_bootstrap, server_name, timeout=60)
         async with agent_worker:
             topics = await _topics(kafka_bootstrap)
             assert f"calf.fanout.{agent_id}.state" in topics
@@ -291,9 +305,9 @@ async def test_concurrent_tool_calls_roundtrip_via_fanout(kafka_bootstrap: str, 
 
     assert result.output is not None and FINAL_OUTPUT in result.output
     returns = tool_returns(result.message_history)
-    assert "add" in returns and "echo" in returns
-    assert "5" in _serialized(returns["add"])
-    assert "hi" in _serialized(returns["echo"])
+    assert _ns(server_name, "add") in returns and _ns(server_name, "echo") in returns
+    assert "5" in _serialized(returns[_ns(server_name, "add")])
+    assert "hi" in _serialized(returns[_ns(server_name, "echo")])
 
     await driver.close()
     await toolbox_worker._client.close()
@@ -309,16 +323,17 @@ async def test_duplicate_tool_concurrent_slots_route_by_call_id(kafka_bootstrap:
     agent_id = f"{topic_namespace}-dup-agent"
     agent_in = f"{topic_namespace}.dup-agent.input"
     control_plane = _control_plane(kafka_bootstrap)
+    server_name = _server_name(topic_namespace)
 
-    toolbox = MCPToolboxNode(_server_name(topic_namespace), connection_params=_server_params(_SERVER_SCRIPT))
+    toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
     agent = Agent(
         agent_id,
         system_prompt="add two pairs",
         subscribe_topics=agent_in,
         model_client=scripted_model(
             [
-                ToolCallPart("add", {"a": 2, "b": 3}, tool_call_id="call-a"),
-                ToolCallPart("add", {"a": 10, "b": 20}, tool_call_id="call-b"),
+                ToolCallPart(_ns(server_name, "add"), {"a": 2, "b": 3}, tool_call_id="call-a"),
+                ToolCallPart(_ns(server_name, "add"), {"a": 10, "b": 20}, tool_call_id="call-b"),
             ]
         ),
         tools=[toolbox.select(include=_TOOLS)],
@@ -329,7 +344,7 @@ async def test_duplicate_tool_concurrent_slots_route_by_call_id(kafka_bootstrap:
     agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
 
     async with toolbox_worker:
-        await _await_capability(kafka_bootstrap, _server_name(topic_namespace), timeout=60)
+        await _await_capability(kafka_bootstrap, server_name, timeout=60)
         async with agent_worker:
             result = await driver.execute("add 2+3 and 10+20", agent_in, timeout=120)
 
@@ -351,16 +366,17 @@ async def test_sequential_mode_dispatches_without_fanout(kafka_bootstrap: str, t
     agent_id = f"{topic_namespace}-seq-agent"
     agent_in = f"{topic_namespace}.seq-agent.input"
     control_plane = _control_plane(kafka_bootstrap)
+    server_name = _server_name(topic_namespace)
 
-    toolbox = MCPToolboxNode(_server_name(topic_namespace), connection_params=_server_params(_SERVER_SCRIPT))
+    toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
     agent = Agent(
         agent_id,
         system_prompt="call both tools sequentially",
         subscribe_topics=agent_in,
         model_client=scripted_model(
             [
-                ToolCallPart("add", {"a": 2, "b": 3}, tool_call_id="call-add"),
-                ToolCallPart("echo", {"text": "hi"}, tool_call_id="call-echo"),
+                ToolCallPart(_ns(server_name, "add"), {"a": 2, "b": 3}, tool_call_id="call-add"),
+                ToolCallPart(_ns(server_name, "echo"), {"text": "hi"}, tool_call_id="call-echo"),
             ]
         ),
         tools=[toolbox.select(include=_TOOLS)],
@@ -373,15 +389,15 @@ async def test_sequential_mode_dispatches_without_fanout(kafka_bootstrap: str, t
     agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
 
     async with toolbox_worker:
-        await _await_capability(kafka_bootstrap, _server_name(topic_namespace), timeout=60)
+        await _await_capability(kafka_bootstrap, server_name, timeout=60)
         async with agent_worker:
             result = await driver.execute("add then echo", agent_in, timeout=120)
             topics = await _topics(kafka_bootstrap)
 
     assert result.output is not None and FINAL_OUTPUT in result.output
     returns = tool_returns(result.message_history)
-    assert "5" in _serialized(returns["add"])
-    assert "hi" in _serialized(returns["echo"])
+    assert "5" in _serialized(returns[_ns(server_name, "add")])
+    assert "hi" in _serialized(returns[_ns(server_name, "echo")])
     # No durable store was opened — the sequential path never fans out.
     assert f"calf.fanout.{agent_id}.state" not in topics
     assert f"calf.fanout.{agent_id}.basestate" not in topics
@@ -397,20 +413,22 @@ async def test_two_mcp_servers_route_each_call_to_its_server(kafka_bootstrap: st
     agent_id = f"{topic_namespace}-multi-server-agent"
     agent_in = f"{topic_namespace}.multi-server-agent.input"
     control_plane = _control_plane(kafka_bootstrap)
+    server_a_name = _server_name(topic_namespace)
+    server_b_name = _server_name(topic_namespace, _SERVER_B_NAME)
 
-    box_a = MCPToolboxNode(_server_name(topic_namespace), connection_params=_server_params(_SERVER_SCRIPT))
-    box_b = MCPToolboxNode(_server_name(topic_namespace, _SERVER_B_NAME), connection_params=_server_params(_SERVER_B_SCRIPT))
+    box_a = MCPToolboxNode(server_a_name, connection_params=_server_params(_SERVER_SCRIPT))
+    box_b = MCPToolboxNode(server_b_name, connection_params=_server_params(_SERVER_B_SCRIPT))
     agent = Agent(
         agent_id,
         system_prompt="use a tool from each server",
         subscribe_topics=agent_in,
         model_client=scripted_model(
             [
-                ToolCallPart("add", {"a": 2, "b": 3}, tool_call_id="call-add"),
-                ToolCallPart("mul", {"a": 4, "b": 5}, tool_call_id="call-mul"),
+                ToolCallPart(_ns(server_a_name, "add"), {"a": 2, "b": 3}, tool_call_id="call-add"),
+                ToolCallPart(_ns(server_b_name, "mul"), {"a": 4, "b": 5}, tool_call_id="call-mul"),
             ]
         ),
-        tools=[box_a.select(include=["add"]), box_b.select(include=["mul"])],
+        tools=[box_a.select(include=["add"]), box_b.select(include=["mul"])],  # each include is BARE
     )
 
     driver = Client.connect(kafka_bootstrap)
@@ -421,15 +439,16 @@ async def test_two_mcp_servers_route_each_call_to_its_server(kafka_bootstrap: st
     agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
 
     async with toolbox_worker:
-        await _await_capability(kafka_bootstrap, _server_name(topic_namespace), timeout=60)
-        await _await_capability(kafka_bootstrap, _server_name(topic_namespace, _SERVER_B_NAME), timeout=60)
+        await _await_capability(kafka_bootstrap, server_a_name, timeout=60)
+        await _await_capability(kafka_bootstrap, server_b_name, timeout=60)
         async with agent_worker:
             result = await driver.execute("add 2+3 and mul 4*5", agent_in, timeout=120)
 
     assert result.output is not None and FINAL_OUTPUT in result.output
     returns = tool_returns(result.message_history)
-    assert "5" in _serialized(returns["add"])  # only server A could produce 5
-    assert "20" in _serialized(returns["mul"])  # only server B could produce 20
+    # Each call namespaced by its OWN toolbox; the server saw the bare name and produced these.
+    assert "5" in _serialized(returns[_ns(server_a_name, "add")])  # only server A could produce 5
+    assert "20" in _serialized(returns[_ns(server_b_name, "mul")])  # only server B could produce 20
 
     await driver.close()
     await toolbox_worker._client.close()
@@ -444,20 +463,21 @@ async def test_two_agents_share_one_toolbox_replies_route_per_caller(kafka_boots
     a2_id = f"{topic_namespace}-agent-2"
     a2_in = f"{topic_namespace}.agent-2.input"
     control_plane = _control_plane(kafka_bootstrap)
+    server_name = _server_name(topic_namespace)
 
-    toolbox = MCPToolboxNode(_server_name(topic_namespace), connection_params=_server_params(_SERVER_SCRIPT))
+    toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
     agent1 = Agent(
         a1_id,
         system_prompt="add",
         subscribe_topics=a1_in,
-        model_client=scripted_model([ToolCallPart("add", {"a": 2, "b": 3}, tool_call_id="c1")]),
+        model_client=scripted_model([ToolCallPart(_ns(server_name, "add"), {"a": 2, "b": 3}, tool_call_id="c1")]),
         tools=[toolbox.select(include=["add"])],
     )
     agent2 = Agent(
         a2_id,
         system_prompt="add",
         subscribe_topics=a2_in,
-        model_client=scripted_model([ToolCallPart("add", {"a": 10, "b": 20}, tool_call_id="c2")]),
+        model_client=scripted_model([ToolCallPart(_ns(server_name, "add"), {"a": 10, "b": 20}, tool_call_id="c2")]),
         tools=[toolbox.select(include=["add"])],
     )
 
@@ -466,7 +486,7 @@ async def test_two_agents_share_one_toolbox_replies_route_per_caller(kafka_boots
     agent_worker = _worker(kafka_bootstrap, nodes=[agent1, agent2], control_plane=control_plane)
 
     async with toolbox_worker:
-        await _await_capability(kafka_bootstrap, _server_name(topic_namespace), timeout=60)
+        await _await_capability(kafka_bootstrap, server_name, timeout=60)
         async with agent_worker:
             h1 = await driver.start("agent 1 add 2+3", a1_in)
             h2 = await driver.start("agent 2 add 10+20", a2_in)
@@ -476,8 +496,8 @@ async def test_two_agents_share_one_toolbox_replies_route_per_caller(kafka_boots
     assert r1.output is not None and FINAL_OUTPUT in r1.output
     assert r2.output is not None and FINAL_OUTPUT in r2.output
     # Each caller got ITS OWN result back, not the other's.
-    assert "5" in _serialized(tool_returns(r1.message_history)["add"])
-    assert "30" in _serialized(tool_returns(r2.message_history)["add"])
+    assert "5" in _serialized(tool_returns(r1.message_history)[_ns(server_name, "add")])
+    assert "30" in _serialized(tool_returns(r2.message_history)[_ns(server_name, "add")])
 
     await driver.close()
     await toolbox_worker._client.close()
@@ -494,14 +514,15 @@ async def test_include_pinning_blocks_unselected_tool(kafka_bootstrap: str, topi
     agent_id = f"{topic_namespace}-pin-agent"
     agent_in = f"{topic_namespace}.pin-agent.input"
     control_plane = _control_plane(kafka_bootstrap)
+    server_name = _server_name(topic_namespace)
 
-    toolbox = MCPToolboxNode(_server_name(topic_namespace), connection_params=_server_params(_SERVER_SCRIPT))
+    toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
     agent = Agent(
         agent_id,
         system_prompt="try to call danger",
         subscribe_topics=agent_in,
-        model_client=scripted_model([ToolCallPart("danger", {}, tool_call_id="call-danger")]),
-        tools=[toolbox.select(include=["add"])],  # danger is advertised but NOT included
+        model_client=scripted_model([ToolCallPart(_ns(server_name, "danger"), {}, tool_call_id="call-danger")]),
+        tools=[toolbox.select(include=["add"])],  # danger is advertised but NOT included (include is BARE)
     )
 
     driver = Client.connect(kafka_bootstrap)
@@ -509,14 +530,14 @@ async def test_include_pinning_blocks_unselected_tool(kafka_bootstrap: str, topi
     agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
 
     async with toolbox_worker:
-        await _await_capability(kafka_bootstrap, _server_name(topic_namespace), timeout=60)
+        await _await_capability(kafka_bootstrap, server_name, timeout=60)
         async with agent_worker:
             result = await driver.execute("call danger", agent_in, timeout=120)
 
     assert result.output is not None and FINAL_OUTPUT in result.output
-    # danger never reached the server / never round-tripped.
-    assert "danger" not in tool_returns(result.message_history)
-    # The agent told the model the tool does not exist.
+    # danger never reached the server / never round-tripped (check the namespaced key it WOULD have had).
+    assert _ns(server_name, "danger") not in tool_returns(result.message_history)
+    # The agent told the model the tool does not exist (retry text carries the emitted name).
     assert any("danger" in text for text in retry_prompt_texts(result.message_history))
 
     await driver.close()
@@ -535,20 +556,21 @@ async def test_tools_list_changed_grows_the_toolset(kafka_bootstrap: str, topic_
     bonus_id = f"{topic_namespace}-bonus-agent"
     bonus_in = f"{topic_namespace}.bonus-agent.input"
     control_plane = _control_plane(kafka_bootstrap)
+    server_name = _server_name(topic_namespace)
 
-    toolbox = MCPToolboxNode(_server_name(topic_namespace), connection_params=_server_params(_SERVER_SCRIPT))
+    toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
     enable_agent = Agent(
         enable_id,
         system_prompt="enable the bonus tool",
         subscribe_topics=enable_in,
-        model_client=scripted_model([ToolCallPart("enable_bonus", {}, tool_call_id="call-enable")]),
+        model_client=scripted_model([ToolCallPart(_ns(server_name, "enable_bonus"), {}, tool_call_id="call-enable")]),
         tools=[toolbox.select(include=["enable_bonus"])],
     )
     bonus_agent = Agent(
         bonus_id,
         system_prompt="use the bonus tool",
         subscribe_topics=bonus_in,
-        model_client=scripted_model([ToolCallPart("bonus", {}, tool_call_id="call-bonus")]),
+        model_client=scripted_model([ToolCallPart(_ns(server_name, "bonus"), {}, tool_call_id="call-bonus")]),
         tools=[toolbox.select(include=["bonus"])],
     )
 
@@ -558,22 +580,23 @@ async def test_tools_list_changed_grows_the_toolset(kafka_bootstrap: str, topic_
     bonus_worker = _worker(kafka_bootstrap, nodes=[bonus_agent], control_plane=control_plane)
 
     async with toolbox_worker:
-        await _await_capability(kafka_bootstrap, _server_name(topic_namespace), timeout=60)
+        await _await_capability(kafka_bootstrap, server_name, timeout=60)
 
         # 1) Trigger the runtime tool registration + list_changed notification.
         async with enable_worker:
             r1 = await driver.execute("enable the bonus tool", enable_in, timeout=120)
         assert r1.output is not None and FINAL_OUTPUT in r1.output
-        assert "enabled" in _serialized(tool_returns(r1.message_history)["enable_bonus"])
+        assert "enabled" in _serialized(tool_returns(r1.message_history)[_ns(server_name, "enable_bonus")])
 
-        # 2) The toolbox re-listed into its cache; the next heartbeat carried the grown record — wait for it.
-        await _await_tool_in_record(kafka_bootstrap, _server_name(topic_namespace), "bonus", timeout=60)
+        # 2) The toolbox re-listed into its cache; the next heartbeat carried the grown record — wait
+        #    for it. The WIRE record carries BARE tool names, so probe for the bare "bonus".
+        await _await_tool_in_record(kafka_bootstrap, server_name, "bonus", timeout=60)
 
         # 3) A fresh agent's view catch-up now includes 'bonus' deterministically.
         async with bonus_worker:
             r2 = await driver.execute("use the bonus tool", bonus_in, timeout=120)
         assert r2.output is not None and FINAL_OUTPUT in r2.output
-        assert "bonus-result" in _serialized(tool_returns(r2.message_history)["bonus"])
+        assert "bonus-result" in _serialized(tool_returns(r2.message_history)[_ns(server_name, "bonus")])
 
     await driver.close()
     await toolbox_worker._client.close()
@@ -584,31 +607,56 @@ async def test_tools_list_changed_grows_the_toolset(kafka_bootstrap: str, topic_
 # ── Group C: the agent's point of view of its advertised tools ───────────────
 
 
-async def test_agent_pov_matches_advertised_capability_view(kafka_bootstrap: str, topic_namespace: str) -> None:
-    """The agent's POV of its tools IS what the toolbox advertised on the Capability View.
+async def test_agent_pov_is_namespaced_and_strips_to_bare_on_dispatch(
+    kafka_bootstrap: str, topic_namespace: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Headline end-to-end namespacing proof, in one test (ADR-0018):
 
-    Instead of hardcoding the available surface, this inspects what the agent actually
-    resolved from the view and handed the model (``AgentInfo.function_tools``), asserts it
-    matches the live ``CapabilityRecord`` on ``calf.capabilities`` by NAME and by SCHEMA,
-    and that a tool drawn from that POV round-trips — proving every advertised tool reaches
-    the model exactly as advertised and is callable on the turn.
+    1. every tool the agent presents in its POV (``AgentInfo.function_tools``) exists and is
+       namespaced ``<toolbox_node_id>__<tool>`` — matched against the live ``CapabilityRecord``
+       on ``calf.capabilities`` by NAME and by SCHEMA, nothing added or dropped;
+    2. calls drawn from that POV (by their namespaced names) are dispatched namespaced and
+       STRIPPED TO BARE at the ``MCPToolboxNode`` before the server — captured at the MCP
+       ``call_tool`` boundary, the truest "what the server received" evidence; and
+    3. the results round-trip back into history.
+
+    Only the broker + MCP server are real; the model is offline (``capturing_model``).
     """
+    import mcp
+
     agent_id = f"{topic_namespace}-pov-agent"
     agent_in = f"{topic_namespace}.pov-agent.input"
     control_plane = _control_plane(kafka_bootstrap)
     server_name = _server_name(topic_namespace)
 
+    # Capture the tool name the MCP server actually receives (after the node strips its prefix).
+    # monkeypatch auto-reverts; patching the class method spies every session in this test.
+    server_names: list[str] = []
+    _orig_call_tool = mcp.ClientSession.call_tool
+
+    async def _spy_call_tool(self: Any, name: str, *args: Any, **kwargs: Any) -> Any:
+        server_names.append(name)
+        return await _orig_call_tool(self, name, *args, **kwargs)
+
+    monkeypatch.setattr(mcp.ClientSession, "call_tool", _spy_call_tool)
+
     toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
-    pov: dict[str, Any] = {}  # name -> ToolDefinition the agent presented to the model
+    pov: dict[str, Any] = {}  # namespaced name -> ToolDefinition the agent presented to the model
     agent = Agent(
         agent_id,
-        system_prompt="call add",
+        system_prompt="call add and echo",
         subscribe_topics=agent_in,
-        model_client=capturing_model(pov, [ToolCallPart("add", {"a": 2, "b": 3}, tool_call_id="call-add")]),
+        model_client=capturing_model(
+            pov,
+            [
+                ToolCallPart(_ns(server_name, "add"), {"a": 2, "b": 3}, tool_call_id="call-add"),
+                ToolCallPart(_ns(server_name, "echo"), {"text": "hi"}, tool_call_id="call-echo"),
+            ],
+        ),
         tools=[toolbox],  # NO include: the agent sees the toolbox's full advertised set
     )
 
-    advertised: dict[str, Any] = {}  # name -> parameters_json_schema, read straight from the view record
+    advertised: dict[str, Any] = {}  # BARE name -> parameters_json_schema, read straight from the view record
 
     def _capture_advertised(view: ControlPlaneView[CapabilityRecord]) -> bool:
         record = view.get(server_name)
@@ -624,26 +672,33 @@ async def test_agent_pov_matches_advertised_capability_view(kafka_bootstrap: str
 
     async with toolbox_worker:
         await _await_capability(kafka_bootstrap, server_name, timeout=60)
-        # The source of truth the agent reads: what the toolbox advertised on the view.
+        # The source of truth the agent reads: what the toolbox advertised on the view (BARE names).
         await _await_view(kafka_bootstrap, _capture_advertised, timeout=60, what=f"advertised tools for {server_name!r}")
         async with agent_worker:
-            result = await driver.execute("add 2 and 3", agent_in, timeout=120)
+            result = await driver.execute("add 2 and 3, and echo hi", agent_in, timeout=120)
 
-    # 1) the call drawn from the advertised set round-tripped to a finalized turn
-    assert result.output is not None and FINAL_OUTPUT in result.output
-    assert "5" in _serialized(tool_returns(result.message_history)["add"])
+    returns = tool_returns(result.message_history)  # keyed by the model-facing (namespaced) name
 
-    # 2) the toolbox advertised exactly the server's tool set — all advertised tools present
-    assert set(advertised) == {"add", "echo", "ping", "danger", "domain_error", "enable_bonus"}
-
-    # 3) the agent's POV == the advertised view record, by NAME and by SCHEMA. The agent
-    #    presented to the model exactly what the toolbox advertised — nothing added or dropped.
+    # (1) Existence + naming for the WHOLE set: the toolbox advertised the bare server set, and the
+    #     agent's POV is exactly that set NAMESPACED — by NAME and by SCHEMA, nothing added or dropped.
+    assert set(advertised) == {"add", "echo", "ping", "danger", "domain_error", "enable_bonus"}  # bare wire names
     assert pov, "the model never captured the agent's tool POV"
-    assert set(pov) == set(advertised)
-    assert {name: td.parameters_json_schema for name, td in pov.items()} == advertised
+    assert set(pov) == {_ns(server_name, n) for n in advertised}
+    assert {name: td.parameters_json_schema for name, td in pov.items()} == {_ns(server_name, n): s for n, s in advertised.items()}
 
-    # 4) the called tool reached the model as advertised — its schema carries its real args
-    assert {"a", "b"} <= set(pov["add"].parameters_json_schema.get("properties", {}))
+    # (2) The called tools were drawn from the POV (by their namespaced names).
+    assert {_ns(server_name, "add"), _ns(server_name, "echo")} <= set(pov)
+
+    # (3) Strip verified at the node->server boundary: the server saw ONLY the BARE names; the
+    #     namespaced prefix never crossed to it.
+    assert set(server_names) == {"add", "echo"}
+    assert all(n in advertised for n in server_names)
+    assert _ns(server_name, "add") not in server_names
+
+    # (4) Results round-trip back into history, keyed by the model-facing namespaced name.
+    assert result.output is not None and FINAL_OUTPUT in result.output
+    assert "5" in _serialized(returns[_ns(server_name, "add")])
+    assert "hi" in _serialized(returns[_ns(server_name, "echo")])
 
     await driver.close()
     await toolbox_worker._client.close()

--- a/tests/integration/test_mcp_toolbox_capability.py
+++ b/tests/integration/test_mcp_toolbox_capability.py
@@ -112,8 +112,10 @@ async def test_capability_parity_toolbox_to_agent(kafka_bootstrap: str) -> None:
 
         registry: dict = {}
         agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: view}, registry)
-        assert sorted(registry) == ["search"]
-        assert registry["search"].dispatch_topic == f"mcp_server.{name}"
+        # The agent's resolved registry is keyed by the NAMESPACED tool name (C1, ADR-0018);
+        # the wire record (asserted above) stays BARE. dispatch_topic is unchanged.
+        assert sorted(registry) == [f"{name}__search"]
+        assert registry[f"{name}__search"].dispatch_topic == f"mcp_server.{name}"
 
         # clean shutdown tombstones the instance; the next turn degrades (empty)
         await pub.stop(ctx)

--- a/tests/test_capability_models.py
+++ b/tests/test_capability_models.py
@@ -102,18 +102,26 @@ class TestCapabilityConstants:
 
 class TestRecordToBindings:
     def test_builds_validatorless_bindings_with_record_topic(self) -> None:
-        record = make_record()
-        bindings = record_to_bindings(record)
-        assert [b.name for b in bindings] == ["search", "fetch"]
+        record = make_record()  # node_kind="toolbox"
+        bindings = record_to_bindings(record, name="docs_server")
+        # C1: a toolbox's LLM-facing tool names are namespaced <node_id>__<tool>.
+        assert [b.name for b in bindings] == ["docs_server__search", "docs_server__fetch"]
         assert all(isinstance(b, ToolBinding) for b in bindings)
         assert all(b.dispatch_topic == "mcp_server.docs_server" for b in bindings)
         # Wire-crossing tools dispatch unvalidated (schema-only carve-out).
         assert all(b.validator is None for b in bindings)
 
     def test_tool_def_fields_survive(self) -> None:
-        [search, _] = record_to_bindings(make_record())
+        [search, _] = record_to_bindings(make_record(), name="docs_server")
         assert search.tool_def.description == "Search the docs"
         assert search.tool_def.parameters_json_schema == {"type": "object", "properties": {"q": {"type": "string"}}}
+
+    def test_tool_node_record_stays_bare(self) -> None:
+        # C2: namespacing is toolbox-scoped. A function tool node's record
+        # (node_kind="tool") expands to BARE names, preserving the
+        # node_id == tool name == capability key identity (ADR-0013).
+        bindings = record_to_bindings(make_record(node_kind="tool"), name="docs_server")
+        assert [b.name for b in bindings] == ["search", "fetch"]
 
 
 class TestClientServerUrlsRetention:

--- a/tests/test_mcp_toolbox.py
+++ b/tests/test_mcp_toolbox.py
@@ -46,14 +46,15 @@ class TestDirectConstruction:
 
         ref = MCPToolbox("github")
         result = ref.resolve_tools({"github": make_record()})
-        assert [b.name for b in result.bindings] == ["search", "create_issue"]
+        # C1: toolbox tools are namespaced <node_id>__<tool> for the LLM.
+        assert [b.name for b in result.bindings] == ["github__search", "github__create_issue"]
 
     def test_include_kwarg_filters(self) -> None:
         from calfkit.mcp import MCPToolbox
 
-        ref = MCPToolbox("github", include=("search",))
+        ref = MCPToolbox("github", include=("search",))  # include uses BARE names (C5)
         result = ref.resolve_tools({"github": make_record()})
-        assert [b.name for b in result.bindings] == ["search"]
+        assert [b.name for b in result.bindings] == ["github__search"]
 
     def test_include_accepts_any_sequence_normalized_to_tuple(self) -> None:
         from calfkit.mcp import MCPToolbox
@@ -124,3 +125,44 @@ class TestDeployingARefFailsLoudAndEarly:
         worker = Worker(Client.connect("kafka:9092"))
         with pytest.raises(TypeError):
             worker.add_nodes("not a node")  # type: ignore[arg-type]
+
+
+class TestDispatchStripsToolboxPrefix:
+    """C4/C6: ``MCPToolboxNode.run`` strips its own ``<node_id>__`` prefix so the MCP
+    server is called with the BARE tool name — robust to a server tool name or a toolbox
+    name that legitimately contains ``__``. The agent dispatches the namespaced name; the
+    strip is local to the node, so the agent's dispatch path stays generic."""
+
+    @pytest.mark.parametrize(
+        ("toolbox_name", "advertised_name", "expected_server_name"),
+        [
+            ("github", "github__search", "search"),  # ordinary case
+            ("my__server", "my__server__a__b", "a__b"),  # embedded __ in BOTH names (C6)
+            ("github", "search", "search"),  # already bare -> removeprefix is a no-op
+        ],
+    )
+    async def test_run_calls_server_with_bare_tool_name(self, toolbox_name: str, advertised_name: str, expected_server_name: str) -> None:
+        from unittest.mock import AsyncMock, MagicMock
+
+        from mcp import ClientSession
+        from mcp.types import CallToolResult as MCPCallToolResult
+        from mcp.types import TextContent
+
+        from calfkit.mcp.mcp_toolbox import MCPToolboxNode
+        from calfkit.mcp.mcp_transport import StreamableHttpParameters
+        from calfkit.models.state import State
+        from calfkit.models.tool_dispatch import ToolCallRef
+        from tests.test_tool_errors import _make_ctx
+
+        node = MCPToolboxNode(toolbox_name, connection_params=StreamableHttpParameters(url="http://unused.local/mcp"))
+        session = MagicMock(spec=ClientSession)  # spec => passes run()'s isinstance(session, ClientSession) guard
+        session.call_tool = AsyncMock(return_value=MCPCallToolResult(content=[TextContent(type="text", text="ok")]))
+
+        ctx = _make_ctx(State())
+        ctx._resources = {node._session_resource_key: session}
+        payload = ToolCallRef(tool_call_id="c1", args={"x": 1}, name=advertised_name)
+
+        await node.run(ctx, payload)
+
+        # The server receives the BARE name; the namespaced prefix never crosses the MCP boundary.
+        session.call_tool.assert_awaited_once_with(name=expected_server_name, arguments={"x": 1})

--- a/tests/test_tool_node_advert.py
+++ b/tests/test_tool_node_advert.py
@@ -96,7 +96,7 @@ class TestEagerDiscoveredParity:
     def test_eager_and_discovered_tool_def_are_identical(self) -> None:
         node = make_node("add")
         eager = node.tool_bindings()[0]  # live path: schema baked in, with a local validator
-        discovered = record_to_bindings(node._capability_advert(make_stamp()))[0]  # discovered path
+        discovered = record_to_bindings(node._capability_advert(make_stamp()), name="add")[0]  # discovered; node_kind="tool" stays BARE (C2)
         # Same ToolDefinition — name, description, JSON schema, and every defaulted field.
         assert discovered.tool_def == eager.tool_def
         # The only difference is the validation locus: eager validates locally; the discovered

--- a/tests/test_tool_selector.py
+++ b/tests/test_tool_selector.py
@@ -70,7 +70,7 @@ class TestResolveTools:
         result = toolbox.resolve_tools(view)
         assert isinstance(result, SelectorResult)
         assert isinstance(result.bindings, tuple)  # frozen value: immutable binding sequence
-        assert [b.name for b in result.bindings] == ["search", "fetch"]
+        assert [b.name for b in result.bindings] == ["docs_server__search", "docs_server__fetch"]
         assert all(isinstance(b, ToolBinding) and b.validator is None for b in result.bindings)
         assert all(b.dispatch_topic == "mcp_server.docs_server" for b in result.bindings)
         assert not result.unresolved
@@ -83,10 +83,10 @@ class TestResolveTools:
 
     def test_include_filter_and_missing_tools(self) -> None:
         toolbox = make_toolbox()
-        selector = toolbox.select(include=["search", "nonexistent"])
+        selector = toolbox.select(include=["search", "nonexistent"])  # include = BARE names (C5)
         result = selector.resolve_tools({"docs_server": make_record()})
-        assert [b.name for b in result.bindings] == ["search"]
-        assert result.missing_tools == ("nonexistent",)
+        assert [b.name for b in result.bindings] == ["docs_server__search"]
+        assert result.missing_tools == ("nonexistent",)  # missing_tools reported bare too
 
     def test_scoped_selector_is_frozen(self) -> None:
         selector = make_toolbox().select(include=["search"])
@@ -122,7 +122,7 @@ class TestResolveTools:
     def test_live_record_resolves_through_view(self) -> None:
         view = make_view(make_record())
         result = make_toolbox().resolve_tools(view)
-        assert [b.name for b in result.bindings] == ["search", "fetch"]
+        assert [b.name for b in result.bindings] == ["docs_server__search", "docs_server__fetch"]
         assert not result.unresolved
 
     def test_wrong_kind_record_is_rejected(self) -> None:
@@ -186,20 +186,37 @@ class TestAgentResolution:
         agent = self.make_agent(make_toolbox())
         registry: dict[str, ToolBinding] = {}
         agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: {"docs_server": make_record()}}, registry)
-        assert sorted(registry) == ["fetch", "search"]
+        assert sorted(registry) == ["docs_server__fetch", "docs_server__search"]
 
-    def test_collision_static_wins_and_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_namespaced_toolbox_tool_does_not_collide_with_static(self, caplog: pytest.LogCaptureFixture) -> None:
+        # C8: namespacing makes a toolbox tool `search` (advertised as docs_server__search)
+        # disjoint from a static local tool named `search` — both coexist, no collision.
+        from calfkit._vendor.pydantic_ai.tools import ToolDefinition
+
         agent = self.make_agent(make_toolbox())
-        static = ToolBinding(
-            tool_def=__import__("calfkit._vendor.pydantic_ai.tools", fromlist=["ToolDefinition"]).ToolDefinition(name="search"),
-            dispatch_topic="static.topic",
-        )
+        static = ToolBinding(tool_def=ToolDefinition(name="search"), dispatch_topic="static.topic")
         registry = {"search": static}
         with caplog.at_level("ERROR"):
             agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: {"docs_server": make_record()}}, registry)
-        assert registry["search"] is static  # remote never shadows local
-        assert any("search" in r.message for r in caplog.records)
-        assert "fetch" in registry  # non-colliding remote tool still merged
+        # Both survive under their own keys; the remote tools merge without shadowing the static.
+        assert registry["search"] is static
+        assert "docs_server__search" in registry and "docs_server__fetch" in registry
+        assert not any("collides" in r.message for r in caplog.records)
+
+    def test_collision_static_wins_and_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+        # The merge rule is unchanged — a static local binding wins over a discovered one on a
+        # genuine key collision. Post-namespacing the collision is at the NAMESPACED name the
+        # toolbox actually advertises (docs_server__search).
+        from calfkit._vendor.pydantic_ai.tools import ToolDefinition
+
+        agent = self.make_agent(make_toolbox())
+        static = ToolBinding(tool_def=ToolDefinition(name="docs_server__search"), dispatch_topic="static.topic")
+        registry = {"docs_server__search": static}
+        with caplog.at_level("ERROR"):
+            agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: {"docs_server": make_record()}}, registry)
+        assert registry["docs_server__search"] is static  # remote never shadows local
+        assert any("docs_server__search" in r.message for r in caplog.records)
+        assert "docs_server__fetch" in registry  # non-colliding remote tool still merged
 
     def test_missing_view_warns_and_degrades(self, caplog: pytest.LogCaptureFixture) -> None:
         agent = self.make_agent(make_toolbox())
@@ -226,7 +243,7 @@ class TestAgentResolution:
         view = make_view(make_record(), status="degraded")
         with caplog.at_level("WARNING"):
             agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: view}, registry)
-        assert sorted(registry) == ["fetch", "search"]  # turn proceeds
+        assert sorted(registry) == ["docs_server__fetch", "docs_server__search"]  # turn proceeds
         assert any("degraded" in r.message.lower() for r in caplog.records)
 
     def test_failed_view_logs_warning_but_proceeds(self, caplog: pytest.LogCaptureFixture) -> None:
@@ -287,7 +304,7 @@ class TestOverridesSuppressSelectors:
         # override gate must short-circuit before resolution.
         ctx._resources = {CAPABILITY_VIEW_RESOURCE_KEY: {"docs_server": make_record()}}
         agent._maybe_resolve_selectors(ctx, registry)
-        assert list(registry) == ["pinned"]  # search/fetch NOT merged
+        assert list(registry) == ["pinned"]  # docs_server tools NOT merged
 
     def test_non_overridden_turn_resolves(self) -> None:
         agent = TestAgentResolution().make_agent(make_toolbox())
@@ -295,4 +312,4 @@ class TestOverridesSuppressSelectors:
         ctx._resources = {CAPABILITY_VIEW_RESOURCE_KEY: {"docs_server": make_record()}}
         registry: dict[str, ToolBinding] = {}
         agent._maybe_resolve_selectors(ctx, registry)
-        assert sorted(registry) == ["fetch", "search"]
+        assert sorted(registry) == ["docs_server__fetch", "docs_server__search"]

--- a/tests/test_tool_selector.py
+++ b/tests/test_tool_selector.py
@@ -88,6 +88,27 @@ class TestResolveTools:
         assert [b.name for b in result.bindings] == ["docs_server__search"]
         assert result.missing_tools == ("nonexistent",)  # missing_tools reported bare too
 
+    def test_include_pins_bare_name_containing_double_underscore(self) -> None:
+        # C6 at the EXPANSION+include layer: a server tool whose BARE name contains `__` must
+        # expand to docs_server__a__b AND stay pinnable by its bare name `a__b` — the include
+        # strip must recover `a__b`, not mangle it (removeprefix, not split("__")).
+        record = make_record(tools=[CapabilityToolDef(name="a__b", parameters_json_schema={"type": "object", "properties": {}})])
+        result = make_toolbox().select(include=["a__b"]).resolve_tools({"docs_server": record})
+        assert [b.name for b in result.bindings] == ["docs_server__a__b"]
+        assert result.missing_tools == ()
+
+    def test_empty_include_pins_nothing(self) -> None:
+        # include=() pins ZERO tools — distinct from include=None (all tools).
+        result = make_toolbox().select(include=[]).resolve_tools({"docs_server": make_record()})
+        assert result.bindings == ()
+        assert result.missing_tools == ()
+
+    def test_empty_toolbox_record_resolves_to_no_bindings(self) -> None:
+        # A toolbox advertising zero tools expands to zero bindings; an include miss is bare.
+        result = make_toolbox().select(include=["search"]).resolve_tools({"docs_server": make_record(tools=[])})
+        assert result.bindings == ()
+        assert result.missing_tools == ("search",)
+
     def test_scoped_selector_is_frozen(self) -> None:
         selector = make_toolbox().select(include=["search"])
         with pytest.raises(Exception):


### PR DESCRIPTION
## What

Namespace the **LLM-facing** name of every MCP tool as `<toolbox_node_name>__<tool_name>` (e.g. `github__search`), so the cluster tool namespace is **collision-free**: toolbox tools can no longer clash with function-tool-node names (`add`) or with each other (`github__search` vs `jira__search`).

Decision record: **ADR-0018** (`docs/adr/0018-mcp-tool-names-namespaced-by-server.md`, accepted in this PR).

## How

- **Expansion (add prefix):** a new `_namespace_prefix(node_kind, name)` helper in `calfkit/models/capability.py` is the single source of truth for the rule — `f"{name}__"` only for `node_kind == "toolbox"` records, `""` otherwise. `record_to_bindings(record, *, name)` gains a required keyword-only `name` and prefixes through it.
- **Dispatch (strip prefix):** `MCPToolboxNode.run` strips its own `<node_id>__` via exact-prefix `payload.name.removeprefix(...)` (never `split("__")`, which would corrupt a server tool name or toolbox name that legitimately contains `__`) before `session.call_tool`.
- **Read-time projection:** the wire `CapabilityRecord` stays **bare** — no `schema_version` bump, the compacted `calf.capabilities` topic is untouched, re-advertising re-projects from bare.
- The agent stays **namespace-agnostic** (`calfkit/nodes/agent.py` untouched) — it treats `github__search` opaquely end-to-end.

## User-facing surface

- `include=` and the `missing_tools` diagnostic use **bare** server-side names (`search`, not `github__search`) — a dev knows the tool by its bare name, so the trust boundary is expressed in bare names.
- The namespaced name exists in exactly one place: the LLM-facing tool surface. It is stripped before the call reaches the MCP server.

## Breaking change (accepted)

The LLM-facing MCP tool surface changes `search` → `<toolbox>__search`. Pre-1.0, no deployments to preserve — a clean break consistent with the project's hard-breaks-over-compat stance.

## Contracts (ADR-0018)

C1 namespaced LLM names · C2 function tool nodes stay bare · C3 wire record bare / no schema bump · C4 dispatch reaches server bare · C5 `include` bare · C6 exact-prefix strip (embedded-`__` safe) · C8 collision-free · C9 breaking change accepted · C10 `include` trust boundary preserved.

## Testing

- **Offline unit suite:** 3186 passed. New/updated: toolbox-namespaced vs tool-stays-bare expansion (C1/C2); `resolve_capability` namespaced output with bare `include`/`missing_tools` (C5); the eager-vs-discovered tool-node parity guard (C2); a new parametrized `MCPToolboxNode.run` dispatch test covering the embedded-`__` edges (C4/C6); the collision test reworked to prove toolbox tools no longer collide with same-named local tools (C8).
- **Kafka lane (real broker):** the full MCP roundtrip suite migrated to namespaced names (10 passed), including a reworked **headline end-to-end test** that, in one run, proves the agent's POV is exactly the advertised set namespaced (by name + schema), calls drawn from that POV are dispatched namespaced and **stripped to bare at the node** (captured at the `ClientSession.call_tool` boundary), and the results round-trip. `test_mcp_toolbox_capability.py` registry assertion updated (2 passed). Function-tool-node kafka tests unaffected (15 passed).
- **Coverage:** 100% on changed lines (`capability.py` 100%; the `mcp_toolbox.py` strip + `call_tool` lines covered by the offline `run()` test).
- `make fix` && `make check` clean (lint + format + type).

## Notes

- Branched from `930286a` (before #268, the agent-POV projection fix). The two changesets are disjoint — this PR touches none of #268's files — so it rebases cleanly.
- Prerequisite for the future discover-mode feature (`Tools(discover=True)`), but stands alone as MCP hardening.
