### PR TITLE
refactor: consumer node ctors take `name` not `node_id`

### DIFF
--- a/calfkit/nodes/consumer.py
+++ b/calfkit/nodes/consumer.py
@@ -46,7 +46,7 @@ class ConsumerNode(Generic[OutputT], BaseNodeDef):
     def __init__(
         self,
         *,
-        node_id: str,
+        name: str,
         consume_fn: ConsumerFn[OutputT],
         subscribe_topics: str | list[str],
         agent_output_type: type[OutputT] = _UNSET,
@@ -54,7 +54,7 @@ class ConsumerNode(Generic[OutputT], BaseNodeDef):
         _validate_consume_fn(consume_fn)
         if not isinstance(subscribe_topics, (list, tuple)):
             subscribe_topics = [subscribe_topics]
-        super().__init__(node_id=node_id, subscribe_topics=list(subscribe_topics))
+        super().__init__(node_id=name, subscribe_topics=list(subscribe_topics))
         self._func: ConsumerFn[OutputT] = consume_fn
         self._output_type = agent_output_type
 
@@ -132,7 +132,7 @@ def consumer(
     *,
     subscribe_topics: str | list[str],
     agent_output_type: type[OutputT] = _UNSET,
-    node_id: str | None = None,
+    name: str | None = None,
 ) -> Callable[[ConsumerFn[OutputT]], ConsumerNode[OutputT]]:
     """Decorator turning a function into a deployable consumer node.
 
@@ -151,7 +151,7 @@ def consumer(
 
     def _wrap(fn: ConsumerFn[OutputT]) -> ConsumerNode[OutputT]:
         return ConsumerNode[OutputT](
-            node_id=node_id or f"consumer_{fn.__name__}",
+            name=name or f"consumer_{fn.__name__}",
             subscribe_topics=subscribe_topics,
             consume_fn=fn,
             agent_output_type=agent_output_type,

--- a/docs/adr/0020-node-identity-ctor-param-is-name.md
+++ b/docs/adr/0020-node-identity-ctor-param-is-name.md
@@ -14,9 +14,12 @@ routing-key-precise `node_id` — applied progressively across the node family.
 This is the orthogonal axis to [ADR-0009](0009-call-side-handle-takes-the-bare-name.md): 0009
 decides *which class* of a two-type pair carries the `Node` suffix; this ADR decides *what the
 identity parameter is called*. The MCP toolbox types led the migration
-(`MCPToolboxNode(name=...)`, PRs #254/#255); the `Agent` ctor followed (PR #272). `BaseNodeDef`,
-`ConsumerNode`, the tool-node factories, and the underlying `BaseNodeSchema.node_id` storage
-field still take/use `node_id` and remain the migration target.
+(`MCPToolboxNode(name=...)`, PRs #254/#255); the `Agent` ctor followed (PR #272), then the
+`@consumer` decorator and `ConsumerNode` (PR #274). The function-tool-node factories
+(`agent_tool` / `create_tool_node`) already take `name` (PR #266). What still uses `node_id` is
+the **raw base construction** — `BaseNodeDef(node_id=...)` / `NodeDef` / the raw `ToolNodeDef(node_id=...)`
+dataclass form — and the underlying `BaseNodeSchema.node_id` storage field, which remain the
+migration target.
 
 ## Notes
 

--- a/tests/test_co_tenant_tool_isolation.py
+++ b/tests/test_co_tenant_tool_isolation.py
@@ -122,7 +122,7 @@ async def test_tool_return_does_not_leak_between_co_tenant_agents(container):
 
     @consumer(
         subscribe_topics="alpha_agent.out",
-        node_id="alpha_final_sink",
+        name="alpha_final_sink",
     )
     def alpha_sink(ctx: ConsumerContext) -> None:
         if not ctx.output_parts:
@@ -131,7 +131,7 @@ async def test_tool_return_does_not_leak_between_co_tenant_agents(container):
 
     @consumer(
         subscribe_topics="bravo_agent.out",
-        node_id="bravo_final_sink",
+        name="bravo_final_sink",
     )
     def bravo_sink(ctx: ConsumerContext) -> None:
         if not ctx.output_parts:
@@ -430,7 +430,7 @@ def test_worker_register_handlers_dedupes_explicit_return_topic(container):
         ),
         pytest.param(
             lambda: ConsumerNode(
-                node_id="empty_consumer",
+                name="empty_consumer",
                 subscribe_topics=[],
                 consume_fn=lambda r: None,
             ),

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -135,7 +135,7 @@ def test_decorator_sets_default_node_id_from_fn_name():
 
 
 def test_decorator_accepts_explicit_node_id_and_list_topics():
-    @consumer(subscribe_topics=["a", "b"], node_id="custom_id")
+    @consumer(subscribe_topics=["a", "b"], name="custom_id")
     def my_sink(ctx: ConsumerContext) -> None:
         return None
 
@@ -144,7 +144,7 @@ def test_decorator_accepts_explicit_node_id_and_list_topics():
 
 
 def test_class_form_normalizes_str_topic_to_list():
-    node = ConsumerNode(node_id="x", subscribe_topics="single_topic", consume_fn=lambda ctx: None)
+    node = ConsumerNode(name="x", subscribe_topics="single_topic", consume_fn=lambda ctx: None)
     assert node.subscribe_topics == ["single_topic"]
     assert node.publish_topic is None
 
@@ -154,7 +154,7 @@ def test_generator_function_rejected_at_construction():
         yield ctx
 
     with pytest.raises(TypeError, match="generator function"):
-        ConsumerNode(node_id="x", subscribe_topics="t", consume_fn=gen)
+        ConsumerNode(name="x", subscribe_topics="t", consume_fn=gen)
 
 
 def test_async_generator_function_rejected_at_construction():
@@ -162,7 +162,7 @@ def test_async_generator_function_rejected_at_construction():
         yield ctx
 
     with pytest.raises(TypeError, match="async generator function"):
-        ConsumerNode(node_id="x", subscribe_topics="t", consume_fn=agen)
+        ConsumerNode(name="x", subscribe_topics="t", consume_fn=agen)
 
 
 # ---------------------------------------------------------------------------
@@ -322,7 +322,7 @@ async def test_consumer_fans_in_across_multiple_topics(container):
 async def test_intermediate_hop_passes_to_fn_with_output_none(caplog):
     """Empty final_output_parts (intermediate hop) → ctx.output is None, NO error log."""
     received: list[ConsumerContext] = []
-    node = ConsumerNode(node_id="int_sink", subscribe_topics="t", consume_fn=received.append)
+    node = ConsumerNode(name="int_sink", subscribe_topics="t", consume_fn=received.append)
 
     with caplog.at_level(logging.ERROR, logger=CONSUMER_LOGGER):
         await _handle(node, _envelope())
@@ -336,7 +336,7 @@ async def test_intermediate_hop_passes_to_fn_with_output_none(caplog):
 async def test_validation_error_on_present_parts_logs_and_skips(caplog):
     """Parts present but don't match output_type → skip + ERROR with context."""
     invocations: list[str] = []
-    node = ConsumerNode(node_id="val_sink", subscribe_topics="t", consume_fn=lambda ctx: invocations.append("ran"), agent_output_type=Report)
+    node = ConsumerNode(name="val_sink", subscribe_topics="t", consume_fn=lambda ctx: invocations.append("ran"), agent_output_type=Report)
 
     with caplog.at_level(logging.ERROR, logger=CONSUMER_LOGGER):
         await _handle(node, _envelope(_data_reply({"unexpected": "shape"})))
@@ -352,7 +352,7 @@ async def test_missing_emitter_header_warns_and_still_invokes_fn(caplog):
     """No x-calf-emitter header → BaseNodeDef.handler warns; fn still runs with
     emitter_node_id=None (a legitimate non-calfkit producer)."""
     received: list[ConsumerContext] = []
-    node = ConsumerNode(node_id="noemit_sink", subscribe_topics="t", consume_fn=received.append)
+    node = ConsumerNode(name="noemit_sink", subscribe_topics="t", consume_fn=received.append)
 
     with caplog.at_level(logging.WARNING, logger=BASE_LOGGER):
         await _handle(node, _envelope(_text_reply("hello")), headers={})
@@ -374,7 +374,7 @@ async def test_consume_fn_exception_swallowed_and_logged(caplog):
     def boom(ctx: ConsumerContext) -> None:
         raise RuntimeError("intentional consumer failure")
 
-    node = ConsumerNode(node_id="boom_sink", subscribe_topics="t", consume_fn=boom)
+    node = ConsumerNode(name="boom_sink", subscribe_topics="t", consume_fn=boom)
 
     with caplog.at_level(logging.ERROR, logger=CONSUMER_LOGGER):
         resp = await _handle(node, _envelope(_text_reply("hi")))
@@ -392,7 +392,7 @@ async def test_cancelled_error_always_propagates():
     async def cancels(ctx: ConsumerContext) -> None:
         raise asyncio.CancelledError()
 
-    node = ConsumerNode(node_id="cancel_sink", subscribe_topics="t", consume_fn=cancels)
+    node = ConsumerNode(name="cancel_sink", subscribe_topics="t", consume_fn=cancels)
     with pytest.raises(asyncio.CancelledError):
         await _handle(node, _envelope(_text_reply("hi")))
 
@@ -403,7 +403,7 @@ async def test_observer_observes_every_kind_even_a_caller_capable_stray_shape(ca
     ordinary ReturnMessage) still reaches the consume body — observers bypass the caller-capable
     stray-check / fault pipeline entirely and never fault or floor a peer's observed traffic."""
     captured: list[ConsumerContext] = []
-    node = ConsumerNode(node_id="obs_sink", subscribe_topics="t", consume_fn=captured.append)
+    node = ConsumerNode(name="obs_sink", subscribe_topics="t", consume_fn=captured.append)
 
     with caplog.at_level(logging.WARNING, logger=BASE_LOGGER):
         await _handle(node, _envelope(_text_reply("observed")), headers={**_HEADERS, HDR_KIND: b"fault"})
@@ -425,7 +425,7 @@ async def test_observer_on_live_frame_never_unwinds_or_publishes(consume_raises:
         if consume_raises:
             raise RuntimeError("observer body blew up on someone else's reply-owing envelope")
 
-    node = ConsumerNode(node_id="forge_sink", subscribe_topics="t", consume_fn=consume)
+    node = ConsumerNode(name="forge_sink", subscribe_topics="t", consume_fn=consume)
 
     # A LIVE frame: a real caller's callback address sits on the stack (the shape a sink
     # would see if mis-wired onto reply-owing traffic). _envelope builds a FRAMELESS stack,
@@ -461,7 +461,7 @@ async def test_callable_class_generator_detected_at_call_site(caplog):
         def __call__(self, ctx):
             yield ctx
 
-    node = ConsumerNode(node_id="gen_sink", subscribe_topics="t", consume_fn=GenSink())
+    node = ConsumerNode(name="gen_sink", subscribe_topics="t", consume_fn=GenSink())
     with caplog.at_level(logging.ERROR, logger=CONSUMER_LOGGER):
         await _handle(node, _envelope(_text_reply("hi")))
 
@@ -476,7 +476,7 @@ async def test_function_returning_generator_object_detected(caplog):
     def sink(ctx):
         return _wrapper_gen()
 
-    node = ConsumerNode(node_id="gen_ret", subscribe_topics="t", consume_fn=sink)
+    node = ConsumerNode(name="gen_ret", subscribe_topics="t", consume_fn=sink)
     with caplog.at_level(logging.ERROR, logger=CONSUMER_LOGGER):
         await _handle(node, _envelope(_text_reply("hi")))
 
@@ -492,7 +492,7 @@ async def test_function_returning_async_generator_object_detected(caplog):
     def sink(ctx):
         return _wrapper_agen()
 
-    node = ConsumerNode(node_id="agen_ret", subscribe_topics="t", consume_fn=sink)
+    node = ConsumerNode(name="agen_ret", subscribe_topics="t", consume_fn=sink)
     with caplog.at_level(logging.ERROR, logger=CONSUMER_LOGGER):
         await _handle(node, _envelope(_text_reply("hi")))
 
@@ -517,7 +517,7 @@ async def test_final_only_consumer_idiom_filters_intermediate():
             return  # intermediate hop — skip
         received.append(ctx)
 
-    node = ConsumerNode(node_id="filtered", subscribe_topics="t", consume_fn=consume)
+    node = ConsumerNode(name="filtered", subscribe_topics="t", consume_fn=consume)
 
     await _handle(node, _envelope(), correlation_id="cid-int")  # intermediate → skipped
     await _handle(node, _envelope(_text_reply("final!")), correlation_id="cid-final")  # terminal → kept
@@ -535,7 +535,7 @@ async def test_consumer_sees_tool_results_via_state():
     """A consumer wired to a tool's output reads the tool's return value through
     ``ctx.state.tool_results`` (full session-state visibility)."""
     captured: list[ConsumerContext] = []
-    node = ConsumerNode(node_id="tool_obs", subscribe_topics="t", consume_fn=captured.append)
+    node = ConsumerNode(name="tool_obs", subscribe_topics="t", consume_fn=captured.append)
 
     state = State()
     tool_call = ToolCallPart(tool_name="get_weather", args={"location": "Tokyo"})
@@ -554,7 +554,7 @@ async def test_consumer_sees_tool_results_via_state():
 
 async def test_consumer_reads_inbound_deps():
     captured: list[ConsumerContext] = []
-    node = ConsumerNode(node_id="deps_sink", subscribe_topics="t", consume_fn=captured.append)
+    node = ConsumerNode(name="deps_sink", subscribe_topics="t", consume_fn=captured.append)
 
     await _handle(node, _envelope(_text_reply("hi"), deps={"discord": {"channel_id": 42}}), correlation_id="cid-deps")
 
@@ -564,7 +564,7 @@ async def test_consumer_reads_inbound_deps():
 
 async def test_consumer_deps_defaults_to_empty_dict():
     captured: list[ConsumerContext] = []
-    node = ConsumerNode(node_id="deps_empty", subscribe_topics="t", consume_fn=captured.append)
+    node = ConsumerNode(name="deps_empty", subscribe_topics="t", consume_fn=captured.append)
 
     await _handle(node, _envelope(_text_reply("hi")))
 
@@ -573,7 +573,7 @@ async def test_consumer_deps_defaults_to_empty_dict():
 
 async def test_consumer_convenience_properties_read_through_state():
     captured: list[ConsumerContext] = []
-    node = ConsumerNode(node_id="props", subscribe_topics="t", consume_fn=captured.append)
+    node = ConsumerNode(name="props", subscribe_topics="t", consume_fn=captured.append)
 
     state = State()
     state.message_history = [ModelRequest.user_text_prompt("hi")]
@@ -589,7 +589,7 @@ async def test_consumer_convenience_properties_read_through_state():
 
 async def test_resources_flow_from_node_bag():
     captured: list[ConsumerContext] = []
-    node = ConsumerNode(node_id="res_sink", subscribe_topics="t", consume_fn=captured.append)
+    node = ConsumerNode(name="res_sink", subscribe_topics="t", consume_fn=captured.append)
     sentinel = object()
     node.resources["db"] = sentinel
 
@@ -684,7 +684,7 @@ def test_unschematizable_output_type_raises_at_construction():
         TypeAdapter(BadType)
     except Exception:
         with pytest.raises(Exception):
-            ConsumerNode(node_id="bad", subscribe_topics="t", consume_fn=lambda ctx: None, agent_output_type=BadType)
+            ConsumerNode(name="bad", subscribe_topics="t", consume_fn=lambda ctx: None, agent_output_type=BadType)
     else:
         pytest.skip("TypeAdapter(BadType) succeeded on this pydantic version")
 
@@ -700,7 +700,7 @@ async def test_unexpected_projection_exception_is_logged_and_skipped(monkeypatch
     import sys
 
     invocations: list[str] = []
-    node = ConsumerNode(node_id="safety", subscribe_topics="t", consume_fn=lambda ctx: invocations.append("ran"))
+    node = ConsumerNode(name="safety", subscribe_topics="t", consume_fn=lambda ctx: invocations.append("ran"))
 
     consumer_mod = sys.modules["calfkit.nodes.consumer"]
 

--- a/tests/test_consumer_ctor_identity.py
+++ b/tests/test_consumer_ctor_identity.py
@@ -1,0 +1,50 @@
+"""The consumer node surfaces take their identity as ``name`` (not ``node_id``).
+
+Both the ``@consumer`` decorator factory and the ``ConsumerNode`` class map ``name`` onto
+the base node's ``node_id`` storage, mirroring ``Agent`` (ADR-0020, PR #272) and the MCP
+node types. ``.name`` and ``.node_id`` both read the same value. A surface-only rename — the
+legacy ``node_id=`` keyword is a clean pre-1.0 break on both surfaces. The factory's
+default-id derivation (``consumer_<fn>`` when no name is given) is unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from calfkit.nodes import ConsumerNode, consumer
+
+
+def test_factory_constructs_with_name_keyword() -> None:
+    @consumer(subscribe_topics="t", name="custom_sink")
+    def sink(ctx: object) -> None:  # pragma: no cover - body never runs
+        return None
+
+    assert sink.name == "custom_sink"
+    assert sink.node_id == "custom_sink"
+
+
+def test_factory_default_id_still_derives_from_fn_name() -> None:
+    @consumer(subscribe_topics="t")
+    def save_weather(ctx: object) -> None:  # pragma: no cover - body never runs
+        return None
+
+    assert save_weather.name == "consumer_save_weather"
+
+
+def test_class_constructs_with_name_keyword() -> None:
+    node = ConsumerNode(name="obs", subscribe_topics="t", consume_fn=lambda ctx: None)
+    assert node.name == "obs"
+    assert node.node_id == "obs"
+
+
+def test_factory_rejects_legacy_node_id_keyword() -> None:
+    with pytest.raises(TypeError):
+
+        @consumer(subscribe_topics="t", node_id="custom_sink")
+        def sink(ctx: object) -> None:  # pragma: no cover - body never runs
+            return None
+
+
+def test_class_rejects_legacy_node_id_keyword() -> None:
+    with pytest.raises(TypeError):
+        ConsumerNode(node_id="obs", subscribe_topics="t", consume_fn=lambda ctx: None)

--- a/tests/test_lifecycle_resource_injection.py
+++ b/tests/test_lifecycle_resource_injection.py
@@ -155,7 +155,7 @@ async def test_consumer_handler_injects_node_resources_into_context() -> None:
         seen["db"] = ctx.resources["db"]
 
     node: ConsumerNode[str] = ConsumerNode(
-        node_id="sink",
+        name="sink",
         subscribe_topics="sink.in",
         consume_fn=sink,
         agent_output_type=str,
@@ -198,7 +198,7 @@ async def test_consumer_context_resources_is_shallow_copy_of_node_bag() -> None:
         ctx.resources["mutated"] = object()  # type: ignore[index]
 
     node: ConsumerNode[str] = ConsumerNode(
-        node_id="sink_iso",
+        name="sink_iso",
         subscribe_topics="sink_iso.in",
         consume_fn=sink,
         agent_output_type=str,

--- a/tests/test_node_id_validation.py
+++ b/tests/test_node_id_validation.py
@@ -32,7 +32,7 @@ def test_legal_node_id_accepted(node_id: str) -> None:
 def test_consumer_node_id_validated_too() -> None:
     # Observers run the same __post_init__ — validation is uniform across kinds.
     with pytest.raises(ValueError, match="node_id"):
-        ConsumerNode(node_id="bad id", consume_fn=lambda ctx: None, subscribe_topics=["t"])
+        ConsumerNode(name="bad id", consume_fn=lambda ctx: None, subscribe_topics=["t"])
 
 
 def test_max_length_component_node_id_accepted() -> None:

--- a/tests/test_seam_registration.py
+++ b/tests/test_seam_registration.py
@@ -117,7 +117,7 @@ class TestNoSeamsOnObservers:
     def test_registering_any_seam_on_a_consumer_raises(self, seam: str) -> None:
         from calfkit.nodes.consumer import ConsumerNode
 
-        node = ConsumerNode(node_id="obs", subscribe_topics="in", consume_fn=lambda ctx: None)
+        node = ConsumerNode(name="obs", subscribe_topics="in", consume_fn=lambda ctx: None)
         register = getattr(node, seam)
         # The guard fires before the callable/arity checks, so a perfectly valid handler
         # is still rejected purely because the node is an observer.

--- a/tests/test_worker_max_workers_pin.py
+++ b/tests/test_worker_max_workers_pin.py
@@ -50,7 +50,7 @@ def test_caller_capable_node_pinned_to_max_workers_1(monkeypatch) -> None:  # no
 
 def test_observer_uses_worker_max_workers(monkeypatch) -> None:  # noqa: ANN001
     client = Client.connect()
-    consumer = ConsumerNode(node_id="obs", consume_fn=lambda ctx: None, subscribe_topics=["events"])
+    consumer = ConsumerNode(name="obs", consume_fn=lambda ctx: None, subscribe_topics=["events"])
     worker = Worker(client, nodes=[consumer], max_workers=4)
     calls = _spy_registration(monkeypatch, client)
 
@@ -105,7 +105,7 @@ def test_observer_honors_extra_subscribe_kwargs_max_workers(monkeypatch) -> None
     # The observer branch uses setdefault, so an explicit extra value wins over the worker
     # default (which only fills in when extra didn't set one).
     client = Client.connect()
-    consumer = ConsumerNode(node_id="obs", consume_fn=lambda ctx: None, subscribe_topics=["events"])
+    consumer = ConsumerNode(name="obs", consume_fn=lambda ctx: None, subscribe_topics=["events"])
     worker = Worker(client, nodes=[consumer], max_workers=2, extra_subscribe_kwargs={"max_workers": 5})
     calls = _spy_registration(monkeypatch, client)
 


### PR DESCRIPTION
## What

Rename the identity parameter `node_id` → `name` on **both** consumer surfaces — continuing the node-family migration after `Agent` (#272):

```python
# before
@consumer(subscribe_topics="agent.output", node_id="sink")     # factory
ConsumerNode(node_id="sink", subscribe_topics=..., consume_fn=...)   # class
# after
@consumer(subscribe_topics="agent.output", name="sink")
ConsumerNode(name="sink", subscribe_topics=..., consume_fn=...)
```

## Why

`name` is the chosen term for node identity (**ADR-0020**). MCP toolbox types led it (#254/#255), `Agent` followed (#272); this PR does the consumer surfaces.

## Scope — surface-only

- `calfkit/nodes/consumer.py` — `ConsumerNode.__init__` param `node_id` → `name` (maps via `super().__init__(node_id=name, ...)`); `consumer()` factory param `node_id` → `name`; the factory's `consumer_<fn>` default-id derivation is **unchanged**.
- **Unchanged:** `.node_id`/`.name` accessors, `BaseNodeSchema.node_id` storage field, the wire format (here `node_id` is also the **consumer-group id**, `worker.py:299,309` — never a serialized field), and all other node types.

## Difference from #272 — keyword-only, so a wider sweep

`Agent`'s identity was the first **positional** arg, so only 2 keyword sites broke. Consumer identity is **keyword-only** on both surfaces (no positional form), so every call-site that names identity used `node_id=` and is updated to `name=` — **~31 sites across 6 test files**. Sites relying on the default id (`@consumer(subscribe_topics=...)`) are unaffected.

Raw base-dataclass constructions (`NodeDef` / `ToolNodeDef(node_id=...)`) deliberately **keep** `node_id` — that's the deferred base-storage layer, not a developer-facing node surface.

## Breaking change (intentional, pre-1.0)

`consumer(node_id=...)` and `ConsumerNode(node_id=...)` no longer work — clean break, no shim (consistent with the MCP/`Agent` precedent).

## Tests (TDD)

New `tests/test_consumer_ctor_identity.py` covering the full contract on both surfaces:
- `name=` constructs and exposes identity via `.name` and `.node_id` (factory + class)
- the `consumer_<fn>` default-id still derives when `name` is omitted
- legacy `node_id=` is rejected (`TypeError`) on both `consumer()` and `ConsumerNode()`

## Verification

- `make fix` + `make check` (lint / format / types): clean
- Offline suite: **3229 passed, 6 skipped**
- Kafka lane (CI-only): statically verified — the only integration consumers use the default id; no `node_id=` consumer sites affected.

## Docs

ADR-0020's "remaining target" line is corrected in this PR (it had wrongly listed the tool-node *factories* — those already use `name` since #266 — and ConsumerNode now moves to migrated; the accurate remaining target is the raw base ctor + the `BaseNodeSchema.node_id` storage field).