### PR TITLE
docs: enable Handoff in README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,17 @@ pip install calfkit
 ### An agent (that can discover other agents)
 
 ```python
-from calfkit import Agent, Messaging, Tools, OpenAIResponsesModelClient
+from calfkit import Agent, Handoff, Messaging, Tools, OpenAIResponsesModelClient
 
 general = Agent(
     name="general",
     description="Answers simple questions and routes requests to whoever can handle it.",
     system_prompt="You are a general assistant. Defer technical questions to other agents.",
     model_client=OpenAIResponsesModelClient(model_name="gpt-5.4-mini"),
-    peers=[Messaging(discover=True)],   # discover and collaborate w/ any agent at runtime
+    peers=[
+        Messaging(discover=True),  # discover and consult any agent at runtime
+        Handoff(discover=True),  # discover and hand off to any agent at runtime
+    ],
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ general = Agent(
     system_prompt="You are a general assistant. Defer technical questions to other agents.",
     model_client=OpenAIResponsesModelClient(model_name="gpt-5.4-mini"),
     peers=[
-        Messaging(discover=True),  # discover and consult any agent at runtime
+        Messaging(discover=True),  # discover and delegate to any agent at runtime
         Handoff(discover=True),  # discover and hand off to any agent at runtime
     ],
 )


### PR DESCRIPTION
## What

Updates the README Quickstart "An agent (that can discover other agents)" example so the `general` agent opens **both** discovery scopes:

- `Messaging(discover=True)` — consult any agent at runtime (already present)
- `Handoff(discover=True)` — hand off to any agent at runtime (added)

`Handoff` is now imported from `calfkit`, and the `peers=[...]` list is broken across lines (one handle per line with a trailing comma) per PEP 8 for readability.

## Why

The quickstart showcased only consult-style collaboration. Adding the handoff handle demonstrates the full peer surface — agents can both consult peers and transfer control — which is the headline capability the README leads with.

## Validation

- Confirmed the snippet constructs successfully: an `Agent` accepts one `Messaging(discover=True)` and one `Handoff(discover=True)` together (separate discovery scopes, no exclusivity conflict).
- `make check` (lint + format + type) passes clean.

Docs-only change; no source behavior affected.