### PR TITLE
fix: decode floor catches `JSONDecodeError` and `UnicodeDecodeError`, not just `ValidationError`

### DIFF
--- a/calfkit/client/middleware.py
+++ b/calfkit/client/middleware.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -38,13 +39,14 @@ class DecodeFloorMiddleware(BaseMiddleware):
     An inbound message whose body fails to decode/validate never reaches a handler — FastStream
     captures the error, logs generically, and the ack-first offset means the message is gone (the
     silent-drop hole on the decode path, below the chokepoint ``BaseNodeDef.handler``). This shim
-    catches the decode ``ValidationError`` in :meth:`consume_scope` (verified empirically on
-    FastStream 0.7.1: BOTH a non-JSON parser failure and a missing-field validator failure surface
-    there as a pydantic ``ValidationError`` — so a single ``consume_scope`` override suffices, and
-    the §6.7 "parser-stage failures bypass ``consume_scope`` / hook both paths" caveat does not
-    hold on 0.7.1), FLOORS a typed ``calf.delivery.undecodable`` event (ERROR + the transport
-    metadata that survives an unreadable body — the correlation id + the clamped decode error),
-    then **re-raises**.
+    catches decode failures in :meth:`consume_scope` — on FastStream 0.7.1 (verified) these are a
+    pydantic ``ValidationError`` (a schema mismatch, or a non-JSON body with no JSON content-type,
+    which the content-type-less decode path hands to pydantic) **and** a ``json.JSONDecodeError`` /
+    ``UnicodeDecodeError`` (a malformed body carrying a JSON/text content-type, which FastStream
+    decodes un-suppressed before the handler). A single ``consume_scope`` override catching that union
+    suffices, so the §6.7 "parser-stage failures bypass ``consume_scope``" caveat does not bite here.
+    It FLOORS a typed ``calf.delivery.undecodable`` event (ERROR + the transport metadata that
+    survives an unreadable body — the correlation id + the clamped decode error), then **re-raises**.
 
     Re-raising is load-bearing (verified): suppressing lets FastStream treat the hop as success and
     push an empty body (``b''``) through any attached ``@publisher`` (the §6.7 empty-payload trap).
@@ -61,7 +63,7 @@ class DecodeFloorMiddleware(BaseMiddleware):
     ) -> Any:
         try:
             return await super().consume_scope(call_next, msg)
