### PR TITLE
feat: agent discovery + addressing substrate [agent-mesh PR-A]

### DIFF
--- a/calfkit/cli/topics.py
+++ b/calfkit/cli/topics.py
@@ -96,8 +96,8 @@ def provision(
     release — calfkit is pre-1.0).
 
     Resolves ``--nodes module:attr`` specs, computes the full topic set
-    (subscribe inboxes, framework return inboxes, publish topics, and agent
-    tool inputs), then best-effort creates them.
+    (subscribe inboxes, framework return + name-scoped private input inboxes,
+    publish topics, and agent tool inputs), then best-effort creates them.
 
     This is a **development convenience** (no ACLs; ``--replication-factor 1``
     is the default and is not durable). In production, topics are typically
@@ -107,6 +107,7 @@ def provision(
         ProvisioningConfig,
         TopicProvisioner,
         TopicProvisioningError,
+        framework_topics_for_nodes,
         topics_for_nodes,
     )
 
@@ -115,7 +116,9 @@ def provision(
     validate_nodes(node_list, source_label="--nodes")
 
     topics = topics_for_nodes(node_list)
-    framework_topics = {node._return_topic for node in node_list}
+    # The single framework-topic authority (shared with the worker): each node's
+    # private return + private input inboxes, never given user topic_configs.
+    framework_topics = framework_topics_for_nodes(node_list)
 
     if not topics:
         typer.echo("No topics to provision (no nodes resolved).")

--- a/calfkit/models/agents.py
+++ b/calfkit/models/agents.py
@@ -1,0 +1,71 @@
+"""Agent control-plane wire model (spec §4.2).
+
+An :class:`AgentCard` is one agent instance's advertisement on the ``calf.agents``
+control-plane topic — keyed on the wire by ``node_id`` × ``worker_id`` (the agent's
+``name`` × its worker instance; held by the substrate, never in the value). Records are
+calfkit-owned models: compacted records outlive deploys, so the wire shape must not move
+when a vendored library does.
+
+The card is **minimal** (spec §7 / L7): the agent's name is the wire key, and the only
+content is an optional, length-bounded ``description`` — no input topic (the caller
+derives ``agent.{name}.private.input``, ADR-0017), no system prompt, no tool list, so an
+agent's internals never leak.
+
+Reader policy: tolerant (unknown fields ignored — a newer writer may add fields).
+Staleness and newer-``schema_version`` filtering are owned by the reader's
+:class:`~calfkit.controlplane.ControlPlaneView`.
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from calfkit.controlplane import ControlPlaneRecord
+
+AGENT_CARD_SCHEMA_VERSION = 1
+"""The record schema major this reader understands. Bump only on breaking wire
+changes; additive fields ride on the tolerant reader instead."""
+
+AGENTS_TOPIC = "calf.agents"
+"""The cluster-wide compacted control-plane topic every agent advertises to.
+
+A control-plane topic (one record schema per topic): the agent's ``@advertises``
+factory and the reader's ``ControlPlaneView[AgentCard]`` both bind to it. Provisioned
+``cleanup.policy=compact`` like ``calf.capabilities``."""
+
+AGENT_CARD_DESCRIPTION_MAX = 512
+"""Max chars for the directory ``description`` — a short blurb, not a system prompt.
+Bounded loudly: an over-long value fails at construction (L12)."""
+
+AGENTS_VIEW_RESOURCE_KEY = "calfkit.controlplane.agents_view"
+"""Worker resource-bag key under which the Agents View (a
+``ControlPlaneView[AgentCard]``) is published to hosted nodes. Distinct from the
+capability view's key (L11): a different topic / record / trigger."""
+
+
+class AgentCard(ControlPlaneRecord):
+    """One agent instance's current advertisement on the ``calf.agents`` control plane.
+
+    A :class:`~calfkit.controlplane.ControlPlaneRecord` (identity ``node_id`` ×
+    ``worker_id`` is the wire key; the worker stamps ``started_at`` /
+    ``last_heartbeat_at`` / ``heartbeat_interval`` / ``node_kind``) plus a single optional
+    ``description``. **No input topic** (derived from the name, ADR-0017), no system
+    prompt, no tool list — the minimal card (L7).
+
+    ``description`` is bounded **loudly** (``Field(max_length=…)``, L12): an over-long
+    value raises at construction, so the fail-loud first advert surfaces it rather than
+    silently truncating or emitting an oversize record that decode-fails (which would drop
+    the agent from every reader's view).
+
+    **Precondition for the collapsed view:** all replicas of one agent (same ``name``)
+    should advertise an *equivalent* ``description``. The view collapses replicas to one
+    record by most-recent heartbeat — it does not merge — so divergent descriptions would
+    flap the visible card tick-to-tick. Trivially satisfied: ``description`` is a static
+    ``Agent(description=…)`` construction value, identical across an agent's replicas.
+
+    Inherits the base's tolerant, frozen ``model_config`` (``extra="ignore"``); the value
+    object is rebuilt per heartbeat tick, never mutated.
+    """
+
+    schema_version: int = AGENT_CARD_SCHEMA_VERSION
+    description: str | None = Field(default=None, max_length=AGENT_CARD_DESCRIPTION_MAX)

--- a/calfkit/models/agents.py
+++ b/calfkit/models/agents.py
@@ -35,7 +35,10 @@ factory and the reader's ``ControlPlaneView[AgentCard]`` both bind to it. Provis
 
 AGENT_CARD_DESCRIPTION_MAX = 512
 """Max chars for the directory ``description`` — a short blurb, not a system prompt.
-Bounded loudly: an over-long value fails at construction (L12)."""
+Bounded loudly: an over-long value fails when the card is built — the fail-loud first
+advert at worker startup — not silent truncation (L12; the cap lives on ``AgentCard``,
+not the ``Agent`` ctor, by design, so an over-long blurb surfaces at boot, not at
+``Agent()``)."""
 
 AGENTS_VIEW_RESOURCE_KEY = "calfkit.controlplane.agents_view"
 """Worker resource-bag key under which the Agents View (a
@@ -53,7 +56,9 @@ class AgentCard(ControlPlaneRecord):
     prompt, no tool list — the minimal card (L7).
 
     ``description`` is bounded **loudly** (``Field(max_length=…)``, L12): an over-long
-    value raises at construction, so the fail-loud first advert surfaces it rather than
+    value raises when the card is built — which is the fail-loud first advert at worker
+    startup (the cap lives on ``AgentCard``, not the ``Agent`` ctor, by design, so an
+    over-long ``Agent(description=…)`` surfaces at boot, not at ``Agent()``) — rather than
     silently truncating or emitting an oversize record that decode-fails (which would drop
     the agent from every reader's view).
 

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -14,8 +14,10 @@ from calfkit._vendor.pydantic_ai.output import OutputSpec
 from calfkit._vendor.pydantic_ai.settings import ModelSettings
 from calfkit._vendor.pydantic_ai.tools import DeferredToolResults
 from calfkit._vendor.pydantic_ai.toolsets.external import ExternalToolset
+from calfkit.controlplane import ControlPlaneStamp, advertises
 from calfkit.exceptions import DeserializationError, safe_exc_message
 from calfkit.models import Call, DataPart, NodeResult, ReturnCall, State, TailCall, TextPart
+from calfkit.models.agents import AGENTS_TOPIC, AgentCard
 from calfkit.models.capability import CAPABILITY_VIEW_RESOURCE_KEY, SelectorResult
 from calfkit.models.node_result import _extract_text, extract_lenient
 from calfkit.models.payload import RETRY_MARKER, ContentPart, is_retry
@@ -43,6 +45,7 @@ class BaseAgentNodeDef(
         name: str,
         *,
         system_prompt: str = "You are a helpful AI assistant.",
+        description: str | None = None,
         subscribe_topics: str | list[str],
         publish_topic: str | None = None,
         before_node: _SeamArg = None,
@@ -57,6 +60,9 @@ class BaseAgentNodeDef(
     ):
         self.final_output_type = final_output_type
         self.system_prompt = system_prompt
+        # Public directory blurb (distinct from system_prompt) advertised on the
+        # AgentCard — the only card content beyond identity + liveness (ADR-0015).
+        self._description = description
         self.tools: list[ToolBinding] = []
         self._tool_selectors: list[ToolSelector] = []
         self._eager_tool_nodes: list[BaseToolNodeDef] = []
@@ -91,6 +97,20 @@ class BaseAgentNodeDef(
             # @resource never runs under the synchronous TestKafkaBroker — offline, the test harness
             # injects a fake into the bag instead (tests/providers.py::prepare_worker).
             self.resource(name=FANOUT_STORE_KEY)(self._fanout_store_resource)
+
+    @advertises(topic=AGENTS_TOPIC, record=AgentCard)
+    def _agent_card_advert(self, stamp: ControlPlaneStamp) -> AgentCard:
+        """Advertise this agent on the shared ``calf.agents`` plane (always-on, no opt-out — L7).
+
+        Static-content advertiser: the directory ``description`` is fixed at construction, so
+        the factory reads ``self._description`` directly — no session, nothing that can fail at
+        publish time. Identity (the agent's name) is the wire key, never in the value;
+        ``node_kind`` ("agent") rides on the worker stamp. The card carries no input topic (the
+        caller derives ``agent.{name}.private.input``, ADR-0017), no system prompt, no tool list
+        — the minimal card. Splatting the bare stamp (never a record) honours the
+        ``@advertises`` duplicate-kwarg contract.
+        """
+        return AgentCard(**stamp.model_dump(), description=self._description)
 
     async def _fanout_store_resource(self, ctx: ResourceSetupContext["BaseAgentNodeDef[AgentOutputT]"]) -> AsyncIterator[FanoutBatchStore]:
         """Open this fan-out agent's durable batch store for the worker's lifetime.

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -1777,3 +1777,33 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin, AdvertRegis
         they target the tool's input topic, not ``_return_topic``.
         """
         return f"{self.node_id}.private.return"
+
+    @property
+    def _private_input_topic(self) -> str:
+        """Framework-private, name-scoped INBOUND inbox for this node instance (ADR-0017).
+
+        The inbound parallel to :meth:`_return_topic` (the continuation inbox): a
+        deterministic ``{node_kind}.{name}.private.input`` any caller can derive from
+        this node's name alone — the addressing primitive agent-to-agent messaging
+        builds on (the ``AgentCard`` carries no topic; the caller derives
+        ``agent.{name}.private.input``). It is contributed at registration like
+        ``_return_topic`` — read by :meth:`Worker.register_handlers` and the startup
+        provisioner and flagged **framework-owned** (never receives user
+        ``topic_configs``) — *not* appended into ``subscribe_topics`` in ``__init__``
+        (the ``@dataclass`` tool/MCP node ``__init__``s bypass ``BaseNodeDef.__init__``,
+        so a list-append would silently miss them).
+
+        **Universal, dormant for non-agents in v1.** Every node kind exposes and
+        subscribes to its inbox, but only agents are dispatched to today — for a tool
+        or consumer the inbox is provisioned and consumed yet receives no traffic. The
+        dormancy contract is "no producer targets it," not "it is a safe sink": a stray
+        non-``ToolCallRef`` body delivered here carries no ``x-calf-kind`` header, so it
+        is classified ``"call"`` (run as an invocation), not floored — harmless only
+        because nothing publishes here in v1.
+
+        Recomputed from identity on every access (like ``_return_topic``); do not mutate
+        ``node_id`` after registration. Uses ``self.name``, which aliases ``node_id``
+        today; the divergence from ``_return_topic``'s ``self.node_id`` is intentional
+        name-centric addressing (spec §4.1), not an inconsistency to "fix".
+        """
+        return f"{self._node_kind}.{self.name}.private.input"

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -1790,16 +1790,19 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin, AdvertRegis
         ``_return_topic`` — read by :meth:`Worker.register_handlers` and the startup
         provisioner and flagged **framework-owned** (never receives user
         ``topic_configs``) — *not* appended into ``subscribe_topics`` in ``__init__``
-        (the ``@dataclass`` tool/MCP node ``__init__``s bypass ``BaseNodeDef.__init__``,
-        so a list-append would silently miss them).
+        (the ``@dataclass`` tool-node ``__init__`` bypasses ``BaseNodeDef.__init__``, so a
+        list-append there would be silently missed; a property sidesteps init-time
+        divergence across every node kind, regardless of which ``__init__`` ran).
 
         **Universal, dormant for non-agents in v1.** Every node kind exposes and
         subscribes to its inbox, but only agents are dispatched to today — for a tool
-        or consumer the inbox is provisioned and consumed yet receives no traffic. The
-        dormancy contract is "no producer targets it," not "it is a safe sink": a stray
-        non-``ToolCallRef`` body delivered here carries no ``x-calf-kind`` header, so it
-        is classified ``"call"`` (run as an invocation), not floored — harmless only
-        because nothing publishes here in v1.
+        or consumer the inbox is provisioned and consumed yet receives no traffic. A
+        stray non-``ToolCallRef`` body delivered here is **not** silently swallowed: a
+        caller-capable node classifies it ``"call"`` (no ``x-calf-kind`` header) and
+        enters the body, where it declines / schema-rejects and is disposed (a DEBUG
+        no-op, or a WARNING auto-fault if the delivery is reply-owing); a consumer
+        observes it (ERROR-floored on failure). Harmless in v1 only because no producer
+        targets it — the dormancy contract is "no producer," not "a safe sink".
 
         Recomputed from identity on every access (like ``_return_topic``); do not mutate
         ``node_id`` after registration. Uses ``self.name``, which aliases ``node_id``

--- a/calfkit/provisioning/__init__.py
+++ b/calfkit/provisioning/__init__.py
@@ -13,6 +13,7 @@ from calfkit.provisioning.provisioner import (
     ProvisionReport,
     TopicProvisioner,
     TopicProvisioningError,
+    framework_topics_for_nodes,
     provision_topics,
     topics_for_nodes,
 )
@@ -24,6 +25,7 @@ __all__ = [
     "StartupTopicEnsurer",
     "TopicProvisioner",
     "TopicProvisioningError",
+    "framework_topics_for_nodes",
     "provision_topics",
     "topics_for_nodes",
 ]

--- a/calfkit/provisioning/provisioner.py
+++ b/calfkit/provisioning/provisioner.py
@@ -35,7 +35,9 @@ def topics_for_nodes(nodes: Iterable[Any]) -> list[str]:
 
     * each entry of ``subscribe_topics`` (the node's public inbox(es)),
     * the node's framework-private ``_return_topic`` (tool ReturnCall /
-      built-in TailCall inbox — issue #141), and
+      built-in TailCall inbox — issue #141),
+    * the node's framework-private ``_private_input_topic`` (the deterministic
+      name-scoped inbound inbox every node subscribes to — ADR-0017), and
     * ``publish_topic`` when set.
 
     Agent nodes additionally contribute each tool binding's dispatch topic
@@ -57,6 +59,7 @@ def topics_for_nodes(nodes: Iterable[Any]) -> list[str]:
         for topic in node.subscribe_topics:
             _add(topic)
         _add(node._return_topic)
+        _add(node._private_input_topic)
         _add(node.publish_topic)
 
         tools = getattr(node, "tools", None)
@@ -65,6 +68,27 @@ def topics_for_nodes(nodes: Iterable[Any]) -> list[str]:
                 _add(binding.dispatch_topic)
 
     return list(seen)
+
+
+def framework_topics_for_nodes(nodes: Iterable[Any]) -> set[str]:
+    """The framework-owned topics referenced by ``nodes`` (the single authority).
+
+    **Experimental** (part of the opt-in provisioning API; pre-1.0).
+
+    Framework-private topics are the ones that must never receive user
+    ``topic_configs`` (:func:`provision_topics` excludes them from
+    ``cleanup.policy`` / ``retention.ms`` overrides): each node's
+
+    * ``_return_topic`` — the continuation inbox (tool ReturnCall / built-in
+      TailCall, issue #141), and
+    * ``_private_input_topic`` — the deterministic name-scoped inbound inbox
+      every node subscribes to (ADR-0017).
+
+    Every provisioning surface (the worker's startup ensurer and the
+    ``ck topics provision`` CLI) derives its framework set from here, so a new
+    framework-owned topic is added in exactly one place.
+    """
+    return {topic for node in nodes for topic in (node._return_topic, node._private_input_topic)}
 
 
 @dataclass
@@ -397,6 +421,7 @@ __all__ = [
     "ProvisionReport",
     "TopicProvisioner",
     "TopicProvisioningError",
+    "framework_topics_for_nodes",
     "provision_topics",
     "topics_for_nodes",
 ]

--- a/calfkit/provisioning/provisioner.py
+++ b/calfkit/provisioning/provisioner.py
@@ -190,7 +190,7 @@ def _build_new_topic(topic: str, framework_topics: set[str], config: Provisionin
 
     # NewTopic(num_partitions=-1, ...) raises client-side (XOR validator), so
     # always supply concrete positive values. User ``topic_configs`` apply to
-    # data topics only — never to framework inboxes (reply / *.private.return).
+    # data topics only — never to framework inboxes (reply / *.private.return / *.private.input).
     topic_configs = None
     if topic not in framework_topics and config.topic_configs:
         topic_configs = dict(config.topic_configs)
@@ -291,7 +291,7 @@ async def provision_topics(
     **not** closed here), so this runs against FastStream's broker-managed admin
     client or a standalone one alike. The create/classify/retry loop is bounded
     by ``config.create_timeout_ms``; ``topic_configs`` apply to data topics only,
-    never to ``framework_topics`` (reply / ``*.private.return`` inboxes).
+    never to ``framework_topics`` (reply / ``*.private.return`` / ``*.private.input`` inboxes).
 
     Raises:
         TopicProvisioningError: on a non-retriable per-topic error, or when the
@@ -381,8 +381,8 @@ class TopicProvisioner:
         ``config.create_timeout_ms`` — a per-phase cap (worst case ~2× total), so
         an unreachable broker can't hang the connect. ``topic_configs`` from the
         config are applied to data topics only, never to ``framework_topics``
-        (reply / ``*.private.return`` inboxes), for which overrides like
-        ``cleanup.policy=compact`` would be semantically wrong.
+        (reply / ``*.private.return`` / ``*.private.input`` inboxes), for which overrides
+        like ``cleanup.policy=compact`` would be semantically wrong.
 
         Raises:
             TopicProvisioningError: On a non-retriable per-topic error, or when

--- a/calfkit/worker/worker.py
+++ b/calfkit/worker/worker.py
@@ -12,10 +12,11 @@ from calfkit.client import Client
 from calfkit.controlplane.config import ControlPlaneConfig
 from calfkit.controlplane.publisher import ControlPlanePublisher, control_plane_writer_key
 from calfkit.controlplane.view import ControlPlaneView
+from calfkit.models.agents import AGENTS_TOPIC, AGENTS_VIEW_RESOURCE_KEY, AgentCard
 from calfkit.models.capability import CAPABILITY_TOPIC, CAPABILITY_VIEW_RESOURCE_KEY, CapabilityRecord
 from calfkit.models.tool_dispatch import ToolSelector
 from calfkit.nodes import BaseNodeDef
-from calfkit.provisioning import topics_for_nodes
+from calfkit.provisioning import framework_topics_for_nodes, topics_for_nodes
 from calfkit.tuning import FanoutConfig
 from calfkit.worker.lifecycle import (
     PHASE_PAIRS,
@@ -221,6 +222,54 @@ class Worker(LifecycleHookMixin):
         yield view
         await view.stop()
 
+    def _maybe_register_agents_view(self) -> None:
+        """Auto-register the Agents View resource (spec §6 / L11).
+
+        Zero user wiring: iff any hosted node declares a ``peers`` handle, ONE
+        worker-level ``ControlPlaneView[AgentCard]`` resource is registered
+        (idempotent — guarded by resource-name lookup) under a **distinct** key
+        (``AGENTS_VIEW_RESOURCE_KEY`` ≠ the capability view's). The gate is
+        ``_peers``, which the ``peers=`` ctor param sets — absent until the
+        messaging surface lands (PR-B), so this is **dormant** today; the view
+        resource + decode are nonetheless fully exercised now. Mirrors
+        :meth:`_maybe_register_capability_view` (which gates on ``_tool_selectors``).
+        """
+        if not any(getattr(node, "_peers", None) for node in self._nodes):
+            return
+        if any(name == AGENTS_VIEW_RESOURCE_KEY for name, _ in self._resource_cms()):
+            return
+        self.resource(name=AGENTS_VIEW_RESOURCE_KEY)(self._agents_view_resource)
+
+    async def _agents_view_resource(self, ctx: ResourceSetupContext["Worker"]) -> AsyncIterator[Any]:
+        """Open the Agents View (``ControlPlaneView[AgentCard]``) for this worker's lifetime.
+
+        Mirrors :meth:`_capability_view_resource`: ``view.start()`` IS the boot gate (the
+        grouped table replays ``calf.agents`` to its start-time end offsets, bounded by
+        ``catchup_timeout``, serving degraded-but-loud on expiry), so an agent never sees a
+        half-built directory. The view collapses the instance-keyed cards to one live card
+        per agent name and owns staleness + schema-version filtering.
+        """
+        cfg = self._control_plane
+        bootstrap = cfg.bootstrap_servers or self._derive_bootstrap_servers()
+        if not bootstrap:
+            raise RuntimeError(
+                "cannot derive Kafka bootstrap servers for the Agents View "
+                "(client built without connect()?); set ControlPlaneConfig(bootstrap_servers=...)."
+            )
+        view: ControlPlaneView[AgentCard] = ControlPlaneView.open(
+            bootstrap_servers=bootstrap,
+            topic=AGENTS_TOPIC,
+            record_type=AgentCard,
+            catchup_timeout=cfg.catchup_timeout,
+            # Readers ensure only in dev/CI; production topics are ops-governed.
+            ensure_topic=self._client._provisioning.enabled,
+            stale_after=cfg.stale_after,
+            reader_tuning=cfg.reader_tuning,
+        )
+        await view.start()
+        yield view
+        await view.stop()
+
     def _derive_bootstrap_servers(self) -> str | None:
         """The Kafka bootstrap address for this worker's client, or ``None`` if underivable.
 
@@ -296,6 +345,7 @@ class Worker(LifecycleHookMixin):
             logger.debug("register_handlers() called again; skipping (already prepared)")
             return
         self._maybe_register_capability_view()
+        self._maybe_register_agents_view()
         self._maybe_register_control_plane()
         # Record the nodes we are about to register as the single source of
         # truth for ``_declare_startup_topics``. Snapshot (not alias) so later
@@ -304,16 +354,18 @@ class Worker(LifecycleHookMixin):
         self._registered_nodes = list(self._nodes)
         for node in self._nodes:
             group_id = self._group_id or node.name
-            # Subscribe to the node's public inboxes plus its
-            # framework-private return inbox. The latter is where tool
-            # ``Call`` returns and ``TailCall`` self-retries are addressed
-            # exclusively to this node instance — see
-            # ``BaseNodeDef._return_topic`` (issue #141). ``dict.fromkeys``
-            # preserves declared order while removing duplicates, so a
-            # user who manually lists ``f'{node_id}.private.return'`` in
-            # ``subscribe_topics`` doesn't end up with a duplicate entry
-            # in registration logs / AsyncAPI / observability tooling.
-            topics = list(dict.fromkeys([*node.subscribe_topics, node._return_topic]))
+            # Subscribe to the node's public inboxes plus its two framework-private
+            # inboxes: the return inbox (``_return_topic`` — tool ``Call`` returns and
+            # ``TailCall`` self-retries addressed to this instance, issue #141) and the
+            # name-scoped input inbox (``_private_input_topic`` — the deterministic
+            # ``{kind}.{name}.private.input`` every node consumes, ADR-0017; dormant for
+            # non-agents in v1). Both are contributed here at registration, never via
+            # ``subscribe_topics`` (the ``@dataclass`` node ``__init__``s bypass
+            # ``BaseNodeDef.__init__``). ``dict.fromkeys`` preserves declared order while
+            # removing duplicates, so a user who manually lists one of these in
+            # ``subscribe_topics`` doesn't end up with a duplicate entry in registration
+            # logs / AsyncAPI / observability tooling.
+            topics = list(dict.fromkeys([*node.subscribe_topics, node._return_topic, node._private_input_topic]))
             logger.info(
                 "registering node=%s subscribe=%s publish=%s",
                 node.name,
@@ -363,16 +415,17 @@ class Worker(LifecycleHookMixin):
 
         The topic set is :func:`~calfkit.provisioning.topics_for_nodes` over the
         nodes recorded by :meth:`register_handlers` (the single source of truth):
-        each node's ``subscribe_topics``, its framework-private ``_return_topic``,
-        its ``publish_topic``, and — for agent nodes — each tool's input
-        ``subscribe_topics``. Every node's ``_return_topic`` is declared
-        ``framework=True`` so user ``topic_configs``
-        (retention / compaction) are never applied to those correlation-keyed
-        return inboxes.
+        each node's ``subscribe_topics``, its framework-private ``_return_topic``
+        and ``_private_input_topic``, its ``publish_topic``, and — for agent nodes —
+        each tool's input ``subscribe_topics``. The framework-private inboxes are
+        re-declared ``framework=True`` via
+        :func:`~calfkit.provisioning.framework_topics_for_nodes` (the single
+        framework-topic authority) so user ``topic_configs`` (retention / compaction)
+        are never applied to those correlation-keyed / name-scoped inboxes.
         """
         ensurer = self._client._startup_ensurer
         ensurer.declare(topics_for_nodes(self._registered_nodes))
-        ensurer.declare({node._return_topic for node in self._registered_nodes}, framework=True)
+        ensurer.declare(framework_topics_for_nodes(self._registered_nodes), framework=True)
 
     async def _on_startup(self) -> None:
         """Register handlers + declare topics, before the broker starts.

--- a/docs/adr/0017-deterministic-name-scoped-private-input-topic.md
+++ b/docs/adr/0017-deterministic-name-scoped-private-input-topic.md
@@ -16,8 +16,9 @@ level: `_private_input_topic = f"{node_kind}.{name}.private.input"`. It is contr
 at registration the same way `{node_id}.private.return` is — a property read by
 `register_handlers` and `topics_for_nodes` and **flagged framework-owned** (so it
 never receives user topic configs) — *not* appended into the `subscribe_topics` list
-in `__init__` (the `@dataclass` node `__init__`s bypass `BaseNodeDef.__init__`, so a
-list-append would silently miss tool/MCP nodes). It parallels the private return
+in `__init__` (the `@dataclass` tool-node `__init__` bypasses `BaseNodeDef.__init__`, so a
+list-append there would be silently missed; a property sidesteps the init-time divergence
+across every node kind). It parallels the private return
 topic: that is the continuation inbox, this is the inbound inbox.
 
 The point is the **deterministic `name → topic` mapping**, and we make it **universal

--- a/docs/adr/0017-deterministic-name-scoped-private-input-topic.md
+++ b/docs/adr/0017-deterministic-name-scoped-private-input-topic.md
@@ -1,0 +1,55 @@
+---
+status: accepted
+---
+
+# Every node has a deterministic, name-scoped private input topic
+
+Agent-to-agent messaging needs a caller to reach a *specific* named peer, but a
+node's user-configured `subscribe_topics` are not guaranteed to be node-unique
+(different nodes may deliberately share a work topic). More broadly, the SDK had no
+deterministic way to map a node's `name` to a topic — callers had to be handed or
+memorize topics, and the capability plane has to *advertise* each tool node's
+`dispatch_topic` because it can't be derived.
+
+We add a framework-owned **private input topic** to **every** node at the base-node
+level: `_private_input_topic = f"{node_kind}.{name}.private.input"`. It is contributed
+at registration the same way `{node_id}.private.return` is — a property read by
+`register_handlers` and `topics_for_nodes` and **flagged framework-owned** (so it
+never receives user topic configs) — *not* appended into the `subscribe_topics` list
+in `__init__` (the `@dataclass` node `__init__`s bypass `BaseNodeDef.__init__`, so a
+list-append would silently miss tool/MCP nodes). It parallels the private return
+topic: that is the continuation inbox, this is the inbound inbox.
+
+The point is the **deterministic `name → topic` mapping**, and we make it **universal
+(every node kind), not agents-only**, deliberately:
+- Agent peer-messaging (ADR-0015) is the first consumer — which is why the
+  `AgentCard` carries no topic field (the caller derives `agent.{name}.private.input`
+  from the name it has from the directory).
+- A future "call any node by name" caller surface reuses the same derivation across
+  kinds. A *conditional* further payoff: **if** tool nodes' public inboxes are later
+  standardized onto this derived topic, their dispatch topics become derivable and
+  the capability plane could stop advertising `dispatch_topic`. That is not automatic
+  from this primitive alone — a tool node's current `dispatch_topic` is its arbitrary
+  `subscribe_topics[0]`, not a derived value — so it is a future opportunity this
+  unlocks, not a guarantee it delivers.
+
+The cost is one provisioned topic per node, and a *dormant* inbox on non-agent nodes
+in v1 (nothing dispatches peer messages to a tool or consumer yet; a stray
+non-`ToolCallRef` body sent to a tool's inbox would fault, but nothing sends there).
+This is an accepted, deliberate trade for the universal mapping — recorded here so it
+is not re-flagged as a per-node-only-needs-it concern.
+
+Considered and rejected: **scoping the topic to agents only** (loses the universal
+mapping and the future derivable tool dispatch topics — the reviewer's suggestion,
+overridden); **a dedicated per-agent ask topic** (solves only agents); **advertising
+the topic on the AgentCard** (redundant once derivable); **reusing the private return
+topic** (conflates fresh inbound calls with continuations).
+
+Consequences: every node also consumes `{node_kind}.{name}.private.input`, so that
+topic must be provisioned (same operational contract as any subscribe topic) and is
+framework-owned. Every provisioning surface (the worker's startup ensurer and the
+`ck topics provision` CLI) derives its framework-owned set from one authority,
+`framework_topics_for_nodes`, so the return and input inboxes are classified
+identically everywhere. The derived key is unique per `(kind, name)`. Node `name`
+(= `node_id`) must remain cluster-wide unique (existing contract). Full design in
+`docs/designs/agent-mesh-spec.md` §4.1.

--- a/docs/topic-provisioning.md
+++ b/docs/topic-provisioning.md
@@ -15,8 +15,10 @@
 
 A calfkit deployment is a mesh of nodes that publish to and subscribe from named
 Kafka topics: agent inboxes (`subscribe_topics`), framework-private return
-inboxes (`*.private.return`, issue #141), agent `publish_topic`s, and per-tool
-input topics. For any of this traffic to flow, the topics have to **exist**.
+inboxes (`*.private.return`, issue #141), framework-private name-scoped input
+inboxes (`{kind}.{name}.private.input`, ADR-0017), agent `publish_topic`s, and
+per-tool input topics. For any of this traffic to flow, the topics have to
+**exist**.
 
 Today that "just works" locally only because the
 [calfkit-broker](https://github.com/calf-ai/calfkit-broker) dev image ships with
@@ -88,7 +90,9 @@ references. For each node:
 
 - every entry of `subscribe_topics` (the node's public inbox(es)),
 - the node's framework-private `_return_topic` (tool `ReturnCall` / built-in
-  `TailCall` inbox — issue #141), and
+  `TailCall` inbox — issue #141),
+- the node's framework-private `_private_input_topic` (the deterministic
+  name-scoped inbound inbox every node subscribes to — ADR-0017), and
 - `publish_topic` when set.
 
 **Agent nodes** additionally contribute *all* of each tool's `subscribe_topics`
@@ -142,8 +146,10 @@ await worker.run()
 When enabled, the worker's FastStream `on_startup` hook runs `provision_topics()`
 **after** `register_handlers()` and **before** `broker.start()` (so every
 subscriber's inbox exists before consumption begins). The topic set is `topics_for_nodes()` over exactly the nodes
-that were registered; each node's `_return_topic` is passed as a framework topic
-so `topic_configs` is never applied to it. A provisioning failure aborts startup.
+that were registered; each node's framework-private inboxes (`_return_topic` and
+`_private_input_topic`) are passed as framework topics — via the single
+`framework_topics_for_nodes()` authority — so `topic_configs` is never applied to
+them. A provisioning failure aborts startup.
 
 For a manual `register_handlers()`-without-`run()` deployment (which bypasses the
 worker's startup hook), provision out-of-band — the CLI (`ck topics provision`,

--- a/tests/integration/test_agents_plane_kafka.py
+++ b/tests/integration/test_agents_plane_kafka.py
@@ -82,9 +82,10 @@ def _open_view(bootstrap: str) -> ControlPlaneView[AgentCard]:
     return ControlPlaneView.open(bootstrap_servers=bootstrap, topic=AGENTS_TOPIC, record_type=AgentCard, ensure_topic=False)
 
 
-async def test_agent_advertises_and_view_roundtrip_and_clean_tombstone(kafka_bootstrap: str, topic_namespace: str) -> None:
+@pytest.mark.parametrize("description", ["Plans the work", None])
+async def test_agent_advertises_and_view_roundtrip_and_clean_tombstone(kafka_bootstrap: str, topic_namespace: str, description: str | None) -> None:
     name = f"{topic_namespace}-planner"
-    agent = _agent(name, description="Plans the work")
+    agent = _agent(name, description=description)
     writer, pub, ctx = await _start_publisher(kafka_bootstrap, agent, "w1", ensure_topic=True)
     view = _open_view(kafka_bootstrap)
     await view.start()
@@ -93,7 +94,7 @@ async def test_agent_advertises_and_view_roundtrip_and_clean_tombstone(kafka_boo
         assert await _poll(view.barrier, lambda: view.get(name) is not None)
         card = view.get(name)
         assert card is not None
-        assert card.description == "Plans the work"
+        assert card.description == description  # incl. the common bare-card None case over the wire
         assert card.node_kind == "agent"
         assert name in view.online_nodes()
 

--- a/tests/integration/test_agents_plane_kafka.py
+++ b/tests/integration/test_agents_plane_kafka.py
@@ -1,0 +1,176 @@
+"""Integration (kafka lane): the AgentCard plane end-to-end on a real broker.
+
+Every agent advertises an :class:`AgentCard` on the compacted ``calf.agents`` topic; a
+``ControlPlaneView[AgentCard]`` reads it back collapsed. Mirrors
+``test_controlplane_substrate_kafka.py``, but with a REAL ``Agent`` + ``AgentCard`` +
+the real ``calf.agents`` topic — isolated per test by a unique agent name keyed on
+``topic_namespace`` (the same shared-topic isolation ``test_tool_discovery_kafka.py``
+uses, since the agent's name is the wire key on the shared topic).
+
+Covers: the advertise→read round-trip + clean-shutdown tombstone, the 2-replica collapse
+(one card per name; a survivor keeps the node live), and the worker's own auto-wired
+publisher + writer creating a **compacted** ``calf.agents`` and round-tripping a card.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from types import SimpleNamespace
+
+import pytest
+from ktables import GroupedKafkaTableWriter
+
+from calfkit.client.client import Client
+from calfkit.controlplane import ControlPlaneView
+from calfkit.controlplane.advert import AdvertInfo
+from calfkit.controlplane.publisher import ControlPlanePublisher, control_plane_writer_key
+from calfkit.models.agents import AGENTS_TOPIC, AgentCard
+from calfkit.nodes.agent import Agent
+from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
+from calfkit.provisioning import ProvisioningConfig
+from calfkit.worker.worker import Worker
+from tests.integration._kafka_helpers import fast_control_plane
+
+pytestmark = pytest.mark.kafka
+
+
+class _FakeModel(PydanticModelClient):
+    @property
+    def model_name(self) -> str:
+        return "fake"
+
+    @property
+    def system(self) -> str:
+        return "fake"
+
+    async def request(self, *args: object, **kwargs: object) -> object:
+        raise NotImplementedError
+
+
+def _agent(name: str, *, description: str | None) -> Agent:
+    return Agent(name, subscribe_topics=f"{name}.in", model_client=_FakeModel(), description=description)
+
+
+def _only_advert(node: Agent) -> AdvertInfo:
+    return next(iter(type(node)._adverts.values()))
+
+
+async def _poll(refresh: Callable[[], Awaitable[object]], predicate: Callable[[], bool], *, tries: int = 300, delay: float = 0.02) -> bool:
+    for _ in range(tries):
+        await refresh()
+        if predicate():
+            return True
+        await asyncio.sleep(delay)
+    return predicate()
+
+
+async def _start_publisher(
+    bootstrap: str, node: Agent, worker_id: str, *, ensure_topic: bool
+) -> tuple[GroupedKafkaTableWriter[AgentCard], ControlPlanePublisher, SimpleNamespace]:
+    writer: GroupedKafkaTableWriter[AgentCard] = GroupedKafkaTableWriter.json(
+        bootstrap_servers=bootstrap, topic=AGENTS_TOPIC, ensure_topic=ensure_topic
+    )
+    await writer.start()
+    pub = ControlPlanePublisher(worker_id=worker_id, adverts=[(node, _only_advert(node))], config=fast_control_plane(bootstrap))
+    ctx = SimpleNamespace(resources={control_plane_writer_key(AGENTS_TOPIC): writer})
+    await pub.start(ctx)
+    return writer, pub, ctx
+
+
+def _open_view(bootstrap: str) -> ControlPlaneView[AgentCard]:
+    return ControlPlaneView.open(bootstrap_servers=bootstrap, topic=AGENTS_TOPIC, record_type=AgentCard, ensure_topic=False)
+
+
+async def test_agent_advertises_and_view_roundtrip_and_clean_tombstone(kafka_bootstrap: str, topic_namespace: str) -> None:
+    name = f"{topic_namespace}-planner"
+    agent = _agent(name, description="Plans the work")
+    writer, pub, ctx = await _start_publisher(kafka_bootstrap, agent, "w1", ensure_topic=True)
+    view = _open_view(kafka_bootstrap)
+    await view.start()
+    try:
+        # round-trip: the advertised agent shows up, collapsed, with its card content
+        assert await _poll(view.barrier, lambda: view.get(name) is not None)
+        card = view.get(name)
+        assert card is not None
+        assert card.description == "Plans the work"
+        assert card.node_kind == "agent"
+        assert name in view.online_nodes()
+
+        # clean shutdown tombstones the instance; the view drops the agent
+        await pub.stop(ctx)
+        assert await _poll(view.barrier, lambda: view.get(name) is None)
+        assert name not in view.online_nodes()
+    finally:
+        if pub._task is not None:
+            await pub.stop(ctx)
+        await view.stop()
+        await writer.stop()
+
+
+async def test_two_replicas_collapse_to_one_card(kafka_bootstrap: str, topic_namespace: str) -> None:
+    name = f"{topic_namespace}-replicated"
+    writer_a, pub_a, ctx_a = await _start_publisher(kafka_bootstrap, _agent(name, description="r"), "w-a", ensure_topic=True)
+    writer_b, pub_b, ctx_b = await _start_publisher(kafka_bootstrap, _agent(name, description="r"), "w-b", ensure_topic=False)
+    view = _open_view(kafka_bootstrap)
+    await view.start()
+    try:
+        # both replicas present under the one name, collapsed to exactly one card
+        assert await _poll(view.barrier, lambda: view.get(name) is not None)
+        assert view.get(name) is not None
+        assert sorted(view.online_nodes()).count(name) == 1
+
+        # one replica leaves cleanly: the agent is STILL online via the survivor
+        await pub_a.stop(ctx_a)
+        await view.barrier()
+        assert view.get(name) is not None
+
+        # when the second replica leaves too, the agent finally goes offline
+        await pub_b.stop(ctx_b)
+        assert await _poll(view.barrier, lambda: view.get(name) is None)
+    finally:
+        for pub, ctx in ((pub_a, ctx_a), (pub_b, ctx_b)):
+            if pub._task is not None:
+                await pub.stop(ctx)
+        await view.stop()
+        await writer_a.stop()
+        await writer_b.stop()
+
+
+async def test_worker_wiring_creates_topic_and_roundtrips(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """The worker's OWN auto-wired publisher + writer create ``calf.agents`` and round-trip a
+    card — no hand-built publisher (mirrors the substrate wiring test).
+
+    Topic config (``cleanup.policy=compact``) is **entirely ktables' create-path concern**
+    (``DEFAULT_TOPIC_CONFIGS``), deferred to ktables and provisioned like ``calf.capabilities``;
+    calfkit owns none of it, so this test asserts the wiring + round-trip, not the policy (which
+    can't be asserted robustly on the shared topic — ktables won't reconfigure an existing one)."""
+    name = f"{topic_namespace}-wired"
+    agent = _agent(name, description="wired")
+    client = Client.connect(kafka_bootstrap, provisioning=ProvisioningConfig(enabled=True))
+    worker = Worker(client, nodes=[agent], control_plane=fast_control_plane(kafka_bootstrap))
+    worker._maybe_register_control_plane()
+
+    key = control_plane_writer_key(AGENTS_TOPIC)
+    [(_, genfn)] = [(n, g) for n, g in worker._resource_cms() if n == key]  # the worker-registered writer resource
+    writer_gen = genfn(None)  # type: ignore[arg-type]
+    writer = await anext(writer_gen)  # ensure_topic=True via provisioning creates the compacted topic
+    pub = worker._control_plane_publisher
+    assert pub is not None
+    ctx = SimpleNamespace(resources={key: writer})
+    view = _open_view(kafka_bootstrap)
+    await view.start()
+    try:
+        await pub.start(ctx)  # looks up the writer under the key the worker registered
+        assert await _poll(view.barrier, lambda: view.get(name) is not None)
+        card = view.get(name)
+        assert card is not None and card.description == "wired"
+
+        await pub.stop(ctx)
+        assert await _poll(view.barrier, lambda: view.get(name) is None)
+    finally:
+        if pub._task is not None:
+            await pub.stop(ctx)
+        await view.stop()
+        with pytest.raises(StopAsyncIteration):
+            await anext(writer_gen)

--- a/tests/test_agent_card_advert.py
+++ b/tests/test_agent_card_advert.py
@@ -1,0 +1,85 @@
+"""Every agent advertises an :class:`AgentCard` on the ``calf.agents`` control plane.
+
+Like the function tool node (``test_tool_node_advert.py``), an agent is a content
+contributor: it declares one ``@advertises`` factory that the worker-owned
+``ControlPlanePublisher`` pulls each heartbeat tick. Its content is static — the
+optional ``Agent(description=…)`` blurb — so the factory reads ``self._description``
+directly (no session, no cache, nothing that can fail at publish time). Advertising is
+**always-on, no opt-out** (spec §7 / L7). The heartbeat loop + tombstone live in the
+substrate's publisher (tested in ``test_controlplane_publisher.py``), not here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from calfkit.controlplane import ControlPlaneStamp
+from calfkit.models.agents import AGENTS_TOPIC, AgentCard
+from calfkit.nodes.agent import Agent
+from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
+
+
+class _FakeModel(PydanticModelClient):
+    @property
+    def model_name(self) -> str:
+        return "fake"
+
+    @property
+    def system(self) -> str:
+        return "fake"
+
+    async def request(self, *args: object, **kwargs: object) -> object:
+        raise NotImplementedError
+
+
+def make_agent(name: str = "planner", description: str | None = "A helpful planner") -> Agent:
+    return Agent(name, subscribe_topics=f"{name}.in", model_client=_FakeModel(), description=description)
+
+
+def make_stamp(*, node_kind: str = "agent") -> ControlPlaneStamp:
+    now = datetime.now(tz=timezone.utc)
+    return ControlPlaneStamp(started_at=now, last_heartbeat_at=now, heartbeat_interval=30.0, node_kind=node_kind)
+
+
+class TestAdvertDeclaration:
+    def test_declares_one_agent_card_advert(self) -> None:
+        adverts = type(make_agent())._adverts
+        assert AGENTS_TOPIC in adverts
+        assert adverts[AGENTS_TOPIC].record is AgentCard
+
+    def test_advert_factory_is_a_bound_method(self) -> None:
+        factories = make_agent().control_plane_adverts()
+        assert AGENTS_TOPIC in factories
+        assert callable(factories[AGENTS_TOPIC])
+
+
+class TestAgentCardFactory:
+    def test_factory_builds_a_card_from_description_and_stamp(self) -> None:
+        agent = make_agent("planner", description="Plans things")
+        stamp = make_stamp()
+        card = agent._agent_card_advert(stamp)
+        assert isinstance(card, AgentCard)
+        # the worker-stamped fields ride through verbatim
+        assert card.started_at == stamp.started_at
+        assert card.last_heartbeat_at == stamp.last_heartbeat_at
+        assert card.heartbeat_interval == 30.0
+        assert card.node_kind == "agent"
+        # content: the directory blurb
+        assert card.description == "Plans things"
+
+    def test_factory_defaults_description_to_none(self) -> None:
+        agent = make_agent("bare", description=None)
+        assert agent._agent_card_advert(make_stamp()).description is None
+
+    def test_node_kind_rides_the_stamp(self) -> None:
+        # The factory never sets node_kind; it rides on the worker stamp ("agent").
+        assert make_agent()._agent_card_advert(make_stamp(node_kind="agent")).node_kind == "agent"
+
+
+class TestDescriptionCtorParam:
+    def test_description_is_stored(self) -> None:
+        assert make_agent("planner", description="Plans things")._description == "Plans things"
+
+    def test_description_defaults_to_none(self) -> None:
+        agent = Agent("noblurb", subscribe_topics="noblurb.in", model_client=_FakeModel())
+        assert agent._description is None

--- a/tests/test_agent_card_advert.py
+++ b/tests/test_agent_card_advert.py
@@ -83,3 +83,51 @@ class TestDescriptionCtorParam:
     def test_description_defaults_to_none(self) -> None:
         agent = Agent("noblurb", subscribe_topics="noblurb.in", model_client=_FakeModel())
         assert agent._description is None
+
+
+class _FakeWriter:
+    def __init__(self) -> None:
+        self.sets: list[tuple[str, str, AgentCard]] = []
+
+    async def set(self, group: str, member: str, value: AgentCard) -> None:
+        self.sets.append((group, member, value))
+
+    async def delete(self, group: str, member: str) -> None:
+        return None
+
+
+class _FakeCtx:
+    def __init__(self, resources: dict[str, _FakeWriter]) -> None:
+        self.resources = resources
+
+
+class TestPublisherDrivenCard:
+    """The full production path: the worker-owned ControlPlanePublisher builds a bare
+    ControlPlaneStamp (node_kind from _node_kind="agent") and splats it into
+    AgentCard(**stamp.model_dump(), description=...). Exercised offline here (the kafka
+    lane covers the real wire) so a future stamp field that collides with the description
+    splat — the duplicate-kwarg TypeError the type checker can't see (advert.py) — fails
+    a unit test, not only a broker test."""
+
+    async def test_publisher_publishes_a_well_formed_agent_card(self) -> None:
+        from calfkit.controlplane import ControlPlaneConfig
+        from calfkit.controlplane.publisher import ControlPlanePublisher, control_plane_writer_key
+
+        agent = make_agent("planner", description="Plans things")
+        writer = _FakeWriter()
+        pub = ControlPlanePublisher(
+            worker_id="wkr",
+            adverts=[(agent, type(agent)._adverts[AGENTS_TOPIC])],
+            config=ControlPlaneConfig(heartbeat_interval=3600.0),
+        )
+        ctx = _FakeCtx({control_plane_writer_key(AGENTS_TOPIC): writer})
+        await pub.start(ctx)  # fail-loud first publish
+        try:
+            assert len(writer.sets) == 1
+            group, member, record = writer.sets[0]
+            assert (group, member) == ("planner", "wkr")  # name × worker is the wire key
+            assert isinstance(record, AgentCard)
+            assert record.description == "Plans things"
+            assert record.node_kind == "agent"
+        finally:
+            await pub.stop(ctx)

--- a/tests/test_agents_models.py
+++ b/tests/test_agents_models.py
@@ -1,0 +1,117 @@
+"""AgentCard wire model on the ``calf.agents`` control plane (spec §4.2).
+
+An :class:`AgentCard` is one agent instance's advertisement: identity (the agent's
+``name``) is the wire key (``node_id`` × ``worker_id``, held by the substrate, never in
+the value); the only content is an optional, length-bounded ``description``. It mirrors
+``CapabilityRecord`` but is **minimal** (L7) — no dispatch topic (derived, ADR-0017), no
+system prompt, no tool list — and bounds ``description`` **loudly** (L12).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+from pydantic_core import PydanticUndefined
+
+from calfkit.controlplane import ControlPlaneRecord
+from calfkit.models.agents import (
+    AGENT_CARD_DESCRIPTION_MAX,
+    AGENT_CARD_SCHEMA_VERSION,
+    AGENTS_TOPIC,
+    AGENTS_VIEW_RESOURCE_KEY,
+    AgentCard,
+)
+
+
+def make_card(**overrides: Any) -> AgentCard:
+    now = datetime.now(tz=timezone.utc)
+    defaults: dict[str, Any] = dict(
+        started_at=now,
+        last_heartbeat_at=now,
+        heartbeat_interval=30.0,
+        node_kind="agent",
+        description="A helpful planner agent",
+    )
+    defaults.update(overrides)
+    return AgentCard(**defaults)
+
+
+class TestAgentCardWireFormat:
+    def test_is_a_control_plane_record(self) -> None:
+        # Carries the substrate's identity/liveness base (started_at, last_heartbeat_at,
+        # heartbeat_interval, node_kind) so the view's staleness filter stays generic.
+        assert issubclass(AgentCard, ControlPlaneRecord)
+        card = make_card()
+        assert card.heartbeat_interval == 30.0
+        assert card.last_heartbeat_at is not None
+        assert card.started_at is not None
+        assert card.node_kind == "agent"
+
+    def test_schema_version_has_a_concrete_default(self) -> None:
+        # Load-bearing: ControlPlaneView derives its reader version from this default.
+        default = AgentCard.model_fields["schema_version"].default
+        assert default is not PydanticUndefined
+        assert default == AGENT_CARD_SCHEMA_VERSION == 1
+
+    def test_identity_is_not_carried_in_the_value(self) -> None:
+        # The agent's name is the wire key, never a field on the record value.
+        assert "node_id" not in AgentCard.model_fields
+        assert "name" not in AgentCard.model_fields
+
+    def test_description_is_optional_default_none(self) -> None:
+        assert make_card(description=None).description is None
+        now = datetime.now(tz=timezone.utc)
+        bare = AgentCard(started_at=now, last_heartbeat_at=now, heartbeat_interval=30.0, node_kind="agent")
+        assert bare.description is None
+
+    def test_round_trips_through_json(self) -> None:
+        card = make_card()
+        restored = AgentCard.model_validate_json(card.model_dump_json())
+        assert restored == card
+        assert restored.schema_version == 1
+
+    def test_tolerant_reader_ignores_unknown_fields(self) -> None:
+        # Records outlive deploys; a newer writer may add fields this reader ignores.
+        payload = make_card().model_dump_json()
+        widened = payload[:-1] + ', "future_field": {"x": 1}}'
+        restored = AgentCard.model_validate_json(widened)
+        assert restored.description == "A helpful planner agent"
+
+    def test_minimal_card_has_no_extra_content_fields(self) -> None:
+        # L7: the card is minimal — name (the key) + bounded description ONLY.
+        # No content_updated_at (capability-only), no published_at, no topic/prompt/tools.
+        assert "content_updated_at" not in AgentCard.model_fields
+        assert "published_at" not in AgentCard.model_fields
+        assert "dispatch_topic" not in AgentCard.model_fields
+        assert "tools" not in AgentCard.model_fields
+        stamp_and_version = {"started_at", "last_heartbeat_at", "heartbeat_interval", "node_kind", "schema_version"}
+        assert set(AgentCard.model_fields) == stamp_and_version | {"description"}
+
+
+class TestLoudDescriptionCap:
+    def test_at_max_length_constructs(self) -> None:
+        make_card(description="x" * AGENT_CARD_DESCRIPTION_MAX)  # must not raise
+
+    def test_over_max_length_raises_at_construction(self) -> None:
+        # L12: an over-long description is a CONSTRUCTION error (never silent
+        # truncation, never an oversize record that decode-fails and drops the node).
+        with pytest.raises(ValidationError):
+            make_card(description="x" * (AGENT_CARD_DESCRIPTION_MAX + 1))
+
+
+class TestAgentsConstants:
+    def test_topic_is_calf_agents(self) -> None:
+        assert AGENTS_TOPIC == "calf.agents"
+
+    def test_view_resource_key_is_distinct_from_capability(self) -> None:
+        # L11: a distinct resource key from the capability view.
+        from calfkit.models.capability import CAPABILITY_VIEW_RESOURCE_KEY
+
+        assert AGENTS_VIEW_RESOURCE_KEY != CAPABILITY_VIEW_RESOURCE_KEY
+        assert AGENTS_VIEW_RESOURCE_KEY == "calfkit.controlplane.agents_view"
+
+    def test_description_max_is_512(self) -> None:
+        assert AGENT_CARD_DESCRIPTION_MAX == 512

--- a/tests/test_co_tenant_tool_isolation.py
+++ b/tests/test_co_tenant_tool_isolation.py
@@ -403,11 +403,19 @@ def test_worker_register_handlers_dedupes_explicit_return_topic(container):
 
     dedup_calls = [c for c in spy.call_args_list if c.kwargs.get("group_id") == "dedup_agent"]
     assert len(dedup_calls) == 1, f"expected one subscriber registration for dedup_agent; got {len(dedup_calls)}"
-    assert dedup_calls[0].args == ("dedup_agent.private.return", "dedup_chan.in"), (
+    # The deduped set: the explicitly-listed return topic (registered ONCE, not twice),
+    # the public inbox, and the framework-private name-scoped input inbox every node now
+    # also subscribes to (ADR-0017, appended at registration after _return_topic).
+    assert dedup_calls[0].args == (
+        "dedup_agent.private.return",
+        "dedup_chan.in",
+        "agent.dedup_agent.private.input",
+    ), (
         f"worker registered subscriber with topics={dedup_calls[0].args}; "
-        f"expected deduped 2-tuple ('dedup_agent.private.return', 'dedup_chan.in'). "
-        f"Without dict.fromkeys, the private return topic would appear twice in registration "
-        f"logs / AsyncAPI / observability — silently tolerated by Kafka clients but noisy."
+        f"expected deduped 3-tuple ('dedup_agent.private.return', 'dedup_chan.in', "
+        f"'agent.dedup_agent.private.input'). Without dict.fromkeys, the private return topic "
+        f"would appear twice in registration logs / AsyncAPI / observability — silently "
+        f"tolerated by Kafka clients but noisy."
     )
 
 

--- a/tests/test_private_input_topic.py
+++ b/tests/test_private_input_topic.py
@@ -1,0 +1,68 @@
+"""ADR-0017: every node exposes a deterministic, name-scoped private INPUT topic.
+
+``_private_input_topic = f"{node_kind}.{name}.private.input"`` — the inbound-inbox
+parallel to ``_return_topic`` (the continuation inbox). Universal across node kinds
+(agents are the first consumer; non-agent inboxes are dormant in v1). The property
+reads the ``_node_kind`` ClassVar + ``name``, so it resolves even on ``@dataclass``
+tool/MCP nodes whose generated ``__init__`` bypasses ``BaseNodeDef.__init__``.
+"""
+
+from __future__ import annotations
+
+from calfkit.mcp.mcp_toolbox import MCPToolboxNode
+from calfkit.mcp.mcp_transport import StreamableHttpParameters
+from calfkit.nodes.agent import Agent
+from calfkit.nodes.consumer import ConsumerNode
+from calfkit.nodes.node import NodeDef
+from calfkit.nodes.tool import agent_tool
+from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
+
+
+class _FakeModel(PydanticModelClient):
+    @property
+    def model_name(self) -> str:
+        return "fake"
+
+    @property
+    def system(self) -> str:
+        return "fake"
+
+    async def request(self, *args: object, **kwargs: object) -> object:
+        raise NotImplementedError
+
+
+def _add(a: int, b: int) -> int:
+    """Add two integers."""
+    return a + b
+
+
+class TestPrivateInputTopicDerivation:
+    """The topic is ``{node_kind}.{name}.private.input`` for every node kind."""
+
+    def test_agent_kind(self) -> None:
+        agent = Agent("planner", subscribe_topics="planner.in", model_client=_FakeModel())
+        assert agent._private_input_topic == "agent.planner.private.input"
+
+    def test_tool_kind(self) -> None:
+        # @dataclass tool node: its generated __init__ bypasses BaseNodeDef.__init__,
+        # so the property must read the _node_kind ClassVar + name, not an __init__ value.
+        tool = agent_tool(_add, name="add")
+        assert tool._private_input_topic == "tool.add.private.input"
+
+    def test_consumer_kind(self) -> None:
+        consumer = ConsumerNode(name="watcher", consume_fn=lambda ctx: None, subscribe_topics=["watcher.in"])
+        assert consumer._private_input_topic == "consumer.watcher.private.input"
+
+    def test_toolbox_kind(self) -> None:
+        toolbox = MCPToolboxNode("docs_server", connection_params=StreamableHttpParameters(url="http://unused.local/mcp"))
+        assert toolbox._private_input_topic == "toolbox.docs_server.private.input"
+
+    def test_bare_node_kind(self) -> None:
+        node = NodeDef(node_id="raw", subscribe_topics=["raw.in"])
+        assert node._private_input_topic == "node.raw.private.input"
+
+    def test_pins_the_name_node_id_alias(self) -> None:
+        # The property uses self.name per spec §4.1; name aliases node_id today. Pin the
+        # equality so a future name/node_id divergence trips loudly here (ADR-0017).
+        agent = Agent("planner", subscribe_topics="planner.in", model_client=_FakeModel())
+        assert agent._private_input_topic == f"agent.{agent.node_id}.private.input"

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -17,6 +17,7 @@ from calfkit.provisioning import (
     ProvisionReport,
     TopicProvisioner,
     TopicProvisioningError,
+    framework_topics_for_nodes,
     topics_for_nodes,
 )
 from calfkit.provisioning import provisioner as provisioner_mod
@@ -136,6 +137,37 @@ def test_topics_for_nodes_dedupes_order_preserving() -> None:
     # Order-preserving: first-seen wins. "shared.in" precedes a.out which
     # precedes b.out.
     assert topics.index("shared.in") < topics.index("a.out") < topics.index("b.out")
+
+
+def test_topics_for_nodes_includes_private_input_topic() -> None:
+    # ADR-0017: every node's framework-owned inbound inbox is provisioned too.
+    node = _tool_node("echo", sub="echo.in", pub="echo.out")
+
+    topics = topics_for_nodes([node])
+
+    assert node._private_input_topic in topics
+    assert node._private_input_topic == "tool.echo.private.input"
+
+
+def test_framework_topics_for_nodes_returns_return_and_input_inboxes() -> None:
+    # The single authority for framework-owned topics (never user topic_configs):
+    # each node's private return inbox + private input inbox (C1 fix; ADR-0017).
+    node = _tool_node("echo", sub="echo.in", pub="echo.out")
+
+    assert framework_topics_for_nodes([node]) == {node._return_topic, node._private_input_topic}
+    assert framework_topics_for_nodes([node]) == {"echo.private.return", "tool.echo.private.input"}
+
+
+def test_framework_topics_for_nodes_unions_across_nodes() -> None:
+    a = _tool_node("a", sub="a.in", pub="a.out")
+    b = _tool_node("b", sub="b.in", pub="b.out")
+
+    assert framework_topics_for_nodes([a, b]) == {
+        "a.private.return",
+        "tool.a.private.input",
+        "b.private.return",
+        "tool.b.private.input",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_provisioning_cli.py
+++ b/tests/test_provisioning_cli.py
@@ -314,6 +314,39 @@ def test_partitions_and_replication_factor_flow_to_new_topic(monkeypatch) -> Non
     assert all(nt.replication_factor == 2 for nt in seen)
 
 
+def test_private_input_topic_classified_framework_owned(monkeypatch) -> None:  # noqa: ANN001
+    """C1/ADR-0017: the CLI must classify every node's private INPUT inbox as
+    framework-owned (via the single ``framework_topics_for_nodes`` authority), not as
+    a data topic. The CLI sets no ``topic_configs`` today, so the classification is
+    asserted at the ``provision()`` seam rather than via an observable config."""
+    from typer.testing import CliRunner
+
+    from calfkit.cli.topics import app
+    from calfkit.provisioning import ProvisionReport, TopicProvisioner
+    from tests import provisioning_cli_nodes
+
+    captured: dict[str, set[str]] = {}
+
+    async def _spy_provision(self, topics, *, framework_topics):  # noqa: ANN001, ANN202
+        captured["topics"] = set(topics)
+        captured["framework_topics"] = set(framework_topics)
+        return ProvisionReport()
+
+    monkeypatch.setattr(TopicProvisioner, "provision", _spy_provision)
+
+    result = CliRunner().invoke(
+        app,
+        ["provision", "--nodes", "tests.provisioning_cli_nodes:nodes", "--bootstrap-servers", "localhost:9092"],
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+
+    expected_inputs = {n._private_input_topic for n in provisioning_cli_nodes.nodes}
+    expected_returns = {n._return_topic for n in provisioning_cli_nodes.nodes}
+    assert expected_inputs <= captured["topics"]  # provisioned at all
+    assert expected_inputs <= captured["framework_topics"]  # AND classified framework-owned
+    assert expected_returns <= captured["framework_topics"]  # return inboxes unchanged
+
+
 def test_unauthorized_report_branch_prints_line(monkeypatch) -> None:  # noqa: ANN001
     """An unauthorized (code 29) topic prints the unauthorized summary line."""
     from typer.testing import CliRunner

--- a/tests/test_provisioning_worker.py
+++ b/tests/test_provisioning_worker.py
@@ -172,3 +172,38 @@ def test_declares_only_registered_nodes_not_later_additions() -> None:
     assert "echo.in" in names
     assert "late.in" not in names
     assert "late.out" not in names
+
+
+# ---------------------------------------------------------------------------
+# ADR-0017: the name-scoped private input inbox is registered framework-owned
+# ---------------------------------------------------------------------------
+
+
+def test_private_input_topic_is_provisioned_framework_owned() -> None:
+    # The inbound inbox is provisioned but framework-owned: never carries user
+    # topic_configs (declared via framework_topics_for_nodes — the C1 fix).
+    cfg = ProvisioningConfig(enabled=True, topic_configs={"retention.ms": "604800000"})
+    client = _make_client(cfg)
+    node = _tool_node("echo", "echo.in", "echo.out")
+    worker = Worker(client, nodes=[node])
+
+    asyncio.run(worker._on_startup())
+    by_name = _by_name(_run_ensurer(client))
+
+    assert node._private_input_topic in by_name  # provisioned
+    assert by_name[node._private_input_topic].topic_configs == {}  # framework-owned
+    assert by_name["echo.in"].topic_configs == {"retention.ms": "604800000"}  # data topic still configured
+
+
+def test_node_subscribes_to_its_private_input_topic() -> None:
+    # Every node CONSUMES its inbound inbox (contributed at registration like
+    # _return_topic — not appended into user-facing subscribe_topics).
+    client = _make_client()
+    node = _tool_node("echo", "echo.in", "echo.out")
+    worker = Worker(client, nodes=[node])
+
+    worker.register_handlers()
+
+    node_topics = next(s.topics for s in worker._client._connection._subscribers if node._return_topic in (s.topics or []))
+    assert node._private_input_topic in node_topics
+    assert node._private_input_topic not in node.subscribe_topics

--- a/tests/test_worker_agents_view.py
+++ b/tests/test_worker_agents_view.py
@@ -201,3 +201,23 @@ class TestAgentsViewResource:
         with pytest.raises(RuntimeError, match="ControlPlaneConfig"):
             await drive(worker)
         assert fake_table.instances == []  # failed before construction
+
+    async def test_stale_after_and_reader_tuning_are_forwarded(self, fake_table: type[FakeGroupedTable]) -> None:
+        # Both are behavior-affecting: reader_tuning lowers convergence latency (reaches
+        # the table), stale_after sets when a card expires (held on the view). A regression
+        # dropping either would otherwise pass every other test.
+        from calfkit.tuning import KTableReaderTuning
+
+        worker = Worker(
+            Client.connect("kafka:9092"),
+            control_plane=ControlPlaneConfig(
+                stale_after=12.0,
+                reader_tuning=KTableReaderTuning(poll_timeout_ms=20, fetch_max_wait_ms=10),
+            ),
+        )
+        gen, view = await drive(worker)
+        kwargs = fake_table.instances[0].kwargs
+        assert kwargs["poll_timeout_ms"] == 20  # reader_tuning -> table
+        assert kwargs["fetch_max_wait_ms"] == 10
+        assert view._stale_after == 12.0  # stale_after -> view
+        await close(gen)

--- a/tests/test_worker_agents_view.py
+++ b/tests/test_worker_agents_view.py
@@ -1,0 +1,203 @@
+"""The worker auto-wires the AgentCard write side (every agent) and the read-side
+Agents View (gated, dormant until ``peers=`` lands in PR-B).
+
+Write side: hosting any agent trips the generic ``@advertises`` auto-wiring — the
+``calf.agents`` writer + the ``ControlPlanePublisher`` — with zero user config (mirrors
+``test_worker_capability_view.py::TestControlPlaneWriterRegistration``). Read side: a
+distinct ``ControlPlaneView[AgentCard]`` resource under ``AGENTS_VIEW_RESOURCE_KEY``,
+registered iff a hosted node carries a ``_peers`` handle — absent in PR-A, so the gate is
+a no-op here and exercised via a stub (mirrors ``TestCapabilityViewRegistration``). The
+collapse/staleness/schema filtering is the substrate's (``test_controlplane_view.py``);
+the live path is the kafka lane.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from calfkit.client.client import Client
+from calfkit.controlplane import ControlPlaneConfig
+from calfkit.controlplane.publisher import control_plane_writer_key
+from calfkit.mcp.mcp_toolbox import MCPToolboxNode
+from calfkit.mcp.mcp_transport import StreamableHttpParameters
+from calfkit.models.agents import AGENTS_TOPIC, AGENTS_VIEW_RESOURCE_KEY, AgentCard
+from calfkit.models.capability import CAPABILITY_TOPIC
+from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
+from calfkit.worker.worker import Worker
+
+
+class _FakeModel(PydanticModelClient):
+    @property
+    def model_name(self) -> str:
+        return "fake"
+
+    @property
+    def system(self) -> str:
+        return "fake"
+
+    async def request(self, *args: object, **kwargs: object) -> object:
+        raise NotImplementedError
+
+
+def make_agent(name: str = "planner", *tools: object):
+    from calfkit.nodes.agent import Agent
+
+    return Agent(name, subscribe_topics=f"{name}.in", model_client=_FakeModel(), tools=list(tools))
+
+
+def make_toolbox() -> MCPToolboxNode:
+    return MCPToolboxNode("docs_server", connection_params=StreamableHttpParameters(url="http://unused.local/mcp"))
+
+
+def worker_resource_names(worker: Worker) -> list[str]:
+    return [name for name, _ in worker._resource_cms()]
+
+
+# ---------------------------------------------------------------------------
+# Write side: every agent advertises on calf.agents (R8)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentCardWriterRegistration:
+    def test_hosting_an_agent_registers_the_agents_writer_and_publisher(self) -> None:
+        worker = Worker(Client.connect("kafka:9092"), nodes=[make_agent()])
+        worker._maybe_register_control_plane()
+        assert control_plane_writer_key(AGENTS_TOPIC) in worker_resource_names(worker)
+        publisher = worker._control_plane_publisher
+        assert publisher is not None
+        assert AGENTS_TOPIC in [info.topic for _, info in publisher._adverts]
+
+    def test_agent_only_worker_registers_no_capability_writer(self) -> None:
+        # A plain agent advertises on calf.agents, NOT calf.capabilities (only
+        # tool/toolbox nodes advertise capabilities).
+        worker = Worker(Client.connect("kafka:9092"), nodes=[make_agent()])
+        worker._maybe_register_control_plane()
+        names = worker_resource_names(worker)
+        assert control_plane_writer_key(AGENTS_TOPIC) in names
+        assert control_plane_writer_key(CAPABILITY_TOPIC) not in names
+
+    def test_mixed_worker_registers_both_writers(self) -> None:
+        # Agent (calf.agents) + toolbox (calf.capabilities) co-reside: one writer per topic.
+        worker = Worker(Client.connect("kafka:9092"), nodes=[make_agent(), make_toolbox()])
+        worker._maybe_register_control_plane()
+        names = worker_resource_names(worker)
+        assert control_plane_writer_key(AGENTS_TOPIC) in names
+        assert control_plane_writer_key(CAPABILITY_TOPIC) in names
+
+    def test_toolbox_only_worker_registers_no_agents_writer(self) -> None:
+        worker = Worker(Client.connect("kafka:9092"), nodes=[make_toolbox()])
+        worker._maybe_register_control_plane()
+        names = worker_resource_names(worker)
+        assert control_plane_writer_key(CAPABILITY_TOPIC) in names
+        assert control_plane_writer_key(AGENTS_TOPIC) not in names
+
+
+# ---------------------------------------------------------------------------
+# Read side: the Agents View resource, gated on a `_peers` handle (R9)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentsViewRegistration:
+    def test_not_registered_for_a_plain_agent(self) -> None:
+        # The PR-A reality: no node sets `_peers`, so the gate is a true no-op.
+        worker = Worker(Client.connect("kafka:9092"), nodes=[make_agent()])
+        worker._maybe_register_agents_view()
+        assert AGENTS_VIEW_RESOURCE_KEY not in worker_resource_names(worker)
+
+    def test_registered_when_a_node_has_peers(self) -> None:
+        # PR-B sets `_peers`; stub it to prove the gate wires the resource.
+        agent = make_agent()
+        agent._peers = [object()]  # type: ignore[attr-defined]
+        worker = Worker(Client.connect("kafka:9092"), nodes=[agent])
+        worker._maybe_register_agents_view()
+        assert AGENTS_VIEW_RESOURCE_KEY in worker_resource_names(worker)
+
+    def test_idempotent_on_repeat_calls(self) -> None:
+        agent = make_agent()
+        agent._peers = [object()]  # type: ignore[attr-defined]
+        worker = Worker(Client.connect("kafka:9092"), nodes=[agent])
+        worker._maybe_register_agents_view()
+        worker._maybe_register_agents_view()
+        assert worker_resource_names(worker).count(AGENTS_VIEW_RESOURCE_KEY) == 1
+
+
+# ---------------------------------------------------------------------------
+# Read side: the Agents View resource open mechanics (R10)
+# ---------------------------------------------------------------------------
+
+
+class FakeGroupedTable:
+    """Stands in for ktables.GroupedKafkaTable; records construction and lifecycle."""
+
+    instances: list[FakeGroupedTable] = []
+
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self.started = False
+        self.stopped = False
+        FakeGroupedTable.instances.append(self)
+
+    @classmethod
+    def json(cls, *, model: object, **kwargs: object) -> FakeGroupedTable:
+        return cls(model=model, **kwargs)
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+@pytest.fixture
+def fake_table(monkeypatch: pytest.MonkeyPatch) -> type[FakeGroupedTable]:
+    FakeGroupedTable.instances = []
+    monkeypatch.setattr("ktables.GroupedKafkaTable", FakeGroupedTable)
+    return FakeGroupedTable
+
+
+async def drive(worker: Worker):
+    gen = worker._agents_view_resource(None)  # type: ignore[arg-type]
+    view = await anext(gen)
+    return gen, view
+
+
+async def close(gen) -> None:
+    with pytest.raises(StopAsyncIteration):
+        await anext(gen)
+
+
+class TestAgentsViewResource:
+    async def test_opens_view_over_calf_agents_with_lifecycle(self, fake_table: type[FakeGroupedTable]) -> None:
+        worker = Worker(Client.connect("kafka:9092"), control_plane=ControlPlaneConfig(catchup_timeout=7.0))
+        gen, _ = await drive(worker)
+        table = fake_table.instances[0]
+        assert table.started and not table.stopped
+        assert table.kwargs["topic"] == AGENTS_TOPIC == "calf.agents"
+        assert table.kwargs["model"] is AgentCard
+        assert table.kwargs["catchup_timeout"] == 7.0
+        assert table.kwargs["ensure_topic"] is False  # provisioning disabled by default
+        await close(gen)
+        assert table.stopped
+
+    async def test_ensure_topic_follows_provisioning(self, fake_table: type[FakeGroupedTable]) -> None:
+        from calfkit.provisioning import ProvisioningConfig
+
+        worker = Worker(Client.connect("kafka:9092", provisioning=ProvisioningConfig(enabled=True)))
+        gen, _ = await drive(worker)
+        assert fake_table.instances[0].kwargs["ensure_topic"] is True
+        await close(gen)
+
+    async def test_bootstrap_derives_from_client(self, fake_table: type[FakeGroupedTable]) -> None:
+        worker = Worker(Client.connect(["kafka-a:9092", "kafka-b:9092"]))
+        gen, _ = await drive(worker)
+        assert fake_table.instances[0].kwargs["bootstrap_servers"] == "kafka-a:9092,kafka-b:9092"
+        await close(gen)
+
+    async def test_underivable_bootstrap_raises_actionable_error(self, fake_table: type[FakeGroupedTable]) -> None:
+        client = Client.connect("kafka:9092")
+        client._server_urls = None
+        client.broker._connection_kwargs = {}
+        worker = Worker(client)
+        with pytest.raises(RuntimeError, match="ControlPlaneConfig"):
+            await drive(worker)
+        assert fake_table.instances == []  # failed before construction

--- a/tests/test_worker_capability_view.py
+++ b/tests/test_worker_capability_view.py
@@ -92,12 +92,16 @@ class TestControlPlaneWriterRegistration:
         from calfkit.controlplane.publisher import control_plane_writer_key
         from calfkit.models.capability import CAPABILITY_TOPIC
 
-        # An agent declares a tool selector but advertises nothing — only the toolbox
-        # (host) advertises. A worker hosting just the agent wires no control-plane writer.
+        # An agent that references a toolbox via a tool selector does not itself advertise
+        # on the CAPABILITY plane — only the hosted toolbox would. (The agent DOES advertise
+        # on the agents plane since ADR-0015, so a publisher exists; this pins the
+        # capability writer specifically as absent.)
         worker = Worker(Client.connect("kafka:9092"), nodes=[make_agent(make_toolbox())])
         worker._maybe_register_control_plane()
         assert control_plane_writer_key(CAPABILITY_TOPIC) not in worker_resource_names(worker)
-        assert worker._control_plane_publisher is None
+        publisher = worker._control_plane_publisher
+        assert publisher is not None  # the agent advertises its AgentCard on calf.agents
+        assert CAPABILITY_TOPIC not in [info.topic for _, info in publisher._adverts]
 
 
 class FakeGroupedTable:


### PR DESCRIPTION
## What

**PR-A of the agent-mesh feature** — the discovery + addressing **substrate** that messaging (PR-B) and handoff (PR-C) build on. Pure composition over the shipped control-plane substrate + `@advertises` mechanism: **zero new ktable/transport code**, mirroring the repo's own `#256` (substrate) → `#260` (capability plane) precedent.

### 1. Base-node private input topic (ADR-0017, `accepted`)
Every node exposes a deterministic `_private_input_topic = {node_kind}.{name}.private.input`, contributed at registration exactly like `_return_topic` (framework-owned, auto-subscribed, provisioned) — **not** appended into `subscribe_topics` (the `@dataclass` tool/MCP node `__init__`s bypass `BaseNodeDef.__init__`). A single `framework_topics_for_nodes()` authority classifies the framework-owned inboxes for **both** the worker startup ensurer and the `ck topics provision` CLI (so a future framework topic is added in one place). Non-agent inboxes are dormant in v1 (accepted).

### 2. The `AgentCard` plane
`AgentCard(ControlPlaneRecord)` on the compacted `calf.agents` topic, advertised by **every agent** (no opt-out) via a new `@advertises` factory on `BaseAgentNodeDef`. New optional `Agent(description=...)` directory blurb, bounded **loudly** (`Field(max_length=512)` — construction error, never silent truncation). Read-side `ControlPlaneView[AgentCard]` resource + `_maybe_register_agents_view` gated on a `peers=` handle (**dormant** until PR-B). Write side + provisioning are automatic via the generic publisher; every agent-hosting worker thus has a `calf.agents` boot dependency.

## Scope discipline
**Nothing from PR-B/PR-C is built:** no `peers=`/`Messaging`/`Handoff` handles, no `message_agent`/`HandoffRequest`, no `Call.isolate_state`/fan-out change, no `CallFrame` cycle guard, no directory render.

## Test plan
TDD (red→green) throughout:
- **Unit / offline:** per-kind topic derivation (agent/tool/consumer/toolbox/node) + dataclass-node survival; framework-owned provisioning across the worker **and** CLI; `AgentCard` schema + loud cap + minimal-card field-set; the `@advertises` factory; worker write-side auto-registration (writer-topic matrix) + read-side gate + view-resource open mechanics.
- **Kafka lane (real broker):** advertise→view roundtrip + clean tombstone; 2-replica collapse (one card per name + survivor); worker-wiring roundtrip.
- **100% coverage on new code.** `make check` clean. Topic config (compaction) is deferred entirely to ktables' create-path (`DEFAULT_TOPIC_CONFIGS`), provisioned like `calf.capabilities`.

## Notes
- One commit (the plan envisioned two, but `worker.py` is shared by both pieces and the import dependency makes a clean each-commit-green split infeasible without interactive staging).
- Design spec (`docs/designs/agent-mesh-spec.md`) + the other ADRs stay off this branch by decision; only ADR-0017 (the primitive this PR ships) is included, flipped to `accepted`.