### PR TITLE
test(perf): parallelize the kafka integration test lane on a shared broker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,14 +70,21 @@ jobs:
         # Non-coverage entries run the offline suite only (FunctionModel +
         # in-memory TestKafkaBroker; the default `-m "not kafka and not live"`),
         # needing no Docker, network, or credentials. The coverage entry (3.10)
-        # also runs the real-broker `kafka` lane in the SAME process —
-        # `-m "not live"` overrides the default deselection — so the uploaded
-        # coverage is the union of both; Redpanda comes from testcontainers
-        # (ADR 0007). The live model-API lane runs separately (integration-live.yml).
+        # also runs the real-broker `kafka` lane (Redpanda via testcontainers,
+        # ADR 0007) as a SECOND pytest run whose coverage is appended
+        # (`--cov-append`) to the offline run's, so the uploaded number stays the
+        # union of both. That kafka run is parallel (`-n auto` on ONE shared
+        # broker) and scoped to `tests/integration` so the xdist controller
+        # registers the shared-broker hook (see tests/integration/conftest.py).
+        # Broker size/worker count are env-tunable (CALF_TEST_REDPANDA_SMP/_MEMORY,
+        # KAFKA_XDIST) if a runner contends. The live lane runs separately
+        # (integration-live.yml).
         run: |
           if [ "${{ matrix.python-version }}" = "3.10" ]; then
-            uv run pytest tests/ -v --tb=short --timeout=180 -m "not live" \
-              --cov=calfkit --cov-report=term-missing --cov-report=xml
+            uv run pytest tests/ -m "not kafka and not live" --tb=short --timeout=180 \
+              --cov=calfkit --cov-report=
+            uv run --group integration pytest tests/integration -m kafka -n auto --tb=short --timeout=180 \
+              --cov=calfkit --cov-append --cov-report=term-missing --cov-report=xml
           else
             uv run pytest tests/ -v --tb=short
           fi

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help:
 	@echo "    make format-check - Check code formatting (ruff format --check)"
 	@echo "    make type-check   - Run type checker (mypy)"
 	@echo "    make test         - Run tests (pytest; opt-in kafka + live lanes deselected)"
-	@echo "    make test-kafka   - Run real-broker tests only (needs Docker; -m kafka)"
+	@echo "    make test-kafka   - Run real-broker tests in parallel (needs Docker; -m kafka; KAFKA_XDIST=N)"
 	@echo "    make test-live    - Run live model-API tests only (needs OPENAI_API_KEY + TEST_LLM_MODEL_NAME; -m live)"
 	@echo ""
 	@echo "  Fixes:"
@@ -50,9 +50,15 @@ test:
 	@echo "Running tests (opt-in 'kafka' and 'live' lanes deselected by default)..."
 	@uv run pytest tests/ -v
 
+# Real-broker lane runs in parallel on ONE shared Redpanda by default. Override the worker
+# count with KAFKA_XDIST (e.g. `make test-kafka KAFKA_XDIST=4`; KAFKA_XDIST=0 runs serially).
+# Broker config is env-overridable: CALF_TEST_KAFKA_BOOTSTRAP (reuse an external broker, no
+# container), CALF_TEST_REDPANDA_IMAGE, CALF_TEST_REDPANDA_SMP, CALF_TEST_REDPANDA_MEMORY.
+KAFKA_XDIST ?= auto
+
 test-kafka:
-	@echo "Running real-broker (Redpanda) tests... (requires Docker)"
-	@uv run --group integration pytest -m kafka -v --timeout=120
+	@echo "Running real-broker (Redpanda) tests... (requires Docker; -n $(KAFKA_XDIST))"
+	@uv run --group integration pytest tests/integration -m kafka -n $(KAFKA_XDIST) --timeout=120
 
 test-live:
 	@echo "Running live model-API tests... (requires OPENAI_API_KEY + TEST_LLM_MODEL_NAME)"

