### PR TITLE
ci: remove CodeQL job from Security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,45 +1,15 @@
 name: Security
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
-  schedule:
-    # Run weekly on Monday at 00:00 UTC
-    - cron: "0 0 * * 1"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  codeql:
-    name: CodeQL Analysis
-    runs-on: ubuntu-latest
-
-    permissions:
-      security-events: write
-      contents: read
-      actions: read
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
-        with:
-          languages: python
-          queries: security-and-quality
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
-        with:
-          category: "/language:python"
-
   dependency-review:
     name: Dependency Review
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
## What

Removes the `codeql` job from `.github/workflows/security.yml`.

## Why

CodeQL analysis is being dropped from CI. The `dependency-review` job remains and continues to run on pull requests.

## Notes

The `push` and `schedule` (weekly cron) triggers existed solely for CodeQL and are removed too. The remaining `dependency-review` job is gated to `if: github.event_name == 'pull_request'`, so leaving those triggers would fire the workflow on every push to `main` and weekly with **zero jobs running**. The workflow now triggers only on PRs.

## Heads-up

If branch protection requires the **"CodeQL Analysis"** status check, it must be removed from the branch-protection rule (admin access) — otherwise that check will never report and will block merges.