### PR TITLE
refactor: `Agent` ctor takes `name` instead of `node_id`

### DIFF
--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -40,7 +40,7 @@ class BaseAgentNodeDef(
 
     def __init__(
         self,
-        node_id: str,
+        name: str,
         *,
         system_prompt: str = "You are a helpful AI assistant.",
         subscribe_topics: str | list[str],
@@ -67,7 +67,7 @@ class BaseAgentNodeDef(
             subscribe_topics = [subscribe_topics]
 
         super().__init__(
-            node_id=node_id,
+            node_id=name,
             subscribe_topics=subscribe_topics,
             publish_topic=publish_topic,
             before_node=before_node,

--- a/docs/adr/0020-node-identity-ctor-param-is-name.md
+++ b/docs/adr/0020-node-identity-ctor-param-is-name.md
@@ -1,0 +1,41 @@
+---
+status: accepted
+---
+
+# Node identity constructor parameter is `name`, not `node_id`
+
+A node's identity — the unique, stable, topic-mapped routing key — is stored on `BaseNodeSchema`
+as `node_id` and exposed as both `self.node_id` and the read-only `self.name` alias. The
+**constructor surface**, however, names this argument **`name`**: developers write
+`Agent("weather_agent", ...)` / `Agent(name="weather_agent", ...)`, not `node_id=`. This is a
+deliberate developer-experience choice — `name` reads more naturally at the call site than the
+routing-key-precise `node_id` — applied progressively across the node family.
+
+This is the orthogonal axis to [ADR-0009](0009-call-side-handle-takes-the-bare-name.md): 0009
+decides *which class* of a two-type pair carries the `Node` suffix; this ADR decides *what the
+identity parameter is called*. The MCP toolbox types led the migration
+(`MCPToolboxNode(name=...)`, PRs #254/#255); the `Agent` ctor followed (PR #272). `BaseNodeDef`,
+`ConsumerNode`, the tool-node factories, and the underlying `BaseNodeSchema.node_id` storage
+field still take/use `node_id` and remain the migration target.
+
+## Notes
+
+- **Surface-only.** Each constructor maps `name` onto the base node's `node_id` storage
+  (`super().__init__(node_id=name, ...)`). The `self.node_id` field and the `self.name` property
+  both remain and read the same value, so internal code, topic derivation, and the control plane
+  are untouched.
+- **No wire change.** Identity is the Kafka key (`node_id × worker_id`), never carried in a
+  serialized record value, so this rename never touches the wire format or any `schema_version`.
+- **Why `name` over the "more honest" `node_id`.** `node_id` arguably describes the value better
+  (a unique, stable routing id, distinct from a mutable display label). The naming was weighed
+  and `name` chosen for call-site readability — a DX-over-precision call. Recorded here so the
+  `name` surface is not "corrected" back to `node_id` by a future reader.
+
+## Consequences
+
+- **A clean pre-1.0 break per migrated type.** `Agent(node_id=...)` (keyword) stops working;
+  positional `Agent("name", ...)` is unaffected — the idiomatic form throughout the repo, README,
+  and examples. No deprecation shim, consistent with the project's hard-breaks-over-compat stance.
+- **A mixed surface during migration.** Until the family-wide pass lands, some constructors take
+  `name` (MCP toolbox types, `Agent`) and others still take `node_id`. The `.name` / `.node_id`
+  accessors are uniform regardless, so reads are unaffected.

--- a/docs/api.md
+++ b/docs/api.md
@@ -151,7 +151,7 @@ One-way send. Publishes `user_prompt` to `topic` and returns the correlation id;
 
 ```python
 Agent(
-    node_id: str,
+    name: str,
     *,
     system_prompt: str = "You are a helpful AI assistant.",
     subscribe_topics: str | list[str],

--- a/tests/test_agent_ctor_identity.py
+++ b/tests/test_agent_ctor_identity.py
@@ -1,0 +1,41 @@
+"""The ``Agent`` constructor takes its identity as ``name`` (not ``node_id``).
+
+This mirrors the MCP node types' precedent (``MCPToolboxNode(name=...)``, PRs #254/#255):
+the ctor surface names identity ``name`` and maps it onto the base node's ``node_id``
+storage. ``.name`` and ``.node_id`` both read the same value. A surface-only rename —
+the legacy ``node_id=`` keyword is a clean pre-1.0 break.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from calfkit._vendor.pydantic_ai.messages import ModelResponse
+from calfkit._vendor.pydantic_ai.messages import TextPart as ModelTextPart
+from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
+from calfkit.nodes import Agent
+
+
+def _model() -> FunctionModel:
+    def _fn(messages: list[Any], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[ModelTextPart("done")])
+
+    return FunctionModel(_fn)
+
+
+def test_constructs_with_name_keyword() -> None:
+    agent = Agent(name="researcher", subscribe_topics="in", model_client=_model())
+    assert agent.name == "researcher"
+    assert agent.node_id == "researcher"
+
+
+def test_constructs_with_positional_identity() -> None:
+    agent = Agent("researcher", subscribe_topics="in", model_client=_model())
+    assert agent.name == "researcher"
+
+
+def test_rejects_legacy_node_id_keyword() -> None:
+    with pytest.raises(TypeError):
+        Agent(node_id="researcher", subscribe_topics="in", model_client=_model())

--- a/tests/test_fanout_handler.py
+++ b/tests/test_fanout_handler.py
@@ -50,7 +50,7 @@ def _model(_messages: object, _info: AgentInfo) -> ModelResponse:
 
 def _agent(*, sequential: bool = False) -> Agent[str]:
     return Agent(
-        node_id="a",
+        name="a",
         subscribe_topics=["a.in"],
         model_client=FunctionModel(_model),
         sequential_only_mode=sequential,

--- a/tests/test_resolve_slot.py
+++ b/tests/test_resolve_slot.py
@@ -45,7 +45,7 @@ def _agent() -> Agent[Any]:
     def _fn(messages: list[Any], info: AgentInfo) -> ModelResponse:
         return ModelResponse(parts=[ModelTextPart("done")])
 
-    return Agent(node_id="a", subscribe_topics="in", model_client=FunctionModel(_fn))
+    return Agent(name="a", subscribe_topics="in", model_client=FunctionModel(_fn))
 
 
 class TestBaseResolveSlot:


### PR DESCRIPTION
## What

Rename the `Agent` constructor's identity parameter `node_id` → `name`:

```python
# before
Agent(node_id="weather_agent", subscribe_topics=..., model_client=...)
# after
Agent(name="weather_agent", subscribe_topics=..., model_client=...)
```

## Why

`name` is the chosen term for node identity across the node family. The MCP node types led this migration (`MCPToolboxNode(name=...)`, PRs #254/#255); this PR continues it for `Agent`. `.name` already existed as the read-only accessor — this aligns the *constructor* with it. The decision is now recorded in **ADR-0020**.

## Scope — surface-only

This is a **Python-API-only** rename of one parameter:

- `calfkit/nodes/agent.py` — ctor param `node_id: str` → `name: str`; internally still maps to the base node's `node_id` storage via `super().__init__(node_id=name, ...)`.
- **Unchanged:** `BaseNodeSchema.node_id` storage field, the `.node_id` / `.name` accessors (both still read the same value), all other node types (`@consumer`, tool nodes — they keep `node_id`), and the **wire format** (`node_id` is the Kafka key, never a serialized record field — no schema bump).
- **Docs:** new `docs/adr/0020-node-identity-ctor-param-is-name.md`; fixed the now-stale `Agent(...)` signature in `docs/api.md`.

## Breaking change (intentional, pre-1.0)

- ❌ `Agent(node_id=...)` keyword no longer works — clean break, no compat shim (consistent with the MCP precedent).
- ✅ `Agent("weather_agent", ...)` positional construction is **unaffected** — the idiomatic path used throughout the repo, README, and examples. The first positional arg is now semantically the `name`.

Only two test call-sites used the legacy `node_id=` keyword (`test_resolve_slot.py`, `test_fanout_handler.py`); both updated.

## Tests (TDD)

New `tests/test_agent_ctor_identity.py` covering the full contract:
- `name=` keyword constructs and exposes identity via `.name` and `.node_id`
- positional construction still works
- legacy `node_id=` keyword is rejected (`TypeError`)

## Verification

- `make fix` + `make check` (lint / format / types): clean
- Offline suite: **3224 passed, 6 skipped**
- Kafka lane (CI-only): statically verified — every `Agent(...)` site there passes identity positionally; no `node_id=` keyword sites affected.

## ADR-0020

Records the **`name`-over-`node_id` constructor-parameter** decision — the axis orthogonal to ADR-0009 (which decided the class-name `Node` suffix). Previously this lived only in PR descriptions; ADR-0020 is its canonical home so the `name` surface isn't "corrected" back to `node_id`. Numbered 0020 to avoid colliding with the unmerged agent-mesh branch's 0015–0017/0019 claims.

## Note

The agent-mesh spec currently folds this same rename into that feature; once this lands, that note flips to "already shipped" and the mesh branch rebases onto it.