--- a/docs/designs/kafka-lane-parallelization-spec.md
+++ b/docs/designs/kafka-lane-parallelization-spec.md
@@ -1,0 +1,210 @@
+# Spec: parallelize the real-broker (`kafka`) integration lane
+
+Status: **proposed** (design converged 2026-06-22). Test-infrastructure change; no production
+code changes.
+
+## 1. Summary
+
+Run the real-broker (`kafka`) integration tests **in parallel against one shared Redpanda
+broker** via `pytest-xdist`, and apply a **preset low-latency ktable config** to the
+capability-plane suites. Target: cut the lane from **~3m41s serial** toward **well under a
+minute**.
+
+The per-test `topic_namespace` fixture — plus the unique, namespaced node names/ids and
+namespace-filtered assertions the suite **already** uses to coexist on one session broker —
+makes the tests safe to run concurrently on a single broker. No test rewrites are needed.
+
+## 2. Baseline & motivation
+
+Measured (`pytest -m kafka --durations`, 2026-06-22): **65 passed, 6 skipped, 221.65s
+(3m41s)**, serial. Slowest single test 14.8s; flat distribution (most 3–8s multi-hop
+round-trips) — the profile where parallelism dominates. The broker is already well-tuned
+(testcontainers runs Redpanda `--mode dev-container --smp 1 --memory 1G`, session-scoped), so
+the time is in **serial execution** + **per-test round-trip / convergence latency**, not
+container churn.
+
+Two levers: **(1) parallelism** (dominant) and **(2) per-test ktable convergence latency**
+(now tunable since the worker-level reader-tuning shipped in #277).
+
+## 3. Goals / non-goals
+
+**Goals**
+- Run the lane in parallel on **one** shared broker; `pytest -m kafka -n auto` works standalone.
+- Broker config (image / smp / memory) and worker count are **env/CLI-overridable**.
+- Preserve the existing `CALF_TEST_KAFKA_BOOTSTRAP` external-broker path and the graceful
+  Docker-absent skip.
+- Cut per-test convergence latency with a shared low-latency ktable test config.
+- Zero change to what the tests assert.
+
+**Non-goals**
+- Rewriting tests or namespacing `CAPABILITY_TOPIC` (not needed — see §5; the suite already
+  coexists on the shared `calf.capabilities` topic).
+- The offline lane (already ~9s) or any production code.
+- CI runner sizing (ops concern; the lane just needs to *support* parallelism).
+
+## 4. Locked design decisions
+
+| # | Decision |
+|---|---|
+| D1 | `pytest-xdist`; one Redpanda shared across all workers. |
+| D2 | Shared-broker lifecycle via the **xdist controller hook** (`pytest_configure_node` injects the bootstrap address into each worker's `workerinput`; `pytest_unconfigure` tears the container down). Race-free, no file-lock / ref-count. The non-xdist path starts its own container (today's behavior). `CALF_TEST_KAFKA_BOOTSTRAP` short-circuits both. |
+| D3 | Broker config is **env-overridable**: image, smp, memory (via a thin `RedpandaContainer` subclass overriding `tc_start()`, since upstream hardcodes `--smp 1 --memory 1G`). Worker count via a Makefile var → `-n`. |
+| D4 | A **preset low-latency ktable config** fixture (`reader_tuning` poll=20ms/fetch=10ms + `heartbeat_interval=0.1`) replaces the discovery/MCP suites' `heartbeat_interval=5.0` + default-cadence configs. |
+| D5 | **No preemptive capability isolation.** The suite already coexists on `calf.capabilities` (unique namespaced node names + namespace-filtered enumeration assertions); parallelize and verify empirically, fixing only what actually flakes. |
+
+## 5. Why the shared `calf.capabilities` topic is already safe (and what to watch)
+
+`calf.capabilities` (`CAPABILITY_TOPIC`) is a fixed, cluster-wide topic — **not** covered by
+`topic_namespace`. Under parallelism, every test's tool records land there and every agent's
+view reads the whole topic. A test would break **only** if it asserted over the *whole plane*
+("exactly N tools total", "snapshot length", "plane empty"). Verified (2026-06-22) that the
+suite does **not**:
+- `test_discover_mode_kafka` filters discover results to its own namespace
+  (`mine = {n for n in pov if n.startswith(topic_namespace)}`), and its docstring explicitly
+  notes other suites' tools coexist on the shared broker.
+- `test_controlplane_substrate_kafka` uses `f"{topic_namespace}.presence"`, not the global topic.
+- Fan-out tests key on namespaced node_ids (`calf.fanout.{topic_namespace}-…`).
+- No unfiltered whole-plane count assertions exist.
+
+This is unsurprising: the lane already shares one **session** broker across all serial tests, so
+the authors already had to make tests coexist (records linger until compaction). Parallelism
+just makes coexistence concurrent. **To watch:** `test_fanout_store_kafka.py:40` has a bare
+`node_id="n"` (the real test cases use `f"{topic_namespace}-n"`); confirm it's a helper default
+and namespace it if a real construction uses it.
+
+## 6. The shared-broker mechanism (`tests/integration/conftest.py`)
+
+Three-way resolution — external env > xdist-shared > local single — with the container owned by
+the xdist controller:
+
+```python
+# xdist controller, once per worker node: start ONE Redpanda, hand its address to each worker.
+def pytest_configure_node(node):
+    if os.getenv("CALF_TEST_KAFKA_BOOTSTRAP"):
+        return  # external broker; nothing to start
+    node.workerinput["calf_kafka_bootstrap"] = _ensure_shared_redpanda(node.config)  # start-once, cached on config; None if Docker absent
+
+def pytest_unconfigure(config):  # controller: stop the shared container if we started one
+    _stop_shared_redpanda(config)
+
+@pytest.fixture(scope="session")
+def kafka_bootstrap(request) -> Iterator[str]:
+    if (ext := os.getenv("CALF_TEST_KAFKA_BOOTSTRAP")):
+        yield ext; return
+    wi = getattr(request.config, "workerinput", None)
+    if wi is not None and "calf_kafka_bootstrap" in wi:           # xdist worker
+        addr = wi["calf_kafka_bootstrap"]
+        if addr is None:
+            pytest.skip("Docker not available for the shared Redpanda testcontainer")
+        yield addr; return
+    # not under xdist (-n0 / plain pytest): own a single container (today's path)
+    with _redpanda_container() as addr:
+        yield addr
+```
+
+- `_ensure_shared_redpanda(config)` is idempotent: start the container once, cache it on
+  `config`, return the bootstrap (or `None` on `DockerException` so each worker skips cleanly).
+- The controller process lives for the whole session, so the container stays up until
+  `pytest_unconfigure`.
+- `pytest_configure_node` is an xdist-only hook — harmless/uncalled when `-n` is absent, so the
+  fixture's last branch preserves today's single-container behavior for plain `pytest`. It is
+  declared with `@pytest.hookimpl(optionalhook=True)` so a plain (xdist-less) run doesn't trip
+  pytest's unknown-hook validation.
+- **The run must be scoped to `tests/integration`** (`make test-kafka` / `pytest tests/integration
+  -m kafka …`). `pytest_configure_node` is a *controller*-only hook, and the controller only loads
+  conftests on the invocation's path; a bare `pytest -m kafka` from the repo root would load this
+  conftest in the *workers* (during collection) but never in the controller, so the hook would
+  never fire and every test would skip. The fixture detects the resulting missing `workerinput`
+  key (vs a `None` address) and skips with an actionable message.
+- **Guard:** `pytest_configure_node` starts the broker only when the marker expression actually
+  selects `kafka` (`"kafka" in markexpr and "not kafka" not in markexpr`), so a future *offline*
+  parallel run (`pytest tests/ -n auto`, which loads this conftest and deselects kafka) does not
+  wastefully spin up Redpanda.
+
+**Measured (M3 Pro, 11 cores):** 221s serial → **~31–36s at `-n auto`** (≈6.2×), stable across
+3 runs, 0 leaked containers, with `_DEFAULT_SMP=2` / `_DEFAULT_MEMORY=2G`.
+
+## 7. Env-overridable broker config (`RedpandaContainer` subclass)
+
+Upstream `RedpandaContainer.tc_start()` hardcodes `--mode dev-container --smp 1 --memory 1G`. A
+thin subclass overrides just that line to read env values:
+
+```python
+class _TunedRedpanda(RedpandaContainer):
+    def tc_start(self) -> None:
+        smp    = os.getenv("CALF_TEST_REDPANDA_SMP", _DEFAULT_SMP)
+        memory = os.getenv("CALF_TEST_REDPANDA_MEMORY", _DEFAULT_MEMORY)
+        ...  # the upstream tc_start template with {smp}/{memory} substituted
+```
+
+Public knobs (all optional; defaults preserve a working lane):
+
+| Env var | Default | Tunes |
+|---|---|---|
+| `CALF_TEST_KAFKA_BOOTSTRAP` | unset | reuse an external broker (no container) — existing |
+| `CALF_TEST_REDPANDA_IMAGE` | the pinned `…/redpanda:v26.1.10` | image override |
+| `CALF_TEST_REDPANDA_SMP` | `2` | Redpanda CPU cores |
+| `CALF_TEST_REDPANDA_MEMORY` | `2G` | Redpanda memory |
+
+Worker count is a CLI/Makefile concern (not an env knob): `make test-kafka KAFKA_XDIST=auto`
+(default) → `pytest -n $(KAFKA_XDIST)`. Defaults (`smp=2`, `memory=2G`, `-n auto`) are a starting
+point — **tuned empirically** during impl against the measured numbers, since parallelism shifts
+the bottleneck from serial execution to broker throughput (N workers vs Redpanda's core/memory).
+
+## 8. Preset low-latency ktable config
+
+A shared fixture/factory in the integration conftest, so the cadence lives in one place:
+
+```python
+@pytest.fixture
+def fast_control_plane():
+    def _make(bootstrap: str, **overrides) -> ControlPlaneConfig:
+        return ControlPlaneConfig(
+            reader_tuning=KTableReaderTuning(poll_timeout_ms=20, fetch_max_wait_ms=10),
+            heartbeat_interval=0.1, bootstrap_servers=bootstrap, **overrides,
+        )
+    return _make
+```
+
+Applied to the discovery/MCP suites that currently build
+`ControlPlaneConfig(heartbeat_interval=5.0, …)` (e.g. `test_discover_mode_kafka`,
+`test_tool_discovery_kafka`, `test_mcp_roundtrip_kafka`). Records then converge in tens of ms
+instead of being gated by the ~500ms idle-barrier floor + 5s heartbeat. Behavior is unchanged —
+only faster. (Fan-out tests barrier against a churning store, already ~1ms — left as-is.)
+
+## 9. Makefile
+
+`test-kafka` gains `-n $(KAFKA_XDIST)` (default `auto`); the help text documents the env knobs
+from §7. The external-broker and `-n0` (serial) invocations remain valid.
+
+## 10. Verification
+
+- `make test-kafka` (parallel) run **3–5×** → all green, no flakes; record wall-clock vs the
+  221s baseline.
+- `make test-kafka KAFKA_XDIST=0` (serial / non-xdist path) → green.
+- `CALF_TEST_KAFKA_BOOTSTRAP=<addr> make test-kafka` → uses the external broker, starts no
+  container.
+- No Docker → lane skips cleanly (controller-hook → `None` → per-worker skip).
+- Tune `smp`/`memory`/`-n` empirically; record the chosen defaults. Audit `node_id="n"`.
+
+## 11. Risks
+
+- **Broker contention** under N workers → mitigated by the smp/memory bump + worker-count
+  tuning; the defaults are a starting point, measured during impl.
+- **Latent shared-state flakes** → mitigated by multi-run verification; the suite already
+  coexists on the shared topics by design (§5).
+- **Docker-absent under xdist** → handled by the `None`-sentinel skip path (§6).
+- **`tc_start` override drift** vs upstream testcontainers → small, pinned dependency; acceptable,
+  and isolated to one method.
+- **CI**: the kafka CI job must invoke the parallel form and have a runner with enough cores to
+  benefit (ops; out of scope here, but flagged).
+
+## 12. Build order
+
+1. Add `pytest-xdist` to the `integration` dependency group.
+2. Env-overridable broker config: the `_TunedRedpanda` subclass + image/smp/memory env knobs.
+3. The shared-broker controller-hook fixture (§6); verify `-n auto`, `-n0`, external-broker, and
+   no-Docker paths.
+4. The `fast_control_plane` fixture; apply to the discovery/MCP suites.
+5. Makefile `-n $(KAFKA_XDIST)` + help/docs.
+6. Empirical verification (multi-run, measure, tune defaults, fix any straggler).

--- a/docs/designs/kafka-lane-parallelization-spec.md
+++ b/docs/designs/kafka-lane-parallelization-spec.md
@@ -1,7 +1,7 @@
 # Spec: parallelize the real-broker (`kafka`) integration lane
 
-Status: **proposed** (design converged 2026-06-22). Test-infrastructure change; no production
-code changes.
+Status: **accepted** — implemented in PR #278 (2026-06-22). Test-infrastructure change; no
+production code changes.
 
 ## 1. Summary
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,5 +132,6 @@ examples = [
     "websockets>=16.0",
 ]
 integration = [
+    "pytest-xdist>=3.6",
     "testcontainers[kafka]>=4.14.2",
 ]

--- a/tests/integration/_kafka_helpers.py
+++ b/tests/integration/_kafka_helpers.py
@@ -1,0 +1,29 @@
+"""Shared non-fixture helpers for the real-broker (``kafka``) integration lane.
+
+The lane's *fixtures* (``kafka_bootstrap``, ``topic_namespace``) live in ``conftest.py``; this
+module is the single home for plain helper functions shared across the discovery/MCP suites
+(mirroring ``_roundtrip_helpers.py``, which is scoped to the offline model/history helpers).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from calfkit.controlplane import ControlPlaneConfig
+from calfkit.tuning import KTableReaderTuning
+
+
+def fast_control_plane(bootstrap: str, **overrides: Any) -> ControlPlaneConfig:
+    """The standard control-plane config for the kafka lane, tuned for low convergence latency.
+
+    Lowers the ktables reader cadence (poll/fetch) and the heartbeat so capability records become
+    visible in tens of ms instead of being gated by the ~500ms idle-``barrier()`` floor + a slow
+    heartbeat — which shortens the discovery/MCP round-trip tests. Behaviour is unchanged, only
+    faster. ``overrides`` pass through to :class:`~calfkit.controlplane.ControlPlaneConfig`.
+    """
+    return ControlPlaneConfig(
+        reader_tuning=KTableReaderTuning(poll_timeout_ms=20, fetch_max_wait_ms=10),
+        heartbeat_interval=0.1,
+        bootstrap_servers=bootstrap,
+        **overrides,
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,24 +1,31 @@
 """Shared fixtures for the real-broker (``kafka``) integration lane.
 
-Tests in this lane are marked ``@pytest.mark.kafka`` and exercise a REAL
-Kafka-protocol broker (Redpanda). They are OPT-IN: ``addopts`` in
-``pyproject.toml`` deselects ``kafka`` by default, so a bare ``pytest`` /
-``make test`` never needs Docker. Run them with ``-m kafka`` / ``make
-test-kafka``.
+Tests in this lane are marked ``@pytest.mark.kafka`` and exercise a REAL Kafka-protocol broker
+(Redpanda). They are OPT-IN: ``addopts`` in ``pyproject.toml`` deselects ``kafka`` by default,
+so a bare ``pytest`` / ``make test`` never needs Docker. Run them with ``make test-kafka``
+(parallel by default; ``make test-kafka KAFKA_XDIST=0`` for serial).
 
 Broker source, in priority order:
 
-1. ``CALF_TEST_KAFKA_BOOTSTRAP`` — if set, reuse that already-running broker
-   (a CI services container, a local ``rpk``/Redpanda, etc.). No container is
-   started and the suite owns no lifecycle. This mirrors the env-var contract
-   the topic-provisioning lane already uses, so one address works everywhere.
-2. Otherwise a single-node Redpanda is started for the test session via
-   testcontainers and torn down at session end.
+1. ``CALF_TEST_KAFKA_BOOTSTRAP`` — if set, reuse that already-running broker (a CI services
+   container, a local ``rpk``/Redpanda, etc.). No container is started and the suite owns no
+   lifecycle.
+2. Under ``pytest-xdist`` (``-n`` > 0): the xdist **controller** starts ONE Redpanda for the
+   whole run (:func:`pytest_configure_node`) and hands its bootstrap address to every worker via
+   ``workerinput``, so all workers share one broker. It is torn down once, in the controller, by
+   :func:`pytest_unconfigure`. The per-test ``topic_namespace`` keeps concurrent tests isolated.
+   NOTE: :func:`pytest_configure_node` is a controller-only hook, so the run must be scoped to
+   this directory (``pytest tests/integration …`` / ``make test-kafka``) for the controller to
+   load this conftest — a bare ``pytest -m kafka`` from the repo root would not register it.
+3. Otherwise (plain ``pytest`` / ``-n0``): a single Redpanda is started for the session and torn
+   down at session end (the original path).
 
-When testcontainers is not installed, or Docker is not reachable, the lane
-SKIPS cleanly rather than erroring — ``-m kafka`` degrades gracefully on a
-machine without Docker. A broker that *is* reachable but fails for any other
-reason propagates as a real error (no silent green).
+Broker config is env-overridable (all optional): ``CALF_TEST_REDPANDA_IMAGE`` /
+``CALF_TEST_REDPANDA_SMP`` / ``CALF_TEST_REDPANDA_MEMORY``.
+
+When testcontainers is not installed, or Docker is not reachable, the lane SKIPS cleanly rather
+than erroring. A broker that *is* reachable but fails for any other reason propagates as a real
+error (no silent green).
 """
 
 from __future__ import annotations
@@ -26,44 +33,144 @@ from __future__ import annotations
 import os
 import uuid
 from collections.abc import Iterator
+from textwrap import dedent
+from typing import Any
 
 import pytest
 
-# A current, pinned Redpanda image. testcontainers' RedpandaContainer otherwise
-# defaults to a stale 2023 tag (v23.1.13); pin a recent release for parity with
-# the broker operators actually run. Bump this deliberately.
-_REDPANDA_IMAGE = "docker.redpanda.com/redpandadata/redpanda:v26.1.10"
+# A current, pinned Redpanda image (testcontainers otherwise defaults to a stale 2023 tag).
+# Overridable via CALF_TEST_REDPANDA_IMAGE; bump this deliberately.
+_DEFAULT_REDPANDA_IMAGE = "docker.redpanda.com/redpandadata/redpanda:v26.1.10"
+# Redpanda dev-container resources. Defaults bumped above testcontainers' --smp 1 --memory 1G for
+# the parallel load; overridable per environment (laptop vs CI) via the env vars below.
+_DEFAULT_SMP = "2"
+_DEFAULT_MEMORY = "2G"
+
+# Distinguishes "the controller never injected an address" (wrong invocation — see below) from
+# "address is None" (Docker/testcontainers absent).
+_UNSET = object()
+
+
+def _make_tuned_container() -> Any:
+    """Build (unstarted) a Redpanda testcontainer with env-overridable image/smp/memory.
+
+    Upstream ``RedpandaContainer.tc_start`` hardcodes ``--smp 1 --memory 1G``; subclass to
+    substitute env values into the otherwise-identical start command. testcontainers is imported
+    lazily so a machine without the ``integration`` extra skips rather than erroring at import.
+    """
+    from testcontainers.kafka import RedpandaContainer
+
+    image = os.getenv("CALF_TEST_REDPANDA_IMAGE", _DEFAULT_REDPANDA_IMAGE)
+    smp = os.getenv("CALF_TEST_REDPANDA_SMP", _DEFAULT_SMP)
+    memory = os.getenv("CALF_TEST_REDPANDA_MEMORY", _DEFAULT_MEMORY)
+
+    class _TunedRedpanda(RedpandaContainer):
+        # Mirrors upstream RedpandaContainer.tc_start, parametrizing --smp/--memory.
+        def tc_start(self) -> None:
+            host = self.get_container_host_ip()
+            port = self.get_exposed_port(self.redpanda_port)
+            data = (
+                dedent(
+                    f"""
+                    #!/bin/bash
+                    /usr/bin/rpk redpanda start --mode dev-container --smp {smp} --memory {memory} \
+                    --kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092  \
+                    --advertise-kafka-addr PLAINTEXT://127.0.0.1:29092,OUTSIDE://{host}:{port}
+                    """
+                )
+                .strip()
+                .encode("utf-8")
+            )
+            self.create_file(data, RedpandaContainer.TC_START_SCRIPT)
+
+    return _TunedRedpanda(image)
+
+
+def _ensure_shared_broker(config: pytest.Config) -> str | None:
+    """Start ONE shared Redpanda (idempotent; cached on ``config``); ``None`` if unavailable.
+
+    Returns the bootstrap address, or ``None`` when testcontainers/Docker is absent (so workers
+    skip). A start failure for any *other* reason propagates (no silent green).
+    """
+    existing = getattr(config, "_calf_shared_redpanda", None)
+    if existing is not None:
+        return existing.get_bootstrap_server()  # type: ignore[no-any-return]
+    try:
+        from docker.errors import DockerException
+
+        container = _make_tuned_container()
+    except ImportError:
+        return None  # the `integration` extra is not installed
+    try:
+        container.start()
+    except DockerException:
+        return None  # Docker daemon absent / unreachable
+    config._calf_shared_redpanda = container  # type: ignore[attr-defined]
+    return container.get_bootstrap_server()  # type: ignore[no-any-return]
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_configure_node(node: Any) -> None:
+    """xdist controller hook: start one shared broker and inject its address into each worker.
+
+    ``optionalhook=True`` so a plain (xdist-less) run does not trip pytest's unknown-hook
+    validation. Runs once per worker node in the controller; the container is started on the
+    first call and cached, so every worker receives the same broker.
+    """
+    if os.getenv("CALF_TEST_KAFKA_BOOTSTRAP"):
+        return  # external broker; nothing to start
+    markexpr = node.config.getoption("markexpr", default="") or ""
+    if "kafka" not in markexpr or "not kafka" in markexpr:
+        return  # the kafka lane isn't selected — don't start a broker for an unrelated parallel run
+    node.workerinput["calf_kafka_bootstrap"] = _ensure_shared_broker(node.config)
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    """Stop the shared container iff THIS process (the controller) started one."""
+    container = getattr(config, "_calf_shared_redpanda", None)
+    if container is not None:
+        container.stop()
+        config._calf_shared_redpanda = None  # type: ignore[attr-defined]
 
 
 @pytest.fixture(scope="session")
-def kafka_bootstrap() -> Iterator[str]:
-    """Bootstrap address of a live broker, shared across the test session.
-
-    See the module docstring for the broker-source resolution order. Yields the
-    ``host:port`` string callers pass to ``Client.connect`` / admin clients.
-    """
+def kafka_bootstrap(request: pytest.FixtureRequest) -> Iterator[str]:
+    """Bootstrap address of a live broker. See the module docstring for the resolution order."""
     external = os.getenv("CALF_TEST_KAFKA_BOOTSTRAP")
     if external:
         yield external
         return
 
-    # testcontainers ships RedpandaContainer under its ``kafka`` module (NOT
-    # ``testcontainers.redpanda``). importorskip turns a missing optional
-    # dependency into a clean skip instead of a collection error.
-    kafka_module = pytest.importorskip(
+    workerinput = getattr(request.config, "workerinput", None)
+    if workerinput is not None:
+        # Under xdist: the controller started one shared broker (pytest_configure_node) and
+        # injected its address here. A MISSING key means the controller never loaded THIS conftest
+        # — i.e. the lane was run without its directory path, so the controller-only hook was never
+        # registered. Surface that as an actionable message rather than a confusing "no broker".
+        addr = workerinput.get("calf_kafka_bootstrap", _UNSET)
+        if addr is _UNSET:
+            pytest.skip(
+                "shared broker not started under xdist — run the lane scoped to its directory so the "
+                "controller registers the broker hook: `make test-kafka` (or "
+                "`pytest tests/integration -m kafka -n auto`)"
+            )
+        if addr is None:
+            pytest.skip("Docker/testcontainers not available for the shared Redpanda testcontainer")
+        yield addr
+        return
+
+    # Plain pytest / -n0: own a single container for this session (the original path).
+    pytest.importorskip(
         "testcontainers.kafka",
         reason="testcontainers not installed; run `uv sync --group integration`",
     )
-    # docker-py is a hard dependency of testcontainers, so it is importable here.
     from docker.errors import DockerException
 
     try:
-        container = kafka_module.RedpandaContainer(_REDPANDA_IMAGE)
+        container = _make_tuned_container()
         container.start()
     except DockerException as exc:
-        # Docker daemon absent / unreachable: skip rather than fail the lane.
         pytest.skip(f"Docker not available for Redpanda testcontainer: {exc}")
-
     try:
         yield container.get_bootstrap_server()
     finally:
@@ -74,9 +181,8 @@ def kafka_bootstrap() -> Iterator[str]:
 def topic_namespace() -> str:
     """A unique, collision-free prefix for one test's topics and consumer groups.
 
-    Tests in this lane share one session broker (and reruns hit the same broker
-    when ``CALF_TEST_KAFKA_BOOTSTRAP`` points at a persistent one), so derive
-    every topic and consumer-group name from this prefix to avoid cross-test
-    bleed and leftover-state flakes.
+    Tests in this lane share one broker, so derive every topic and consumer-group name from this
+    prefix to avoid cross-test bleed and leftover-state flakes — and to stay isolated when the
+    lane runs in parallel under ``pytest-xdist``.
     """
     return f"calf-test-{uuid.uuid4().hex[:8]}"

--- a/tests/integration/test_discover_mode_kafka.py
+++ b/tests/integration/test_discover_mode_kafka.py
@@ -37,6 +37,7 @@ from calfkit.controlplane import ControlPlaneConfig, ControlPlaneView
 from calfkit.models.capability import CAPABILITY_TOPIC, CapabilityRecord
 from calfkit.nodes import Agent, ToolNodeDef, Tools, agent_tool
 from calfkit.worker import Worker
+from tests.integration._kafka_helpers import fast_control_plane
 from tests.integration._roundtrip_helpers import FINAL_OUTPUT, capturing_model, tool_returns
 
 # Every test here needs a real broker. FunctionModel is offline, but pydantic-ai still
@@ -45,10 +46,6 @@ pytestmark = pytest.mark.kafka
 models.ALLOW_MODEL_REQUESTS = True
 
 _EARLIEST = {"auto_offset_reset": "earliest"}
-
-
-def _control_plane(bootstrap: str) -> ControlPlaneConfig:
-    return ControlPlaneConfig(heartbeat_interval=5.0, bootstrap_servers=bootstrap)
 
 
 def _worker(bootstrap: str, *, nodes: list, control_plane: ControlPlaneConfig) -> Worker:
@@ -110,7 +107,7 @@ async def test_discover_finds_all_separately_deployed_tool_nodes(kafka_bootstrap
     mul_name = f"{topic_namespace}-mul"
     agent_id = f"{topic_namespace}-disc-all"
     agent_in = f"{topic_namespace}.disc-all.input"
-    control_plane = _control_plane(kafka_bootstrap)
+    control_plane = fast_control_plane(kafka_bootstrap)
 
     pov: dict[str, Any] = {}  # name -> ToolDefinition the agent resolved from the view and presented to the model
     agent = Agent(

--- a/tests/integration/test_mcp_roundtrip_kafka.py
+++ b/tests/integration/test_mcp_roundtrip_kafka.py
@@ -52,6 +52,7 @@ from calfkit.mcp import MCPToolboxNode, StdioServerParameters
 from calfkit.models.capability import CAPABILITY_TOPIC, CapabilityRecord
 from calfkit.nodes import Agent
 from calfkit.worker import Worker
+from tests.integration._kafka_helpers import fast_control_plane
 from tests.integration._roundtrip_helpers import (
     FINAL_OUTPUT,
     capturing_model,
@@ -101,10 +102,6 @@ def _server_params(script: Path) -> StdioServerParameters:
     site-packages regardless of env); env is forwarded for PATH parity.
     """
     return StdioServerParameters(command=sys.executable, args=[str(script)], env=dict(os.environ))
-
-
-def _control_plane(bootstrap: str) -> ControlPlaneConfig:
-    return ControlPlaneConfig(heartbeat_interval=5.0, bootstrap_servers=bootstrap)
 
 
 def _server_name(topic_namespace: str, base: str = _SERVER_NAME) -> str:
@@ -195,7 +192,7 @@ async def test_single_tool_call_roundtrips_over_the_wire(kafka_bootstrap: str, t
     value travels all the way back into the agent's history."""
     agent_id = f"{topic_namespace}-mcp-agent"
     agent_in = f"{topic_namespace}.mcp-agent.input"
-    control_plane = _control_plane(kafka_bootstrap)
+    control_plane = fast_control_plane(kafka_bootstrap)
     server_name = _server_name(topic_namespace)
 
     toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
@@ -233,7 +230,7 @@ async def test_mcp_iserror_result_passes_through_transparently(kafka_bootstrap: 
     finalizes normally, and the error content travels back in history."""
     agent_id = f"{topic_namespace}-mcp-iserror"
     agent_in = f"{topic_namespace}.mcp-iserror.input"
-    control_plane = _control_plane(kafka_bootstrap)
+    control_plane = fast_control_plane(kafka_bootstrap)
     server_name = _server_name(topic_namespace)
 
     toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
@@ -273,7 +270,7 @@ async def test_concurrent_tool_calls_roundtrip_via_fanout(kafka_bootstrap: str, 
     and each result lands back in its own slot."""
     agent_id = f"{topic_namespace}-mcp-fanout-agent"
     agent_in = f"{topic_namespace}.mcp-fanout-agent.input"
-    control_plane = _control_plane(kafka_bootstrap)
+    control_plane = fast_control_plane(kafka_bootstrap)
     server_name = _server_name(topic_namespace)
 
     toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
@@ -322,7 +319,7 @@ async def test_duplicate_tool_concurrent_slots_route_by_call_id(kafka_bootstrap:
     tool_call_id (not tool name), so both results return to their own slot."""
     agent_id = f"{topic_namespace}-dup-agent"
     agent_in = f"{topic_namespace}.dup-agent.input"
-    control_plane = _control_plane(kafka_bootstrap)
+    control_plane = fast_control_plane(kafka_bootstrap)
     server_name = _server_name(topic_namespace)
 
     toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
@@ -365,7 +362,7 @@ async def test_sequential_mode_dispatches_without_fanout(kafka_bootstrap: str, t
     results still round-trip."""
     agent_id = f"{topic_namespace}-seq-agent"
     agent_in = f"{topic_namespace}.seq-agent.input"
-    control_plane = _control_plane(kafka_bootstrap)
+    control_plane = fast_control_plane(kafka_bootstrap)
     server_name = _server_name(topic_namespace)
 
     toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
@@ -412,7 +409,7 @@ async def test_two_mcp_servers_route_each_call_to_its_server(kafka_bootstrap: st
     to the correct toolbox topic: ``add`` resolves on server A, ``mul`` on B."""
     agent_id = f"{topic_namespace}-multi-server-agent"
     agent_in = f"{topic_namespace}.multi-server-agent.input"
-    control_plane = _control_plane(kafka_bootstrap)
+    control_plane = fast_control_plane(kafka_bootstrap)
     server_a_name = _server_name(topic_namespace)
     server_b_name = _server_name(topic_namespace, _SERVER_B_NAME)
 
@@ -462,7 +459,7 @@ async def test_two_agents_share_one_toolbox_replies_route_per_caller(kafka_boots
     a1_in = f"{topic_namespace}.agent-1.input"
     a2_id = f"{topic_namespace}-agent-2"
     a2_in = f"{topic_namespace}.agent-2.input"
-    control_plane = _control_plane(kafka_bootstrap)
+    control_plane = fast_control_plane(kafka_bootstrap)
     server_name = _server_name(topic_namespace)
 
     toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
@@ -513,7 +510,7 @@ async def test_include_pinning_blocks_unselected_tool(kafka_bootstrap: str, topi
     — the agent answers the model with an unknown-tool retry and finalizes."""
     agent_id = f"{topic_namespace}-pin-agent"
     agent_in = f"{topic_namespace}.pin-agent.input"
-    control_plane = _control_plane(kafka_bootstrap)
+    control_plane = fast_control_plane(kafka_bootstrap)
     server_name = _server_name(topic_namespace)
 
     toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
@@ -555,7 +552,7 @@ async def test_tools_list_changed_grows_the_toolset(kafka_bootstrap: str, topic_
     enable_in = f"{topic_namespace}.enable-agent.input"
     bonus_id = f"{topic_namespace}-bonus-agent"
     bonus_in = f"{topic_namespace}.bonus-agent.input"
-    control_plane = _control_plane(kafka_bootstrap)
+    control_plane = fast_control_plane(kafka_bootstrap)
     server_name = _server_name(topic_namespace)
 
     toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
@@ -626,7 +623,7 @@ async def test_agent_pov_is_namespaced_and_strips_to_bare_on_dispatch(
 
     agent_id = f"{topic_namespace}-pov-agent"
     agent_in = f"{topic_namespace}.pov-agent.input"
-    control_plane = _control_plane(kafka_bootstrap)
+    control_plane = fast_control_plane(kafka_bootstrap)
     server_name = _server_name(topic_namespace)
 
     # Capture the tool name the MCP server actually receives (after the node strips its prefix).

--- a/tests/integration/test_tool_discovery_kafka.py
+++ b/tests/integration/test_tool_discovery_kafka.py
@@ -44,6 +44,7 @@ from calfkit.nodes import Agent, ToolNodeDef, Tools, agent_tool
 from calfkit.worker import Worker
 from tests.integration._fault_kafka import ensure_topic
 from tests.integration._fault_tap import fault_tap
+from tests.integration._kafka_helpers import fast_control_plane
 from tests.integration._roundtrip_helpers import FINAL_OUTPUT, capturing_model, scripted_model, tool_returns
 
 # Every test here needs a real broker. FunctionModel is offline, but pydantic-ai still
@@ -52,10 +53,6 @@ pytestmark = pytest.mark.kafka
 models.ALLOW_MODEL_REQUESTS = True
 
 _EARLIEST = {"auto_offset_reset": "earliest"}
-
-
-def _control_plane(bootstrap: str) -> ControlPlaneConfig:
-    return ControlPlaneConfig(heartbeat_interval=5.0, bootstrap_servers=bootstrap)
 
 
 def _worker(bootstrap: str, *, nodes: list, control_plane: ControlPlaneConfig) -> Worker:
@@ -111,7 +108,7 @@ async def test_discovered_tool_node_roundtrips_over_the_wire(kafka_bootstrap: st
     tool_name = f"{topic_namespace}-add"
     agent_id = f"{topic_namespace}-disc-agent"
     agent_in = f"{topic_namespace}.disc-agent.input"
-    control_plane = _control_plane(kafka_bootstrap)
+    control_plane = fast_control_plane(kafka_bootstrap)
 
     tool = _add_tool(tool_name)
     agent = Agent(
@@ -152,7 +149,7 @@ async def test_model_pov_matches_the_advertised_tool(kafka_bootstrap: str, topic
     tool_name = f"{topic_namespace}-add"
     agent_id = f"{topic_namespace}-pov-agent"
     agent_in = f"{topic_namespace}.pov-agent.input"
-    control_plane = _control_plane(kafka_bootstrap)
+    control_plane = fast_control_plane(kafka_bootstrap)
 
     tool = _add_tool(tool_name)
     pov: dict[str, Any] = {}  # name -> ToolDefinition the agent resolved from the view and presented to the model
@@ -215,7 +212,7 @@ async def test_discovered_bad_args_escalate_unhandled_fault(kafka_bootstrap: str
     agent_id = f"{topic_namespace}-disc-fault"
     agent_in = f"{topic_namespace}.disc-fault.input"
     agent_pub = f"{topic_namespace}.disc-fault.mirror"
-    control_plane = _control_plane(kafka_bootstrap)
+    control_plane = fast_control_plane(kafka_bootstrap)
 
     tool = _add_tool(tool_name)
     agent = Agent(


### PR DESCRIPTION
## What

Runs the real-broker (`kafka`) integration lane **in parallel against one shared Redpanda** via `pytest-xdist`, cutting it from **~221s serial → ~31–36s** (≈**6.2×** on an 11-core host), plus a preset low-latency ktable config for the discovery/MCP suites. **Test-infrastructure only — no production code changes.**

Design: `docs/designs/kafka-lane-parallelization-spec.md`.

## How

- **One shared broker across all xdist workers** via the xdist *controller* hook: `pytest_configure_node` starts a single container and injects its bootstrap address into each worker's `workerinput`; `pytest_unconfigure` tears it down once. Resolution order stays **external-env > xdist-shared > local-single**, preserving the `-n0`/plain-`pytest` path and the no-Docker skip.
- **Safe to share** because each test already isolates its own topics via `topic_namespace`, and the capability-plane suites already coexist on the fixed `calf.capabilities` topic (unique namespaced node ids + namespace-filtered enumeration assertions). Validated by running the three capability suites concurrently.
- **Env-overridable broker config** (a thin `RedpandaContainer` subclass — upstream `tc_start` hardcodes `--smp 1 --memory 1G`): `CALF_TEST_REDPANDA_IMAGE` / `_SMP` / `_MEMORY`; worker count via `make test-kafka KAFKA_XDIST=N` (default `auto`; `KAFKA_XDIST=0` = serial).
- **`fast_control_plane`** shared helper (`reader_tuning` 20/10ms + `heartbeat 0.1`) replaces the three duplicate `_control_plane` builders with one definition (uses the worker-level tuning shipped in #277).

## Two implementation notes (in the spec)

- The lane **must be scoped to `tests/integration`** (`make test-kafka` does this) so the *controller* loads this conftest and registers `pytest_configure_node` — a bare `pytest -m kafka` from the root loads it only in workers, so nothing would fire. The fixture detects this and **skips with an actionable message**.
- `pytest_configure_node` is **guarded on the marker** (`"kafka" in markexpr and "not kafka" not in markexpr`) so a future *offline* parallel run (`pytest tests/ -n auto`) doesn't wastefully start Redpanda.

## Verification

- Full lane: **65 passed, 6 skipped**, stable across **3 runs** (~31–36s), **0 leaked containers**.
- Capability suites pass concurrently (`-n 4`); `-n0` serial (local-container) path green; offline-parallel guard starts no broker.
- `make check` clean (lint + format + mypy).

No ADR (test-infra; no architectural decision). CI's kafka job should adopt the parallel invocation on a multi-core runner to benefit.