### PR TITLE
feat!: surface ktable reader config tuning at the worker level

### DIFF
--- a/calfkit/__init__.py
+++ b/calfkit/__init__.py
@@ -7,6 +7,7 @@ from calfkit.models import ErrorReport, FaultTypes, ToolContext
 from calfkit.nodes import Agent, BaseNodeDef, ConsumerFn, ConsumerNode, NodeDef, ToolNodeDef, Tools, agent_tool, consumer
 from calfkit.providers import AnthropicModelClient, OpenAIModelClient, OpenAIResponsesModelClient
 from calfkit.provisioning import ProvisioningConfig
+from calfkit.tuning import FanoutConfig, KTableReaderTuning
 from calfkit.worker import LifecycleContext, ResourceSetupContext, ServingContext, Worker
 
 __version__ = version("calfkit")
@@ -47,6 +48,9 @@ __all__ = [
     "ControlPlaneStamp",
     "ControlPlaneView",
     "advertises",
+    # ktables tuning
+    "FanoutConfig",
+    "KTableReaderTuning",
     # exceptions
     "DeserializationError",
     "LifecycleConfigError",

--- a/calfkit/controlplane/config.py
+++ b/calfkit/controlplane/config.py
@@ -27,9 +27,9 @@ class ControlPlaneConfig(BaseModel):
         heartbeat_interval: Seconds between record re-publishes (the publisher's
             loop cadence). Also stamped on every record so a reader can judge
             staleness without knowing this value.
-        stale_after: Read-side override/floor for the staleness threshold. ``None``
+        stale_after: Read-side override/floor for the staleness threshold (seconds). ``None``
             (default) derives ``STALE_MULTIPLIER × record.heartbeat_interval``.
-        catchup_timeout: Bound on a view's catch-up gate.
+        catchup_timeout: Bound (seconds) on a view's catch-up gate.
         bootstrap_servers: Override for the control-plane Kafka cluster. ``None``
             (default) derives from the connected client; set only for the
             split-cluster case (control plane on different brokers than data).

--- a/calfkit/controlplane/config.py
+++ b/calfkit/controlplane/config.py
@@ -1,8 +1,9 @@
-"""Worker-level control-plane configuration (spec §11).
+"""Worker-level control-plane configuration (spec §11, ADR-0021).
 
 Optional tuning for the control-plane substrate. The knobs split by side:
 ``heartbeat_interval`` is the *publisher's* (and is stamped on every record, so it
 reaches readers); ``stale_after`` and ``catchup_timeout`` are the *view's*;
+``reader_tuning`` tunes the view reader's cadence (idle ``barrier()`` latency);
 ``bootstrap_servers`` applies to whichever side opens a table. A reader in a
 different process than the writer needs no agreement on ``heartbeat_interval`` —
 it arrives on the record (spec §5, §9).
@@ -10,16 +11,16 @@ it arrives on the record (spec §5, §9).
 
 from __future__ import annotations
 
-import math
-from dataclasses import dataclass
+from pydantic import BaseModel, ConfigDict, Field
+
+from calfkit.tuning import KTableReaderTuning, PositiveFiniteFloat
 
 STALE_MULTIPLIER = 3
 """Default staleness threshold = ``STALE_MULTIPLIER × record.heartbeat_interval``
 when a reader sets no explicit ``stale_after`` (spec §9)."""
 
 
-@dataclass(frozen=True)
-class ControlPlaneConfig:
+class ControlPlaneConfig(BaseModel):
     """Tuning for the control-plane substrate; every field is optional.
 
     Args:
@@ -32,18 +33,15 @@ class ControlPlaneConfig:
         bootstrap_servers: Override for the control-plane Kafka cluster. ``None``
             (default) derives from the connected client; set only for the
             split-cluster case (control plane on different brokers than data).
+        reader_tuning: Cadence for the capability-view reader (reader-only). Lower
+            both knobs to cut idle ``barrier()`` latency; see
+            :class:`~calfkit.tuning.KTableReaderTuning`.
     """
 
-    heartbeat_interval: float = 30.0
-    stale_after: float | None = None
-    catchup_timeout: float = 30.0
-    bootstrap_servers: str | None = None
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
-    def __post_init__(self) -> None:
-        # `not isfinite(...)` guards NaN/inf, which slip past every `<= 0` comparison.
-        if not math.isfinite(self.heartbeat_interval) or self.heartbeat_interval <= 0:
-            raise ValueError(f"heartbeat_interval must be a finite number > 0, got {self.heartbeat_interval}")
-        if not math.isfinite(self.catchup_timeout) or self.catchup_timeout <= 0:
-            raise ValueError(f"catchup_timeout must be a finite number > 0, got {self.catchup_timeout}")
-        if self.stale_after is not None and (not math.isfinite(self.stale_after) or self.stale_after <= 0):
-            raise ValueError(f"stale_after must be a finite number > 0 or None, got {self.stale_after}")
+    heartbeat_interval: PositiveFiniteFloat = 30.0
+    stale_after: PositiveFiniteFloat | None = None
+    catchup_timeout: PositiveFiniteFloat = 30.0
+    bootstrap_servers: str | None = None
+    reader_tuning: KTableReaderTuning = Field(default_factory=KTableReaderTuning)

--- a/calfkit/controlplane/view.py
+++ b/calfkit/controlplane/view.py
@@ -27,6 +27,8 @@ from calfkit.exceptions import RegistryConfigError
 if TYPE_CHECKING:
     from ktables import TableStatus
 
+    from calfkit.tuning import KTableReaderTuning
+
 logger = logging.getLogger(__name__)
 
 R = TypeVar("R", bound=ControlPlaneRecord)
@@ -209,6 +211,7 @@ class ControlPlaneView(Generic[R]):
         catchup_timeout: float = 30.0,
         ensure_topic: bool = False,
         stale_after: float | None = None,
+        reader_tuning: KTableReaderTuning | None = None,
     ) -> ControlPlaneView[R]:  # pragma: no cover - exercised in the kafka lane
         """Open a view over a real ``GroupedKafkaTable``. The caller still awaits ``start()``."""
         from ktables import GroupedKafkaTable
@@ -219,5 +222,6 @@ class ControlPlaneView(Generic[R]):
             model=record_type,
             catchup_timeout=catchup_timeout,
             ensure_topic=ensure_topic,
+            **(reader_tuning.as_kwargs() if reader_tuning else {}),
         )
         return cls(table, record_type, stale_after=stale_after)

--- a/calfkit/nodes/_fanout_store.py
+++ b/calfkit/nodes/_fanout_store.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 from calfkit.models.error_report import FaultTypes
 from calfkit.models.fanout import EnvelopeSnapshot, FanoutBaseState, FanoutOpen, FanoutOutcome, FanoutState, SlotRef
+from calfkit.tuning import KTableReaderTuning
 
 if TYPE_CHECKING:
     from ktables import KafkaTable, KafkaTableWriter
@@ -267,14 +268,21 @@ class KtablesFanoutBatchStore:
     ``ensure_topic`` (spec §9) — no calfkit provisioner involvement.
     """
 
-    _BARRIER_TIMEOUT_S = 30.0
-
-    def __init__(self, *, bootstrap_servers: str, node_id: str, catchup_timeout: float | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        bootstrap_servers: str,
+        node_id: str,
+        reader_tuning: KTableReaderTuning | None = None,
+        catchup_timeout: float | None = None,
+        barrier_timeout: float = 30.0,
+    ) -> None:
         import ktables  # lazy: keep ktables off the offline import path (only a real store touches it)
 
+        self._barrier_timeout = barrier_timeout
         state_topic = f"calf.fanout.{node_id}.state"
         basestate_topic = f"calf.fanout.{node_id}.basestate"
-        reader_kwargs: dict[str, Any] = {"ensure_topic": True}
+        reader_kwargs: dict[str, Any] = {"ensure_topic": True, **(reader_tuning.as_kwargs() if reader_tuning else {})}
         if catchup_timeout is not None:
             reader_kwargs["catchup_timeout"] = catchup_timeout
         self._state_reader: KafkaTable[FanoutState] = ktables.KafkaTable.json(
@@ -308,7 +316,7 @@ class KtablesFanoutBatchStore:
         ``status == "failed"`` is terminal (raise); any other ``False`` (timeout / stop-race /
         snapshot-error / loading / degraded) is transient and retried — a persistently degraded
         table is an operational failure (spec §7), not a floor."""
