### PR TITLE
fix(deps): cap pydantic-graph below 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,12 @@ dependencies = [
     "typing-inspection>=0.4.0",
     "opentelemetry-api>=1.28.0",
     "genai-prices>=0.0.48",
-    "pydantic-graph>=1.47.0",
+    # pydantic-graph capped to <2: the vendored pydantic-ai (v1.47.0) imports the
+    # BaseNode-based runner and the `pydantic_graph.beta`/`pydantic_graph.nodes`
+    # modules, all of which were removed in 2.0.0 (upstream's own deprecation
+    # warning instructs pinning to `<2` to keep using them). 2.0.0 makes calfkit
+    # entirely unimportable (ModuleNotFoundError: No module named 'pydantic_graph.beta').
+    "pydantic-graph>=1.47.0,<2",
     "exceptiongroup>=1.2.2; python_version < '3.11'",
     # Provider SDKs
     "openai>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,11 +35,8 @@ dependencies = [
     "typing-inspection>=0.4.0",
     "opentelemetry-api>=1.28.0",
     "genai-prices>=0.0.48",
-    # pydantic-graph capped to <2: the vendored pydantic-ai (v1.47.0) imports the
-    # BaseNode-based runner and the `pydantic_graph.beta`/`pydantic_graph.nodes`
-    # modules, all of which were removed in 2.0.0 (upstream's own deprecation
-    # warning instructs pinning to `<2` to keep using them). 2.0.0 makes calfkit
-    # entirely unimportable (ModuleNotFoundError: No module named 'pydantic_graph.beta').
+    # Capped to <2: the vendored pydantic-ai imports `pydantic_graph.beta`,
+    # which 2.0.0 removed (makes calfkit unimportable).
     "pydantic-graph>=1.47.0,<2",
     "exceptiongroup>=1.2.2; python_version < '3.11'",
     # Provider SDKs


### PR DESCRIPTION
## Problem

`pydantic-graph 2.0.0` is now the latest release on PyPI, and the project's pin was unbounded above (`pydantic-graph>=1.47.0`) — so any fresh resolve (`uv lock --upgrade`, a clean install) would pull 2.0.0 and **break the build entirely**.

calfkit has no first-party `pydantic_graph` usage; it consumes it only through the vendored `pydantic_ai` (snapshot of pydantic-ai-slim v1.47.0). That vendored code imports three things that **2.0.0 removed**:

| Vendored import | Status in 2.0.0 |
|---|---|
| `from pydantic_graph.beta import Graph, GraphBuilder` (`_agent_graph.py:25`) | `pydantic_graph.beta` module **removed** |
| `from pydantic_graph.beta.graph` / `.beta.step import ...` (`run.py`) | **removed** |
| `from pydantic_graph.nodes import End, NodeRunEndT` (`_agent_graph.py:26`) | `pydantic_graph.nodes` module **removed** |
| `from pydantic_graph import GraphRun, GraphRunResult` (`_utils.py`) | `GraphRunResult` no longer exported |

### Verified empirically

Installing 2.0.0 into the venv and importing the package fails immediately — even `import calfkit.models` raises:

```
File ".../calfkit/_vendor/pydantic_ai/_agent_graph.py", line 25, in <module>
    from pydantic_graph.beta import Graph, GraphBuilder
ModuleNotFoundError: No module named 'pydantic_graph.beta'
```

The whole package becomes unimportable (the chain `calfkit.nodes.agent` → vendored `Agent` → `run` → `_agent_graph`).

## Fix

Cap to `<2`. The entire 1.x line (1.47.0 → 1.99.0) remains compatible with the vendored snapshot — 1.99.0 still imports every symbol, with deprecation warnings. pydantic-graph's **own** warning text confirms the remedy:

> "...deprecated and will be removed (or repurposed) in v2; ...or pin to `pydantic_graph<2` to keep using them."

```diff
-    "pydantic-graph>=1.47.0",
+    "pydantic-graph>=1.47.0,<2",
```

`uv.lock` is gitignored, so `pyproject.toml` is the tracked source of truth; re-locking still resolves to 1.47.0 (unchanged).

## Follow-up (out of scope)

This cap freezes calfkit out of pydantic-graph 2.x as long as the vendored pydantic-ai stays on the deprecated BaseNode runner. The long-term fix is re-vendoring a newer pydantic-ai built on the `GraphBuilder` API.

## Checks

- `make fix` — clean
- `make check` — lint, format, type-check all pass
- Config-only change; compatibility verified by import probes against 1.47.0 / 1.99.0 / 2.0.0