### PR TITLE
feat(cli)!: rename the CLI command from `calfkit` to `ck`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Calfkit shifts the paradigm of agent development from orchestration (centralized
 $ pip install calfkit
 ```
 
-The command-line tools (`calfkit run`, `calfkit topics`) live behind an optional extra:
+The command-line tools (`ck run`, `ck topics`) live behind an optional extra:
 
 ```console
 $ pip install "calfkit[cli]"
@@ -119,10 +119,10 @@ def get_weather(location: str) -> str:
     return f"It's sunny in {location}"
 ```
 
-`calfkit run` points at a `module:attr` target and starts the tool for you — no extra wiring required. This requires the `[cli]` extra installed.
+`ck run` points at a `module:attr` target and starts the tool for you — no extra wiring required. This requires the `[cli]` extra installed.
 
 ```console
-$ calfkit run weather_tool:get_weather
+$ ck run weather_tool:get_weather
 ```
 
 ### 2. Deploy the agent node
@@ -154,7 +154,7 @@ $ export OPENAI_API_KEY=sk-...
 Start the agent:
 
 ```console
-$ calfkit run agent_service:agent
+$ ck run agent_service:agent
 ```
 
 ### 3. Invoke the agent
@@ -267,7 +267,7 @@ In-repo documentation lives under [`docs/`](docs/).
 **Reference:**
 
 - **[API reference](docs/api.md)** — the public surface re-exported from the top-level `calfkit` package, with the key entry-point signatures.
-- **[CLI reference](docs/cli.md)** — the `calfkit run` and `calfkit topics` commands.
+- **[CLI reference](docs/cli.md)** — the `ck run` and `ck topics` commands.
 - **[Topic provisioning](docs/topic-provisioning.md)** — the experimental, opt-in topic-creation helper for dev/CI.
 
 **Design & background:**

--- a/calfkit/cli/__init__.py
+++ b/calfkit/cli/__init__.py
@@ -1,10 +1,10 @@
-"""calfkit top-level CLI entry point.
+"""``ck`` top-level CLI entry point.
 
 Mounts subcommands as typer sub-apps: ``topics`` (with ``topics
 provision``), plus the top-level ``run`` command. Future subcommands land
 alongside via the same mounting pattern.
 
-Invoked via the ``calfkit`` console script registered in pyproject.toml's
+Invoked via the ``ck`` console script registered in pyproject.toml's
 ``[project.scripts]``.
 """
 
@@ -14,7 +14,7 @@ from typing import Any
 
 
 def _build_app() -> Any:
-    """Construct the top-level ``calfkit`` typer app with all sub-apps mounted.
+    """Construct the top-level ``ck`` typer app with all sub-apps mounted.
 
     typer is imported lazily so calfkit's regular runtime imports
     (e.g. ``from calfkit import Agent``) don't pay the typer cost. If typer
@@ -29,12 +29,12 @@ def _build_app() -> Any:
     from calfkit.cli.run import run as run_command
     from calfkit.cli.topics import app as topics_app
 
-    app = typer.Typer(name="calfkit", help="Calfkit SDK command-line tools.", no_args_is_help=True)
+    app = typer.Typer(name="ck", help="Calfkit SDK command-line tools.", no_args_is_help=True)
     app.add_typer(topics_app, name="topics")
     app.command(name="run")(run_command)
     return app
 
 
 def main() -> None:
-    """Entry point for the ``calfkit`` console script."""
+    """Entry point for the ``ck`` console script."""
     _build_app()()

--- a/calfkit/cli/_loader.py
+++ b/calfkit/cli/_loader.py
@@ -1,7 +1,7 @@
 """Shared node loader for the calfkit CLI.
 
 Resolves ``module:attr`` specs into a flat list of node objects. Used by both
-``calfkit topics provision`` (``--nodes module:attr``) and ``calfkit run``
+``ck topics provision`` (``--nodes module:attr``) and ``ck run``
 (positional ``module:attr`` targets).
 
 Each ``attr`` may resolve to a single node or an iterable of nodes; iterables
@@ -39,8 +39,8 @@ def resolve_specs(specs: list[str], *, app_dir: str | None = None, source_label:
             user runs the command from). The path is absolutised; duplicates are
             not re-inserted.
         source_label: How to name the spec source in error messages (e.g.
-            ``"target"`` for ``calfkit run`` or ``"--nodes"`` for
-            ``calfkit topics provision``).
+            ``"target"`` for ``ck run`` or ``"--nodes"`` for
+            ``ck topics provision``).
 
     Raises:
         typer.Exit: (code 2) on a malformed spec, an import failure, or a
@@ -117,7 +117,7 @@ def validate_nodes(objs: list[Any], *, source_label: str = "target") -> None:
 def load_nodes(targets: list[str], *, app_dir: str | None = None, source_label: str = "target") -> list[Any]:
     """Resolve, validate, and de-duplicate ``targets`` into a non-empty node list.
 
-    The composition used by ``calfkit run`` for both the inline (no-reload) path
+    The composition used by ``ck run`` for both the inline (no-reload) path
     and the parent-side pre-flight before the reload supervisor starts. Raising
     on an empty result means a misconfigured run fails fast and loud (exit 2)
     instead of starting an idle worker.

--- a/calfkit/cli/_run.py
+++ b/calfkit/cli/_run.py
@@ -1,4 +1,4 @@
-"""Runtime glue for ``calfkit run``.
+"""Runtime glue for ``ck run``.
 
 ``serve`` is the single entrypoint that turns resolved ``module:attr`` targets
 into a running :class:`~calfkit.worker.Worker`. It is deliberately a

--- a/calfkit/cli/run.py
+++ b/calfkit/cli/run.py
@@ -1,11 +1,11 @@
-"""``calfkit run`` typer command.
+"""``ck run`` typer command.
 
 A development convenience that runs one or more node(s) as a worker without the
 ``Client``/``Worker``/``run()`` boilerplate — point it at ``module:attr``
 targets and it starts serving, FastAPI-CLI style::
 
-    calfkit run weather_tool:get_weather
-    calfkit run myapp.agents:weather_agent myapp.tools:get_weather --reload
+    ck run weather_tool:get_weather
+    ck run myapp.agents:weather_agent myapp.tools:get_weather --reload
 
 Targets are dotted Python import paths (``module:attr``); each ``attr`` may be
 a single node or an iterable of nodes. All resolved nodes run in one worker.

--- a/calfkit/cli/topics.py
+++ b/calfkit/cli/topics.py
@@ -1,4 +1,4 @@
-"""``calfkit topics`` typer subcommand.
+"""``ck topics`` typer subcommand.
 
 **Experimental** (part of the opt-in topic-provisioning feature; may change or
 be removed in a minor release — calfkit is pre-1.0).
@@ -13,16 +13,16 @@ import raises with a clear remediation message rather than silently failing.
 
 Example invocations::
 
-    calfkit topics provision \\
+    ck topics provision \\
         --nodes myapp.workers:all_nodes \\
         --bootstrap-servers localhost:9092
 
-    calfkit topics provision \\
+    ck topics provision \\
         --nodes myapp.workers:agent \\
         --nodes myapp.workers:tool \\
         --partitions 3 --replication-factor 3
 
-    calfkit topics provision \\
+    ck topics provision \\
         --nodes myapp.workers:all_nodes \\
         --dry-run          # resolve + print the topic set, create nothing
 
@@ -38,7 +38,7 @@ import asyncio
 try:
     import typer
 except ImportError as e:  # pragma: no cover -- exercised manually
-    raise ImportError("calfkit topics provision requires the 'cli' optional extra. Install with: pip install calfkit[cli]") from e
+    raise ImportError("ck topics provision requires the 'cli' optional extra. Install with: pip install calfkit[cli]") from e
 
 from calfkit.cli._loader import resolve_specs, validate_nodes
 
@@ -171,5 +171,5 @@ if __name__ == "__main__":  # pragma: no cover
     main()
 
 
-# Re-export the typer app so the top-level ``calfkit`` script can mount it.
+# Re-export the typer app so the top-level ``ck`` script can mount it.
 __all__ = ["app", "main"]

--- a/calfkit/client/_broker.py
+++ b/calfkit/client/_broker.py
@@ -4,7 +4,7 @@ FastStream 0.7.x has no broker-level startup hook, and a bare
 ``client.broker.start()`` has no FastStream app to host ``on_startup`` hooks.
 ``KafkaBroker.start()`` is the single choke point every start path funnels
 through (bare ``broker.start()``, ``Worker.run()``/``start()``/``async with``,
-``calfkit run``, and auto-start on first publish). This subclass adds a generic
+``ck run``, and auto-start on first publish). This subclass adds a generic
 seam there: run an injected async hook **after** ``connect()`` (so the broker's
 admin client and the cluster are reachable) and **before** subscribers begin
 consuming.

--- a/calfkit/provisioning/ensurer.py
+++ b/calfkit/provisioning/ensurer.py
@@ -5,7 +5,7 @@ reply topic; a worker's node topics) and, **when provisioning is enabled**,
 creates them at broker start — before any subscriber begins consuming — reusing
 FastStream's broker-managed admin client. It is wired as a generic pre-start
 hook on the client's broker, so every start path (bare ``broker.start()``,
-``Worker.run()``/``start()``/``async with``, ``calfkit run``) is covered.
+``Worker.run()``/``start()``/``async with``, ``ck run``) is covered.
 
 When provisioning is **disabled** (the default), ``run`` is a pure no-op: the
 admin client is never touched and the broker's own / cluster's topic-creation

--- a/docs/api.md
+++ b/docs/api.md
@@ -425,7 +425,7 @@ The top-level package re-exports the symbols above. A few public capabilities li
 - **[How to give agents MCP tools](mcp-tool-discovery.md)** — fronting an MCP server as a toolbox.
 - **[How to give agents discoverable tool nodes](tool-discovery.md)** — referencing deployed function tool nodes by name with `Tools`.
 - **[Worker lifecycle & embedding](worker-lifecycle.md)** — `Worker`, the lifecycle contexts, and `@resource`.
-- **[CLI reference](cli.md)** — the `calfkit run` and `calfkit topics` commands.
+- **[CLI reference](cli.md)** — the `ck run` and `ck topics` commands.
 - **[Topic provisioning](topic-provisioning.md)** — `ProvisioningConfig` and the opt-in topic-creation helper.
 
 Full signatures and behavior live in the source docstrings.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,35 +1,35 @@
 # Calfkit CLI reference
 
-The `calfkit` command bundles the SDK's command-line tooling. It is installed
+The `ck` command bundles the SDK's command-line tooling. It is installed
 via the **`cli` optional extra** (it pulls in `typer` and `watchfiles`):
 
 ```console
 $ pip install "calfkit[cli]"
 ```
 
-If the extra isn't installed, invoking `calfkit` raises a clear remediation
+If the extra isn't installed, invoking `ck` raises a clear remediation
 message instead of failing obscurely.
 
 Commands:
 
 | Command | Purpose |
 | --- | --- |
-| [`calfkit run`](#calfkit-run) | Run node(s) as a worker for local development (no `Worker` boilerplate). |
-| [`calfkit topics`](#calfkit-topics) | Best-effort create the Kafka topics a set of nodes reference. |
+| [`ck run`](#ck-run) | Run node(s) as a worker for local development (no `Worker` boilerplate). |
+| [`ck topics`](#ck-topics) | Best-effort create the Kafka topics a set of nodes reference. |
 
 ---
 
-## `calfkit run`
+## `ck run`
 
 Run one or more nodes as a worker without writing the
 `Client.connect(...)` → `Worker(...)` → `worker.run()` boilerplate — point it at
 a node and it serves, in the spirit of `fastapi dev`.
 
 ```text
-calfkit run TARGET [TARGET ...] [OPTIONS]
+ck run TARGET [TARGET ...] [OPTIONS]
 ```
 
-> **Development only.** `calfkit run` is a convenience for running nodes locally.
+> **Development only.** `ck run` is a convenience for running nodes locally.
 > Production deployments should use an explicit `Worker` so startup, scaling, and
 > topic governance stay under operator control — see
 > [Production deployment](#production-deployment) below.
@@ -41,7 +41,7 @@ Each `TARGET` is a dotted **`module:attr`** import path (like `uvicorn main:app`
 - `attr` may be a **single node** or an **iterable of nodes** — iterables are
   expanded, so `mypkg.workers:all_nodes` (a list) works.
 - Pass **multiple targets** to run them in one worker:
-  `calfkit run app.agents:planner app.tools:search`.
+  `ck run app.agents:planner app.tools:search`.
 - Targets de-duplicate by `node_id`, so listing the same node twice is harmless.
 
 Targets are resolved with Python's import machinery, so the module must be
@@ -50,10 +50,10 @@ is placed on the import path (see `--app-dir`), so run from your project root:
 
 ```console
 $ # project root contains weather_tool.py
-$ calfkit run weather_tool:get_weather
+$ ck run weather_tool:get_weather
 
 $ # nested package (dots, not slashes; no .py suffix)
-$ calfkit run app.tools.weather:get_weather
+$ ck run app.tools.weather:get_weather
 ```
 
 Nested directories work as packages, including
@@ -63,7 +63,7 @@ Nested directories work as packages, including
 
 ### Node files need no boilerplate
 
-Because `calfkit run` imports your module and runs the node, the file only needs
+Because `ck run` imports your module and runs the node, the file only needs
 the node definition at module scope — no `main()`, no `asyncio.run(...)`, no
 `Worker`:
 
@@ -79,7 +79,7 @@ def get_weather(location: str) -> str:
 
 If a file *does* keep its own runnable entrypoint, guard it with
 `if __name__ == "__main__": asyncio.run(...)` — the guard does not fire on
-import, so `calfkit run` ignores it. (A `Worker.run()` left at module top level
+import, so `ck run` ignores it. (A `Worker.run()` left at module top level
 would block the import; keep it under the guard.)
 
 ### Options
@@ -121,21 +121,21 @@ re-import) on every change.
 
 ```console
 $ # One tool node
-$ calfkit run weather_tool:get_weather
+$ ck run weather_tool:get_weather
 
 $ # An agent and its tool in one worker, against a specific broker
-$ calfkit run agent_service:agent weather_tool:get_weather --host localhost:9092
+$ ck run agent_service:agent weather_tool:get_weather --host localhost:9092
 
 $ # Auto-restart on edits, auto-create dev topics
-$ calfkit run agent_service:agent --reload --provision
+$ ck run agent_service:agent --reload --provision
 
 $ # Resolve targets relative to ./src, load a custom env file
-$ calfkit run workers:all_nodes --app-dir src --env-file .env.local
+$ ck run workers:all_nodes --app-dir src --env-file .env.local
 ```
 
 ### Production deployment
 
-`calfkit run` is for development. In production, deploy each node with an
+`ck run` is for development. In production, deploy each node with an
 explicit `Worker`:
 
 ```python
@@ -160,10 +160,10 @@ $ python serve_tool.py
 
 ---
 
-## `calfkit topics`
+## `ck topics`
 
 ```text
-calfkit topics provision --nodes module:attr [--nodes module:attr ...] [OPTIONS]
+ck topics provision --nodes module:attr [--nodes module:attr ...] [OPTIONS]
 ```
 
 Resolve the Kafka topics a set of nodes reference (subscribe inboxes, framework

--- a/docs/topic-provisioning.md
+++ b/docs/topic-provisioning.md
@@ -146,7 +146,7 @@ that were registered; each node's `_return_topic` is passed as a framework topic
 so `topic_configs` is never applied to it. A provisioning failure aborts startup.
 
 For a manual `register_handlers()`-without-`run()` deployment (which bypasses the
-worker's startup hook), provision out-of-band — the CLI (`calfkit topics provision`,
+worker's startup hook), provision out-of-band — the CLI (`ck topics provision`,
 §4.3), or programmatically via `TopicProvisioner.from_connection(...).provision(...)`
 (§3). Both are idempotent.
 
@@ -164,25 +164,25 @@ reuses the broker's own admin client, so admin-side security is whatever you set
 the broker — a FastStream `security=` object passed to `Client.connect(...)`; there
 is no separate credential handling.
 
-### 4.3 CLI: `calfkit topics provision`
+### 4.3 CLI: `ck topics provision`
 
 A static, out-of-band path for CI/setup scripts. It does **not** require a running
 worker — it imports node definitions, resolves their topics, and creates them.
 
 ```shell
 # Resolve + create every topic the nodes reference
-calfkit topics provision \
+ck topics provision \
     --nodes myapp.workers:all_nodes \
     --bootstrap-servers localhost:9092
 
 # Multiple node sources, custom partition/replication
-calfkit topics provision \
+ck topics provision \
     --nodes myapp.workers:agent \
     --nodes myapp.workers:tool \
     --partitions 3 --replication-factor 3
 
 # Resolve + print the topic set, create nothing
-calfkit topics provision --nodes myapp.workers:all_nodes --dry-run
+ck topics provision --nodes myapp.workers:all_nodes --dry-run
 ```
 
 - `--nodes module:attr` (repeatable) — each `attr` may be a single node or an

--- a/examples/quickstart/agent_service.py
+++ b/examples/quickstart/agent_service.py
@@ -3,7 +3,7 @@ from weather_tool import get_weather  # Import the tool definition (reusable)
 from calfkit.nodes import Agent
 from calfkit.providers import OpenAIResponsesModelClient
 
-# Run it with: calfkit run agent_service:agent
+# Run it with: ck run agent_service:agent
 agent = Agent(
     "weather_agent",
     system_prompt="You are a helpful assistant.",

--- a/examples/quickstart/weather_tool.py
+++ b/examples/quickstart/weather_tool.py
@@ -2,7 +2,7 @@ from calfkit.nodes import agent_tool
 
 
 # Define a tool — the @agent_tool decorator turns any function into a deployable tool node.
-# Run it with: calfkit run weather_tool:get_weather
+# Run it with: ck run weather_tool:get_weather
 @agent_tool
 def get_weather(location: str) -> str:
     """Get the current weather at a location"""

--- a/examples/quickstart_mcp/README.md
+++ b/examples/quickstart_mcp/README.md
@@ -28,10 +28,10 @@ agent one tool — `fetch` (URL → markdown) — so it can read the live web.
 
 ```console
 # 1) the toolbox node (spawns the MCP fetch server)
-$ calfkit run fetch_toolbox:fetcher
+$ ck run fetch_toolbox:fetcher
 
 # 2) the agent — references the toolbox by name
-$ calfkit run research_agent:agent
+$ ck run research_agent:agent
 
 # 3) ask it something that needs the web
 $ python ask.py

--- a/examples/quickstart_mcp/fetch_toolbox.py
+++ b/examples/quickstart_mcp/fetch_toolbox.py
@@ -7,7 +7,7 @@ toolbox is the cluster's MCP client.
 
 Prerequisites: a running broker, and ``uv`` on your PATH (for ``uvx``).
 
-Run it with:  calfkit run fetch_toolbox:fetcher
+Run it with:  ck run fetch_toolbox:fetcher
 """
 
 from calfkit.mcp import MCPToolboxNode, StdioServerParameters

--- a/examples/quickstart_mcp/research_agent.py
+++ b/examples/quickstart_mcp/research_agent.py
@@ -7,7 +7,7 @@ re-resolves them every turn, so bring-up order does not matter.
 
 Prerequisites: a running broker, and ``export OPENAI_API_KEY=sk-...``.
 
-Run it with:  calfkit run research_agent:agent
+Run it with:  ck run research_agent:agent
 """
 
 from calfkit.mcp import MCPToolbox

--- a/examples/topic_provisioning.py
+++ b/examples/topic_provisioning.py
@@ -36,7 +36,7 @@ Run::
 
 The same one-off provisioning is available from the CLI (no Python)::
 
-    calfkit topics provision --nodes topic_provisioning:NODES \\
+    ck topics provision --nodes topic_provisioning:NODES \\
         --bootstrap-servers localhost:9092 --partitions 3
 """
 
@@ -78,7 +78,7 @@ async def log_results(result: InvocationResult) -> None:
 
 
 # The nodes a deployment would serve. Exposed at module scope so the CLI can
-# resolve them too: ``calfkit topics provision --nodes topic_provisioning:NODES``.
+# resolve them too: ``ck topics provision --nodes topic_provisioning:NODES``.
 NODES = [agent, get_weather, log_results]
 
 # A richer-than-default config. The defaults (partitions=1, rf=1, no configs) are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,17 +52,18 @@ Repository = "https://github.com/calf-ai/calfkit-sdk"
 Issues = "https://github.com/calf-ai/calfkit-sdk/issues"
 
 [project.scripts]
-# Top-level calfkit CLI. Mounts the `topics` (provision) subcommand and the
-# `run` command. Requires the `cli` optional extra (typer); the entry-point's
-# importer surfaces a clear remediation message if typer isn't installed.
-calfkit = "calfkit.cli:main"
+# Top-level `ck` CLI (the calfkit SDK's command-line tool). Mounts the `topics`
+# (provision) subcommand and the `run` command. Requires the `cli` optional
+# extra (typer); the entry-point's importer surfaces a clear remediation message
+# if typer isn't installed.
+ck = "calfkit.cli:main"
 
 [project.optional-dependencies]
 dev = []
 # Installed via `pip install calfkit[cli]`. Off the critical install path
 # because the CLI is only invoked at schema-generation / provisioning /
-# dev-run time, not at library runtime. Gates the whole `calfkit` console
-# script (typer); `watchfiles` powers `calfkit run --reload`.
+# dev-run time, not at library runtime. Gates the whole `ck` console
+# script (typer); `watchfiles` powers `ck run --reload`.
 cli = ["typer>=0.12", "watchfiles>=0.21"]
 
 [build-system]
@@ -121,7 +122,7 @@ dev = [
     # typer is the dep for the `cli` optional extra; dev includes it
     # so the CLI tests can run against the same install.
     "typer>=0.12",
-    # watchfiles powers `calfkit run --reload`; dev includes it so the
+    # watchfiles powers `ck run --reload`; dev includes it so the
     # CLI reload tests can import and patch it.
     "watchfiles>=0.21",
 ]

--- a/tests/provisioning_cli_import_boom.py
+++ b/tests/provisioning_cli_import_boom.py
@@ -1,6 +1,6 @@
 """Module whose top-level (import side-effect) code raises.
 
-Used by the ``calfkit topics provision`` CLI tests to assert that an import
+Used by the ``ck topics provision`` CLI tests to assert that an import
 *side-effect* failure is reported distinctly from a missing-module
 ``ImportError`` (both still exit 2).
 """

--- a/tests/provisioning_cli_nodes.py
+++ b/tests/provisioning_cli_nodes.py
@@ -1,4 +1,4 @@
-"""Small importable nodes module for ``calfkit topics provision`` CLI tests.
+"""Small importable nodes module for ``ck topics provision`` CLI tests.
 
 The CLI resolves ``--nodes module:attr``; these attrs give it a single node
 and a list of nodes.
@@ -31,7 +31,7 @@ nodes = [
 # actionable error rather than letting an AttributeError escape as exit 1.
 not_a_node = object()
 
-# An attr that is an empty iterable — resolves to zero nodes. ``calfkit run``
+# An attr that is an empty iterable — resolves to zero nodes. ``ck run``
 # must treat "nothing resolved" as an error (exit 2), not silently start an
 # idle worker.
 empty_list: list = []

--- a/tests/test_provisioning_cli.py
+++ b/tests/test_provisioning_cli.py
@@ -1,4 +1,4 @@
-"""Tests for the ``calfkit topics provision`` CLI subcommand and the
+"""Tests for the ``ck topics provision`` CLI subcommand and the
 top-level ``ProvisioningConfig`` export.
 
 Uses typer's ``CliRunner`` + a small in-repo nodes module so the topic-set

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -1,4 +1,4 @@
-"""Tests for the ``calfkit run`` typer command and its top-level mounting.
+"""Tests for the ``ck run`` typer command and its top-level mounting.
 
 The ``serve`` engine is patched out (it would block on a real broker), so
 these tests assert the command's dispatch: no-reload calls ``serve`` directly,

--- a/tests/test_run_loader.py
+++ b/tests/test_run_loader.py
@@ -1,7 +1,7 @@
 """Tests for the shared CLI node loader (``calfkit.cli._loader``).
 
 The loader resolves ``module:attr`` specs into a flat list of node objects and
-is shared by ``calfkit topics provision`` and ``calfkit run``. These tests
+is shared by ``ck topics provision`` and ``ck run``. These tests
 exercise it directly (no CliRunner) against the small in-repo
 ``tests.provisioning_cli_nodes`` fixture module.
 """
@@ -71,7 +71,7 @@ def test_resolve_specs_missing_attr_exits_2() -> None:
 def test_resolve_specs_app_dir_enables_nested_dotted_import(tmp_path: object, monkeypatch: pytest.MonkeyPatch) -> None:
     """``app_dir`` puts a directory on sys.path so a nested dotted module that
     is otherwise unimportable resolves — incl. PEP-420 namespace packages
-    (no __init__.py), matching ``calfkit run subdir.agent_file:agent``."""
+    (no __init__.py), matching ``ck run subdir.agent_file:agent``."""
     from calfkit.cli._loader import resolve_specs
 
     subdir = tmp_path / "subpkg"  # type: ignore[operator]

--- a/tests/test_run_serve.py
+++ b/tests/test_run_serve.py
@@ -1,4 +1,4 @@
-"""Tests for the ``calfkit run`` serve entrypoint (``calfkit.cli._run.serve``).
+"""Tests for the ``ck run`` serve entrypoint (``calfkit.cli._run.serve``).
 
 ``serve`` is the picklable function the reload supervisor spawns and the
 no-reload path calls directly. These tests patch the ``Client``/``Worker``


### PR DESCRIPTION
## What

Renames the console-script command from `calfkit` to **`ck`**. This is the **typed command only** — the Python package, imports, and PyPI name stay `calfkit` (you still `import calfkit` and `pip install calfkit[cli]`).

Hard rename, no alias kept (pre-1.0, clean break).

## Changes

- **Functional:** `[project.scripts]` `calfkit` → `ck` (entry point `calfkit.cli:main` unchanged).
- Typer app display name `calfkit` → `ck`.
- Every docstring / comment / doc / example that **names a command** (`calfkit run` / `calfkit topics` / the `calfkit` script) updated to `ck`, including `docs/cli.md` headings and their `#ck-run` / `#ck-topics` anchors, `README.md`, `docs/topic-provisioning.md`, `docs/api.md`, CLI source docstrings, two non-CLI module docstrings (`client/_broker.py`, `provisioning/ensurer.py`), test docstrings/fixtures, and the example "Run it with:" comments.

**Intentionally left unchanged:** Python package / imports / `pip install calfkit[cli]`, product prose ("the calfkit CLI", "Calfkit SDK"), the historical `docs/designs/*`, and the release-please-generated `CHANGELOG.md` (its existing `calfkit run` entry correctly records past history; this PR gets its own generated entry from the commit).

## Breaking change

The `calfkit` console command is **removed** and replaced by `ck`. Existing checkouts must reinstall (`uv sync` / `pip install -e .`) to pick up the new script.

## Verification

- `uv sync --extra cli` → `which ck` resolves to the venv; old `calfkit` command gone.
- `ck --help`, `ck run --help`, `ck topics provision --help` → all render `Usage: ck …`.
- End-to-end `ck topics provision --nodes … --dry-run` → resolved 6 topics, exit 0.
- `ck run no_colon_here` → exit 2 (bad-spec path).
- CLI suites: 56 passed. Full offline suite: **3221 passed, 6 skipped**.
- `make fix` (no changes) + `make check` (lint + format + type) → clean.