### PR TITLE
feat: discover mode — `discover=True` on `Tools`  for open-ended tool-node discovery

### DIFF
--- a/calfkit/models/capability.py
+++ b/calfkit/models/capability.py
@@ -179,3 +179,40 @@ def resolve_capability(
         bindings = [b for bare, b in tagged if bare in wanted]
         missing_tools = tuple(n for n in include if n not in present_bare)
     return SelectorResult(bindings=tuple(bindings), missing_tools=missing_tools)
+
+
+class EnumerableCapabilityView(CapabilityLookup, Protocol):
+    """:class:`CapabilityLookup` plus bulk enumeration: ``snapshot() -> {node_id: record}``.
+
+    The discover-mode read surface. Satisfied by a ``ControlPlaneView[CapabilityRecord]``
+    (which already exposes ``snapshot()``) and by the tests' ``_FakeView``. The
+    single-target path (:func:`resolve_capability`, ``MCPToolbox``) keeps the narrower
+    :class:`CapabilityLookup` — it never enumerates (Interface Segregation): point-lookup
+    clients must not depend on a ``snapshot()`` they never call.
+    """
+
+    def snapshot(self) -> dict[str, CapabilityRecord]: ...
+
+
+def resolve_all_capabilities(view: EnumerableCapabilityView, *, node_kind: str) -> SelectorResult:
+    """Bind every live record of ``node_kind`` (the discover-mode kernel).
+
+    A POSITIVE FILTER, not the over-pull guard: a record of another kind is out of scope
+    (skipped), not ``wrong_kind_targets`` — so ``missing_targets`` / ``missing_tools`` /
+    ``wrong_kind_targets`` are always empty. Only a poisoned record of the RIGHT kind (e.g.
+    an empty ``dispatch_topic`` failing ``ToolBinding``'s ``min_length``) degrades to
+    ``invalid_targets``; one bad record never crashes the turn (mirrors
+    :func:`resolve_capability`).
+    """
+    bindings: list[ToolBinding] = []
+    invalid: list[str] = []
+    for node_id, record in view.snapshot().items():
+        if record.node_kind != node_kind:
+            continue
+        try:
+            # ``name`` is required since ADR-0018; for ``node_kind == "tool"`` the prefix is
+            # "" so the snapshot key adds no namespace (and it stays correct for any kind).
+            bindings.extend(record_to_bindings(record, name=node_id))
+        except ValidationError:
+            invalid.append(node_id)
+    return SelectorResult(bindings=tuple(bindings), invalid_targets=tuple(invalid))

--- a/calfkit/models/tool_dispatch.py
+++ b/calfkit/models/tool_dispatch.py
@@ -10,9 +10,9 @@ from calfkit._vendor.pydantic_ai.messages import ToolCallPart
 from calfkit._vendor.pydantic_ai.tools import ToolDefinition
 
 if TYPE_CHECKING:
-    # Type-only: the Capability View lookup the resolver consumes lives a layer up
+    # Type-only: the Capability View the resolver consumes lives a layer up
     # (it references CapabilityRecord). A runtime import would cycle; this does not.
-    from calfkit.models.capability import CapabilityLookup
+    from calfkit.models.capability import EnumerableCapabilityView
 
 ArgsValidator = Callable[[dict[str, Any]], Any]
 """Validates LLM-emitted tool args pre-dispatch; raises ``pydantic.ValidationError`` on mismatch."""
@@ -105,12 +105,13 @@ class ToolSelector(Protocol):
     :class:`~calfkit.mcp.mcp_toolbox.MCPToolboxNode` that delegates to it, and by
     :class:`~calfkit.nodes.tool.Tools` for function tool nodes: passing any of them
     to an agent extracts only a lookup key — no session contact, no deployment. The
-    ``view`` is a :class:`~calfkit.models.capability.CapabilityLookup` (anything with
-    ``get(target_id) -> CapabilityRecord | None``), so the agent layer needs no
-    ktables import and tests can use plain dicts.
+    ``view`` is an :class:`~calfkit.models.capability.EnumerableCapabilityView` (``get``
+    + ``snapshot``), so the agent layer needs no ktables import. A by-name selector uses
+    only ``get(target_id)`` (so plain ``dict``s suffice in its tests); a discover selector
+    enumerates via ``snapshot()``.
     """
 
-    def resolve_tools(self, view: "CapabilityLookup") -> SelectorResult: ...
+    def resolve_tools(self, view: "EnumerableCapabilityView") -> SelectorResult: ...
 
 
 def split_tool_declarations(

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -240,6 +240,11 @@ class BaseAgentNodeDef(
             )
         for selector in self._tool_selectors:
             result: SelectorResult = selector.resolve_tools(view)
+            if isinstance(selector, Tools) and selector.discover:
+                # Discover names nothing, so a healthy view with zero tool nodes resolves silently
+                # (a legitimate empty cluster, not a misconfiguration). A DEBUG count aids the
+                # "why does my agent have no tools?" case without crying wolf.
+                logger.debug("agent=%s discover mode resolved %d tool node(s)", self.name, len(result.bindings))
             if result.unresolved:
                 logger.warning(
                     "agent=%s tool selection partially unresolved by %r (missing_targets=%s "

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -25,6 +25,7 @@ from calfkit.models.tool_dispatch import ToolBinding, ToolCallRef, ToolProvider,
 from calfkit.nodes._fanout_store import FANOUT_STORE_KEY, FanoutBatchStore, KtablesFanoutBatchStore
 from calfkit.nodes._projection import project, structured_output_preamble
 from calfkit.nodes.base import BaseNodeDef, _SeamArg, _SlotFailed, _SlotResolved
+from calfkit.nodes.tool import BaseToolNodeDef, Tools
 from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
 from calfkit.worker.lifecycle import ResourceSetupContext
 
@@ -56,7 +57,10 @@ class BaseAgentNodeDef(
     ):
         self.final_output_type = final_output_type
         self.system_prompt = system_prompt
-        self.tools, self._tool_selectors = split_tool_declarations(tools)
+        self.tools: list[ToolBinding] = []
+        self._tool_selectors: list[ToolSelector] = []
+        self._eager_tool_nodes: list[BaseToolNodeDef] = []
+        self._add_tools(tools)  # enforce the tool-surface contract, then commit (raises before agent-loop build)
         self.sequential_only_mode = sequential_only_mode
 
         if not isinstance(subscribe_topics, (list, tuple)):
@@ -516,8 +520,47 @@ class BaseAgentNodeDef(
             # chokepoint), not the retired State.final_output_parts side-channel (§4.5).
             return ReturnCall[State](state=ctx.state, value=parts)
 
+    def _add_tools(self, raw_tools: Sequence[ToolProvider | ToolBinding | ToolSelector] | None) -> None:
+        """Validate the prospective tool surface against the contract, then commit.
+
+        Shared by ``__init__`` and :meth:`add_tools`. The tool-surface contract (spec §15.3) is
+        checked over the RAW entries — types intact before ``split_tool_declarations`` flattens a
+        tool node into a bare :class:`ToolBinding`:
+
+          1. **No duplicate tool names** across eager bindings + named ``Tools``.
+          2. **``Tools(discover=True)`` owns the tool-node surface** — no eager tool node and no
+             named ``Tools(...)`` may accompany it (an ``MCPToolbox``, a different node kind, may).
+
+        Validate-before-commit: a raised ``ValueError`` leaves the existing surface unchanged.
+        """
+        bindings, selectors = split_tool_declarations(raw_tools)
+        # The eager tool nodes, kept TYPED — read off the raw ``BaseToolNodeDef`` entries (which the
+        # split flattens into bindings). The discover-exclusivity check needs to know which
+        # references are tool nodes, and that type is gone from ``self.tools`` after the split.
+        new_nodes = [t for t in (raw_tools or ()) if isinstance(t, BaseToolNodeDef)]
+        eager_nodes = self._eager_tool_nodes + new_nodes
+        selectors_all = self._tool_selectors + selectors
+        named = [s for s in selectors_all if isinstance(s, Tools) and not s.discover]
+        discover = any(isinstance(s, Tools) and s.discover for s in selectors_all)
+
+        # (2) discover owns the tool-node surface
+        if discover and (eager_nodes or named):
+            raise ValueError(
+                "Tools(discover=True) owns the agent's tool-node surface: no eager tool node "
+                "or named Tools(...) may accompany it (an MCPToolbox may)."
+            )
+        # (1) no duplicate tool names across the statically-named sources
+        static_names = [b.name for b in self.tools + bindings] + [n for s in named for n in s.names]
+        dupes = sorted({n for n in static_names if static_names.count(n) > 1})
+        if dupes:
+            raise ValueError(f"duplicate tool name(s) in tools=: {dupes}; each tool may be referenced once")
+
+        self.tools += bindings  # commit only after both checks pass
+        self._tool_selectors += selectors
+        self._eager_tool_nodes = eager_nodes
+
     def add_tools(self, *tools: ToolProvider | ToolBinding | ToolSelector) -> None:
-        """Add tools after construction.
+        """Add tools after construction (enforces the §15.3 tool-surface contract).
 
         Note: a ToolSelector added AFTER the hosting worker's
         ``register_handlers()`` has run will not get a Capability View
@@ -525,9 +568,7 @@ class BaseAgentNodeDef(
         provisioning) — it degrades per the unresolved-selector policy.
         Declare selectors before registering, or at construction.
         """
-        bindings, selectors = split_tool_declarations(tools)
-        self.tools.extend(bindings)
-        self._tool_selectors.extend(selectors)
+        self._add_tools(tools)
 
     def instructions(self, func: Callable[..., str | None]) -> Callable[..., str | None]:
         """Decorator to define dynamic instruction functions that can build instructions at runtime."""

--- a/calfkit/nodes/tool.py
+++ b/calfkit/nodes/tool.py
@@ -14,7 +14,14 @@ from calfkit._vendor.pydantic_ai.tools import ToolDefinition
 from calfkit.controlplane import ControlPlaneStamp, advertises
 from calfkit.models import SessionRunContext, State, ToolContext
 from calfkit.models.actions import NodeResult, ReturnCall
-from calfkit.models.capability import CAPABILITY_TOPIC, CapabilityLookup, CapabilityRecord, CapabilityToolDef, resolve_capability
+from calfkit.models.capability import (
+    CAPABILITY_TOPIC,
+    CapabilityRecord,
+    CapabilityToolDef,
+    EnumerableCapabilityView,
+    resolve_all_capabilities,
+    resolve_capability,
+)
 from calfkit.models.payload import retry_text_part
 from calfkit.models.tool_dispatch import SelectorResult, ToolBinding, ToolCallRef
 from calfkit.nodes.base import BaseNodeDef
@@ -197,37 +204,59 @@ def agent_tool(func: Callable[..., Any] | None = None, *, name: str | None = Non
 
 @dataclass(frozen=True)
 class Tools:
-    """Identity-only handle to one or more function tool nodes, resolved per agent turn.
+    """Identity-only handle to function tool nodes, resolved per agent turn.
 
     The call-side counterpart to deployed tool nodes (mirrors :class:`~calfkit.mcp.MCPToolbox`):
     constructible anywhere with just the tool names — no schema, no import of the tool's code.
-    Each name is a tool node's identity (its ``node_id``, which equals the LLM-facing tool name).
-    Resolution reuses :func:`~calfkit.models.capability.resolve_capability` with
-    ``expected_kind="tool"`` (the over-pull guard), so a name that resolves to a toolbox record is
-    rejected rather than absorbed. Frozen value semantics: names are order-preserving-deduped, so
-    equal handles compare and hash equal.
+    Two modes, mutually exclusive on one handle:
 
-    Accepts either ``Tools("add", "subtract")`` or ``Tools(names=[...])`` (not both). There is no
-    ``strict`` knob — an unresolved selection warns and degrades (mirrors MCP).
+    - **named** — ``Tools("add", "subtract")`` / ``Tools(names=[...])``: each name is a tool node's
+      identity (its ``node_id``, which equals the LLM-facing tool name). Resolution reuses
+      :func:`~calfkit.models.capability.resolve_capability` with ``expected_kind="tool"`` (the
+      over-pull guard), so a name that resolves to a toolbox record is rejected rather than absorbed.
+    - **discover** — ``Tools(discover=True)``: selects *every* live tool node (``node_kind == "tool"``),
+      resolved fresh each turn via :func:`~calfkit.models.capability.resolve_all_capabilities`. It
+      carries no names; the empty handle is a construction error, never an implicit "everything".
+
+    Exactly one of {non-empty names, ``discover=True``} — both, or neither, raise. Frozen value
+    semantics: names are order-preserving-deduped, so equal handles compare and hash equal. There is
+    no ``strict`` knob — an unresolved selection warns and degrades (mirrors MCP).
     """
 
     names: tuple[str, ...]
+    discover: bool = False
 
     # ``*positional`` varargs (the common case) plus a keyword-only ``names=`` list; no name
     # collision because the varargs param is ``positional`` while the stored field is ``names``.
-    def __init__(self, *positional: str, names: Sequence[str] | None = None) -> None:
-        if positional and names is not None:
-            raise ValueError("Tools: pass tool names positionally or via names=, not both")
-        source = positional if positional else tuple(names or ())
-        collected = tuple(dict.fromkeys(source))  # order-preserving dedupe
-        if not collected:
-            raise ValueError("Tools requires at least one tool name")
-        if any(not n for n in collected):
-            raise ValueError("Tools names must be non-empty")
-        object.__setattr__(self, "names", collected)
+    def __init__(self, *positional: str, names: Sequence[str] | None = None, discover: bool = False) -> None:
+        # ``discover`` IS the absence of names (it takes every live tool node), so pairing it with
+        # names is contradictory: exactly one of {non-empty names, discover=True}.
+        if discover and (positional or names is not None):
+            raise ValueError("Tools(discover=True) takes no tool names")
+        if discover:
+            object.__setattr__(self, "names", ())
+        else:
+            if positional and names is not None:
+                raise ValueError("Tools: pass tool names positionally or via names=, not both")
+            source = positional if positional else tuple(names or ())
+            collected = tuple(dict.fromkeys(source))  # order-preserving dedupe
+            if not collected:
+                # Empty STILL raises — never an implicit "everything" (the fail-loud rail: an
+                # accidental empty splat ``Tools(*[])`` must not silently become all-tools).
+                raise ValueError("Tools requires at least one tool name, or discover=True")
+            if any(not n for n in collected):
+                raise ValueError("Tools names must be non-empty")
+            object.__setattr__(self, "names", collected)
+        object.__setattr__(self, "discover", discover)
 
-    def resolve_tools(self, view: CapabilityLookup) -> SelectorResult:
-        """Resolve each name against the capability view and aggregate (one binding per tool node)."""
+    def resolve_tools(self, view: EnumerableCapabilityView) -> SelectorResult:
+        """Resolve against the capability view.
+
+        Discover mode binds every live tool node (``resolve_all_capabilities``); named mode
+        resolves each name (one binding per tool node).
+        """
+        if self.discover:
+            return resolve_all_capabilities(view, node_kind="tool")
         bindings: list[ToolBinding] = []
         missing: list[str] = []
         invalid: list[str] = []

--- a/docs/adr/0014-discover-mode-on-the-tools-handle.md
+++ b/docs/adr/0014-discover-mode-on-the-tools-handle.md
@@ -1,0 +1,106 @@
+---
+status: accepted
+---
+
+# Open-ended tool discovery rides the `Tools` handle as an exclusive discover mode
+
+ADR-0013 gave agents a by-name handle (`Tools(*names)`) onto function tool nodes, but
+left "discover *every* tool node, not a named set" as deferred future work (spec §14.2).
+We add that as a **mode on the existing handle** — `Tools(discover=True)` — rather than a
+new `AllTools` type or an `Agent` constructor flag. It resolves per turn against the same
+`ControlPlaneView[CapabilityRecord]`, binding **only `node_kind == "tool"` records** (it
+never absorbs an MCP toolbox's tools), via a new bulk kernel `resolve_all_capabilities`
+that walks the view's existing `snapshot()`. Because it is still an ordinary `ToolSelector`,
+it trips the existing read-side view-registration trigger (`worker.py` keys on
+`_tool_selectors`) with **zero new worker wiring** — which is precisely what the deferred
+note feared would "need a new view-registration trigger." Modeling it as a selector rather
+than a flag dissolves that.
+
+## The tool-surface contract (enforced at construction)
+
+The agent's `tools=[...]` surface obeys one contract, checked when the agent is built:
+
+1. **No duplicate tool names.** Across every developer-provided source — eager tool nodes,
+   eager bindings/providers, and named `Tools(...)` — no tool name may appear twice
+   (order-independent). A duplicate is a config mistake and **raises**.
+2. **Discover owns the tool-node surface.** If `Tools(discover=True)` is present, no eager
+   tool node and no named `Tools(...)` may sit alongside it — discover *is* the agent's
+   tool-node surface, so any explicit tool-node reference is redundant with it. **Raises**.
+3. **`MCPToolbox` is orthogonal.** A toolbox is `node_kind == "toolbox"`, not a tool, so it
+   composes freely with discover *and* with named `Tools`. The narrow rule, not the broad
+   "discover must be the sole entry."
+
+This is enforced by **construction-time checks over the raw `tools=` list**, where the type
+information is still intact (`BaseToolNodeDef` / `Tools` instances) — *before*
+`split_tool_declarations` flattens a tool node into a bare `ToolBinding`. The duplicate
+check is a pure name comparison; the discover-exclusivity reads the raw entry types. The
+illegal combinations therefore never reach runtime, so **there is no runtime collision
+policy** and **no provenance carried on `ToolBinding`**.
+
+## Considered options
+
+- **A separate `AllTools` type** — rejected: a second type to import and learn for what is
+  the same concept ("function tool nodes for this agent") expressed by enumeration instead
+  of by name. The mode keeps one handle, one mental model.
+- **An `Agent(discover_tools=...)` constructor flag** — rejected: a flag lives *outside* the
+  `tools=[...]` list, so it would not be a `ToolSelector` and would need a brand-new
+  view-registration trigger (the deferred note's own suggestion). It also breaks composition
+  with the rest of the `tools=` surface.
+- **Resolve collisions at runtime (binding-merge existing-wins, dispatch-topic comparison)
+  with a provenance marker on `ToolBinding`** — rejected: the construction-time contract
+  prevents tool-node collisions *upstream*, where the raw `tools=` types are still intact, so
+  there is nothing to resolve at the binding merge. Pushing it downstream forced a
+  `source_kind` provenance field (because `split_tool_declarations` flattens the tool node
+  away) and a per-turn collision policy — complexity that vanishes once the contract is
+  enforced where the types are known.
+- **Broad exclusivity (discover must be the sole `tools=` entry, MCP excluded)** — rejected:
+  it couples discover and MCP toolboxes, two orthogonal planes (`node_kind=="tool"` vs
+  `"toolbox"`), purely for enforcement simplicity. The narrow rule keeps orthogonal concerns
+  orthogonal — a toolbox is not a tool.
+- **One widened `CapabilityLookup` carrying both `get` and `snapshot`** — rejected on
+  Interface-Segregation grounds: the point-lookup clients (`resolve_capability`, the
+  MCP/named paths) would depend on a `snapshot()` they never call. Instead
+  `EnumerableCapabilityView(CapabilityLookup)` adds enumeration as a separate role; the
+  bulk kernel consumes it, the point kernel keeps the minimal surface.
+- **Reshaping `tools=` handling so the discover check needs no retained state** — investigated
+  (two grounded passes incl. an adversarial one) and **rejected**. The incremental `add_tools`
+  path can't see the raw `BaseToolNodeDef` type (the split flattens an eager tool node into a
+  bare `ToolBinding`), so the discover-exclusivity check retains a small typed
+  `list[BaseToolNodeDef]`. Two reshapes were weighed:
+  - *Third `eager_tool_nodes` bucket from `split_tool_declarations`* — not worth it. It does **not**
+    remove the retained state (incremental `add_tools` must accumulate it regardless of how the
+    split returns), and it adds a model→node layering edge (`tool_dispatch.py` would `isinstance`
+    a concrete node class) plus a silent-break risk in the duck-typed provisioner
+    (`provisioner.py:62` reads dispatch topics off `self.tools`). *(Correction: an earlier draft of
+    this note claimed the split's return is consumed by the shipped by-name/MCP paths — that is
+    wrong. `split_tool_declarations` has exactly two callers, both in `agent.py`; the by-name path
+    uses `resolve_capability`, MCP uses `record_to_bindings`, client overrides use
+    `normalize_tool_bindings` — none consume the split.)*
+  - *A unified `ToolSource` protocol* (collapse `ToolBinding`/`ToolProvider`/`ToolSelector` to one
+    list) — rejected as a wash/regression: it relocates rather than removes complexity (the
+    eager/deferred partition resurfaces as a `view_dependent` flag + an eager-bindings cache; the
+    frozen wire `ToolBinding` needs a ceremony adapter; the provisioner integration regresses;
+    `resolve()` either drops `SelectorResult` diagnostics or forces eager sources to fabricate
+    them), and it re-opens the locked "no protocol merge" (L9/L19, non-goal §3).
+  The accepted interim is the **agent-local typed `list[BaseToolNodeDef]`**: extracted in
+  `_add_tools` from the raw entries (which `agent.py` already imports `BaseToolNodeDef` to read),
+  the split left unchanged so tool-node bindings still flow into `self.tools` (provisioner and
+  registry untouched). It is small, correct, and proportionate to the wart.
+
+## Consequences
+
+- **No wire change.** Discover is call-side only: it reuses the `node_kind` field shipped in
+  ADR-0013, adds no `CapabilityRecord` field, and triggers no `schema_version` bump.
+- **`Tools` gains a `discover: bool` field** with the invariant *exactly one of {non-empty
+  names, `discover=True`}*; the empty handle remains a construction error (never an implicit
+  "everything"), preserving the fail-loud safety rail against an accidental empty splat.
+- **One small protocol + one kernel** are added (`EnumerableCapabilityView`,
+  `resolve_all_capabilities`); the named/MCP point-lookup path is untouched.
+- **Prerequisite: MCP tool-name namespacing (ADR-0018).** Namespacing MCP tool names as
+  `<server>__<tool>` makes the cluster tool namespace collision-free (tool-node names are
+  globally unique by contract; MCP names become disjoint from them), which is what lets an
+  `MCPToolbox` compose with discover/named `Tools` without any cross-plane name clash. It is
+  a separate, isolated change to the MCP surface and lands first.
+- **An empty cluster degrades silently** (discover names nothing, so there is no "missing"
+  to report); a DEBUG count log aids the "why does my agent have no tools?" case, and the
+  existing degraded-view WARNING still covers a broken view.

--- a/docs/api.md
+++ b/docs/api.md
@@ -36,7 +36,7 @@ from calfkit import (
 | --- | --- |
 | `Agent` | An agent node — an LLM-backed node that consumes prompts, calls tools, and publishes output. |
 | `agent_tool` | Decorator that turns a function into a deployable tool node (`@agent_tool(name=...)` or `agent_tool(func, name=...)` overrides its name). |
-| `Tools` | Identity-only handle that references deployed tool nodes by name; pass in `Agent(tools=[...])` to discover their schemas at runtime. |
+| `Tools` | Identity-only handle that references deployed tool nodes — by name, or every live one with `discover=True`; pass in `Agent(tools=[...])` to discover their schemas at runtime. |
 | `consumer` | Decorator that turns a function into a deployable consumer node (a terminal sink on a topic). |
 
 ### Node types
@@ -181,10 +181,13 @@ Turns a function into a tool node. The function's parameters and type annotation
 
 ```python
 agent = Agent("researcher", subscribe_topics="researcher.input", model_client=model,
-              tools=[Tools("add", "subtract")])    # reference tool nodes by name
+              tools=[Tools("add", "subtract")])    # named: reference specific tool nodes
+# or
+agent = Agent("researcher", subscribe_topics="researcher.input", model_client=model,
+              tools=[Tools(discover=True)])         # discover: every live tool node
 ```
 
-A frozen, identity-only handle to one or more deployed tool nodes. The agent discovers each named tool's schema at runtime from the capability control plane instead of importing the tool's code — the call-side counterpart to a deployed tool node. Resolved per turn; an unresolved name warns and degrades. See [discoverable tool nodes](tool-discovery.md).
+A frozen, identity-only handle to deployed function tool nodes, resolved per turn from the capability control plane (the agent discovers schemas at runtime instead of importing the tool's code). Two mutually exclusive modes: **named** — `Tools("add", "subtract")` / `Tools(names=[...])` references specific tool nodes; **discover** — `Tools(discover=True)` selects every live tool node (`node_kind == "tool"`; never an MCP toolbox's tools), carrying no names. Exactly one of {non-empty names, `discover=True`} holds — both, or the empty handle, raise. An unresolved selection warns and degrades. The agent's tool surface admits no duplicate tool names, and `Tools(discover=True)` owns the tool-node surface (no eager tool node or named `Tools` alongside it — an `MCPToolbox` may); a violation raises at construction. See [discoverable tool nodes](tool-discovery.md).
 
 ### `@consumer`
 

--- a/docs/designs/runtime-tool-discoverability-spec.md
+++ b/docs/designs/runtime-tool-discoverability-spec.md
@@ -1,6 +1,7 @@
 # Runtime Tool Discoverability Spec
 
-- **Status:** Implemented (2026-06-20) on branch `feat/runtime-tool-discoverability` — built TDD per the §10 build order; review rounds 1 & 2 folded (§13); offline suite + full kafka lane green. Decision recorded in ADR-0013.
+- **Status:** §1–§13 (the by-name feature) **MERGED to main** (PR #266, `930286a`); built TDD per the §10 build order; review rounds 1 & 2 folded (§13); offline suite + full kafka lane green. Decision recorded in ADR-0013. **Note:** the `node_kind` work described in §6.4/§9/§10 (presented in this doc as work the spec adds) **already shipped with that PR** — the discover extension below touches none of it and adds no wire surface.
+- **Extension — Discover mode (Implemented, 2026-06-21):** §15 specifies an open-ended `Tools(discover=True)` mode (the promotion of the §14.2 deferred item). Built TDD on branch `feat/discover-mode` (off `origin/main` with #269); decision recorded in ADR-0014, with the MCP tool-name namespacing prerequisite shipped as ADR-0018 (#269). The §1–§13 by-name feature above is unchanged by it. See §13 for its review status.
 - **Date:** 2026-06-19
 - **Depends on:** the control-plane substrate (`calfkit/controlplane/`, ADR-0010/0011) and the MCP capability plane migration (ADR-0012). This feature is a second *adopter* of the same substrate, sharing the capability plane with MCP.
 - **Relationship to prior specs:** consumes the machinery defined in `docs/designs/control-plane-substrate-spec.md` and reuses the wire model from the (now-migrated) `docs/designs/mcp-capability-discovery-spec.md`. It does **not** introduce a new control plane.
@@ -39,7 +40,7 @@ The eager path is **kept** unchanged. `Tools` is purely additive: the same tool 
 
 ### Non-goals
 - **No `strict` mode.** Removed from MCP in ADR-0012; not added for `Tools`. Unresolved selections warn and degrade.
-- **No open-ended discovery.** An agent discovers exactly the names it declares. There is no "discover whatever tool nodes are online" mode (§14).
+- **No open-ended discovery** *(v1 non-goal; lifted by the §15 extension).* In the by-name feature an agent discovers exactly the names it declares. The **Discover mode** extension (§15, ADR-0014) adds `Tools(discover=True)` — "discover whatever tool nodes are online" — as an opt-in mode on the same handle.
 - **No new control plane / topic / record type.** Tool nodes share `calf.capabilities` and `CapabilityRecord`.
 - **No protocol merge.** Collapsing `ToolProvider` + `ToolSelector` is an orthogonal refactor, out of scope (L9).
 - **No opt-in advertising in v1.** Every tool node advertises (L7). Opt-in is designed and recorded as future work (§14.1).
@@ -467,6 +468,17 @@ No wire-format break to `CapabilityRecord`/`CapabilityToolDef` content (MCP and 
 | L13 | Required `node_kind: str` discriminator on `ControlPlaneStamp` (worker-stamped from `_node_kind`); breaking wire change (recreate `calf.capabilities`), no compat default. | Canonical home for worker-stamped node metadata; powers the over-pull guard (L5) and C1 observability; free via the stamp. Required (not defaulted) matches the sibling stamp fields and fails loud on a missing stamp; pre-1.0 hard break, no deployments to preserve. |
 | L14 | C1 (heterogeneous-owner collision): document + tie to the existing global `node_id`-uniqueness contract, **plus** a dedup'd **cross-kind** mixed-`node_kind` view warning for observability (same-kind collisions stay silent — covered by the contract). | A facet of an already-required contract; namespacing the key would break L2/L6. |
 
+### Discover mode (§15, ADR-0014) — additional locked decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| L15 | Open-ended discovery is a **mode on `Tools`** — `Tools(discover=True)` — not a new `AllTools` type and not an `Agent` flag. `discover: bool` field; invariant *exactly one of {non-empty names, `discover=True`}* (both, or neither, raises). Empty `Tools()` still raises. | One handle, one concept; stays a `ToolSelector` so it trips the existing view trigger with zero new wiring; the empty-raises rail blocks an accidental empty splat becoming "everything". |
+| L16 | Discover binds **`node_kind == "tool"` only**, via a new bulk kernel `resolve_all_capabilities(view, *, node_kind)` over the view's existing `snapshot()` — a **positive filter**, not the over-pull *guard* (a non-tool record is out of scope, not `wrong_kind_targets`). | Symmetric with named `Tools`; never absorbs a toolbox; reuses the view primitive that already exists. |
+| L17 | Enumeration via a **second protocol** `EnumerableCapabilityView(CapabilityLookup)` (adds `snapshot()`); the point kernel/`MCPToolbox` keep the narrow `CapabilityLookup`. | Interface Segregation: point-lookup clients must not depend on a `snapshot()` they never call. The real view satisfies both for free. |
+| L18 | One **tool-surface contract**, enforced at construction (ctor + `add_tools`) over the **raw `tools=` entries** (types intact before the split flattens them): (1) **no duplicate tool names** across eager + named sources; (2) **discover owns the tool-node surface** — `Tools(discover=True)` forbids any eager tool node or named `Tools(...)` alongside it; (3) `MCPToolbox` (a `toolbox` kind) and non-tool-node providers compose freely (narrow). | Enforcing upstream where the raw types are known kills the runtime collision policy, the `ToolBinding` `source_kind` provenance field, and `Tools.merge` — all of which were artifacts of trying to resolve collisions downstream after the split flattened the types. `MCPToolbox` name-disjointness is guaranteed by the ADR-0018 namespacing prerequisite. |
+| L19 | **No runtime collision machinery and no `Tools.merge`.** A duplicate name is caught at construction by L18(1); the per-turn binding-assembly merge is unchanged but, given L18, no tool-node name collision can reach it. Do **not** add `source_kind` to `ToolBinding`, **not** unify `ToolBinding`/`ToolSelector` types, and **not** resolve collisions at the binding merge. | The contract makes the illegal combinations unreachable at runtime, so the downstream machinery has nothing to do. Keeping it would be solving a prevented problem. |
+| L20 | **Prerequisite: MCP tool-name namespacing (ADR-0018)** — `<server>__<tool>` — lands first as its own isolated PR. | Makes the cluster tool namespace collision-free (tool-node names unique by contract; MCP names disjoint), which is what lets a toolbox compose with discover/named `Tools` per L18(3). Orthogonal to discover; improves named MCP use on its own. |
+
 ---
 
 ## 13. Review status
@@ -474,6 +486,13 @@ No wire-format break to `CapabilityRecord`/`CapabilityToolDef` content (MCP and 
 - **Round 1 (2026-06-19): complete, folded in.** Four lenses (correctness/runtime, architecture, gaps/blast-radius, type-design), all source-grounded. No CRITICAL architecture breaks. Verified: `Tool(func, name=)` works; §7 parity holds empirically; frozen-dataclass-custom-`__init__` is sound; `@advertises` MRO collection + topic-uniqueness OK; worker triggers fire. Folded: C1→L14 (`node_kind` + mixed-kind warning), structural over-pull guard (`expected_kind`/`wrong_kind_targets`), name dedupe, `SelectorResult.bindings`→tuple, collision-log-via-selector, reject mixed/empty, validation-taxonomy precision, `add_tools` caveat, identity-collision note, replica-equivalence note, `subscribe_topics[0]` guard, fail-loud comment retention, blast-radius checklist (§9), test scenarios (§11).
 - **Round 2 (2026-06-19): complete, folded in.** Three lenses (wire/schema-evolution, regression/C1-completeness, consistency/gaps), source-grounded; all converged on one CRITICAL — adding `node_kind` to an existing wire model means pre-change records lacking it fail `model_validate_json`, and ktables' poison-tolerance skips them (orphaning the node from the view). Verified empirically. **Resolution (Ryan): accept the breaking change** — `node_kind` is **required** (no compat default); the `calf.capabilities` topic is recreated on upgrade (pre-1.0, no deployments; a default shim was explicitly rejected as it would mask a missing stamp and conflicts with the hard-breaks stance). Also folded: C1 partial-coverage honesty (cross-kind only; same-kind silent) + dedup key `(node_id, frozenset(kinds))`; blast-radius extended to every stamp/record construction site + field-set assertions + the `calfkit` export; §10/§11 wording. No redesign — the `node_kind`-on-stamp architecture is sound. All four round-1 fixes re-verified with no regression.
 - **Round 3: pending.** A light confirm pass over the round-2 edits (the default, the `wrong_kind_targets` transient semantics, the blast-radius additions) to declare convergence before implementation.
+
+### Discover mode (§15) review
+
+- **Round 1 (2026-06-20): complete, folded.** Four lenses over the first §15 draft (which used a `Tools.merge` algebra + a `_has_eager_tool_node`/`source_kind` provenance scheme + a runtime binding-merge collision policy). Found 1 CRITICAL (`Tools.merge` defined but never invoked) + provenance/over-reject MAJORs. **Resolution (Ryan):** the "no local tool" insight (eager vs discovered = validated-at-origin vs validated-at-node; both dispatch over Kafka) collapsed the design — §15 was **rewritten** around a construction-time tool-surface contract (no-duplicate-names + discover-owns-the-tool-node-surface), deleting `Tools.merge`, the `source_kind` provenance, and the runtime collision policy; MCP tool-name namespacing was split out as the ADR-0018 prerequisite.
+- **Round 2 (2026-06-20): complete, folded.** Three lenses (contract logic, staleness/consistency, grounding/engineering-quality) over the rewritten §15. Architecture affirmed (moving enforcement upstream genuinely removed the complexity). Fixed: **CRITICAL** — `_eager_tool_node_names` uninitialized (`AttributeError` on first `|=`) → now initialized in `__init__` via the shared enforce-then-commit `_add_tools` path; **MAJOR** — `add_tools` mutated state before validating (corrupt agent on caught `ValueError`) → now validates the prospective surface and commits only on success; **MAJOR** — ADR number collision (two `0015`) → MCP namespacing renumbered to **ADR-0018**; **MAJOR** — ADR-0018 underspecified the shared `record_to_bindings` kernel → now states namespacing is `node_kind=="toolbox"`-scoped and dispatch strips via `removeprefix(f"{node_id}__")`. Folded MINORs: eager-set keys on tool name (not `node_id`); the `_eager_tool_node_names` "only for `add_tools`" rationale + the deferred "don't-flatten-at-split" alternative (ADR-0014); the intra-handle-vs-cross-source asymmetry rationale; the `node_kind`-already-shipped note (§1). **Convergence:** no CRITICAL/MAJOR remaining; ready for a TDD impl plan pending Ryan's sign-off.
+- **Round 3 (2026-06-20): tool-surface factoring pass.** Question raised: is the retained eager-tool-node state a symptom of `tools=` heterogeneity, and would a unified abstraction remove it? Two grounded passes (design + adversarial) on two reshapes: (a) a third `eager_tool_nodes` bucket from `split_tool_declarations`, and (b) a unified `ToolSource` protocol collapsing `ToolBinding`/`ToolProvider`/`ToolSelector`. **Both rejected.** The retained state is **inherent to incremental `add_tools`** (it accumulates cumulative provenance regardless of the split), not an artifact of flattening; (a) adds a model→node layering edge + a duck-typed-provisioner silent-break risk; (b) is a wash/regression (the eager/deferred partition resurfaces as `view_dependent` + an eager-bindings cache, the frozen wire `ToolBinding` needs a ceremony adapter, the provisioner regresses, `resolve()` drops `SelectorResult` diagnostics) and re-opens the locked "no protocol merge" (L9/L19, non-goal §3). **Folded:** §15.3 switched from a re-derived `_eager_tool_node_names: set[str]` to the typed `self._eager_tool_nodes: list[BaseToolNodeDef]` (agent-local extraction, split unchanged) — the one improvement that survived; ADR-0014's deferred-option reasoning corrected (the prior "shipped paths consume the split" claim was false — two callers, both in `agent.py`) and the `ToolSource` rejection recorded.
+- **Round 4 — plan review + implementation (2026-06-21): complete.** Three lenses over the TDD impl plan (code-grounding, commit-3 regression blast-radius, completeness) found 1 CRITICAL (the plan wrongly claimed `agent.py` already imported `BaseToolNodeDef` — it imports neither it nor `Tools`; both added) + folded MAJORs (`_FakeView` placement; `docs/tool-discovery.md` doc-drift correction; regression sweep made a gating green bar; keep the runtime collision branch); the blast-radius was confirmed smaller than first framed (no existing test newly raises — one comment re-anchor + added tests). **Implemented TDD in 6 commits** (kernel → `Tools(discover=True)` → contract → diagnostics → kafka roundtrip → docs); offline suite + the cross-process kafka roundtrip green; `make check` clean. The api.md export level follows `resolve_capability` (documented in the spec, not added to `calfkit.__all__` nor api.md).
 
 ---
 
@@ -495,6 +514,168 @@ A plain `ToolNodeDef` has empty `_adverts` → contributes nothing → eager-onl
 
 ### 14.2 Other deferred items
 - **Extended `CapabilityToolDef` fidelity** — carry `requires_approval`/`strict`/`sequential`/`timeout`/`metadata` if the tool-node surface grows (§7). Additive.
-- **Open-ended discovery** — an agent that discovers tool nodes it did not pre-name (needs a new view-registration trigger, e.g. a `discover=True` agent flag). Out of scope (§3).
+- **Open-ended discovery** — **PROMOTED.** Now specified as **Discover mode** in §15 (ADR-0014). The "needs a new view-registration trigger" concern dissolved by modeling it as a `ToolSelector` (`Tools(discover=True)`) rather than an agent flag, so it trips the existing `_tool_selectors` trigger.
 - **Protocol merge** — collapse `ToolProvider` + `ToolSelector` (L9).
 - **Multi-tool tool nodes** — `CapabilityRecord.tools` is already a list; a future multi-tool node would advertise N entries and `Tools` would need an `include` filter, converging with `MCPToolbox`. (The `expected_kind="tool"` guard already admits it — it filters by kind, not count.)
+
+---
+
+## 15. Discover mode (extension — Proposed, ADR-0014)
+
+**Status:** Implemented (2026-06-21) on branch `feat/discover-mode` — built TDD per the §15.6 build order; the MCP tool-name namespacing prerequisite (ADR-0018) shipped first in #269. This section promotes the §14.2 "open-ended discovery" deferred item to an opt-in mode on the `Tools` handle. It adds **no wire surface** — discover is call-side only, reusing the `node_kind` field shipped with §1–§13.
+
+**Prerequisite — MCP tool-name namespacing (ADR-0018).** Namespacing MCP tool names as `<server>__<tool>` makes the cluster tool namespace collision-free (tool-node names are globally unique by contract; MCP names become disjoint), which is what lets an `MCPToolbox` compose with discover/named `Tools` without a cross-plane clash. It is a separate, isolated change to the MCP surface and lands first; this section assumes it.
+
+### 15.1 Surface — a mode on `Tools`, not a new type
+
+`Tools(discover=True)` selects **every live function tool node** instead of a named set. It is the same `ToolSelector` flowing the same path (§6.5); the only new state is a `discover` flag with a strict either/or invariant:
+
+```python
+@dataclass(frozen=True)
+class Tools:
+    names: tuple[str, ...]
+    discover: bool = False
+
+    def __init__(self, *positional: str, names: Sequence[str] | None = None, discover: bool = False) -> None:
+        # discover is the *absence of names*: passing both is contradictory.
+        if discover and (positional or names is not None):
+            raise ValueError("Tools(discover=True) takes no tool names")
+        if not discover:
+            collected = tuple(positional) if positional else tuple(names or ())
+            collected = tuple(dict.fromkeys(collected))            # order-preserving dedupe
+            if not collected:
+                # Empty STILL raises — never an implicit "everything". The fail-loud rail:
+                # an accidental empty splat (Tools(*[])) must not silently become all-tools.
+                raise ValueError("Tools requires at least one tool name, or discover=True")
+            if any(not n for n in collected):
+                raise ValueError("Tools names must be non-empty")
+            object.__setattr__(self, "names", collected)
+        else:
+            object.__setattr__(self, "names", ())
+        object.__setattr__(self, "discover", discover)
+```
+
+Invariant: **exactly one of {non-empty `names`, `discover=True`}**. `Tools()`, `Tools(*[])`, `Tools(names=[])`, and `Tools(discover=False)` (no names) all raise — the empty handle is a construction error (L15). `discover` is a real field so `Tools(discover=True) == Tools(discover=True)` and the handle appears in the collision-log `selector` repr.
+
+### 15.2 Resolution — a bulk kernel over an enumerable view (ISP)
+
+The point kernel `resolve_capability` consumes only `view.get(target_id)`. Discover needs to walk *all* live records, which the real view already exposes as `snapshot()` (`view.py:98` — one-clock-consistent, collapsed to one live record per node, staleness + schema filtered). Per **Interface Segregation** (L17), enumeration is a *second* role, not a widening of the point-lookup surface:
+
+```python
+# calfkit/models/capability.py
+class EnumerableCapabilityView(CapabilityLookup, Protocol):
+    """CapabilityLookup + bulk enumeration. Satisfied by ControlPlaneView (snapshot
+    already exists) and the test _FakeView. The point-lookup path (resolve_capability,
+    MCPToolbox.resolve_tools) keeps the narrow CapabilityLookup — it never enumerates."""
+    def snapshot(self) -> dict[str, CapabilityRecord]: ...
+
+
+def resolve_all_capabilities(view: EnumerableCapabilityView, *, node_kind: str) -> SelectorResult:
+    """Discover-mode kernel: bind EVERY live record of `node_kind`.
+
+    A POSITIVE FILTER, not the over-pull *guard*: a record of another kind is out of
+    scope, not an error — so missing_targets / missing_tools / wrong_kind_targets are
+    always empty. Only a poisoned record of the RIGHT kind (e.g. empty dispatch_topic)
+    degrades to invalid_targets; it never crashes the turn (mirrors resolve_capability).
+    """
+    bindings: list[ToolBinding] = []
+    invalid: list[str] = []
+    for node_id, record in view.snapshot().items():
+        if record.node_kind != node_kind:
+            continue                                     # out of scope, not wrong-kind
+        try:
+            # name= is required since ADR-0018 (MCP namespacing). For node_kind=="tool"
+            # the _namespace_prefix is "" so node_id adds no prefix — but pass it anyway
+            # (the snapshot key IS the node_id), so this kernel is correct for any kind.
+            bindings.extend(record_to_bindings(record, name=node_id))
+        except ValidationError:
+            invalid.append(node_id)
+    return SelectorResult(bindings=tuple(bindings), invalid_targets=tuple(invalid))
+```
+
+`Tools.resolve_tools` branches on the mode; its param widens to `EnumerableCapabilityView` (the agent always hands selectors the real, enumerable view). `MCPToolbox.resolve_tools` keeps `CapabilityLookup` — sound (a parameter may accept a supertype) and it documents "MCP never enumerates". The named branch is unchanged (an enumerable view *is* a `CapabilityLookup`):
+
+```python
+def resolve_tools(self, view: EnumerableCapabilityView) -> SelectorResult:
+    if self.discover:
+        return resolve_all_capabilities(view, node_kind="tool")
+    # named branch: the §6.3 loop, unchanged (resolve_capability needs only get()).
+    ...
+```
+
+The `ToolSelector` protocol's `resolve_tools` param becomes `EnumerableCapabilityView`. This is **not breaking for custom selectors**: a user-authored `ToolSelector` typed `resolve_tools(view: CapabilityLookup)` still conforms (a parameter may accept a supertype — sound contravariance, verified with mypy), and the agent always supplies the real, enumerable view at runtime. Only the **discover-path** `Tools` test fakes need a one-line `_FakeView(dict)` that adds `.snapshot()` (the named path never calls it); the MCP/point-lookup test fakes keep their bare dicts. Note `tests/` is outside the `make check` mypy gate, so this is a strict-typing/IDE concern and a discover-test requirement, not a `make check` break.
+
+### 15.3 The tool-surface contract (enforced at construction)
+
+The agent's `tools=[...]` surface obeys one contract, checked when the agent is built (and on every `add_tools`). It is enforced over the **raw `tools=` entries**, where the types are still intact (`BaseToolNodeDef` / `Tools` instances) — *before* `split_tool_declarations` flattens a tool node into a bare `ToolBinding`. So there is **no provenance field on `ToolBinding`** and **no runtime collision policy**: the illegal combinations never reach a turn.
+
+1. **No duplicate tool names.** Across every developer-provided source — eager tool nodes, eager bindings/providers, and named `Tools(...)` — no tool name may appear twice. Order-independent. Raises.
+2. **Discover owns the tool-node surface.** If `Tools(discover=True)` is present, no eager tool node and no named `Tools(...)` may sit alongside it. Raises.
+3. **`MCPToolbox` is orthogonal.** A toolbox is `node_kind == "toolbox"`, not a tool, so it composes freely with discover *and* with named `Tools` (the narrow rule). MCP names are made disjoint by the namespacing prerequisite (ADR-0018), so an MCP tool can never duplicate a tool-node name.
+
+`__init__` initializes the empty surface — including `self._eager_tool_nodes: list[BaseToolNodeDef] = []` — then routes through the **same** enforce-then-commit path as the public `add_tools`. Both validate the *prospective* combined surface and mutate instance state **only after both checks pass**, so a caught `ValueError` on `add_tools` leaves a live agent unchanged (an `__init__` raise discards the half-built object):
+
+```python
+# calfkit/nodes/agent.py — the shared path behind __init__ and add_tools.
+def _add_tools(self, raw_tools):
+    bindings, selectors = split_tool_declarations(raw_tools)   # split UNCHANGED: tool nodes still flatten into bindings
+    # The eager tool nodes, kept TYPED — extracted from the raw entries (agent.py already imports
+    # BaseToolNodeDef). The split flattens these into `self.tools` too (so the dup check / provisioner
+    # see their bindings); this typed list exists only so the discover check can ask "any tool node?".
+    new_nodes = [t for t in raw_tools if isinstance(t, BaseToolNodeDef)]
+    eager_nodes = self._eager_tool_nodes + new_nodes
+    selectors_all = self._tool_selectors + selectors
+    named = [s for s in selectors_all if isinstance(s, Tools) and not s.discover]
+    discover = any(isinstance(s, Tools) and s.discover for s in selectors_all)
+
+    # (2) discover owns the tool-node surface — a typed query, no name-set reconstruction
+    if discover and (eager_nodes or named):
+        raise ValueError("Tools(discover=True) owns the agent's tool-node surface: no eager "
+                         "tool node or named Tools(...) may accompany it (MCPToolbox may).")
+    # (1) no duplicate tool names across the statically-named sources
+    static = [b.name for b in self.tools + bindings] + [n for s in named for n in s.names]
+    dupes = sorted({n for n in static if static.count(n) > 1})
+    if dupes:
+        raise ValueError(f"duplicate tool name(s) in tools=: {dupes}; each tool may be referenced once")
+
+    self.tools += bindings                       # commit only after both checks pass
+    self._tool_selectors += selectors
+    self._eager_tool_nodes = eager_nodes
+```
+
+- The duplicate check (1) reads **names**, which the split preserves on `self.tools` (tool-node bindings included, since the split is unchanged), so it needs no provenance and runs identically in `__init__` and `add_tools` over the accumulated surface.
+- The discover-exclusivity (2) needs to know which references are *tool nodes* (only those overlap discover). `self._eager_tool_nodes` (the typed node objects, not a re-derived name set) carries that across the incremental `add_tools` path — it exists **only** because the split discards the `BaseToolNodeDef` type before `add_tools` runs; in `__init__` alone the raw list would suffice. `MCPToolbox` and non-tool-node providers are never in that list, so they compose with discover as the narrow rule intends. (The deeper reshapes that would remove this small retained list — a third split bucket, or a unified `ToolSource` protocol — were investigated and rejected as wash/regression; see ADR-0014.)
+- **`Tools.merge` is gone.** Multiple `Tools` handles no longer collapse via a merge algebra — they are ordinary selectors, and a repeated name trips the duplicate check (1); the named+discover contradiction is caught by (2). There is no `Tools.merge`, no `_has_eager_tool_node` bool, no `source_kind` on `ToolBinding`, and no per-turn binding-merge collision policy. The complexity in earlier drafts came from trying to resolve collisions *downstream* (after the split flattened the types); enforcing the contract *upstream* on the raw list removes it.
+
+> **Intra-handle dedupe is unchanged.** The shipped `Tools("a", "a")` constructor de-dupes *within one handle* (`dict.fromkeys`, §6.3). That ergonomic stays; the "no duplicates" contract above is the *cross-source* rule (two handles, or eager + named). A name repeated within a single handle is *one selection stated twice* (one resolution, one binding) — safely collapsed. A name repeated across sources is *two competing intents* under one name, which can carry different validation/dispatch semantics (an eager binding validates args locally; a discovered one defers to the fault rail), so silently picking one is unsafe — it raises.
+
+### 15.4 Diagnostics
+
+Discover names nothing, so the named diagnostics do not apply: `missing_targets` / `missing_tools` / `wrong_kind_targets` are always empty, and `unresolved` is true only when a poisoned tool record lands in `invalid_targets` — which rides the **existing** unresolved-selector WARNING (`agent.py`), no new code. A degraded/failed view still logs the existing WARNING. The one new state, **healthy view + zero tool nodes**, is *silent by design* (a legitimate empty cluster). To aid the "why does my agent have no tools?" case without crying wolf, add a **DEBUG** count, emitted once for the discover selector in the resolution loop:
+
+```python
+if isinstance(selector, Tools) and selector.discover:
+    logger.debug("agent=%s discover mode resolved %d tool node(s)", self.name, len(result.bindings))
+```
+
+No new `SelectorResult` fields; no WARNING on a healthy empty cluster.
+
+### 15.5 What does not change
+
+- **No wire surface.** No `CapabilityRecord` field, no `schema_version` bump; `node_kind` (shipped §6.4) is reused.
+- **Worker wiring.** `Tools(discover=True)` is a `ToolSelector`, so the read-side view trigger (keyed on `_tool_selectors`) fires unchanged — the deferred note's "needs a new trigger" concern dissolves.
+- **Per-run overrides.** Selector resolution (discover included) is uniformly skipped when `override_agent_tools` pins a turn (`agent.py`) — discovery must not widen a scoped-down turn. No discover-specific handling.
+- **Eager path / named path / the per-turn registry build.** Untouched. (With the §15.3 contract enforced at construction, no tool-node name collision can reach the registry build, so its existing collision branch is never exercised by a discover/named tool-node duplicate.)
+
+### 15.6 Build order (TDD), test scenarios & docs
+
+Build order (each step TDD, red→green):
+
+1. `Tools(discover=True)` construction: valid; `discover` + names raises; empty raises; `discover=False` no-names raises; equality/hash; intra-handle dedupe still holds.
+2. `EnumerableCapabilityView` + `resolve_all_capabilities`: kind filter (tool vs toolbox records present); poisoned record → `invalid_targets`; empty view → zero bindings, not unresolved. `_FakeView(dict)` helper.
+3. The tool-surface contract at **construction**: duplicate names raise (`[Tools('a'), Tools('a')]`; `[add, Tools('add')]`; `[Tools('add'), add]`); discover + eager tool node raises; discover + named `Tools` raises; discover + `MCPToolbox` is allowed; discover + a non-tool-node provider is allowed.
+4. The contract on **`add_tools`**: the raises fire incrementally — `add_tools(Tools(discover=True))` on an agent built with an eager tool node raises; `add_tools(add_node)` on an agent built with `Tools('add')` raises.
+5. Agent resolution: discover binds all live tool nodes; the DEBUG count; per-run overrides skip discover.
+6. Kafka lane: deploy N tool nodes; an agent with `Tools(discover=True)` discovers all N and dispatches one (agent-POV: the model sees the advertised schemas).
+
+Docs deliverables: a "discover everything" how-to section in `docs/tool-discovery.md`; `Tools(discover=True)`, `resolve_all_capabilities`, and `EnumerableCapabilityView` in `docs/api.md`; ADR-0014 flips `proposed → accepted` at the implementing PR (mirroring ADR-0013); ADR-0018 (MCP namespacing) ships first as its own PR.

--- a/docs/tool-discovery.md
+++ b/docs/tool-discovery.md
@@ -58,6 +58,30 @@ locally *before* dispatch, at the cost of importing the tool. Same node, either
 handle. (A discovered binding defers argument validation to the tool node; see the
 [design spec](designs/runtime-tool-discoverability-spec.md) for the full trade-off.)
 
+## Discover every tool node
+
+To give an agent *all* the tool nodes on the cluster instead of naming each one,
+pass `Tools(discover=True)`. It resolves every live tool node from the capability
+view at the start of each turn, so a node deployed later is picked up automatically —
+no names to maintain:
+
+```python
+from calfkit import Agent, Tools
+
+agent = Agent(
+    "researcher",
+    subscribe_topics="researcher.input",
+    model_client=model,
+    tools=[Tools(discover=True)],   # every live tool node — no names
+)
+```
+
+Discover mode takes no names and **owns the agent's tool-node surface**: you cannot
+pair `Tools(discover=True)` with an eager tool node or a named `Tools(...)` — that
+raises at construction, so pick one or the other. It still composes with an
+`MCPToolbox` (a different kind of provider), and it binds only function tool nodes,
+never an MCP toolbox's tools.
+
 ## Names are cluster-wide identities
 
 A tool node's name is its key on the shared capability topic, so names must be
@@ -76,8 +100,9 @@ def search(query: str) -> list[str]:
 
 `Tools` binds only tool-node records, so `Tools("github")` pointed at a multi-tool
 MCP toolbox (or any non-tool-node record) resolves nothing rather than absorbing
-the whole toolbox. If a discovered tool name collides with a tool the agent
-already has, the existing one wins and an error is logged.
+the whole toolbox. An agent's tool surface must also have no duplicate tool names:
+referencing the same tool node both eagerly and by name, or naming it twice, raises
+at construction — each tool is referenced once.
 
 ## Outages and topic creation
 

--- a/tests/_capability_fakes.py
+++ b/tests/_capability_fakes.py
@@ -1,0 +1,17 @@
+"""Shared test fakes for the capability view.
+
+``_FakeView`` is a dict-backed :class:`~calfkit.models.capability.EnumerableCapabilityView`:
+``get()`` is inherited from ``dict`` (the :class:`CapabilityLookup` surface) and
+``snapshot()`` adds the bulk enumeration the discover-mode kernel needs. Named-path
+selector tests keep using bare ``dict``s (their resolution calls only ``get()``); only
+the discover path needs ``snapshot()``.
+"""
+
+from __future__ import annotations
+
+from calfkit.models.capability import CapabilityRecord
+
+
+class _FakeView(dict[str, CapabilityRecord]):
+    def snapshot(self) -> dict[str, CapabilityRecord]:
+        return dict(self)

--- a/tests/integration/test_discover_mode_kafka.py
+++ b/tests/integration/test_discover_mode_kafka.py
@@ -88,15 +88,15 @@ async def _wait(predicate: Callable[[], bool], *, timeout: float, what: str) -> 
     raise AssertionError(f"timed out after {timeout}s waiting for: {what}")
 
 
-async def _await_capability(bootstrap: str, node_id: str, *, timeout: float) -> None:
-    """Block until ``node_id``'s CapabilityRecord is live on ``calf.capabilities``, so the
-    agent's view catch-up includes it and ``Tools(discover=True)`` enumerates it."""
+async def _await_view(bootstrap: str, predicate: Callable[[ControlPlaneView[CapabilityRecord]], bool], *, timeout: float, what: str) -> None:
+    """Open a transient capability view, wait for ``predicate`` over it, then close it — so the
+    agent's view catch-up will include whatever the predicate confirmed is live."""
     view: ControlPlaneView[CapabilityRecord] = ControlPlaneView.open(
         bootstrap_servers=bootstrap, topic=CAPABILITY_TOPIC, record_type=CapabilityRecord, ensure_topic=False
     )
     try:
         await view.start()
-        await _wait(lambda: view.get(node_id) is not None, timeout=timeout, what=f"capability record {node_id!r}")
+        await _wait(lambda: predicate(view), timeout=timeout, what=what)
     finally:
         await view.stop()
 
@@ -121,6 +121,17 @@ async def test_discover_finds_all_separately_deployed_tool_nodes(kafka_bootstrap
         tools=[Tools(discover=True)],  # no names — discover every live tool node
     )
 
+    advertised: dict[str, Any] = {}  # bare tool name -> parameters_json_schema, read straight from the view records
+
+    def _both_advertised(view: ControlPlaneView[CapabilityRecord]) -> bool:
+        records = [view.get(add_name), view.get(mul_name)]
+        if any(record is None for record in records):
+            return False
+        advertised.clear()
+        for record in records:
+            advertised.update({t.name: t.parameters_json_schema for t in record.tools or []})
+        return True
+
     driver = Client.connect(kafka_bootstrap)
     # SEPARATE workers per tool node — the cross-process property under test.
     add_worker = _worker(kafka_bootstrap, nodes=[_add_tool(add_name)], control_plane=control_plane)
@@ -128,9 +139,9 @@ async def test_discover_finds_all_separately_deployed_tool_nodes(kafka_bootstrap
     agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
 
     async with add_worker, mul_worker:
-        # the agent's view must materialize BOTH separately-published records before it runs
-        await _await_capability(kafka_bootstrap, add_name, timeout=60)
-        await _await_capability(kafka_bootstrap, mul_name, timeout=60)
+        # the agent's view must materialize BOTH separately-published records before it runs;
+        # capture what each node advertised (the source of truth the agent reads) in the same pass
+        await _await_view(kafka_bootstrap, _both_advertised, timeout=60, what=f"advertised tools for {add_name!r} and {mul_name!r}")
         async with agent_worker:
             result = await driver.execute("add 2 and 3", agent_in, timeout=120)
 
@@ -144,6 +155,11 @@ async def test_discover_finds_all_separately_deployed_tool_nodes(kafka_bootstrap
     assert pov, "the model never captured the agent's tool POV"
     mine = {name for name in pov if name.startswith(topic_namespace)}
     assert mine == {add_name, mul_name}
+
+    # 3) the model's POV SCHEMAS == what each tool node advertised on the view, discovered at
+    #    runtime (nothing baked in). For a tool node the LLM-facing name is the bare node_id, so
+    #    pov[name] and advertised[name] key alike.
+    assert {n: pov[n].parameters_json_schema for n in mine} == {n: advertised[n] for n in mine}
 
     await driver.close()
     await add_worker._client.close()

--- a/tests/integration/test_discover_mode_kafka.py
+++ b/tests/integration/test_discover_mode_kafka.py
@@ -1,0 +1,151 @@
+"""Real-broker (``kafka`` lane) end-to-end DISCOVER-mode roundtrip (cross-process).
+
+The open-ended counterpart to ``test_tool_discovery_kafka.py`` (by name): an agent holds
+only ``Tools(discover=True)`` — no names — and discovers EVERY live tool node from the
+shared capability view. Two tool nodes are DEPLOYED in two SEPARATE workers (the
+cross-process property under test: the agent reads tool processes it does not host); the
+agent in a third worker resolves both at runtime, the model's POV includes exactly the two
+it advertised, and a call drawn from that POV round-trips over Kafka:
+
+    two tool nodes advertise (separate workers) -> the agent's view catch-up includes both
+      -> the model's POV (``AgentInfo.function_tools``) is exactly the two discovered tools
+      -> the model calls one -> a ToolCallRef is dispatched over Kafka to that node's topic
+      -> the return value comes back and the agent finalizes.
+
+The discover surface is asserted over this test's unique ``topic_namespace`` only: the kafka
+lane shares one session broker, so other suites' (still-live) tool nodes may also be on
+``calf.capabilities`` — discover correctly pulls them too, but they are not this test's
+subject. Filtering to the namespace proves discover found *all of this test's* separately
+deployed tool processes.
+
+Opt-in (``-m kafka``); skips cleanly without Docker. Run with
+``uv run --group integration pytest tests/integration/test_discover_mode_kafka.py -m kafka``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from calfkit._vendor.pydantic_ai import models
+from calfkit._vendor.pydantic_ai.messages import ToolCallPart
+from calfkit.client import Client
+from calfkit.controlplane import ControlPlaneConfig, ControlPlaneView
+from calfkit.models.capability import CAPABILITY_TOPIC, CapabilityRecord
+from calfkit.nodes import Agent, ToolNodeDef, Tools, agent_tool
+from calfkit.worker import Worker
+from tests.integration._roundtrip_helpers import FINAL_OUTPUT, capturing_model, tool_returns
+
+# Every test here needs a real broker. FunctionModel is offline, but pydantic-ai still
+# gates "model requests" behind this flag (matches the other kafka-lane agent suites).
+pytestmark = pytest.mark.kafka
+models.ALLOW_MODEL_REQUESTS = True
+
+_EARLIEST = {"auto_offset_reset": "earliest"}
+
+
+def _control_plane(bootstrap: str) -> ControlPlaneConfig:
+    return ControlPlaneConfig(heartbeat_interval=5.0, bootstrap_servers=bootstrap)
+
+
+def _worker(bootstrap: str, *, nodes: list, control_plane: ControlPlaneConfig) -> Worker:
+    """A Worker on its own broker connection, control plane on, reading earliest.
+
+    Each tool node needs the control plane to advertise; the agent worker needs it to
+    materialize the capability view ``Tools(discover=True)`` enumerates.
+    """
+    return Worker(Client.connect(bootstrap), nodes=nodes, control_plane=control_plane, extra_subscribe_kwargs=_EARLIEST)
+
+
+def _add_tool(name: str) -> ToolNodeDef:
+    """A per-test, uniquely-named ``add`` tool node (the node_id IS the capability key on the
+    shared ``calf.capabilities`` topic, so it must be unique across tests)."""
+
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    return agent_tool(add, name=name)
+
+
+def _mul_tool(name: str) -> ToolNodeDef:
+    """A second, distinct uniquely-named tool node, deployed in its own worker."""
+
+    def mul(a: int, b: int) -> int:
+        return a * b
+
+    return agent_tool(mul, name=name)
+
+
+async def _wait(predicate: Callable[[], bool], *, timeout: float, what: str) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.1)
+    raise AssertionError(f"timed out after {timeout}s waiting for: {what}")
+
+
+async def _await_capability(bootstrap: str, node_id: str, *, timeout: float) -> None:
+    """Block until ``node_id``'s CapabilityRecord is live on ``calf.capabilities``, so the
+    agent's view catch-up includes it and ``Tools(discover=True)`` enumerates it."""
+    view: ControlPlaneView[CapabilityRecord] = ControlPlaneView.open(
+        bootstrap_servers=bootstrap, topic=CAPABILITY_TOPIC, record_type=CapabilityRecord, ensure_topic=False
+    )
+    try:
+        await view.start()
+        await _wait(lambda: view.get(node_id) is not None, timeout=timeout, what=f"capability record {node_id!r}")
+    finally:
+        await view.stop()
+
+
+async def test_discover_finds_all_separately_deployed_tool_nodes(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """``Tools(discover=True)`` discovers EVERY separately-deployed tool node. Two tool nodes
+    live in two separate workers; the agent in a third worker holds only ``Tools(discover=True)``
+    — within its namespace its model-POV is exactly the two advertised tools, and a call drawn
+    from that POV round-trips."""
+    add_name = f"{topic_namespace}-add"
+    mul_name = f"{topic_namespace}-mul"
+    agent_id = f"{topic_namespace}-disc-all"
+    agent_in = f"{topic_namespace}.disc-all.input"
+    control_plane = _control_plane(kafka_bootstrap)
+
+    pov: dict[str, Any] = {}  # name -> ToolDefinition the agent resolved from the view and presented to the model
+    agent = Agent(
+        agent_id,
+        system_prompt="use the available tools",
+        subscribe_topics=agent_in,
+        model_client=capturing_model(pov, [ToolCallPart(add_name, {"a": 2, "b": 3}, tool_call_id="c1")]),
+        tools=[Tools(discover=True)],  # no names — discover every live tool node
+    )
+
+    driver = Client.connect(kafka_bootstrap)
+    # SEPARATE workers per tool node — the cross-process property under test.
+    add_worker = _worker(kafka_bootstrap, nodes=[_add_tool(add_name)], control_plane=control_plane)
+    mul_worker = _worker(kafka_bootstrap, nodes=[_mul_tool(mul_name)], control_plane=control_plane)
+    agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
+
+    async with add_worker, mul_worker:
+        # the agent's view must materialize BOTH separately-published records before it runs
+        await _await_capability(kafka_bootstrap, add_name, timeout=60)
+        await _await_capability(kafka_bootstrap, mul_name, timeout=60)
+        async with agent_worker:
+            result = await driver.execute("add 2 and 3", agent_in, timeout=120)
+
+    # 1) the call drawn from a discovered tool round-tripped to a finalized turn
+    assert result.output is not None and FINAL_OUTPUT in result.output
+    assert tool_returns(result.message_history)[add_name] == 5
+
+    # 2) discover found EXACTLY this test's two separately-deployed tool nodes (namespace-scoped:
+    #    the shared lane broker may also carry other suites' live tools, which discover correctly
+    #    pulls too — but only this test's two are the subject)
+    assert pov, "the model never captured the agent's tool POV"
+    mine = {name for name in pov if name.startswith(topic_namespace)}
+    assert mine == {add_name, mul_name}
+
+    await driver.close()
+    await add_worker._client.close()
+    await mul_worker._client.close()
+    await agent_worker._client.close()

--- a/tests/test_discover_kernel.py
+++ b/tests/test_discover_kernel.py
@@ -1,0 +1,65 @@
+"""``resolve_all_capabilities`` — the discover-mode bulk kernel (spec §15.2).
+
+Binds EVERY live record of a given ``node_kind`` from the capability view's
+``snapshot()`` — the discover analogue of the single-target ``resolve_capability``.
+A POSITIVE FILTER, not the over-pull guard: a record of another kind is out of
+scope (skipped), not ``wrong_kind_targets``; only a poisoned record of the right
+kind degrades to ``invalid_targets``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from calfkit.models.capability import CapabilityRecord, CapabilityToolDef, resolve_all_capabilities
+from tests._capability_fakes import _FakeView
+
+
+def _record(name: str, *, node_kind: str = "tool", dispatch: str | None = None) -> CapabilityRecord:
+    now = datetime.now(tz=timezone.utc)
+    return CapabilityRecord(
+        started_at=now,
+        last_heartbeat_at=now,
+        heartbeat_interval=30.0,
+        node_kind=node_kind,
+        dispatch_topic=f"tool.{name}.input" if dispatch is None else dispatch,
+        tools=[CapabilityToolDef(name=name, parameters_json_schema={"type": "object", "properties": {}})],
+        content_updated_at=now,
+    )
+
+
+class TestResolveAllCapabilities:
+    def test_binds_only_records_of_the_requested_kind(self) -> None:
+        view = _FakeView(
+            {
+                "add": _record("add", node_kind="tool"),
+                "sub": _record("sub", node_kind="tool"),
+                "github": _record("search", node_kind="toolbox", dispatch="mcp_server.github"),
+            }
+        )
+        result = resolve_all_capabilities(view, node_kind="tool")
+        assert sorted(b.name for b in result.bindings) == ["add", "sub"]  # toolbox record excluded
+        # Nothing was named, so the named-path diagnostics are always empty (positive filter).
+        assert result.missing_targets == ()
+        assert result.missing_tools == ()
+        assert result.wrong_kind_targets == ()
+        assert not result.unresolved
+
+    def test_discovered_bindings_are_validatorless(self) -> None:
+        result = resolve_all_capabilities(_FakeView({"add": _record("add")}), node_kind="tool")
+        assert [b.name for b in result.bindings] == ["add"]
+        assert result.bindings[0].validator is None  # discovered = schema-only (node validates on receipt)
+
+    def test_poisoned_record_of_the_right_kind_degrades_to_invalid_targets(self) -> None:
+        # An empty dispatch_topic survives the tolerant reader but fails ToolBinding's
+        # min_length in record_to_bindings -> the node lands in invalid_targets; others still bind.
+        view = _FakeView({"add": _record("add"), "broken": _record("broken", dispatch="")})
+        result = resolve_all_capabilities(view, node_kind="tool")
+        assert [b.name for b in result.bindings] == ["add"]
+        assert result.invalid_targets == ("broken",)
+        assert result.unresolved
+
+    def test_empty_view_binds_nothing_and_is_not_unresolved(self) -> None:
+        result = resolve_all_capabilities(_FakeView({}), node_kind="tool")
+        assert result.bindings == ()
+        assert not result.unresolved

--- a/tests/test_tools_selector.py
+++ b/tests/test_tools_selector.py
@@ -286,6 +286,64 @@ class TestToolSurfaceContract:
         assert agent._tool_selectors == []
 
 
+class TestDiscoverDiagnostics:
+    """Discover-mode diagnostics (spec §15.4): a per-turn DEBUG count; healthy-empty is
+    silent by design; a degraded view still warns; per-run overrides skip discover."""
+
+    def test_discover_binds_all_tool_nodes_and_logs_count(self, caplog: pytest.LogCaptureFixture) -> None:
+        agent = make_agent(Tools(discover=True))
+        registry: dict[str, ToolBinding] = {}
+        view = _FakeView(
+            {
+                "add": make_tool_record("add"),
+                "sub": make_tool_record("sub"),
+                "github": make_tool_record("search", dispatch="mcp_server.github", node_kind="toolbox"),
+            }
+        )
+        with caplog.at_level("DEBUG"):
+            agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: view}, registry)
+        assert sorted(registry) == ["add", "sub"]  # every live tool node; the toolbox is excluded
+        assert any("discover mode resolved 2 tool node(s)" in r.getMessage() for r in caplog.records)
+
+    def test_discover_on_healthy_empty_view_is_silent_with_debug_count(self, caplog: pytest.LogCaptureFixture) -> None:
+        agent = make_agent(Tools(discover=True))
+        registry: dict[str, ToolBinding] = {}
+        with caplog.at_level("DEBUG"):
+            agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: _FakeView({})}, registry)
+        assert registry == {}
+        assert any("discover mode resolved 0 tool node(s)" in r.getMessage() for r in caplog.records)
+        # An empty cluster is a legitimate state, not a misconfiguration — no WARNING (don't cry wolf).
+        assert not any(r.levelname == "WARNING" for r in caplog.records)
+
+    def test_discover_against_degraded_view_still_warns_and_binds(self, caplog: pytest.LogCaptureFixture) -> None:
+        class _DegradedView(_FakeView):
+            status = "degraded"
+            failure = None
+
+        agent = make_agent(Tools(discover=True))
+        registry: dict[str, ToolBinding] = {}
+        view = _DegradedView({"add": make_tool_record("add")})
+        with caplog.at_level("WARNING"):
+            agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: view}, registry)
+        assert "add" in registry  # binds whatever the frozen view holds
+        assert any(r.levelname == "WARNING" and "degraded" in r.getMessage() for r in caplog.records)
+
+    def test_per_run_overrides_skip_discover(self) -> None:
+        from types import SimpleNamespace
+
+        from calfkit.models.state import OverridesState
+
+        agent = make_agent(Tools(discover=True))
+        registry: dict[str, ToolBinding] = {}
+        # Overrides pin the exact surface for the turn; discovery must not widen it.
+        ctx = SimpleNamespace(
+            state=SimpleNamespace(overrides=OverridesState(override_agent_tools=[])),
+            resources={CAPABILITY_VIEW_RESOURCE_KEY: _FakeView({"add": make_tool_record("add")})},
+        )
+        agent._maybe_resolve_selectors(ctx, registry)  # type: ignore[arg-type]
+        assert registry == {}  # discover did not run — the view's "add" was not bound
+
+
 class TestToolsExport:
     def test_importable_from_calfkit_and_nodes(self) -> None:
         import calfkit

--- a/tests/test_tools_selector.py
+++ b/tests/test_tools_selector.py
@@ -20,6 +20,7 @@ from calfkit.models.tool_dispatch import ToolBinding, ToolSelector, split_tool_d
 from calfkit.nodes.tool import Tools
 from tests._capability_fakes import _FakeView  # dict-backed EnumerableCapabilityView (adds snapshot())
 from tests.test_controlplane_view import _FakeTable  # the substrate's dict-backed GroupedTableReader fake
+from tests.test_tool_binding import make_tool_node  # builds a real ToolNodeDef (eager tool node)
 
 
 def make_tool_record(name: str = "add", *, dispatch: str | None = None, **overrides: Any) -> CapabilityRecord:
@@ -148,7 +149,11 @@ class TestToolsThroughAgent:
         assert all(registry[n].validator is None for n in registry)  # discovered = schema-only
 
     def test_eager_static_tool_wins_on_collision(self, caplog: pytest.LogCaptureFixture) -> None:
-        # Tools + an eager tool of the same name: the eager (locally validated) binding wins.
+        # The per-turn registry merge: when a discovered binding's name is already in the
+        # registry (e.g. a pre-seeded static/override binding), the existing one wins and the
+        # collision is error-logged. The construction-time contract forbids pairing an eager
+        # tool node with a same-named Tools handle — that combination raises before any turn
+        # (see TestToolSurfaceContract); this exercises the residual runtime merge path.
         from calfkit._vendor.pydantic_ai.tools import ToolDefinition
 
         agent = make_agent(Tools("add"))
@@ -202,6 +207,83 @@ class TestToolsDiscoverMode:
         assert sorted(b.name for b in result.bindings) == ["add", "sub"]  # toolbox record excluded
         assert all(b.validator is None for b in result.bindings)  # discovered = schema-only
         assert not result.unresolved
+
+
+class TestToolSurfaceContract:
+    """The construction-time tool-surface contract (spec §15.3, L18), enforced in both
+    ``Agent(tools=...)`` and ``add_tools``:
+      (1) no duplicate tool names across eager bindings + named ``Tools``;
+      (2) ``Tools(discover=True)`` owns the tool-node surface (no eager tool node or named
+          ``Tools`` alongside it; an ``MCPToolbox`` — a different kind — may).
+    """
+
+    # --- (1) no duplicate tool names ------------------------------------------------
+    def test_duplicate_named_handles_raise(self) -> None:
+        with pytest.raises(ValueError, match="duplicate tool name"):
+            make_agent(Tools("add"), Tools("add"))
+
+    def test_eager_node_and_named_same_name_raises(self) -> None:
+        with pytest.raises(ValueError, match="duplicate tool name"):
+            make_agent(make_tool_node("add"), Tools("add"))
+
+    def test_eager_node_and_named_same_name_raises_order_independent(self) -> None:
+        with pytest.raises(ValueError, match="duplicate tool name"):
+            make_agent(Tools("add"), make_tool_node("add"))
+
+    # --- (2) discover owns the tool-node surface ------------------------------------
+    def test_discover_with_eager_tool_node_raises(self) -> None:
+        with pytest.raises(ValueError, match="tool-node surface"):
+            make_agent(make_tool_node("add"), Tools(discover=True))
+
+    def test_discover_with_named_tools_raises(self) -> None:
+        with pytest.raises(ValueError, match="tool-node surface"):
+            make_agent(Tools("add"), Tools(discover=True))
+
+    # --- legal combinations ---------------------------------------------------------
+    def test_discover_alone_is_legal(self) -> None:
+        agent = make_agent(Tools(discover=True))
+        assert agent._tool_selectors == [Tools(discover=True)]
+
+    def test_discover_composes_with_mcp_toolbox(self) -> None:
+        from calfkit.mcp import MCPToolbox
+
+        agent = make_agent(Tools(discover=True), MCPToolbox("fs"))
+        assert Tools(discover=True) in agent._tool_selectors
+        assert MCPToolbox("fs") in agent._tool_selectors
+
+    def test_distinct_named_handles_are_legal(self) -> None:
+        agent = make_agent(Tools("add"), Tools("sub"))
+        assert agent._tool_selectors == [Tools("add"), Tools("sub")]
+
+    def test_distinct_eager_nodes_are_legal(self) -> None:
+        agent = make_agent(make_tool_node("add"), make_tool_node("sub"))
+        assert [b.name for b in agent.tools] == ["add", "sub"]
+
+    # --- add_tools enforces the contract incrementally ------------------------------
+    def test_add_tools_discover_onto_eager_node_raises(self) -> None:
+        agent = make_agent(make_tool_node("add"))
+        with pytest.raises(ValueError, match="tool-node surface"):
+            agent.add_tools(Tools(discover=True))
+
+    def test_add_tools_duplicate_onto_named_raises(self) -> None:
+        agent = make_agent(Tools("add"))
+        with pytest.raises(ValueError, match="duplicate tool name"):
+            agent.add_tools(make_tool_node("add"))
+
+    def test_add_tools_accumulates_disjoint_surfaces(self) -> None:
+        agent = make_agent(make_tool_node("add"))
+        agent.add_tools(make_tool_node("sub"))
+        agent.add_tools(Tools("mul"))
+        assert [b.name for b in agent.tools] == ["add", "sub"]
+        assert agent._tool_selectors == [Tools("mul")]
+
+    def test_add_tools_raise_leaves_surface_unchanged(self) -> None:
+        # validate-before-commit: a failed add must not mutate the live surface.
+        agent = make_agent(make_tool_node("add"))
+        with pytest.raises(ValueError, match="duplicate tool name"):
+            agent.add_tools(make_tool_node("add"))
+        assert [b.name for b in agent.tools] == ["add"]
+        assert agent._tool_selectors == []
 
 
 class TestToolsExport:

--- a/tests/test_tools_selector.py
+++ b/tests/test_tools_selector.py
@@ -18,6 +18,7 @@ from calfkit.controlplane import ControlPlaneView
 from calfkit.models.capability import CAPABILITY_VIEW_RESOURCE_KEY, CapabilityRecord, CapabilityToolDef, SelectorResult
 from calfkit.models.tool_dispatch import ToolBinding, ToolSelector, split_tool_declarations
 from calfkit.nodes.tool import Tools
+from tests._capability_fakes import _FakeView  # dict-backed EnumerableCapabilityView (adds snapshot())
 from tests.test_controlplane_view import _FakeTable  # the substrate's dict-backed GroupedTableReader fake
 
 
@@ -158,6 +159,49 @@ class TestToolsThroughAgent:
         assert registry["add"] is static  # existing (eager) wins; discovered never shadows it
         assert registry["add"].validator is not None  # local fail-fast validation preserved
         assert any("add" in r.message for r in caplog.records)
+
+
+class TestToolsDiscoverMode:
+    """``Tools(discover=True)`` — open-ended discovery of every live tool node (spec §15.1)."""
+
+    def test_discover_constructs_with_no_names(self) -> None:
+        t = Tools(discover=True)
+        assert t.discover is True
+        assert t.names == ()
+
+    def test_discover_with_positional_names_raises(self) -> None:
+        with pytest.raises(ValueError, match="no tool names"):
+            Tools("add", discover=True)
+
+    def test_discover_with_names_kwarg_raises(self) -> None:
+        with pytest.raises(ValueError, match="no tool names"):
+            Tools(names=["add"], discover=True)
+
+    def test_named_handle_defaults_to_discover_false(self) -> None:
+        assert Tools("add").discover is False
+
+    def test_empty_with_discover_false_raises(self) -> None:
+        # The fail-loud rail: a bare/empty handle is never an implicit "everything".
+        with pytest.raises(ValueError, match="at least one"):
+            Tools(discover=False)
+
+    def test_discover_value_semantics(self) -> None:
+        assert Tools(discover=True) == Tools(discover=True)
+        assert len({Tools(discover=True), Tools(discover=True)}) == 1
+        assert Tools(discover=True) != Tools("add")
+
+    def test_discover_resolves_all_tool_nodes_excluding_toolboxes(self) -> None:
+        view = _FakeView(
+            {
+                "add": make_tool_record("add"),
+                "sub": make_tool_record("sub"),
+                "github": make_tool_record("search", dispatch="mcp_server.github", node_kind="toolbox"),
+            }
+        )
+        result = Tools(discover=True).resolve_tools(view)
+        assert sorted(b.name for b in result.bindings) == ["add", "sub"]  # toolbox record excluded
+        assert all(b.validator is None for b in result.bindings)  # discovered = schema-only
+        assert not result.unresolved
 
 
 class TestToolsExport:

--- a/tests/test_tools_selector.py
+++ b/tests/test_tools_selector.py
@@ -270,6 +270,19 @@ class TestToolSurfaceContract:
         with pytest.raises(ValueError, match="duplicate tool name"):
             agent.add_tools(make_tool_node("add"))
 
+    def test_add_tools_discover_onto_named_raises(self) -> None:
+        # The contract re-validates the FULL accumulated surface: a discover handle added onto
+        # an agent that already holds a named Tools is the discover-exclusivity violation.
+        agent = make_agent(Tools("add"))
+        with pytest.raises(ValueError, match="tool-node surface"):
+            agent.add_tools(Tools(discover=True))
+
+    def test_add_tools_named_onto_discover_raises(self) -> None:
+        # ...and the reverse: a named Tools added onto an agent already in discover mode.
+        agent = make_agent(Tools(discover=True))
+        with pytest.raises(ValueError, match="tool-node surface"):
+            agent.add_tools(Tools("add"))
+
     def test_add_tools_accumulates_disjoint_surfaces(self) -> None:
         agent = make_agent(make_tool_node("add"))
         agent.add_tools(make_tool_node("sub"))
@@ -278,12 +291,14 @@ class TestToolSurfaceContract:
         assert agent._tool_selectors == [Tools("mul")]
 
     def test_add_tools_raise_leaves_surface_unchanged(self) -> None:
-        # validate-before-commit: a failed add must not mutate the live surface.
+        # validate-before-commit: a failed add must not mutate the live surface — all three
+        # pieces of tool-surface state (bindings, selectors, eager tool nodes) stay as they were.
         agent = make_agent(make_tool_node("add"))
         with pytest.raises(ValueError, match="duplicate tool name"):
             agent.add_tools(make_tool_node("add"))
         assert [b.name for b in agent.tools] == ["add"]
         assert agent._tool_selectors == []
+        assert [n.name for n in agent._eager_tool_nodes] == ["add"]
 
 
 class TestDiscoverDiagnostics:
@@ -314,6 +329,21 @@ class TestDiscoverDiagnostics:
         assert any("discover mode resolved 0 tool node(s)" in r.getMessage() for r in caplog.records)
         # An empty cluster is a legitimate state, not a misconfiguration — no WARNING (don't cry wolf).
         assert not any(r.levelname == "WARNING" for r in caplog.records)
+
+    def test_discover_with_poisoned_record_warns_and_binds_the_healthy(self, caplog: pytest.LogCaptureFixture) -> None:
+        # A poisoned tool record (empty dispatch_topic fails ToolBinding expansion) degrades to
+        # invalid_targets: the healthy node still binds, the unresolved WARNING names the poisoned
+        # one, and the DEBUG count reflects the successfully-resolved nodes.
+        agent = make_agent(Tools(discover=True))
+        registry: dict[str, ToolBinding] = {}
+        # Override dispatch_topic to "" directly: make_tool_record's `dispatch=` param coalesces ""
+        # to the default, so poison it via the override (empty topic fails ToolBinding expansion).
+        view = _FakeView({"add": make_tool_record("add"), "broken": make_tool_record("broken", dispatch_topic="")})
+        with caplog.at_level("DEBUG"):
+            agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: view}, registry)
+        assert "add" in registry and "broken" not in registry  # healthy survives, poisoned dropped
+        assert any("discover mode resolved 1 tool node(s)" in r.getMessage() for r in caplog.records)
+        assert any(r.levelname == "WARNING" and "broken" in r.getMessage() for r in caplog.records)
 
     def test_discover_against_degraded_view_still_warns_and_binds(self, caplog: pytest.LogCaptureFixture) -> None:
         class _DegradedView(_FakeView):


### PR DESCRIPTION
## What

Adds an open-ended **discover mode** to the `Tools` handle — `Tools(discover=True)` —
so an agent can use *every* live function tool node on the cluster instead of naming
each one. It is the promotion of the runtime-tool-discoverability spec's own deferred
"open-ended discovery" item (§14.2 → §15), and the call-side mirror of how a named
`Tools("add")` already works, applied to the whole tool-node surface.

```python
# Reference every live tool node — no names, schemas discovered at runtime:
agent = Agent("researcher", subscribe_topics="...", model_client=model,
              tools=[Tools(discover=True)])
```

Design: `docs/designs/runtime-tool-discoverability-spec.md` §15 (ADR-0014). The MCP
tool-name namespacing prerequisite shipped first in #269 (ADR-0018), which makes the
cluster tool namespace collision-free so an `MCPToolbox` composes with discover.

## How (commit by commit, TDD)

1. **Bulk kernel + enumerable view** — `resolve_all_capabilities(view, *, node_kind)`
   binds every live record of a kind from the view's `snapshot()` (the discover analogue
   of the single-target `resolve_capability`); a **positive filter** (off-kind records
   are out of scope, only a poisoned right-kind record degrades to `invalid_targets`).
   `EnumerableCapabilityView(CapabilityLookup)` adds `snapshot()`; the point-lookup path
   keeps the narrow `CapabilityLookup` (ISP). `ToolSelector.resolve_tools`'s param widens
   accordingly (contravariantly sound — `MCPToolbox` keeps the narrow param).
2. **`Tools(discover=True)`** — a `discover: bool` field on the existing frozen handle;
   invariant *exactly one of {non-empty names, `discover=True`}* (both, or the empty
   handle, raise). `resolve_tools` branches on the mode; named mode is unchanged.
3. **Construction-time tool-surface contract** — one contract over `tools=`, enforced in
   `__init__` and `add_tools` via a shared validate-then-commit path: (1) no duplicate
   tool names; (2) `Tools(discover=True)` owns the tool-node surface (no eager tool node
   or named `Tools` alongside it — an `MCPToolbox` may). Checked over the *raw* entries
   (types intact before the split flattens a tool node into a bare binding); a typed
   `_eager_tool_nodes` carries tool-node identity across `add_tools`. Validate-before-commit.
4. **Diagnostics** — a per-turn DEBUG count for a discover selector; a healthy view with
   zero tool nodes resolves silently (a legitimate empty cluster), a degraded view still
   warns, per-run overrides still skip discover.
5. **Kafka-lane cross-process roundtrip** — two tool nodes deployed in two *separate*
   workers, an agent in a third holds only `Tools(discover=True)`, discovers both, the
   model's POV is exactly the two advertised tools, and a call round-trips. Passes against
   testcontainers Redpanda.
6. **Docs + ADR** — discover how-to + `Tools(discover=True)` reference; ADR-0014 accepted;
   spec §15 → Implemented.

## Behavior change (pre-1.0, no deployments)

The construction-time contract is general: an agent with **duplicate tool names**, or the
same tool node referenced both eagerly and by name (`[add_node, Tools("add")]`), now
**raises at construction** instead of silently de-duping / runtime existing-wins. The full
offline suite is green — no existing configuration newly raises. The per-turn registry
collision branch is unchanged (still reachable for a static-binding vs MCP-resolved-name
clash).

## No wire change

Discover is call-side only: it reuses the `node_kind` field shipped with the by-name
feature, adds no `CapabilityRecord` field, and triggers no `schema_version` bump.

## Tests

- Offline suite: **3218 passed, 6 skipped**. New: the bulk kernel (kind filter / poisoned
  → invalid / empty view), `Tools(discover=True)` construction + resolution, the contract
  (every illegal combo raises, legal compose, `add_tools` incremental + accumulation,
  validate-before-commit), diagnostics (count / healthy-empty silence / degraded-view warn
  / override skip).
- Kafka lane: the cross-process discover roundtrip passes against a real broker.
- Changed-line coverage 100% (`capability.py` / `tool.py` 100%; all new `agent.py` lines
  covered). `make check` clean.
