### PR TITLE
fix: correct misleading log labels in agent.py

### DIFF
--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -533,7 +533,7 @@ class BaseAgentNodeDef(
         latest_tool_calls = ctx.state.latest_tool_calls()
 
         logger.debug(
-            "[%s] agent run entered node=%s pending_tool_calls=%d history_len=%d",
+            "[%s] agent run entered node=%s latest_tool_calls=%d history_len=%d",
             ctx.correlation_id[:8],
             self.name,
             len(latest_tool_calls),
@@ -744,7 +744,11 @@ class BaseAgentNodeDef(
             if ctx.state.all_call_ids_complete(*[tc.tool_call_id for tc in latest_tool_calls]):
                 # TODO: maybe consider a node retry return type that doesn't require round trip to itself.
                 # Tailcall to itself is a roundtrip.
-                logger.debug("[%s] all tool calls invalid, TailCall retry node=%s", ctx.correlation_id[:8], self.name)
+                logger.debug(
+                    "[%s] all dispatched calls resolved pre-dispatch (no Kafka hop); tail-calling self so LLM sees retry prompts node=%s",
+                    ctx.correlation_id[:8],
+                    self.name,
+                )
                 return TailCall[State](target_topic=self._return_topic, state=ctx.state)
 
             pending_tool_calls = [tc for tc in latest_tool_calls if tc.tool_call_id not in ctx.state.tool_results]


### PR DESCRIPTION
## Summary

Fixes two log accuracy nits flagged across review rounds in `calfkit/nodes/agent.py` (#150). These are **label/message-only** changes — no behavior change.

## Changes

**1. `agent.py:536` — log label mismatched its value**
- Old: `"[%s] agent run entered node=%s pending_tool_calls=%d history_len=%d"`
- New: `"[%s] agent run entered node=%s latest_tool_calls=%d history_len=%d"`
- The value passed is `len(latest_tool_calls)`, not the count of *pending* calls (`tool_call_id not in tool_results`). Renamed the label to match the value so log-grepping operators aren't misled.

**2. `agent.py:747` — misleading "all invalid" framing**
- Old: `"[%s] all tool calls invalid, TailCall retry node=%s"`
- New: `"[%s] all dispatched calls resolved pre-dispatch (no Kafka hop); tail-calling self so LLM sees retry prompts node=%s"`
- This branch fires whenever every call is already complete in `tool_results` (e.g. all resolved to `RetryPromptPart`, OR successful results collected pre-dispatch) — not only the "all invalid" case. Reworded to neutral, accurate phrasing.

## Item 3 (no change)

The issue's third item (comment at the validation gate) is already resolved on main: the gate is now the capability check `if binding.validator is not None:` with an accurate comment ("Validator-less bindings ... skip this step and dispatch unvalidated"). Left unchanged.

## Verification

- `uv run ruff check calfkit/nodes/agent.py` — passed
- `uv run ruff format --check calfkit/nodes/agent.py` — passed
- `uv run python -c "import calfkit.nodes.agent"` — OK
- `make check` (lint + format + type-check) — all passed

Closes #150.