-        while not await reader.barrier(timeout=self._BARRIER_TIMEOUT_S):
+        while not await reader.barrier(timeout=self._barrier_timeout):
             if reader.status == "failed":
                 raise FanoutStoreUnavailableError(f"fan-out table {reader.topic!r} reader died ({reader.failure!r})") from reader.failure
             logger.warning("fan-out table %r barrier not yet fresh (status=%s); retrying", reader.topic, reader.status)

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -108,7 +108,14 @@ class BaseAgentNodeDef(
             raise RuntimeError(
                 f"cannot derive Kafka bootstrap servers for fan-out agent {self.node_id!r}'s durable store (client built without connect()?)."
             )
-        store = KtablesFanoutBatchStore(bootstrap_servers=bootstrap, node_id=self.node_id)
+        fcfg = worker._fanout
+        store = KtablesFanoutBatchStore(
+            bootstrap_servers=bootstrap,
+            node_id=self.node_id,
+            reader_tuning=fcfg.reader_tuning,
+            catchup_timeout=fcfg.catchup_timeout,
+            barrier_timeout=fcfg.barrier_timeout,
+        )
         await store.start()
         try:
             yield store

--- a/calfkit/tuning.py
+++ b/calfkit/tuning.py
@@ -16,14 +16,29 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 
 #: A positive timeout in milliseconds. ``strict=True`` so a config knob is a real ``int`` —
 #: not a coerced ``bool`` (``True -> 1``), ``float`` (``5.0 -> 5``), or ``str`` (``"5" -> 5``).
 PositiveTimeoutMs = Annotated[int, Field(ge=1, strict=True)]
 
-#: A finite, strictly-positive timeout in seconds (rejects ``0``, negatives, ``inf``, ``nan``).
-PositiveFiniteFloat = Annotated[float, Field(gt=0, allow_inf_nan=False)]
+
+def _reject_non_number(value: object) -> object:
+    """Reject ``bool`` and non-numeric input before float coercion.
+
+    ``bool`` is an ``int`` subclass, so a flag mistaken for a timeout would otherwise coerce
+    (``True -> 1.0``); strings would coerce too (``"5" -> 5.0``). We still allow a plain ``int``
+    (``30 -> 30.0`` is the natural way to write a float default) — this keeps the float knobs in
+    parity with the strict int knobs, rejecting exactly what ``strict=True`` rejects bar ``int``.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("must be an int or float")
+    return value
+
+
+#: A finite, strictly-positive timeout in seconds. Accepts ``int``/``float``; rejects ``0``,
+#: negatives, ``inf``, ``nan``, ``bool``, and strings.
+PositiveFiniteFloat = Annotated[float, BeforeValidator(_reject_non_number), Field(gt=0, allow_inf_nan=False)]
 
 
 class KTableReaderTuning(BaseModel):
@@ -31,6 +46,11 @@ class KTableReaderTuning(BaseModel):
 
     ``None`` (the default for both) omits the knob so ktables applies its own default
     (``poll_timeout_ms=200``, ``fetch_max_wait_ms=500``).
+
+    Invariant: **every field on this model is a ktables reader-constructor kwarg.**
+    :meth:`as_kwargs` splats the whole (non-``None``) model into ``KafkaTable.json(...)`` /
+    ``GroupedKafkaTable.json(...)``, so do not add a field here that is not one — it would be
+    forwarded to ktables/aiokafka and fail far from its cause.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
@@ -61,4 +81,6 @@ class FanoutConfig(BaseModel):
     """Per-read ``barrier()`` timeout for the read-your-own-writes freshness wait."""
 
 
-__all__ = ["FanoutConfig", "KTableReaderTuning", "PositiveFiniteFloat", "PositiveTimeoutMs"]
+# `PositiveTimeoutMs` / `PositiveFiniteFloat` are field-constraint implementation detail (used
+# here and in `controlplane.config`), not public API — users construct configs with plain int/float.
+__all__ = ["FanoutConfig", "KTableReaderTuning"]

--- a/calfkit/tuning.py
+++ b/calfkit/tuning.py
@@ -16,29 +16,17 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field
 
-#: A positive timeout in milliseconds. ``strict=True`` so a config knob is a real ``int`` —
-#: not a coerced ``bool`` (``True -> 1``), ``float`` (``5.0 -> 5``), or ``str`` (``"5" -> 5``).
+#: A positive timeout in milliseconds. ``strict=True`` keeps it a real ``int`` — rejecting a
+#: coerced ``bool`` (``True``), ``float`` (``5.0``), or ``str`` (``"5"``).
 PositiveTimeoutMs = Annotated[int, Field(ge=1, strict=True)]
 
-
-def _reject_non_number(value: object) -> object:
-    """Reject ``bool`` and non-numeric input before float coercion.
-
-    ``bool`` is an ``int`` subclass, so a flag mistaken for a timeout would otherwise coerce
-    (``True -> 1.0``); strings would coerce too (``"5" -> 5.0``). We still allow a plain ``int``
-    (``30 -> 30.0`` is the natural way to write a float default) — this keeps the float knobs in
-    parity with the strict int knobs, rejecting exactly what ``strict=True`` rejects bar ``int``.
-    """
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        raise ValueError("must be an int or float")
-    return value
-
-
-#: A finite, strictly-positive timeout in seconds. Accepts ``int``/``float``; rejects ``0``,
-#: negatives, ``inf``, ``nan``, ``bool``, and strings.
-PositiveFiniteFloat = Annotated[float, BeforeValidator(_reject_non_number), Field(gt=0, allow_inf_nan=False)]
+#: A finite, strictly-positive timeout in seconds. Same ``strict=True`` pattern as
+#: :data:`PositiveTimeoutMs`: it rejects ``bool``/``str`` and (with ``allow_inf_nan=False``)
+#: ``inf``/``nan``/non-positive, while still accepting a plain ``int`` — pydantic coerces
+#: ``int -> float`` even under strict, so both ``30`` and ``30.0`` are valid.
+PositiveFiniteFloat = Annotated[float, Field(gt=0, allow_inf_nan=False, strict=True)]
 
 
 class KTableReaderTuning(BaseModel):

--- a/calfkit/tuning.py
+++ b/calfkit/tuning.py
@@ -44,10 +44,10 @@ class KTableReaderTuning(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     poll_timeout_ms: PositiveTimeoutMs | None = None
-    """Reader-loop ``getmany`` cadence; gates the barrier resolution half + idle CPU."""
+    """Reader-loop ``getmany`` cadence (**milliseconds**); gates the barrier resolution half + idle CPU."""
 
     fetch_max_wait_ms: PositiveTimeoutMs | None = None
-    """Consumer fetch long-poll; gates the barrier end-offset snapshot half."""
+    """Consumer fetch long-poll (**milliseconds**); gates the barrier end-offset snapshot half."""
 
     def as_kwargs(self) -> dict[str, Any]:
         """The set (non-``None``) knobs, ready to splat into a ktables ``*.json(...)`` factory."""
@@ -63,10 +63,10 @@ class FanoutConfig(BaseModel):
     """Cadence applied to the store's two compacted-table readers (``state`` + ``basestate``)."""
 
     catchup_timeout: PositiveFiniteFloat | None = None
-    """Bound on each reader's catch-up gate at ``start()``; ``None`` => ktables' default."""
+    """Bound (**seconds**) on each reader's catch-up gate at ``start()``; ``None`` => ktables' default."""
 
     barrier_timeout: PositiveFiniteFloat = 30.0
-    """Per-read ``barrier()`` timeout for the read-your-own-writes freshness wait."""
+    """Per-read ``barrier()`` timeout (**seconds**) for the read-your-own-writes freshness wait."""
 
 
 # `PositiveTimeoutMs` / `PositiveFiniteFloat` are field-constraint implementation detail (used

--- a/calfkit/tuning.py
+++ b/calfkit/tuning.py
@@ -1,0 +1,64 @@
+"""Worker-level tuning for the ktables-backed substrates (ADR-0021).
+
+`KTableReaderTuning` is the shared reader-cadence value object; `FanoutConfig` is the
+worker-level config for fan-out agents' durable batch stores. Both are passed to
+``Worker(...)`` (``fanout=``); see :class:`~calfkit.controlplane.ControlPlaneConfig` for the
+control-plane equivalent, which composes the same `KTableReaderTuning`.
+
+The two reader-cadence knobs are ktables `KafkaTable`/`GroupedKafkaTable` constructor
+parameters: lowering both cuts idle ``barrier()`` latency
+(``~ max(fetch_max_wait_ms, poll_timeout_ms)``) at the cost of more fetches/wakeups. ``None``
+means "omit it, let ktables apply its own default" — so ktables stays the single source of
+truth for the default value.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+#: A positive timeout in milliseconds. ``strict=True`` so a config knob is a real ``int`` —
+#: not a coerced ``bool`` (``True -> 1``), ``float`` (``5.0 -> 5``), or ``str`` (``"5" -> 5``).
+PositiveTimeoutMs = Annotated[int, Field(ge=1, strict=True)]
+
+#: A finite, strictly-positive timeout in seconds (rejects ``0``, negatives, ``inf``, ``nan``).
+PositiveFiniteFloat = Annotated[float, Field(gt=0, allow_inf_nan=False)]
+
+
+class KTableReaderTuning(BaseModel):
+    """Reader-cadence knobs for one ktables reader the worker opens (reader-only).
+
+    ``None`` (the default for both) omits the knob so ktables applies its own default
+    (``poll_timeout_ms=200``, ``fetch_max_wait_ms=500``).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    poll_timeout_ms: PositiveTimeoutMs | None = None
+    """Reader-loop ``getmany`` cadence; gates the barrier resolution half + idle CPU."""
+
+    fetch_max_wait_ms: PositiveTimeoutMs | None = None
+    """Consumer fetch long-poll; gates the barrier end-offset snapshot half."""
+
+    def as_kwargs(self) -> dict[str, Any]:
+        """The set (non-``None``) knobs, ready to splat into a ktables ``*.json(...)`` factory."""
+        return self.model_dump(exclude_none=True)
+
+
+class FanoutConfig(BaseModel):
+    """Worker-level tuning for fan-out agents' durable batch stores."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    reader_tuning: KTableReaderTuning = Field(default_factory=KTableReaderTuning)
+    """Cadence applied to the store's two compacted-table readers (``state`` + ``basestate``)."""
+
+    catchup_timeout: PositiveFiniteFloat | None = None
+    """Bound on each reader's catch-up gate at ``start()``; ``None`` => ktables' default."""
+
+    barrier_timeout: PositiveFiniteFloat = 30.0
+    """Per-read ``barrier()`` timeout for the read-your-own-writes freshness wait."""
+
+
+__all__ = ["FanoutConfig", "KTableReaderTuning", "PositiveFiniteFloat", "PositiveTimeoutMs"]

--- a/calfkit/worker/worker.py
+++ b/calfkit/worker/worker.py
@@ -16,6 +16,7 @@ from calfkit.models.capability import CAPABILITY_TOPIC, CAPABILITY_VIEW_RESOURCE
 from calfkit.models.tool_dispatch import ToolSelector
 from calfkit.nodes import BaseNodeDef
 from calfkit.provisioning import topics_for_nodes
+from calfkit.tuning import FanoutConfig
 from calfkit.worker.lifecycle import (
     PHASE_PAIRS,
     LifecycleContext,
@@ -69,6 +70,7 @@ class Worker(LifecycleHookMixin):
         id: str | None = None,
         name: str | None = None,
         control_plane: ControlPlaneConfig | None = None,
+        fanout: FanoutConfig | None = None,
     ):
         """Initialize a worker.
 
@@ -95,6 +97,9 @@ class Worker(LifecycleHookMixin):
                 whenever a hosted node declares an advert (``@advertises``), and
                 the MCP Capability View whenever a hosted agent declares MCP tool
                 selectors — both with these defaults, zero user wiring.
+            fanout: Optional tuning for fan-out agents' durable batch stores
+                (reader cadence, catch-up + barrier timeouts). Applied uniformly to
+                every fan-out agent this worker hosts. Entirely optional.
         """
         if id is not None and not id.strip():
             raise ValueError("id must be a non-empty string or None")
@@ -102,6 +107,7 @@ class Worker(LifecycleHookMixin):
             raise ValueError("name must be a non-empty string or None")
         self._client = client
         self._control_plane = control_plane if control_plane is not None else ControlPlaneConfig()
+        self._fanout = fanout if fanout is not None else FanoutConfig()
         self._max_workers = max_workers
         self._group_id = group_id
         self._extra_publish_kwargs = extra_publish_kwargs
@@ -209,6 +215,7 @@ class Worker(LifecycleHookMixin):
             # and a missing topic fails setup loudly.
             ensure_topic=self._client._provisioning.enabled,
             stale_after=cfg.stale_after,
+            reader_tuning=cfg.reader_tuning,
         )
         await view.start()
         yield view

