### PR TITLE
feat: make Agent subscribe_topics ctor argument optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ general = Agent(
     name="general",
     description="Answers simple questions and routes requests to whoever can handle it.",
     system_prompt="You are a general assistant. Defer technical questions to other agents.",
-    subscribe_topics="general.input",
     model_client=OpenAIResponsesModelClient(model_name="gpt-5.4-mini"),
     peers=[Messaging(discover=True)],   # discover and collaborate w/ any agent at runtime
 )
@@ -49,7 +48,6 @@ finance = Agent(
     name="finance",
     description="Answers the user's personal finance questions.",
     system_prompt="You are the personal finance specialist. Use tools to look up user data.",
-    subscribe_topics="finance.input",
     model_client=OpenAIResponsesModelClient(model_name="gpt-5.4-mini"),
     tools=[Tools(discover=True)],   # discover and use any tool at runtime
 )

--- a/calfkit/models/node_schema.py
+++ b/calfkit/models/node_schema.py
@@ -1,4 +1,5 @@
 from dataclasses import KW_ONLY, dataclass
+from typing import ClassVar
 
 from calfkit._protocol import is_topic_safe
 
@@ -10,19 +11,29 @@ class BaseNodeSchema:
     subscribe_topics: list[str]
     publish_topic: str | None
 
+    # Whether this node kind is reachable with no public ``subscribe_topics``.
+    # Default False: the empty-inbox guard below applies. Overridden True on
+    # ``BaseAgentNodeDef`` — an agent is always reachable via its name-derived
+    # private input inbox (``agent.{name}.private.input``, ADR-0017), so an empty
+    # list is valid for agents while still a silent-zombie error for every other
+    # kind (whose private inbox is dormant in v1 — no producer targets it).
+    _reachable_without_public_inbox: ClassVar[bool] = False
+
     def __post_init__(self) -> None:
         if not isinstance(self.subscribe_topics, (list, tuple)):
             self.subscribe_topics = [self.subscribe_topics]
-        # Reject empty subscribe_topics for every node kind (Agent, Consumer,
-        # Tool, …). Lives here rather than in ``BaseNodeDef.__init__`` because
-        # ``@dataclass`` subclasses like ``BaseToolNodeDef`` get an
-        # auto-generated ``__init__`` that bypasses ``BaseNodeDef.__init__``
-        # entirely; ``__post_init__`` is the one hook every subclass runs.
-        # Without this guard, ``Worker.register_handlers`` would still add
-        # ``_return_topic`` to the subscriber set (issue #141 fix), so the
-        # node would "register" successfully but have no public inbox — a
-        # silent zombie consumer.
-        if not self.subscribe_topics:
+        # Reject empty subscribe_topics for node kinds with no other inbox a
+        # producer targets (Consumer, Tool, …). Lives here rather than in
+        # ``BaseNodeDef.__init__`` because ``@dataclass`` subclasses like
+        # ``BaseToolNodeDef`` get an auto-generated ``__init__`` that bypasses
+        # ``BaseNodeDef.__init__`` entirely; ``__post_init__`` is the one hook
+        # every subclass runs. Without this guard, ``Worker.register_handlers``
+        # would still add ``_return_topic`` to the subscriber set (issue #141
+        # fix), so the node would "register" successfully but have no public
+        # inbox — a silent zombie consumer. Agents are exempt
+        # (``_reachable_without_public_inbox``): they are always addressable on
+        # their private name-derived inbox.
+        if not self.subscribe_topics and not self._reachable_without_public_inbox:
             raise ValueError(f"node {self.node_id!r} requires at least one subscribe_topic; got empty list")
         # node_id is interpolated raw into this node's framework topic
         # ("{node_id}.private.return"), so it must be a legal Kafka topic-name component.

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -61,6 +61,13 @@ class BaseAgentNodeDef(
     BaseNodeDef,
 ):
     _node_kind: ClassVar[NodeKind] = "agent"