-        except ValidationError as exc:
+        except (ValidationError, json.JSONDecodeError, UnicodeDecodeError) as exc:
             correlation_id = getattr(msg, "correlation_id", None)
             report = ErrorReport.build_safe(
                 error_type=FaultTypes.DELIVERY_UNDECODABLE,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 requires-python = ">=3.10"
 
 dependencies = [
-    "faststream[kafka]>=0.6.6",
+    "faststream[kafka]>0.7",
     "pydantic>=2.12.5",
     "python-dotenv>=1.2.1",
     "uuid-utils>=0.14.0",

--- a/tests/test_decode_floor.py
+++ b/tests/test_decode_floor.py
@@ -9,6 +9,7 @@ through any attached ``@publisher`` — verified by the FastStream 0.7.1 spike).
 
 from __future__ import annotations
 
+import json
 import logging
 
 import pytest
@@ -36,6 +37,45 @@ async def test_undecodable_body_is_floored_and_reraised(caplog: pytest.LogCaptur
         with caplog.at_level(logging.ERROR, logger=_MW_LOGGER):
             with pytest.raises(ValidationError):  # re-raised after flooring (no empty-body publish)
                 await broker.publish(b'{"not": "valid"}', "n.in")  # missing x → decode fails
+
+    assert ran == []  # the handler never ran — the decode failed first
+    assert "calf.delivery.undecodable" in caplog.text  # floored, typed
+
+
+async def test_malformed_json_with_json_content_type_is_floored_and_reraised(caplog: pytest.LogCaptureFixture) -> None:
+    # A JSON-content-type body that is not valid JSON raises ``json.JSONDecodeError`` at decode
+    # (FastStream's ``json_loads`` is un-suppressed on the JSON content-type path), which a narrow
+    # ``except ValidationError`` misses. The floor must catch, floor, and re-raise it too.
+    ran: list[_Body] = []
+    broker = KafkaBroker(middlewares=[DecodeFloorMiddleware])
+
+    @broker.subscriber("n.in")
+    async def node(body: _Body) -> None:
+        ran.append(body)
+
+    async with TestKafkaBroker(broker):
+        with caplog.at_level(logging.ERROR, logger=_MW_LOGGER):
+            with pytest.raises(json.JSONDecodeError):  # re-raised after flooring (no empty-body publish)
+                await broker.publish(b"{not valid json", "n.in", headers={"content-type": "application/json"})
+
+    assert ran == []  # the handler never ran — the decode failed first
+    assert "calf.delivery.undecodable" in caplog.text  # floored, typed
+
+
+async def test_bad_utf8_with_text_content_type_is_floored_and_reraised(caplog: pytest.LogCaptureFixture) -> None:
+    # A ``text/plain`` body with invalid UTF-8 raises ``UnicodeDecodeError`` at decode
+    # (``body.decode()``), which a narrow ``except ValidationError`` misses too.
+    ran: list[_Body] = []
+    broker = KafkaBroker(middlewares=[DecodeFloorMiddleware])
+
+    @broker.subscriber("n.in")
+    async def node(body: _Body) -> None:
+        ran.append(body)
+
+    async with TestKafkaBroker(broker):
+        with caplog.at_level(logging.ERROR, logger=_MW_LOGGER):
+            with pytest.raises(UnicodeDecodeError):  # re-raised after flooring (no empty-body publish)
+                await broker.publish(b"\xff\xfe\xfa", "n.in", headers={"content-type": "text/plain"})
 
     assert ran == []  # the handler never ran — the decode failed first
     assert "calf.delivery.undecodable" in caplog.text  # floored, typed


### PR DESCRIPTION
## What

The broker-wide `DecodeFloorMiddleware` caught only pydantic `ValidationError`, so two real classes of undecodable inbound body escaped it **uncaught**, re-opening the silent-drop hole the floor exists to close:

- a **JSON-content-type body with a malformed payload** → `json.JSONDecodeError` (FastStream's `json_loads` is un-suppressed on the JSON content-type path);
- a **`text/plain` body with invalid UTF-8** → `UnicodeDecodeError` (`body.decode()`).

When these escape there is no `calf.delivery.undecodable` synthesis and no structured ERROR-log. Verified empirically on **FastStream 0.7.1** (the version the project resolves to), which also contradicts the floor's prior docstring claim that 0.7.1 surfaces parser failures as `ValidationError`.

## Change

- Widen the floor's `except` to `(ValidationError, json.JSONDecodeError, UnicodeDecodeError)`. The surviving `correlation_id` header still drives synthesis, and the **load-bearing re-raise is preserved** (no empty-body publish, so the §6.7 trap stays shut).
- Correct the docstring to 0.7.1 reality.
- Bump `faststream[kafka]>0.7` (0.7.x is the validated line).

## Tests

- +2 offline `TestKafkaBroker` tests (malformed-JSON / bad-UTF-8 → floored + re-raised), written test-first (RED-verified, then GREEN).
- Existing wrong-shape / valid-body / registration tests unchanged → **no regression**.
- `make fix` + `make check` clean; full offline suite **3445 passed**. (`test_decode_floor_kafka.py` runs in the CI `kafka` lane; its valid-JSON-wrong-shape cases still floor as `ValidationError`.)

## Why standalone

A pre-existing `main` bug, fixed on its own. It is a prerequisite for the #250 client fault-reception arm — the caller-surface redesign's Option-B undecodable-sink seam only fires for exceptions the floor catches.