--- a/docs/adr/0021-worker-level-ktable-reader-tuning.md
+++ b/docs/adr/0021-worker-level-ktable-reader-tuning.md
@@ -1,0 +1,62 @@
+---
+status: accepted
+---
+
+# Worker-level ktable reader tuning via a shared cadence value object
+
+calfkit opens [ktables](https://github.com/ryan-yuuu/ktables) readers for two substrates — the
+control-plane **capability view** (`ControlPlaneView` over a `GroupedKafkaTable`) and each
+fan-out agent's **durable batch store** (`KtablesFanoutBatchStore` over two `KafkaTable`s). Both
+ran at ktables' default reader cadence (`poll_timeout_ms=200`, `fetch_max_wait_ms=500`) with no
+way for a developer to change them. ktables' benchmark shows an idle `barrier()` costs
+`≈ max(fetch_max_wait_ms, poll_timeout_ms)` — ~500 ms by default, ~30 ms with both lowered —
+which lands directly in tool/MCP/agent-mesh discovery latency against the (quiet) capability view.
+
+This ADR records the decision to surface those two **reader-only** cadence knobs at the
+**worker level**, modeled as one shared value object **composed per subsystem**, and to make the
+ktables-backed configs Pydantic models.
+
+- `KTableReaderTuning(poll_timeout_ms, fetch_max_wait_ms)` — the cadence pair, defined and
+  validated once.
+- `ControlPlaneConfig` (existing, `Worker(control_plane=...)`) and the new `FanoutConfig`
+  (`Worker(fanout=...)`) each hold their **own** `reader_tuning: KTableReaderTuning`. A node
+  constructor never carries a ktable knob (config is a worker/deployment concern).
+
+## Notes
+
+- **Per-subsystem, not one worker-global instance.** The capability view is *quiet* (heartbeats
+  every `heartbeat_interval`, so an idle barrier sits on the ~500 ms floor) while the fan-out
+  `state` table *churns* during an aggregation (barriers already ~1 ms). Their optimal cadence is
+  opposite, so each composes its own tuning rather than sharing one knob.
+- **`None` means "ktables' default".** A `None` knob is omitted from the `*.json(...)` factory
+  call (`as_kwargs()` = `model_dump(exclude_none=True)`), so ktables stays the single source of
+  truth for the default value — no duplicated 200/500 to drift.
+- **Asymmetric siblings.** `ControlPlaneConfig` and `FanoutConfig` share only `reader_tuning`.
+  The control-plane config keeps `heartbeat_interval`/`stale_after`/`bootstrap_servers` (a
+  heartbeated, splittable presence plane); `FanoutConfig` has `barrier_timeout` (read-your-own-
+  writes) and no `bootstrap_servers` (fan-out tables ride the client's data cluster). Two configs
+  composing one cadence object, not one merged config.
+- **Two smells folded in.** `FanoutConfig` gives the fan-out store's previously *dead*
+  `catchup_timeout` constructor parameter a real source, and replaces its hardcoded
+  `_BARRIER_TIMEOUT_S = 30.0` with `barrier_timeout`.
+- **Pydantic, scoped to the ktables configs.** The three ktables-backed configs
+  (`KTableReaderTuning`, `FanoutConfig`, `ControlPlaneConfig`) are Pydantic `BaseModel`s
+  (`frozen=True, extra="forbid"`) with declarative constrained types
+  (`Field(ge=1, strict=True)` for the ms ints, `Field(gt=0, allow_inf_nan=False)` for the floats)
+  rather than stdlib dataclasses with hand-rolled `__post_init__`. This is the better-engineering
+  default ([engineering-over-legacy]); non-ktables configs (`ProvisioningConfig`, …) are out of
+  scope and unchanged.
+
+## Consequences
+
+- **Behavior-preserving at defaults.** With no config supplied, `as_kwargs()` is empty and
+  `barrier_timeout` is 30.0 — identical to the prior hardcoded behavior. An explicit
+  invariant test pins this.
+- **`ControlPlaneConfig` becomes keyword-only.** Converting it from a `@dataclass` to a
+  `BaseModel` means positional construction (`ControlPlaneConfig(30.0, …)`) no longer works;
+  the keyword form (`ControlPlaneConfig(heartbeat_interval=30.0, …)`) is the idiomatic one. A
+  clean pre-1.0 break, consistent with the project's hard-breaks-over-compat stance. Validation
+  failures raise `pydantic.ValidationError`, which subclasses `ValueError`, so existing
+  type-based `pytest.raises(ValueError)` still holds.
+- **New public surface.** `KTableReaderTuning` and `FanoutConfig` are exported from the top-level
+  `calfkit` package alongside `ControlPlaneConfig`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,6 +13,7 @@ from calfkit import (
     OpenAIModelClient, OpenAIResponsesModelClient, AnthropicModelClient,  # providers
     Worker, LifecycleContext, ResourceSetupContext, ServingContext,       # worker + lifecycle
     ProvisioningConfig,                                  # provisioning (config only)
+    KTableReaderTuning, FanoutConfig,                    # ktables tuning (config only)
     NodeFaultError, ErrorReport, FaultTypes,             # faults
     DeserializationError, LifecycleConfigError,          # exceptions
 )
@@ -84,6 +85,15 @@ The definition types that node authoring produces or builds on.
 | Symbol | Purpose |
 | --- | --- |
 | `ProvisioningConfig` | Opt-in configuration for best-effort Kafka topic auto-creation. The full provisioning surface lives at `calfkit.provisioning`. |
+
+### Ktables tuning
+
+Optional worker-level tuning for the ktables-backed substrates (the control-plane capability view and fan-out stores). All knobs default to ktables' own values, so omitting them changes nothing.
+
+| Symbol | Purpose |
+| --- | --- |
+| `KTableReaderTuning` | Reader-cadence knobs (`poll_timeout_ms`, `fetch_max_wait_ms`) for a ktables reader. Lower both to cut idle `barrier()` latency (`~ max(fetch_max_wait_ms, poll_timeout_ms)`). Composed by `ControlPlaneConfig` (view) and `FanoutConfig`. |
+| `FanoutConfig` | Worker-level tuning for fan-out agents' durable batch stores (reader cadence, catch-up + barrier timeouts). Passed as `Worker(fanout=...)`. |
 
 ### Exceptions
 

--- a/docs/designs/ktable-reader-tuning-spec.md
+++ b/docs/designs/ktable-reader-tuning-spec.md
@@ -1,0 +1,352 @@
+# Spec: worker-level ktable reader tuning (`KTableReaderTuning`, `FanoutConfig`)
+
+Status: **proposed** (design converged 2026-06-22). Pre-1.0, additive.
+
+## 1. Summary
+
+Surface ktables' two reader-cadence knobs — `poll_timeout_ms` and `fetch_max_wait_ms`
+— to developers at the **worker level**, for both ktables-backed substrates calfkit
+opens: the control-plane **capability view** and each fan-out agent's **durable
+batch store**.
+
+The restructure introduces one shared value object and one new worker-level config,
+and in doing so pays down two existing fan-out smells:
+
+- a new shared `KTableReaderTuning` (the reader-cadence pair, defined + validated once);
+- a new worker-level `FanoutConfig` (sibling to `ControlPlaneConfig`) that composes it
+  and additionally surfaces the fan-out store's **`catchup_timeout`** (currently a *dead*
+  constructor parameter) and **`barrier_timeout`** (currently the hardcoded
+  `_BARRIER_TIMEOUT_S = 30.0`).
+
+The developer surface is **worker-only**: node constructors (`Agent`, …) are untouched;
+the config is wired into each node's store internally at resource-open time.
+
+## 2. Motivation
+
+ktables' `REPORT.md` (finding #1) shows an idle `barrier()` costs
+`≈ max(fetch_max_wait_ms, poll_timeout_ms)` — ~500 ms at the stock 200/500 defaults,
+collapsing to ~30 ms when both are lowered, and to ~1 ms on a churning table. calfkit
+currently leaves both knobs at ktables' defaults **everywhere** and exposes neither.
+
+The capability view is the high-value target: it is quiet between heartbeats (default
+`heartbeat_interval = 30 s`) yet by-name tool / MCP / agent-mesh resolution does reads +
+`barrier()` against it, so the ~500 ms idle floor lands directly in discovery latency.
+The fan-out store's win is smaller (its `state` table churns during an aggregation → ~1 ms
+barriers already), but wiring it *properly* is the occasion to remove the two smells above.
+
+## 3. Goals / non-goals
+
+**Goals**
+
+- A single, validated definition of the reader-cadence knobs, composed by each
+  reader-owning subsystem (control plane, fan-out) — no duplication, no cross-subsystem
+  config reads.
+- Worker-level developer surface for both planes; node constructors unchanged.
+- Behavior-preserving at defaults (no config set ⇒ identical to today).
+- Fold the dead `catchup_timeout` param and the hardcoded `_BARRIER_TIMEOUT_S` into the
+  new `FanoutConfig`.
+
+**Non-goals**
+
+- Per-agent (node-constructor) tuning. Deliberately omitted — config is a
+  worker/deployment concern, not a node-definition concern.
+- Writer cadence / relaxing `enable_idempotence` (`acks=all`). Both planes hold
+  correctness-critical state; durability is not a knob.
+- Provisioning knobs (`num_partitions`, `topic_configs`) — governed by `ProvisioningConfig`
+  / ops, not here.
+- A `**kwargs` passthrough to aiokafka — ktables does not offer one.
+- Changing any default value. This change only adds the *ability* to set the knobs.
+- Migrating **non-ktables** configs to Pydantic. The Pydantic conversion is scoped to the
+  ktables-backed configs (`KTableReaderTuning`, `FanoutConfig`, `ControlPlaneConfig`).
+  `ProvisioningConfig` and the other stdlib `__post_init__` config dataclasses are **out of
+  scope** and left as-is — a separate concern, not a follow-up this change implies.
+
+## 4. Locked design decisions
+
+| # | Decision |
+|---|---|
+| D1 | The cadence pair lives in a shared frozen value object `KTableReaderTuning`. |
+| D2 | Each reader-owning subsystem **composes its own** instance (`ControlPlaneConfig.reader_tuning`, `FanoutConfig.reader_tuning`) — **not** one worker-global instance. Their workloads are opposite (quiet vs churning), so independent tuning is the correct default. |
+| D3 | Knob names mirror ktables 1:1 (`poll_timeout_ms`, `fetch_max_wait_ms`); no calfkit aliases. |
+| D4 | Default `None` ⇒ omit the kwarg ⇒ ktables owns the default value (single source of truth; no drift). |
+| D5 | `catchup_timeout` stays a **flat** field on each config (a boot-gate, conceptually distinct from steady-state cadence); it is **not** folded into `KTableReaderTuning`. |
+| D6 | `FanoutConfig` is a new worker-level arg `Worker(fanout=...)`, sibling to `control_plane=...`. |
+| D7 | The two configs are intentionally **not symmetric** — they share only `reader_tuning`. `ControlPlaneConfig` keeps `heartbeat_interval`/`stale_after`/`bootstrap_servers` (heartbeated, splittable presence plane); `FanoutConfig` has `barrier_timeout` (RYOW) and **no** `bootstrap_servers` (fan-out tables ride the client's data cluster, derived internally). |
+| D8 | **The three ktables configs are Pydantic `BaseModel`s (frozen, `extra="forbid"`), with declarative constrained types** — not stdlib `@dataclass` + hand-rolled `__post_init__`. This is the better engineering pattern (declarative validation, free error messages), adopted per the project's engineering-over-legacy priority. |
+| D9 | **Scope is the ktables-backed configs only:** `KTableReaderTuning`, `FanoutConfig`, and `ControlPlaneConfig` (the control plane and fan-out store are both ktables-backed). `ControlPlaneConfig` is **converted** as part of this change so the two sibling worker configs share one idiom. **Non-ktables configs are explicitly untouched** — `ProvisioningConfig` (Kafka topic provisioning) and the other `__post_init__` validators keep their current form; migrating them is a separate concern, *not* part of this change. |
+
+## 5. Public developer surface (the end state)
+
+```python
+from calfkit import Worker, ControlPlaneConfig, FanoutConfig, KTableReaderTuning
+
+worker = Worker(
+    client,
+    nodes=[...],
+    control_plane: ControlPlaneConfig | None = None,   # existing
+    fanout:        FanoutConfig       | None = None,    # NEW
+)
+```
+
+All three are Pydantic `BaseModel`s (frozen). Two shared constrained-type aliases carry the
+positivity/finiteness rules declaratively (defined once in `calfkit/tuning.py`):
+
+```python
+from typing import Annotated
+from pydantic import Field
+
+PositiveTimeoutMs   = Annotated[int,   Field(ge=1, strict=True)]          # reject bool/float/str coercion
+PositiveFiniteFloat = Annotated[float, Field(gt=0, allow_inf_nan=False)]  # reject 0 / -n / inf / nan
+```
+
+### `KTableReaderTuning` (new, shared)
+
+```python
+class KTableReaderTuning(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+    poll_timeout_ms:   PositiveTimeoutMs | None = None   # None -> ktables default (200 ms)
+    fetch_max_wait_ms: PositiveTimeoutMs | None = None   # None -> ktables default (500 ms)
+
+    def as_kwargs(self) -> dict[str, int]:
+        return self.model_dump(exclude_none=True)         # exactly the non-None cadence subset
+```
+
+### `ControlPlaneConfig` (existing — converted to BaseModel + one new field)
+
+```python
+class ControlPlaneConfig(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+    heartbeat_interval: PositiveFiniteFloat = 30.0
+    stale_after:        PositiveFiniteFloat | None = None
+    catchup_timeout:    PositiveFiniteFloat = 30.0
+    bootstrap_servers:  str | None = None
+    reader_tuning:      KTableReaderTuning = Field(default_factory=KTableReaderTuning)   # NEW (view cadence)
+```
+
+### `FanoutConfig` (new)
+
+```python
+class FanoutConfig(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+    reader_tuning:   KTableReaderTuning = Field(default_factory=KTableReaderTuning)   # the 2 store readers' cadence
+    catchup_timeout: PositiveFiniteFloat | None = None                               # was a DEAD ctor param -> now live
+    barrier_timeout: PositiveFiniteFloat = 30.0                                       # was hardcoded _BARRIER_TIMEOUT_S
+```
+
+### Worked examples
+
+```python
+# 1. Default — everything at ktables stock (200/500); identical to today.
+Worker(client, nodes=[agent])
+
+# 2. High-value: fast tool/MCP/mesh discovery (control plane only).
+Worker(client, nodes=[agent],
+    control_plane=ControlPlaneConfig(
+        reader_tuning=KTableReaderTuning(poll_timeout_ms=20, fetch_max_wait_ms=10),
+    ),
+)
+
+# 3. Both planes, tuned independently (opposite workloads).
+Worker(client, nodes=[fanout_agent],
+    control_plane=ControlPlaneConfig(
+        heartbeat_interval=10.0, stale_after=30.0,
+        reader_tuning=KTableReaderTuning(poll_timeout_ms=20, fetch_max_wait_ms=10),   # quiet -> low
+    ),
+    fanout=FanoutConfig(
+        barrier_timeout=10.0,
+        reader_tuning=KTableReaderTuning(fetch_max_wait_ms=50),                        # churns -> light touch
+    ),
+)
+```
+
+## 6. Internal data flow
+
+```
+developer ── Worker(control_plane=…, fanout=…)
+                │  stored as self._control_plane / self._fanout
+                ├─► _capability_view_resource ─► ControlPlaneView.open(reader_tuning=cfg.reader_tuning)
+                │        └─► GroupedKafkaTable.json(**reader_tuning.as_kwargs())
+                └─► (per fan-out agent) BaseAgentNodeDef._fanout_store_resource
+                         reads self._worker._fanout
+                         └─► KtablesFanoutBatchStore(reader_tuning=…, catchup_timeout=…, barrier_timeout=…)
+                                  └─► KafkaTable.json(**reader_tuning.as_kwargs(), …)  ×2 readers
+```
+
+The agent reaches its hosting worker via the existing back-reference `node._worker`
+(set in `Worker.register_handlers`, `worker.py:168`), the same seam
+`_fanout_store_resource` already uses for `_derive_bootstrap_servers()`. The config is
+read at **resource-open time** (worker boot), never at node construction — which is why
+it can be worker-level rather than a node-ctor arg.
+
+## 7. Module layout & exports
+
+New module **`calfkit/tuning.py`** holds `KTableReaderTuning`, `FanoutConfig`, and the two
+shared constrained-type aliases (`PositiveTimeoutMs`, `PositiveFiniteFloat`). The fan-out
+machinery itself lives in the *private* `calfkit/nodes/_fanout_store.py`, so its public
+config needs a public home. It is a leaf module (only `pydantic` + `typing`), so
+`controlplane/config.py` importing `KTableReaderTuning` + `PositiveFiniteFloat` from it
+introduces no cycle.
+
+`ControlPlaneConfig` **stays** in `calfkit/controlplane/config.py` (it configures the whole
+substrate, not just tuning; it is heavily referenced) but is **converted from a stdlib
+`@dataclass` to a Pydantic `BaseModel`** (frozen) and gains
+`reader_tuning: KTableReaderTuning`.
+
+Exports added to **`calfkit/__init__.py`** (next to `ControlPlaneConfig`):
+`KTableReaderTuning`, `FanoutConfig`.
+
+## 8. File-by-file change map
+
+1. **`calfkit/tuning.py`** *(new)* — the `PositiveTimeoutMs` / `PositiveFiniteFloat` aliases,
+   `KTableReaderTuning` (BaseModel + `as_kwargs()`), `FanoutConfig` (BaseModel). `__all__`.
+2. **`calfkit/controlplane/config.py`** — **convert `ControlPlaneConfig` from `@dataclass` to
+   `BaseModel`** (frozen): drop `__post_init__` + the `math` import, express the existing
+   positivity/finiteness rules via `PositiveFiniteFloat`, add the `reader_tuning` field
+   (import `KTableReaderTuning`, `PositiveFiniteFloat` from `calfkit.tuning`). Keep
+   `STALE_MULTIPLIER` and the docstring (extended).
+3. **`calfkit/controlplane/view.py`** (`ControlPlaneView.open`, ~`:202-223`) — add
+   `reader_tuning: KTableReaderTuning | None = None`; splat
+   `**(reader_tuning.as_kwargs() if reader_tuning else {})` into `GroupedKafkaTable.json`.
+4. **`calfkit/worker/worker.py`**
+   - `__init__` (~`:61-110`): add `fanout: FanoutConfig | None = None`; store
+     `self._fanout = fanout if fanout is not None else FanoutConfig()`.
+   - `_capability_view_resource` (~`:203-212`): pass `reader_tuning=cfg.reader_tuning`.
+5. **`calfkit/nodes/_fanout_store.py`** (`KtablesFanoutBatchStore`, ~`:255-345`)
+   - ctor: add `reader_tuning: KTableReaderTuning | None = None` and
+     `barrier_timeout: float = 30.0` (keep the existing `catchup_timeout`, now fed).
+     `reader_kwargs = {"ensure_topic": True, **(reader_tuning.as_kwargs() if reader_tuning else {})}`;
+     conditionally add `catchup_timeout`. Store `self._barrier_timeout`.
+   - delete the `_BARRIER_TIMEOUT_S` class constant; `_await_fresh` uses
+     `self._barrier_timeout`.
+6. **`calfkit/nodes/agent.py`** (`_fanout_store_resource`, ~`:95-116`) — read
+   `fcfg = worker._fanout`; pass `reader_tuning=fcfg.reader_tuning,
+   catchup_timeout=fcfg.catchup_timeout, barrier_timeout=fcfg.barrier_timeout`.
+7. **`calfkit/__init__.py`** — import + `__all__` for `KTableReaderTuning`, `FanoutConfig`.
+
+The `FanoutBatchStore` Protocol and `tests._fanout_fakes.FakeFanoutBatchStore` are
+**untouched** — tuning affects only the *real* store's construction, not the fold/close
+logic, so the offline (fake-backed) unit lane is unaffected.
+
+## 9. Validation (declarative, via constrained types)
+
+No `__post_init__`. Constraints are expressed on the field types and enforced by Pydantic
+at construction. Behavior **verified empirically against the installed pydantic 2.12.5**:
+
+- `PositiveTimeoutMs = Annotated[int, Field(ge=1, strict=True)]` — accepts `int >= 1`;
+  **rejects** `0`, negatives, and (because of `strict=True`) `bool` / `float` / `str`
+  coercion. *(Verified: lax `ge=1` would coerce `True -> 1` and `"5" -> 5`; `strict=True`
+  rejects them — the right contract for a config knob.)*
+- `PositiveFiniteFloat = Annotated[float, Field(gt=0, allow_inf_nan=False)]` — accepts
+  finite `> 0` (incl. an `int` like `30`, naturally coerced); **rejects** `0`, negatives,
+  `inf`, `nan`. *(Verified: this is an exact replacement for the old
+  `math.isfinite(x) and x > 0` guard — note plain `PositiveFloat` would let `inf` through.)*
+- `model_config = ConfigDict(frozen=True, extra="forbid")` makes each model
+  immutable/hashable (mutation raises `pydantic.ValidationError`) **and rejects unknown
+  field names** — so a typo like `ControlPlaneConfig(heatbeat_interval=10)` raises instead of
+  silently no-opping (Pydantic's default `extra="ignore"` would swallow it).
+- Nested defaults use `Field(default_factory=KTableReaderTuning)`; `reader_tuning`
+  validates recursively on construction.
+
+Failure mode: invalid construction raises `pydantic.ValidationError`, which **is a subclass
+of `ValueError`** in 2.12.5 *(verified)* — so existing `pytest.raises(ValueError)` assertions
+on `ControlPlaneConfig` keep passing; only assertions on the **message text** change.
+
+## 10. Behavior-preservation invariant
+
+With no config supplied, defaults must reproduce today's behavior exactly:
+
+- `ControlPlaneConfig().reader_tuning.as_kwargs() == {}` ⇒ view passes **no** cadence
+  kwargs ⇒ ktables defaults (200/500), as today.
+- `FanoutConfig().reader_tuning.as_kwargs() == {}` ⇒ store readers pass no cadence kwargs,
+  as today.
+- `FanoutConfig().catchup_timeout is None` ⇒ not passed ⇒ ktables default (30 s), as today.
+- `FanoutConfig().barrier_timeout == 30.0` ⇒ identical to the deleted
+  `_BARRIER_TIMEOUT_S = 30.0`.
+
+This invariant is asserted by an explicit test (§11).
+
+## 11. Test plan (TDD)
+
+New `tests/test_tuning.py` (all reject-cases assert `pydantic.ValidationError`):
+- `KTableReaderTuning`: `None`/`int >= 1` accepted; `0`/`-1`/`True`/`5.0`/`"5"` rejected
+  (strict int); `as_kwargs()` returns only the non-`None` subset and `== {}` at defaults;
+  frozen (mutation raises).
+- `FanoutConfig`: `catchup_timeout` `None`/finite `>0` (rejects `0`/`-1`/`inf`/`nan`);
+  `barrier_timeout` finite `>0`; defaults (`reader_tuning` empty, `catchup_timeout is None`,
+  `barrier_timeout == 30.0`); frozen.
+
+Extend existing suites (offline; patch the ktables factories — no broker):
+- `tests/test_controlplane_config.py`: `reader_tuning` default + type; the now-`BaseModel`
+  reject-cases still satisfy `pytest.raises(ValueError)` (ValidationError ⊂ ValueError), but
+  any assertions on the **message text** are updated to Pydantic's format.
+- `tests/test_controlplane_view.py` (or a wiring test): `ControlPlaneView.open` splats
+  `reader_tuning.as_kwargs()` into a spy `GroupedKafkaTable.json`; default ⇒ no cadence
+  kwargs. (This also covers the currently `# pragma: no cover` `open()`.)
+- `tests/test_controlplane_worker_wiring.py` / `test_worker_capability_view.py`:
+  `_capability_view_resource` forwards `cfg.reader_tuning`; `Worker(fanout=...)` stored,
+  defaults to `FanoutConfig()`.
+- `tests/test_fanout_store.py`: `KtablesFanoutBatchStore` forwards `reader_tuning.as_kwargs()`
+  + `catchup_timeout` to **both** readers (patch `ktables.KafkaTable.json` /
+  `KafkaTableWriter.json`); `_await_fresh` calls `reader.barrier(timeout=barrier_timeout)`.
+- An agent-resource test: `_fanout_store_resource` reads `worker._fanout` and passes the
+  three pieces (patch `KtablesFanoutBatchStore`).
+- **Behavior-preservation test** (§10): default configs ⇒ no cadence kwargs reach ktables,
+  `barrier_timeout == 30.0`.
+
+Regression (must stay green): the offline fold/close suites over the fake, and the
+kafka-lane `test_durable_fanout_e2e.py` + capability-view kafka tests (unchanged at
+defaults). Latency itself is **ktables'** benchmark to prove — calfkit does not re-measure
+it; at most a kafka-lane smoke that a tuned view/store still starts.
+
+## 12. Docs
+
+- `docs/dev/control-plane-substrate.md`: add `ControlPlaneConfig.reader_tuning` + the
+  `max(fmw, poll)` idle-barrier note.
+- A config/tuning reference (new or in the control-plane doc): the full surface from §5,
+  incl. `FanoutConfig` + `KTableReaderTuning`, with the "tune the quiet plane, leave the
+  churning one" guidance.
+- `docs/api.md`: add the two new public types.
+- Review (do not necessarily edit) the in-node fan-out spec passages that call
+  `_BARRIER_TIMEOUT_S` hardcoded and "ops out of scope" — now configurable via
+  `FanoutConfig`; note the drift.
+
+## 13. ADR
+
+Add **ADR-0021 — "Worker-level ktable reader tuning via a shared cadence value object."**
+Captures: (a) reader cadence is a cross-cutting concern modeled as one `KTableReaderTuning`
+composed per-subsystem (not global, not per-node); (b) `FanoutConfig` as a worker-level
+sibling to `ControlPlaneConfig`; (c) node constructors stay free of ktable knobs;
+(d) surfacing the previously-dead `catchup_timeout` and hardcoded barrier timeout;
+(e) the ktables-backed configs are Pydantic `BaseModel`s with declarative constrained
+types (engineering-over-legacy), scoped to the ktables configs only — non-ktables configs
+(`ProvisioningConfig`, …) are untouched. Status **proposed**, flips to **accepted** on merge
+(per repo convention).
+
+## 14. Build order
+
+Two stacked PRs (one logical change; split along the high-value/low-risk seam):
+
+- **PR1 — control plane / view.** `calfkit/tuning.py` (`KTableReaderTuning`) +
+  `ControlPlaneConfig.reader_tuning` + `view.open` + `_capability_view_resource` + exports +
+  tests + docs + ADR-0021 (describing the whole shape). Independently shippable; delivers
+  the high-value win.
+- **PR2 — fan-out.** Add `FanoutConfig` to `calfkit/tuning.py` + `Worker(fanout=...)` +
+  store ctor (`reader_tuning` / `barrier_timeout`, `catchup_timeout` now fed) + agent
+  resource + delete `_BARRIER_TIMEOUT_S` + tests + docs. Pays down the two debt items.
+
+(May also land as a single PR; the two-PR stack keeps review surfaces small and lets the
+view ship without waiting on the fan-out wiring.)
+
+## 15. Risks
+
+- **Behavior drift at defaults** — guarded by the §10 invariant + test. None expected.
+- **Public surface addition** — additive, non-breaking; pre-1.0.
+- **`ControlPlaneConfig` dataclass → BaseModel conversion** — two behavior changes to audit:
+  (1) **keyword-only construction** — Pydantic `BaseModel` does not accept positional args,
+  so any positional `ControlPlaneConfig(30.0, …)` in code or tests must become keyword
+  (the one production site, `worker.py:104`, is `ControlPlaneConfig()` — safe; audit tests).
+  (2) **exception text** — reject-cases raise `ValidationError` (⊂ `ValueError`, so
+  `pytest.raises(ValueError)` survives; message-text assertions update).
+- **Coverage** — `ControlPlaneView.open` was `# pragma: no cover`; the new spy test covers
+  the forwarding path (net coverage gain).
+

--- a/docs/dev/control-plane-substrate.md
+++ b/docs/dev/control-plane-substrate.md
@@ -138,6 +138,15 @@ so a consumer can wait for the log to replay before its first read, and it passe
 through the table's `status`/`failure` so a degraded reader is *observable*
 rather than silently serving an empty map.
 
+The reader's **cadence is tunable** for latency. An idle `barrier()` costs roughly
+`max(fetch_max_wait_ms, poll_timeout_ms)` — ~500 ms at ktables' defaults, ~30 ms with both
+lowered — which matters because by-name tool/MCP/agent-mesh resolution barriers against this
+(usually quiet) view. Pass
+`ControlPlaneConfig(reader_tuning=KTableReaderTuning(poll_timeout_ms=…, fetch_max_wait_ms=…))`
+to trade more broker fetches for a lower idle-barrier floor. Both knobs default to `None`
+(ktables' own defaults), so the substrate is unchanged unless you opt in. The same
+`KTableReaderTuning` tunes fan-out stores via `Worker(fanout=FanoutConfig(reader_tuning=…))`.
+
 ## The worker drives liveness; the node owns content
 
 The publisher is **worker-owned** — one loop and one tombstone pass per worker,

--- a/tests/_fanout_fakes.py
+++ b/tests/_fanout_fakes.py
@@ -76,7 +76,15 @@ class OfflineFanoutBatchStore(FakeFanoutBatchStore):
     in-memory store has no cluster to reach.
     """
 
-    def __init__(self, *, bootstrap_servers: str, node_id: str, catchup_timeout: float | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        bootstrap_servers: str,
+        node_id: str,
+        reader_tuning: object | None = None,
+        catchup_timeout: float | None = None,
+        barrier_timeout: float = 30.0,
+    ) -> None:
         super().__init__()
 
     async def start(self) -> None:

--- a/tests/test_controlplane_config.py
+++ b/tests/test_controlplane_config.py
@@ -1,11 +1,11 @@
 """Unit tests for ControlPlaneConfig (spec §11, plan §3.3)."""
 
-import dataclasses
-
 import pytest
+from pydantic import ValidationError
 
 from calfkit.controlplane import ControlPlaneConfig
 from calfkit.controlplane.config import STALE_MULTIPLIER
+from calfkit.tuning import KTableReaderTuning
 
 
 def test_defaults() -> None:
@@ -45,8 +45,28 @@ def test_positive_stale_after_allowed() -> None:
 
 def test_is_frozen() -> None:
     cfg = ControlPlaneConfig()
-    with pytest.raises(dataclasses.FrozenInstanceError):
+    with pytest.raises(ValidationError):
         cfg.heartbeat_interval = 10.0  # type: ignore[misc]
+
+
+def test_reader_tuning_defaults_to_empty() -> None:
+    assert ControlPlaneConfig().reader_tuning == KTableReaderTuning()
+
+
+def test_accepts_reader_tuning() -> None:
+    cfg = ControlPlaneConfig(reader_tuning=KTableReaderTuning(poll_timeout_ms=20, fetch_max_wait_ms=10))
+    assert cfg.reader_tuning.as_kwargs() == {"poll_timeout_ms": 20, "fetch_max_wait_ms": 10}
+
+
+def test_reader_tuning_is_validated() -> None:
+    # Nested validation: a bad cadence value is rejected when built from a dict.
+    with pytest.raises(ValidationError):
+        ControlPlaneConfig(reader_tuning={"poll_timeout_ms": 0})
+
+
+def test_forbids_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        ControlPlaneConfig(heatbeat_interval=10.0)  # typo must raise, not silently no-op
 
 
 def test_rejects_nonfinite_fields() -> None:

--- a/tests/test_fanout_tuning.py
+++ b/tests/test_fanout_tuning.py
@@ -1,0 +1,172 @@
+"""Wiring tests for fan-out ktable tuning (spec §11, plan §3.5, ADR-0021).
+
+Covers ``Worker(fanout=...)`` storage, ``KtablesFanoutBatchStore`` forwarding the cadence/
+catch-up knobs to its two readers and using ``barrier_timeout``, and the agent resource
+threading ``worker._fanout`` into the store. The real store is exercised offline by patching
+the ktables ``KafkaTable``/``KafkaTableWriter`` factories.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from calfkit.client.client import Client
+from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
+from calfkit.tuning import FanoutConfig, KTableReaderTuning
+from calfkit.worker.worker import Worker
+
+
+class _FakeModel(PydanticModelClient):
+    @property
+    def model_name(self) -> str:
+        return "fake"
+
+    @property
+    def system(self) -> str:
+        return "fake"
+
+    async def request(self, *args: object, **kwargs: object) -> object:
+        raise NotImplementedError
+
+
+class FakeKafkaTable:
+    """Records the kwargs passed to ``KafkaTable.json`` and the barrier timeout used."""
+
+    instances: list[FakeKafkaTable] = []
+
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self.status = "ready"
+        self.topic = kwargs.get("topic")
+        self.barrier_timeouts: list[float | None] = []
+        FakeKafkaTable.instances.append(self)
+
+    @classmethod
+    def json(cls, *, model: object, **kwargs: object) -> FakeKafkaTable:
+        return cls(model=model, **kwargs)
+
+    async def barrier(self, timeout: float | None = None) -> bool:
+        self.barrier_timeouts.append(timeout)
+        return True
+
+    def get(self, key: str) -> None:
+        return None
+
+    async def start(self) -> None: ...
+
+    async def stop(self) -> None: ...
+
+
+class FakeKafkaTableWriter:
+    instances: list[FakeKafkaTableWriter] = []
+
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        FakeKafkaTableWriter.instances.append(self)
+
+    @classmethod
+    def json(cls, *, model: object = None, **kwargs: object) -> FakeKafkaTableWriter:
+        return cls(model=model, **kwargs)
+
+    async def start(self) -> None: ...
+
+    async def stop(self) -> None: ...
+
+
+@pytest.fixture
+def fake_ktables(monkeypatch: pytest.MonkeyPatch) -> None:
+    FakeKafkaTable.instances = []
+    FakeKafkaTableWriter.instances = []
+    monkeypatch.setattr("ktables.KafkaTable", FakeKafkaTable)
+    monkeypatch.setattr("ktables.KafkaTableWriter", FakeKafkaTableWriter)
+
+
+def _store(**kwargs: object):
+    from calfkit.nodes._fanout_store import KtablesFanoutBatchStore
+
+    return KtablesFanoutBatchStore(bootstrap_servers="kafka:9092", node_id="agent1", **kwargs)
+
+
+# ── Worker(fanout=) storage ───────────────────────────────────────────────────
+
+
+def test_worker_stores_fanout_config() -> None:
+    cfg = FanoutConfig(barrier_timeout=5.0)
+    worker = Worker(Client.connect("kafka:9092"), fanout=cfg)
+    assert worker._fanout is cfg
+
+
+def test_worker_fanout_defaults_when_omitted() -> None:
+    worker = Worker(Client.connect("kafka:9092"))
+    assert worker._fanout == FanoutConfig()
+
+
+# ── KtablesFanoutBatchStore construction ──────────────────────────────────────
+
+
+def test_store_forwards_reader_tuning_to_both_readers(fake_ktables: None) -> None:
+    _store(reader_tuning=KTableReaderTuning(poll_timeout_ms=20, fetch_max_wait_ms=10))
+    assert len(FakeKafkaTable.instances) == 2  # state + basestate readers
+    for reader in FakeKafkaTable.instances:
+        assert reader.kwargs["poll_timeout_ms"] == 20
+        assert reader.kwargs["fetch_max_wait_ms"] == 10
+
+
+def test_store_forwards_catchup_timeout_to_both_readers(fake_ktables: None) -> None:
+    _store(catchup_timeout=7.0)
+    for reader in FakeKafkaTable.instances:
+        assert reader.kwargs["catchup_timeout"] == 7.0
+
+
+def test_store_default_omits_cadence_and_catchup(fake_ktables: None) -> None:
+    _store()
+    for reader in FakeKafkaTable.instances:
+        assert "poll_timeout_ms" not in reader.kwargs
+        assert "fetch_max_wait_ms" not in reader.kwargs
+        assert "catchup_timeout" not in reader.kwargs
+
+
+async def test_await_fresh_uses_configured_barrier_timeout(fake_ktables: None) -> None:
+    store = _store(barrier_timeout=9.0)
+    await store.read_state("X")  # _await_fresh barriers the state reader before reading
+    assert store._state_reader.barrier_timeouts == [9.0]
+
+
+async def test_await_fresh_default_barrier_timeout_is_30(fake_ktables: None) -> None:
+    store = _store()
+    await store.read_state("X")
+    assert store._state_reader.barrier_timeouts == [30.0]  # behavior-preserving (was _BARRIER_TIMEOUT_S)
+
+
+# ── agent resource threads worker._fanout into the store ──────────────────────
+
+
+async def test_fanout_resource_passes_worker_fanout(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class SpyStore:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        async def start(self) -> None: ...
+
+        async def stop(self) -> None: ...
+
+    monkeypatch.setattr("calfkit.nodes.agent.KtablesFanoutBatchStore", SpyStore)
+
+    from calfkit.nodes.agent import Agent
+
+    agent = Agent("a", subscribe_topics="a.in", model_client=_FakeModel())
+    worker = Worker(
+        Client.connect("kafka:9092"),
+        nodes=[agent],
+        fanout=FanoutConfig(reader_tuning=KTableReaderTuning(poll_timeout_ms=5), catchup_timeout=7.0, barrier_timeout=9.0),
+    )
+    agent._worker = worker  # the back-reference the resource reads
+    gen = agent._fanout_store_resource(None)  # type: ignore[arg-type]
+    await anext(gen)
+    assert captured["reader_tuning"].poll_timeout_ms == 5  # type: ignore[attr-defined]
+    assert captured["catchup_timeout"] == 7.0
+    assert captured["barrier_timeout"] == 9.0
+    with pytest.raises(StopAsyncIteration):
+        await anext(gen)

--- a/tests/test_fanout_tuning.py
+++ b/tests/test_fanout_tuning.py
@@ -126,6 +126,14 @@ def test_store_default_omits_cadence_and_catchup(fake_ktables: None) -> None:
         assert "catchup_timeout" not in reader.kwargs
 
 
+def test_store_forwards_a_single_set_knob(fake_ktables: None) -> None:
+    # Partial tuning: exactly the set knob is forwarded; the unset one is omitted.
+    _store(reader_tuning=KTableReaderTuning(fetch_max_wait_ms=10))
+    for reader in FakeKafkaTable.instances:
+        assert reader.kwargs["fetch_max_wait_ms"] == 10
+        assert "poll_timeout_ms" not in reader.kwargs
+
+
 async def test_await_fresh_uses_configured_barrier_timeout(fake_ktables: None) -> None:
     store = _store(barrier_timeout=9.0)
     await store.read_state("X")  # _await_fresh barriers the state reader before reading
@@ -168,5 +176,27 @@ async def test_fanout_resource_passes_worker_fanout(monkeypatch: pytest.MonkeyPa
     assert captured["reader_tuning"].poll_timeout_ms == 5  # type: ignore[attr-defined]
     assert captured["catchup_timeout"] == 7.0
     assert captured["barrier_timeout"] == 9.0
+    with pytest.raises(StopAsyncIteration):
+        await anext(gen)
+
+
+async def test_fanout_resource_boots_through_offline_store_mirror() -> None:
+    # No SpyStore re-patch here: the autouse `_offline_fanout_store` fixture swaps in the real
+    # `OfflineFanoutBatchStore`, so this exercises its signature mirror — it must accept the new
+    # kwargs the resource now passes (`reader_tuning`/`catchup_timeout`/`barrier_timeout`), or
+    # construction raises `TypeError`. This makes the fake's "loud failure on drift" claim real.
+    from calfkit.nodes.agent import Agent
+    from tests._fanout_fakes import OfflineFanoutBatchStore
+
+    agent = Agent("a", subscribe_topics="a.in", model_client=_FakeModel())
+    worker = Worker(
+        Client.connect("kafka:9092"),
+        nodes=[agent],
+        fanout=FanoutConfig(reader_tuning=KTableReaderTuning(poll_timeout_ms=5), catchup_timeout=7.0, barrier_timeout=9.0),
+    )
+    agent._worker = worker
+    gen = agent._fanout_store_resource(None)  # type: ignore[arg-type]
+    store = await anext(gen)
+    assert isinstance(store, OfflineFanoutBatchStore)
     with pytest.raises(StopAsyncIteration):
         await anext(gen)

--- a/tests/test_tuning.py
+++ b/tests/test_tuning.py
@@ -1,0 +1,113 @@
+"""Unit tests for the ktables tuning configs (spec §9/§11, plan §3.2).
+
+`KTableReaderTuning` (the shared reader-cadence pair) and `FanoutConfig` (the worker-level
+fan-out store config), both Pydantic models with declarative constrained types.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from calfkit.tuning import FanoutConfig, KTableReaderTuning
+
+
+def test_top_level_exports() -> None:
+    import calfkit
+
+    assert calfkit.KTableReaderTuning is KTableReaderTuning
+    assert calfkit.FanoutConfig is FanoutConfig
+
+
+# ── KTableReaderTuning ────────────────────────────────────────────────────────
+
+
+def test_reader_tuning_defaults_are_none() -> None:
+    t = KTableReaderTuning()
+    assert t.poll_timeout_ms is None
+    assert t.fetch_max_wait_ms is None
+
+
+def test_as_kwargs_empty_at_defaults() -> None:
+    # None => omit => ktables owns the default (behavior-preserving).
+    assert KTableReaderTuning().as_kwargs() == {}
+
+
+def test_as_kwargs_returns_only_the_set_subset() -> None:
+    assert KTableReaderTuning(poll_timeout_ms=20).as_kwargs() == {"poll_timeout_ms": 20}
+    assert KTableReaderTuning(poll_timeout_ms=20, fetch_max_wait_ms=10).as_kwargs() == {
+        "poll_timeout_ms": 20,
+        "fetch_max_wait_ms": 10,
+    }
+
+
+def test_reader_tuning_accepts_positive_int() -> None:
+    assert KTableReaderTuning(poll_timeout_ms=1, fetch_max_wait_ms=500).poll_timeout_ms == 1
+
+
+@pytest.mark.parametrize("bad", [0, -1])
+def test_reader_tuning_rejects_nonpositive(bad: int) -> None:
+    with pytest.raises(ValidationError):
+        KTableReaderTuning(poll_timeout_ms=bad)
+    with pytest.raises(ValidationError):
+        KTableReaderTuning(fetch_max_wait_ms=bad)
+
+
+@pytest.mark.parametrize("bad", [True, 5.0, "5"])
+def test_reader_tuning_is_strict_int(bad: object) -> None:
+    # strict=True: a config knob must be a real int, not a coerced bool/float/str.
+    with pytest.raises(ValidationError):
+        KTableReaderTuning(poll_timeout_ms=bad)
+
+
+def test_reader_tuning_is_frozen() -> None:
+    t = KTableReaderTuning()
+    with pytest.raises(ValidationError):
+        t.poll_timeout_ms = 10  # type: ignore[misc]
+
+
+def test_reader_tuning_forbids_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        KTableReaderTuning(pol_timeout_ms=20)  # typo must raise, not silently no-op
+
+
+# ── FanoutConfig ──────────────────────────────────────────────────────────────
+
+
+def test_fanout_config_defaults() -> None:
+    c = FanoutConfig()
+    assert c.reader_tuning == KTableReaderTuning()
+    assert c.reader_tuning.as_kwargs() == {}
+    assert c.catchup_timeout is None
+    assert c.barrier_timeout == 30.0
+
+
+def test_fanout_config_accepts_tuning_and_timeouts() -> None:
+    c = FanoutConfig(
+        reader_tuning=KTableReaderTuning(fetch_max_wait_ms=50),
+        catchup_timeout=10.0,
+        barrier_timeout=5.0,
+    )
+    assert c.reader_tuning.fetch_max_wait_ms == 50
+    assert c.catchup_timeout == 10.0
+    assert c.barrier_timeout == 5.0
+
+
+@pytest.mark.parametrize("bad", [0, -1.0, float("inf"), float("nan")])
+def test_fanout_config_rejects_bad_catchup_timeout(bad: float) -> None:
+    with pytest.raises(ValidationError):
+        FanoutConfig(catchup_timeout=bad)
+
+
+@pytest.mark.parametrize("bad", [0, -1.0, float("inf"), float("nan")])
+def test_fanout_config_rejects_bad_barrier_timeout(bad: float) -> None:
+    with pytest.raises(ValidationError):
+        FanoutConfig(barrier_timeout=bad)
+
+
+def test_fanout_config_catchup_timeout_none_allowed() -> None:
+    assert FanoutConfig(catchup_timeout=None).catchup_timeout is None
+
+
+def test_fanout_config_is_frozen() -> None:
+    c = FanoutConfig()
+    with pytest.raises(ValidationError):
+        c.barrier_timeout = 10.0  # type: ignore[misc]

--- a/tests/test_tuning.py
+++ b/tests/test_tuning.py
@@ -91,16 +91,22 @@ def test_fanout_config_accepts_tuning_and_timeouts() -> None:
     assert c.barrier_timeout == 5.0
 
 
-@pytest.mark.parametrize("bad", [0, -1.0, float("inf"), float("nan")])
-def test_fanout_config_rejects_bad_catchup_timeout(bad: float) -> None:
+@pytest.mark.parametrize("bad", [0, -1.0, float("inf"), float("nan"), True, "5"])
+def test_fanout_config_rejects_bad_catchup_timeout(bad: object) -> None:
     with pytest.raises(ValidationError):
         FanoutConfig(catchup_timeout=bad)
 
 
-@pytest.mark.parametrize("bad", [0, -1.0, float("inf"), float("nan")])
-def test_fanout_config_rejects_bad_barrier_timeout(bad: float) -> None:
+@pytest.mark.parametrize("bad", [0, -1.0, float("inf"), float("nan"), True, "5"])
+def test_fanout_config_rejects_bad_barrier_timeout(bad: object) -> None:
+    # `True`/`"5"` must NOT silently coerce to a number — parity with the strict int knobs.
     with pytest.raises(ValidationError):
         FanoutConfig(barrier_timeout=bad)
+
+
+def test_fanout_config_accepts_int_for_float_field() -> None:
+    # ...but a plain int IS a natural way to write a float timeout.
+    assert FanoutConfig(barrier_timeout=5).barrier_timeout == 5.0
 
 
 def test_fanout_config_catchup_timeout_none_allowed() -> None:

--- a/tests/test_worker_capability_view.py
+++ b/tests/test_worker_capability_view.py
@@ -182,6 +182,28 @@ class TestCapabilityViewResource:
         assert fake_table.instances[0].kwargs["ensure_topic"] is True
         await close(gen)
 
+    async def test_reader_tuning_forwarded_to_table(self, fake_table: type[FakeGroupedTable]) -> None:
+        from calfkit.tuning import KTableReaderTuning
+
+        worker = Worker(
+            Client.connect("kafka:9092"),
+            control_plane=ControlPlaneConfig(reader_tuning=KTableReaderTuning(poll_timeout_ms=20, fetch_max_wait_ms=10)),
+        )
+        gen, _ = await drive(worker)
+        kwargs = fake_table.instances[0].kwargs
+        assert kwargs["poll_timeout_ms"] == 20
+        assert kwargs["fetch_max_wait_ms"] == 10
+        await close(gen)
+
+    async def test_reader_tuning_default_omits_cadence(self, fake_table: type[FakeGroupedTable]) -> None:
+        # Behavior-preserving: no tuning set => no cadence kwargs reach ktables (its defaults apply).
+        worker = Worker(Client.connect("kafka:9092"))
+        gen, _ = await drive(worker)
+        kwargs = fake_table.instances[0].kwargs
+        assert "poll_timeout_ms" not in kwargs
+        assert "fetch_max_wait_ms" not in kwargs
+        await close(gen)
+
 
 class TestRegisterHandlersIdempotency:
     def test_second_call_is_a_guarded_no_op(self) -> None:


### PR DESCRIPTION
## What

Surfaces ktables' two reader-cadence knobs — `poll_timeout_ms` and `fetch_max_wait_ms` — to developers at the **worker level**, for both ktables-backed substrates: the control-plane **capability view** and each fan-out agent's **durable batch store**. Modeled as one shared `KTableReaderTuning` value object **composed per subsystem**.

Per the [ktables benchmark](https://github.com/ryan-yuuu/ktables), an idle `barrier()` costs `≈ max(fetch_max_wait_ms, poll_timeout_ms)` (~500 ms at defaults, ~30 ms tuned), which lands directly in tool/MCP/agent-mesh discovery latency against the (quiet) capability view.

Design: `docs/designs/ktable-reader-tuning-spec.md` · decision record: `docs/adr/0021-worker-level-ktable-reader-tuning.md`.

## Developer surface

```python
from calfkit import Worker, ControlPlaneConfig, FanoutConfig, KTableReaderTuning

Worker(client, nodes=[...],
    control_plane=ControlPlaneConfig(reader_tuning=KTableReaderTuning(poll_timeout_ms=20, fetch_max_wait_ms=10)),
    fanout=FanoutConfig(barrier_timeout=10.0, reader_tuning=KTableReaderTuning(fetch_max_wait_ms=50)),
)
```

Node constructors are untouched — config stays a worker concern, wired into each node's store internally at boot.

## Changes

- **New `calfkit.tuning`** — `KTableReaderTuning` (shared cadence pair + `as_kwargs()`) and `FanoutConfig` (`Worker(fanout=...)`), both Pydantic `BaseModel`s (`frozen=True, extra="forbid"`) with declarative constrained types. Exported top-level.
- **`ControlPlaneConfig`** converted to a `BaseModel`; gains `reader_tuning`, wired into the capability-view reader.
- **Fan-out store** gains `reader_tuning` + `barrier_timeout`; the agent resource threads `worker._fanout` in. Folds in the previously **dead** `catchup_timeout` param and replaces the hardcoded `_BARRIER_TIMEOUT_S`.
- **Per-subsystem composition** (not one worker-global knob): the control plane is quiet (benefits from low cadence) while a fan-out `state` table churns (already ~1 ms), so they tune independently.

## Behavior-preserving at defaults

`None` ⇒ the knob is omitted ⇒ ktables applies its own default (200/500); `barrier_timeout` defaults to 30.0 (== the old constant). Pinned by tests: default `as_kwargs() == {}` reaches ktables, default barrier 30.0.

## Breaking change

`ControlPlaneConfig` is now a Pydantic `BaseModel`, hence **keyword-only** — positional `ControlPlaneConfig(30.0, …)` no longer works (the idiomatic keyword form is unchanged). Validation raises `pydantic.ValidationError` (a `ValueError` subclass, so existing `pytest.raises(ValueError)` still holds). No positional construction exists in the codebase.

## Verification

- TDD throughout (red → green per step). New: `tests/test_tuning.py`, `tests/test_fanout_tuning.py`; extended config/view-wiring suites.
- Full offline suite: **3267 passed, 6 skipped** (no regression; +46 tests).
- `make check` (ruff + format + mypy) clean.
- Kafka lane (`-m kafka`) not run locally (needs a broker) — changes are behavior-preserving at defaults; CI covers it.

Scope note: the Pydantic conversion is **scoped to the ktables-backed configs only** (`KTableReaderTuning`, `FanoutConfig`, `ControlPlaneConfig`). `ProvisioningConfig` and other `__post_init__` configs are intentionally untouched.