### PR TITLE
docs: accept ADR-0024: exception harvest

### DIFF
--- a/docs/adr/0024-uncaught-exceptions-harvested-into-a-structured-slot.md
+++ b/docs/adr/0024-uncaught-exceptions-harvested-into-a-structured-slot.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # Uncaught exceptions are harvested into a structured `ErrorReport.exception` slot, not flattened to a string


### PR DESCRIPTION
Flip ADR-0024 (uncaught exceptions harvested into a structured ErrorReport.exception slot) from **proposed** to **accepted** — the implementing feature shipped on main in #298, and the repo convention is for an ADR to flip to accepted on merge of its implementing PR (matching ADR-0003/0004/0006 and all of 0010-0023).

Docs-only, one-line frontmatter change; `make check` clean.