+    # An agent is always reachable via its name-derived private input topic
+    # (``agent.{name}.private.input``, ADR-0017) — the topic every caller (client
+    # gateway, ``message_agent``, handoff) addresses it by. So ``subscribe_topics``
+    # is optional: an empty list is a valid, fully-reachable agent (relaxes the
+    # ``BaseNodeSchema.__post_init__`` non-empty guard, which still applies to the
+    # other node kinds whose private inbox is dormant in v1).
+    _reachable_without_public_inbox: ClassVar[bool] = True
 
     def __init__(
         self,
@@ -68,7 +75,7 @@ class BaseAgentNodeDef(
         *,
         system_prompt: str = "You are a helpful AI assistant.",
         description: str | None = None,
-        subscribe_topics: str | list[str],
+        subscribe_topics: str | list[str] | None = None,
         publish_topic: str | None = None,
         before_node: _SeamArg = None,
         after_node: _SeamArg = None,
@@ -129,7 +136,11 @@ class BaseAgentNodeDef(
                     f"tool name {_MESSAGE_AGENT_TOOL!r} is reserved for the built-in messaging tool (a Messaging handle is set); rename the user tool"
                 )
 
-        if not isinstance(subscribe_topics, (list, tuple)):
+        # Omitted/None → no public inbox (reachable via the private name-derived
+        # inbox, see ``_reachable_without_public_inbox``); a bare string → one topic.
+        if subscribe_topics is None:
+            subscribe_topics = []
+        elif not isinstance(subscribe_topics, (list, tuple)):
             subscribe_topics = [subscribe_topics]
 
         super().__init__(

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -284,20 +284,26 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin, AdvertRegis
         Args:
             node_id: Unique identifier for the node.
             subscribe_topics: One or more topics the node consumes from.
-                Must be non-empty — a node with no public inbox cannot be
+                Must be non-empty for node kinds whose only inbound traffic
+                arrives here — a Consumer / Tool with no public inbox cannot be
                 invoked by any client or peer. Without the validation in
                 :meth:`BaseNodeSchema.__post_init__`, ``Worker.register_handlers``
                 would still wire the node up to ``_return_topic`` (issue #141
                 fix), so the node would "register" successfully while being
-                functionally unreachable from the outside.
+                functionally unreachable from the outside. Agents are exempt
+                (``BaseNodeSchema._reachable_without_public_inbox``): they are
+                always addressable on their name-derived private input inbox
+                (``agent.{name}.private.input``, ADR-0017), so an empty list is
+                valid for an agent.
             publish_topic: Optional default topic to publish results to.
             before_node, after_node, on_node_error, on_callee_error: Optional policy-seam
                 handlers — a single callable or a list (spec §6.1). Constructor entries
                 precede any decorator-registered handlers in the same chain.
 
         Raises:
-            ValueError: If ``subscribe_topics`` is empty. Enforced uniformly
-                across all node kinds in :meth:`BaseNodeSchema.__post_init__`.
+            ValueError: If ``subscribe_topics`` is empty for a node kind that is
+                not reachable without it. Enforced in
+                :meth:`BaseNodeSchema.__post_init__` (agents are exempt).
         """
         super().__init__(
             node_id=node_id,

--- a/docs/api.md
+++ b/docs/api.md
@@ -183,7 +183,7 @@ Agent(
     *,
     system_prompt: str = "You are a helpful AI assistant.",
     description: str | None = None,
-    subscribe_topics: str | list[str],
+    subscribe_topics: str | list[str] | None = None,
     publish_topic: str | None = None,
     tools: Sequence[...] | None = None,
     model_client: PydanticModelClient,
@@ -194,7 +194,7 @@ Agent(
 )
 ```
 
-An agent node. Consumes prompts from `subscribe_topics`, calls its `tools`, and publishes its output to `publish_topic` (when set). `final_output_type` enforces a structured output type (default: plain `str`). `description` is a short public blurb (≤512 chars) advertised on the `calf.agents` directory so other agents can discover this one. `peers` declares the agents it may reach — `Messaging` (consult) and `Handoff` (transfer); see [Agent-to-agent messaging & handoff](#agent-to-agent-messaging--handoff).
+An agent node. It is always reachable by name — every caller (the [client gateway](#client), `message_agent`, and handoff) addresses it on its name-derived private inbox (`agent.<name>.private.input`), so `subscribe_topics` is **optional**: omit it for a name-addressed agent, or pass one or more topics to also consume from those public inboxes. It calls its `tools` and publishes its output to `publish_topic` (when set). `final_output_type` enforces a structured output type (default: plain `str`). `description` is a short public blurb (≤512 chars) advertised on the `calf.agents` directory so other agents can discover this one. `peers` declares the agents it may reach — `Messaging` (consult) and `Handoff` (transfer); see [Agent-to-agent messaging & handoff](#agent-to-agent-messaging--handoff).
 
 ### `@agent_tool`
 

--- a/tests/test_co_tenant_tool_isolation.py
+++ b/tests/test_co_tenant_tool_isolation.py
@@ -428,15 +428,6 @@ def test_worker_register_handlers_dedupes_explicit_return_topic(container):
     "node_factory",
     [
         pytest.param(
-            lambda: Agent(
-                "empty_agent",
-                system_prompt="x",
-                subscribe_topics=[],
-                model_client=_call_one_tool_then_finalize(),
-            ),
-            id="Agent",
-        ),
-        pytest.param(
             lambda: ConsumerNode(
                 name="empty_consumer",
                 subscribe_topics=[],
@@ -458,13 +449,35 @@ def test_worker_register_handlers_dedupes_explicit_return_topic(container):
 )
 def test_empty_subscribe_topics_raises_value_error(node_factory):
     """The ``BaseNodeSchema.__post_init__`` guard must reject empty
-    ``subscribe_topics`` for every node kind. ``Agent`` and
-    ``ConsumerNode`` reach the guard via ``BaseNodeDef.__init__``'s
-    ``super().__init__(...)`` chain; ``ToolNodeDef`` reaches it via the
-    dataclass-auto-generated ``__init__`` (which bypasses
-    ``BaseNodeDef.__init__`` entirely). A regression that moved the guard
-    back into ``BaseNodeDef.__init__`` would silently re-open the
-    ``ToolNodeDef`` bypass.
+    ``subscribe_topics`` for node kinds whose private inbox is dormant in v1
+    (no producer targets it): a ``ConsumerNode`` / ``ToolNodeDef`` with no
+    public inbox is a silent zombie consumer. ``ConsumerNode`` reaches the
+    guard via ``BaseNodeDef.__init__``'s ``super().__init__(...)`` chain;
+    ``ToolNodeDef`` reaches it via the dataclass-auto-generated ``__init__``
+    (which bypasses ``BaseNodeDef.__init__`` entirely). A regression that
+    moved the guard back into ``BaseNodeDef.__init__`` would silently re-open
+    the ``ToolNodeDef`` bypass.
+
+    ``Agent`` is intentionally **exempt** — it is always reachable via its
+    name-derived private input topic (ADR-0017), so an empty (or omitted)
+    ``subscribe_topics`` is valid. See
+    ``test_agent_allows_omitted_subscribe_topics`` /
+    ``test_agent_allows_explicit_empty_subscribe_topics``.
     """
     with pytest.raises(ValueError, match="requires at least one subscribe_topic"):
         node_factory()
+
+
+def test_agent_allows_omitted_subscribe_topics():
+    """An ``Agent`` is reachable via its name-derived private input topic
+    (ADR-0017), so ``subscribe_topics`` is optional: omitting it constructs a
+    valid agent whose public inbox list is empty."""
+    agent = Agent("bare_agent", model_client=_call_one_tool_then_finalize())
+    assert agent.subscribe_topics == []
+
+
+def test_agent_allows_explicit_empty_subscribe_topics():
+    """Passing an explicit empty list is equivalent to omitting it — the agent
+    carries no public inbox and relies on its private name-derived inbox."""
+    agent = Agent("bare_agent", subscribe_topics=[], model_client=_call_one_tool_then_finalize())
+    assert agent.subscribe_topics == []

--- a/tests/test_provisioning_worker.py
+++ b/tests/test_provisioning_worker.py
@@ -207,3 +207,19 @@ def test_node_subscribes_to_its_private_input_topic() -> None:
     node_topics = next(s.topics for s in worker._client._connection._subscribers if node._return_topic in (s.topics or []))
     assert node._private_input_topic in node_topics
     assert node._private_input_topic not in node.subscribe_topics
+
+
+def test_bare_agent_is_reachable_via_its_private_input_topic() -> None:
+    # An agent with no public subscribe_topics is still reachable: registration
+    # contributes its name-derived private input inbox (ADR-0017), the topic every
+    # caller (client gateway, message_agent, handoff) addresses it by.
+    client = _make_client()
+    agent = Agent("bare", model_client=_FakeModel())
+    assert agent.subscribe_topics == []  # no public inbox declared
+    worker = Worker(client, nodes=[agent])
+
+    worker.register_handlers()
+
+    agent_topics = next(s.topics for s in worker._client._connection._subscribers if agent._return_topic in (s.topics or []))
+    assert agent._private_input_topic in agent_topics
+    assert agent._private_input_topic == "agent.bare.private.input"


### PR DESCRIPTION
## Summary

Agents are now reachable **by name** without declaring a `subscribe_topics`. Every caller already addresses an agent on its name-derived private input topic (`agent.{name}.private.input`, ADR-0017):

| Caller | Target topic | Source |
|---|---|---|
| Client gateway `client.agent(name)` | `derive_input_topic(name)` | `client/caller.py` |
| `message_agent` peer tool | `derive_input_topic(args["name"])` | `nodes/agent.py` |
| Handoff (`TailCall`) | `derive_input_topic(handoff.name)` | `nodes/agent.py` |

The worker auto-subscribes every node to its `_private_input_topic` at registration (`worker.py`), independent of `subscribe_topics`. So the explicit `subscribe_topics` ctor arg was only being kept alive by the universal non-empty validation — which is stale for agents.

## Change (Option A)

- **`BaseAgentNodeDef.__init__`** — `subscribe_topics` defaults to `None` (→ `[]`), normalized before the `str`→`list` wrap so `None` never becomes `[None]`.
- **`BaseNodeSchema`** — new `_reachable_without_public_inbox` ClassVar (default `False`) gates the empty-inbox guard; `BaseAgentNodeDef` overrides it `True`. Consumer/Tool nodes still **require** a public inbox — their private inbox is dormant in v1 (no producer targets it), so the silent-zombie guard (issue #141) stays in force for them.
- **`subscribe_topics` is still accepted** when passed (additional public inbox(es)) — fully backward compatible.

## Docs

- `docs/api.md` — `Agent` signature marks `subscribe_topics` optional; prose explains name-addressing.
- Docstrings in `node_schema.py` / `base.py` updated for the agent carve-out.
- **README quickstart no longer passes `subscribe_topics`** (it already addresses the agent by name via `client.agent("general").execute(...)`).

## Tests (TDD)

- `test_agent_allows_omitted_subscribe_topics` / `test_agent_allows_explicit_empty_subscribe_topics` — bare agent constructs, `subscribe_topics == []`.
- `test_bare_agent_is_reachable_via_its_private_input_topic` — a bare agent is registered to `agent.bare.private.input`.
- `test_empty_subscribe_topics_raises_value_error` — `Agent` param removed (now valid); **Consumer/Tool retained** to pin the carve-out as agent-only.

`make check` (lint/format/mypy) is clean. Full suite runs in CI.

## ADR

No new ADR — this is an ergonomic follow-through on the already-accepted ADR-0017 (name-derived addressing), not a new architectural decision.