### PR TITLE
feat: HandoffRequest field descriptions + sharper agent-messaging copy

### DIFF
--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -317,10 +317,10 @@ class BaseAgentNodeDef(
         return ToolDefinition(
             name=_MESSAGE_AGENT_TOOL,
             description=(
-                "Use this tool to send a message to another agent to ask questions or handle complex, multi-step tasks, "
-                "and get its reply back as the tool result. You keep control of this conversation and continue after the "
-                "reply (the reply is not shown to the user, so relay what matters). The peer answers on a fresh conversation "
-                "that sees only this message and remembers nothing between calls, so include all the context it needs.\n"
+                "Use this tool to send a message to another agent to ask questions or handle complex, multi-step tasks. "
+                "The agent's reply comes back to you as the tool result. You keep control of this conversation and continue "
+                "after the reply (the reply is not shown to the user, so relay what matters). The agent answers on a fresh "
+                "conversation that sees only this message and remembers nothing between calls, so include all the context it needs.\n"
                 f"Available agents (name — description):\n{directory}"
             ),
             parameters_json_schema={

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -317,15 +317,18 @@ class BaseAgentNodeDef(
         return ToolDefinition(
             name=_MESSAGE_AGENT_TOOL,
             description=(
-                "Send a message to another agent and get its reply — a consultation: the peer answers on "
-                "a fresh conversation (it sees only your message) and you keep control of this one.\n"
+                "Use this tool to send a message to another agent to ask questions or handle complex, multi-step tasks. "
+                "Each agent has specific capabilities and tools available to it. "
+                "The agent's final message is returned to you as the tool result; it is not shown to the user — relay what matters. "
+                "Each message to an agent is a fresh conversation (it sees only your message) so every message must contain adequate context. "
+                "Context is not persisted from turn to turn, each message to an agent is a fresh conversation for that agent.\n"
                 f"Available agents (name — description):\n{directory}"
             ),
             parameters_json_schema={
                 "type": "object",
                 "properties": {
-                    "name": {"type": "string", "description": "The agent to message (a name from the list above)."},
-                    "message": {"type": "string", "description": "Your message or question for that agent."},
+                    "name": {"type": "string", "description": "The agent to message (a name from the list of available agents)."},
+                    "message": {"type": "string", "description": "Your message or question for that agent, including any necessary context."},
                 },
                 "required": ["name", "message"],
                 "additionalProperties": False,

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -317,11 +317,10 @@ class BaseAgentNodeDef(
         return ToolDefinition(
             name=_MESSAGE_AGENT_TOOL,
             description=(
-                "Use this tool to send a message to another agent to ask questions or handle complex, multi-step tasks. "
-                "Each agent has specific capabilities and tools available to it. "
-                "The agent's final message is returned to you as the tool result; it is not shown to the user — relay what matters. "
-                "Each message to an agent is a fresh conversation (it sees only your message) so every message must contain adequate context. "
-                "Context is not persisted from turn to turn, each message to an agent is a fresh conversation for that agent.\n"
+                "Use this tool to send a message to another agent to ask questions or handle complex, multi-step tasks, "
+                "and get its reply back as the tool result. You keep control of this conversation and continue after the "
+                "reply (the reply is not shown to the user, so relay what matters). The peer answers on a fresh conversation "
+                "that sees only this message and remembers nothing between calls, so include all the context it needs.\n"
                 f"Available agents (name — description):\n{directory}"
             ),
             parameters_json_schema={

--- a/calfkit/peers/handoff.py
+++ b/calfkit/peers/handoff.py
@@ -60,10 +60,14 @@ class HandoffRequest(BaseModel):
     - ``name`` — the peer to hand off to (validated against the live ``Literal`` in the per-turn subclass).
     - ``message`` — the handing agent's summary/context for the peer, required non-empty (``min_length=1``),
       so an empty value is auto-retried by pydantic-ai like an out-of-``Literal`` ``name`` (L5/C2).
+
+    Both fields carry a model-facing ``Field(description=...)`` that pydantic-ai forwards inside the schema's
+    ``properties`` (the per-turn subclass inherits ``message``'s and re-declares ``name``'s alongside the
+    ``Literal``); this is the structured-output analog of the ``message_agent`` tool's per-param descriptions.
     """
 
     name: str
-    message: str = Field(min_length=1)
+    message: str = Field(min_length=1, description="Your summary or context for the peer, so it can continue the conversation.")
 
     @field_validator("message")
     @classmethod
@@ -76,10 +80,14 @@ class HandoffRequest(BaseModel):
         return v
 
 
+# The per-field "how to fill this" guidance lives in the field descriptions (`name`/`message` below), which
+# pydantic-ai forwards inside the schema's `properties` — mirroring how the `message_agent` tool splits its
+# top-level description from its per-param descriptions. The preamble keeps only the handoff *semantics* + the
+# directory it points at, so the two are documented once each, not duplicated.
 _HANDOFF_PREAMBLE = (
-    "Transfer this conversation to another agent. You relinquish control and will NOT regain it — the "
-    "chosen agent continues the full conversation and answers the original caller in your place. Choose by "
-    "exact name from the agents below, and put any summary or context the agent needs in `message`.\n\n"
+    "Use HandoffRequest to transfer this conversation to another agent. You relinquish control and will NOT "
+    "regain it — the chosen agent continues and will have context of the conversation, and answers the "
+    "original caller in your place.\n\n"
     "Agents (name — description):\n"
 )
 
@@ -107,5 +115,7 @@ def _build_handoff_request(live: tuple[tuple[str, str | None], ...]) -> type[Han
         "HandoffRequest",
         __base__=HandoffRequest,
         __doc__=_HANDOFF_PREAMBLE + render_peer_directory(live),
-        name=(Literal[names], ...),  # names is a runtime tuple -> a dynamic Literal over the live directory
+        # The Literal carries the allowed values; the description is re-declared here (the base's `name` has
+        # none, and this override would discard it anyway) so it rides into the schema's `properties`.
+        name=(Literal[names], Field(description="The peer to hand off to (a name from the list of available agents).")),
     )

--- a/calfkit/peers/handoff.py
+++ b/calfkit/peers/handoff.py
@@ -85,9 +85,10 @@ class HandoffRequest(BaseModel):
 # top-level description from its per-param descriptions. The preamble keeps only the handoff *semantics* + the
 # directory it points at, so the two are documented once each, not duplicated.
 _HANDOFF_PREAMBLE = (
-    "Use HandoffRequest to transfer this conversation to another agent. You relinquish control and will NOT "
-    "regain it — the chosen agent continues and will have context of the conversation, and answers the "
-    "original caller in your place.\n\n"
+    "Use HandoffRequest to hand the whole conversation to a better-suited agent — when the request belongs to "
+    "another agent's domain and should be handled by them, not just consulted. You relinquish control and will "
+    "NOT regain it: the chosen agent continues with full context of the conversation and answers the original "
+    "caller in your place.\n\n"
     "Agents (name — description):\n"
 )
 

--- a/tests/test_handoff_request.py
+++ b/tests/test_handoff_request.py
@@ -47,6 +47,15 @@ def test_handoff_request_message_rejects_whitespace_only() -> None:
         _build_handoff_request((("billing", None),))(name="billing", message="  ")
 
 
+def test_handoff_request_message_field_carries_a_description() -> None:
+    # The base `message` Field(description=...) rides into the schema's `properties` (pydantic-ai forwards
+    # it to the provider) — the structured-output analog of message_agent's per-param descriptions. Asserts
+    # presence (not exact prose, which is copy that may be tuned) so the field-level guidance can't silently
+    # regress to a bare `title`-only property.
+    msg = HandoffRequest.model_json_schema()["properties"]["message"]
+    assert msg.get("description")
+
+
 # ── the memoized per-turn builder ──
 
 
@@ -70,6 +79,17 @@ def test_build_handoff_request_doc_is_the_handoff_directory() -> None:
     assert built.__doc__ is not None
     assert "billing — Billing questions." in built.__doc__
     assert "refunds" in built.__doc__
+
+
+def test_build_handoff_request_fields_carry_descriptions() -> None:
+    # Both fields the model fills carry a `description` in the per-turn subclass's schema `properties`: the
+    # inherited `message` one + the re-declared `name` one (the base `name` is bare, and the `Literal`
+    # override would discard a base description, so it must be re-declared in the create_model call). The
+    # `name` Literal stays intact alongside the description.
+    props = _build_handoff_request((("billing", "Billing."), ("refunds", None))).model_json_schema()["properties"]
+    assert props["name"].get("description")
+    assert props["message"].get("description")
+    assert props["name"]["enum"] == ["billing", "refunds"]
 
 
 def test_build_handoff_request_inherits_message_min_length() -> None:


### PR DESCRIPTION
## What

Adds model-facing field descriptions to the `HandoffRequest` structured-output schema, and refreshes the LLM-facing copy on both agent-to-agent peer surfaces.

### 1. `HandoffRequest` field descriptions (`handoff.py` + tests)
Previously the `message_agent` **tool** gave per-param descriptions but the `HandoffRequest` **structured output** did not — its `name`/`message` properties were bare (`title` + `enum`/`minLength` only). The model's only per-field guidance was one compound sentence buried in the top-level preamble.

Now both fields carry a `Field(description=...)`:
- **`message`** — declared on the base model; the per-turn subclass inherits it.
- **`name`** — re-declared in the `_build_handoff_request` `create_model` call, because the subclass replaces `name` with the live `Literal` each turn (a base description would be discarded).

Verified end-to-end that pydantic-ai forwards these into the schema sent to the provider: the object def's `json_schema` is the full `TypeAdapter(...).json_schema(...)` with `properties` intact — only the **top-level** `description` (the `__doc__`/preamble) is popped off separately (`_vendor/pydantic_ai/_output.py`). The `name` `Literal`/`enum` and required-ness are preserved.

The preamble is trimmed so the per-field "how to fill this" guidance lives on the fields, not duplicated in the top-level doc — mirroring how `message_agent` splits its top-level description from its per-param descriptions.

### 2. Sharpened LLM-facing copy (`agent.py` + `handoff.py`)
- `message_agent` tool description + param descriptions reworded to stress that each message is a **fresh conversation** requiring self-contained context, and that the reply returns to the caller (not the user).
- Handoff preamble reworded: `"Use HandoffRequest to transfer this conversation…"`, and the peer now explicitly **"will have context of the conversation"** (a handoff transfers the full conversation, unlike a `message_agent` consult).

## Why
Closes the asymmetry between the consult (`message_agent`) and handoff surfaces, and gives the model field-attached guidance rather than relying on it to map a single top-level sentence onto the right property.

## Tests
- `test_handoff_request_message_field_carries_a_description` — base `message` property has a description.
- `test_build_handoff_request_fields_carry_descriptions` — the per-turn subclass's `name` **and** `message` carry descriptions, and `name`'s `enum` stays intact.

Both assert *presence* (not exact prose), so copy can be tuned without breaking tests but field-level guidance can't silently regress to a `title`-only property.

`pytest` (handoff_request / message_agent / peers_surface / handoff_dispatch / handoff_output_injection), `ruff`, and `mypy` all green.

## Notes
- Branched off `main` (the agent-mesh feature is already on `main` via #282); does **not** include the unmerged `docs-agent-peers` docs work.