### PR TITLE
refactor: rename CALF_HOST_URL to CALFKIT_MESH_URL via a shared mesh-URL resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ def lookup_account_balance(ctx: ToolContext) -> str:
 
 ## Running your agents
 
-> Agents sit on a mesh. Set the `CALFKIT_MESH_URL` environment variable.
+Agents sit on a mesh. Set the `CALFKIT_MESH_URL` environment variable.
 
 Start the general assistant independently. Assuming it's saved in `general_help.py`.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ def lookup_account_balance(ctx: ToolContext) -> str:
 
 ## Running your agents
 
+> **An agent mesh is required** for agents to discover and connect with each other — set the `CALFKIT_MESH_URL` environment variable to point at it (defaults to `localhost`). Starting one is covered below.
+
 Start the general assistant independently. Assuming it's saved in `general_help.py`.
 
 ```bash
@@ -83,7 +85,7 @@ import asyncio
 from calfkit import Client
 
 async def main():
-    async with Client.connect("<calfkit_agent_mesh_url>") as client:
+    async with Client.connect() as client:
         result = await client.agent(name="general").execute(
             "Do I have enough money to afford a new car?"
         )

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ def lookup_account_balance(ctx: ToolContext) -> str:
 
 ## Running your agents
 
-> **An agent mesh is required** for agents to discover and connect with each other — set the `CALFKIT_MESH_URL` environment variable to point at it (defaults to `localhost`). Starting one is covered below.
+> Agents sit on a mesh. Set the `CALFKIT_MESH_URL` environment variable.
 
 Start the general assistant independently. Assuming it's saved in `general_help.py`.
 

--- a/calfkit/cli/_run.py
+++ b/calfkit/cli/_run.py
@@ -16,6 +16,7 @@ from typing import Any
 import typer
 
 from calfkit.cli._loader import load_nodes
+from calfkit.client._mesh import resolve_mesh_url
 
 
 def _load_env(env_file: str | None) -> None:
@@ -57,11 +58,9 @@ def _parse_host(host: str | None) -> str | list[str] | None:
 
 def _print_banner(nodes: list[Any], server_urls: str | list[str] | None, provision: bool) -> None:
     """Print a concise startup banner describing what is being served."""
-    # Resolve through the same helper Client.connect uses (deferred import, matching
-    # serve()'s pattern) so the banner reports the exact broker the client connects
-    # to — its arg > $CALFKIT_MESH_URL > localhost fallback, never a placeholder.
-    from calfkit.client._mesh import resolve_mesh_url
-
+    # Resolve through the same helper Client.connect uses, so the banner reports
+    # the exact broker the client connects to (its arg > $CALFKIT_MESH_URL >
+    # localhost fallback), never a placeholder.
     broker = ", ".join(resolve_mesh_url(server_urls))
     typer.echo("🐮 Calfkit — starting dev worker")
     typer.echo(f"   broker: {broker}")

--- a/calfkit/cli/_run.py
+++ b/calfkit/cli/_run.py
@@ -44,7 +44,7 @@ def _parse_host(host: str | None) -> str | list[str] | None:
     """Map the ``--host`` flag to a ``server_urls`` value for ``Client.connect``.
 
     ``None`` (flag omitted) is passed through unchanged so ``Client.connect``
-    applies its ``CALF_HOST_URL`` → ``localhost`` fallback — preserving the
+    applies its ``CALFKIT_MESH_URL`` → ``localhost`` fallback — preserving the
     flag > env > localhost precedence. A comma-separated value becomes a list.
     """
     if not host:
@@ -57,10 +57,12 @@ def _parse_host(host: str | None) -> str | list[str] | None:
 
 def _print_banner(nodes: list[Any], server_urls: str | list[str] | None, provision: bool) -> None:
     """Print a concise startup banner describing what is being served."""
-    # Show the broker the worker will actually connect to. When --host is
-    # omitted, mirror Client.connect's own CALF_HOST_URL -> localhost fallback
-    # so the banner reflects the effective target, not a placeholder.
-    broker = server_urls if server_urls else (os.getenv("CALF_HOST_URL") or "localhost")
+    # Resolve through the same helper Client.connect uses (deferred import, matching
+    # serve()'s pattern) so the banner reports the exact broker the client connects
+    # to — its arg > $CALFKIT_MESH_URL > localhost fallback, never a placeholder.
+    from calfkit.client._mesh import resolve_mesh_url
+
+    broker = ", ".join(resolve_mesh_url(server_urls))
     typer.echo("🐮 Calfkit — starting dev worker")
     typer.echo(f"   broker: {broker}")
     typer.echo(f"   topic provisioning: {'on' if provision else 'off'}")

--- a/calfkit/cli/run.py
+++ b/calfkit/cli/run.py
@@ -44,7 +44,7 @@ def run(
         None,
         "--host",
         "-H",
-        help="Kafka bootstrap server(s), comma-separated. Precedence: this flag > $CALF_HOST_URL > localhost.",
+        help="Kafka bootstrap server(s), comma-separated. Precedence: this flag > $CALFKIT_MESH_URL > localhost.",
     ),
     provision: bool = typer.Option(
         False,

--- a/calfkit/client/_broker.py
+++ b/calfkit/client/_broker.py
@@ -21,6 +21,8 @@ from typing import Any
 
 from faststream.kafka import KafkaBroker
 
+from calfkit.client._mesh import DEFAULT_MESH_URL
+
 PreStartHook = Callable[[KafkaBroker], Awaitable[None]]
 
 
@@ -34,7 +36,7 @@ class _PreStartHookBroker(KafkaBroker):
 
     def __init__(
         self,
-        bootstrap_servers: str | Iterable[str] = "localhost",
+        bootstrap_servers: str | Iterable[str] = DEFAULT_MESH_URL,
         *,
         pre_start: PreStartHook | None = None,
         **kwargs: Any,

--- a/calfkit/client/_mesh.py
+++ b/calfkit/client/_mesh.py
@@ -1,0 +1,33 @@
+"""Resolve the mesh URL — the Kafka bootstrap server(s) the client connects to.
+
+The single source of truth for the ``arg > $CALFKIT_MESH_URL > localhost``
+precedence and the normalization to the list form aiokafka expects. Both
+:meth:`Client.connect <calfkit.client.caller.Client.connect>` and the ``ck run``
+startup banner resolve through :func:`resolve_mesh_url`, so the banner can never
+report a different broker than the one the client actually connects to.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+
+MESH_URL_ENV_VAR = "CALFKIT_MESH_URL"
+DEFAULT_MESH_URL = "localhost"
+
+
+def resolve_mesh_url(mesh_url: str | Iterable[str] | None) -> list[str]:
+    """Resolve and normalize the mesh URL to a list of bootstrap servers.
+
+    Precedence: an explicit *mesh_url* wins; otherwise ``$CALFKIT_MESH_URL`` (a
+    set-but-empty value is ignored); otherwise :data:`DEFAULT_MESH_URL`.
+
+    The result is always a ``list[str]``: FastStream wraps a bare ``str`` into
+    ``[str]`` and aiokafka never comma-splits inside a list element, so a string
+    is materialized as a single-element list and any other iterable (including a
+    one-shot generator) is materialized once here so the broker receives real
+    bootstrap servers rather than an already-consumed iterator.
+    """
+    if mesh_url is None:
+        mesh_url = os.getenv(MESH_URL_ENV_VAR) or DEFAULT_MESH_URL
+    return [mesh_url] if isinstance(mesh_url, str) else list(mesh_url)

--- a/calfkit/client/caller.py
+++ b/calfkit/client/caller.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 from collections.abc import Callable, Iterable, Sequence
 from typing import Any, overload
 
@@ -22,6 +21,7 @@ from calfkit._types import OutputT
 from calfkit._vendor.pydantic_ai.messages import ModelMessage, ModelRequest
 from calfkit._vendor.pydantic_ai.settings import ModelSettings
 from calfkit.client._broker import _PreStartHookBroker
+from calfkit.client._mesh import resolve_mesh_url
 from calfkit.client.events import DEFAULT_FIREHOSE_BUFFER_SIZE, EventStream
 from calfkit.client.gateway import AgentGateway
 from calfkit.client.hub import _Hub
@@ -110,11 +110,9 @@ class Client:
         topics are auto-created at broker start. It is a separate, removable concern from the §2.7
         boot-check posture — see :meth:`_make_provisioned_broker`.
         """
-        if server_urls is None:
-            server_urls = os.getenv("CALF_HOST_URL") or "localhost"
-        # FastStream wraps a str into [str] and aiokafka never comma-splits inside a list element, so a
-        # one-shot iterable is materialized once into a list for the broker.
-        server_list = [server_urls] if isinstance(server_urls, str) else list(server_urls)
+        # Resolve the mesh URL once (arg > $CALFKIT_MESH_URL > localhost) and normalize to the list
+        # form the broker needs — see calfkit.client._mesh.resolve_mesh_url.
+        server_list = resolve_mesh_url(server_urls)
 
         rejected_security = [k for k in broker_kwargs if k in ("security_protocol", "ssl_context") or k.startswith(("sasl_plain_", "sasl_mechanism"))]
         if rejected_security:

--- a/docs/api.md
+++ b/docs/api.md
@@ -134,7 +134,7 @@ Client.connect(
 ) -> Client
 ```
 
-Build a `Client` — **synchronous and lazy**: no I/O until the first dispatch / `events()`, so a connection error surfaces there, not from `connect()`. `server_urls` defaults to the `CALF_HOST_URL` environment variable, then `"localhost"`. `inbox_topic` is the named topic this client receives its runs' replies on and routes callbacks to — `None` gives an ephemeral per-client inbox; set it for a durable, shareable one. `deps_factory` seeds ambient `deps` merged under each call's `deps`. `firehose_buffer_size` bounds each `events()` observer's drop-oldest buffer. Configure auth with a FastStream `security=` object in `broker_kwargs` (raw security kwargs are rejected).
+Build a `Client` — **synchronous and lazy**: no I/O until the first dispatch / `events()`, so a connection error surfaces there, not from `connect()`. `server_urls` defaults to the `CALFKIT_MESH_URL` environment variable, then `"localhost"`. `inbox_topic` is the named topic this client receives its runs' replies on and routes callbacks to — `None` gives an ephemeral per-client inbox; set it for a durable, shareable one. `deps_factory` seeds ambient `deps` merged under each call's `deps`. `firehose_buffer_size` bounds each `events()` observer's drop-oldest buffer. Configure auth with a FastStream `security=` object in `broker_kwargs` (raw security kwargs are rejected).
 
 ### `Client.agent`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -78,7 +78,7 @@ would block the import; keep it under the guard.)
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--host`, `-H` | `$CALF_HOST_URL` → `localhost` | Kafka bootstrap server(s), comma-separated. Precedence: this flag **>** `$CALF_HOST_URL` **>** `localhost`. |
+| `--host`, `-H` | `$CALFKIT_MESH_URL` → `localhost` | Kafka bootstrap server(s), comma-separated. Precedence: this flag **>** `$CALFKIT_MESH_URL` **>** `localhost`. |
 | `--provision` | off | Opt-in dev topic auto-creation (**experimental**; `replication_factor=1`, no ACLs). See [Topic provisioning](topic-provisioning.md). |
 | `--reload` | off | Watch source files and restart the worker on change (see [Reload](#reload)). |
 | `--reload-dir` | current dir | Directory to watch with `--reload`. Repeatable. |

--- a/docs/designs/mcp-capability-discovery-spec.md
+++ b/docs/designs/mcp-capability-discovery-spec.md
@@ -355,7 +355,7 @@ client = Client.connect("kafka:9092")          # the only URL the user types
 worker = Worker(client, nodes=[agent, docs_toolbox])
 ```
 
-Today `Client.connect` resolves `server_urls` (arg → `CALF_HOST_URL` →
+Today `Client.connect` resolves `server_urls` (arg → `CALFKIT_MESH_URL` →
 `"localhost"`, `base.py:144`) but does not retain it. PR A adds retention: the
 resolved value is stored on the client and exposed as a read-only
 `client.server_urls`. Derivation chain, in order:

--- a/tests/test_capability_models.py
+++ b/tests/test_capability_models.py
@@ -134,7 +134,7 @@ class TestClientServerUrlsRetention:
         assert client.server_urls == "kafka-a:9092,kafka-b:9092"
 
     def test_connect_retains_env_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("CALF_HOST_URL", "env-kafka:9092")
+        monkeypatch.setenv("CALFKIT_MESH_URL", "env-kafka:9092")
         client = Client.connect()
         assert client.server_urls == "env-kafka:9092"
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,0 +1,59 @@
+"""Unit tests for mesh-URL resolution (``calfkit.client._mesh``).
+
+``resolve_mesh_url`` is the single source of truth for the
+arg > ``$CALFKIT_MESH_URL`` > localhost precedence and the normalization to the
+list form aiokafka expects. Both ``Client.connect`` and the ``ck run`` banner
+resolve through it, so the banner can never drift from the real target.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from calfkit.client._mesh import DEFAULT_MESH_URL, MESH_URL_ENV_VAR, resolve_mesh_url
+
+
+def test_env_var_name_is_calfkit_mesh_url() -> None:
+    assert MESH_URL_ENV_VAR == "CALFKIT_MESH_URL"
+
+
+def test_default_is_localhost() -> None:
+    assert DEFAULT_MESH_URL == "localhost"
+
+
+def test_explicit_str_is_normalized_to_a_single_element_list() -> None:
+    # aiokafka never comma-splits inside a list element, so a single string must
+    # reach the broker as exactly one bootstrap entry.
+    assert resolve_mesh_url("kafka-a:9092") == ["kafka-a:9092"]
+
+
+def test_explicit_str_ignores_the_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(MESH_URL_ENV_VAR, "env-kafka:9092")
+    assert resolve_mesh_url("explicit:9092") == ["explicit:9092"]
+
+
+def test_explicit_iterable_is_materialized_to_a_list() -> None:
+    assert resolve_mesh_url(["a:9092", "b:9092"]) == ["a:9092", "b:9092"]
+
+
+def test_one_shot_generator_is_materialized_once() -> None:
+    # A generator must be materialized here so the broker receives real
+    # bootstrap servers, not an already-consumed iterator.
+    gen = (u for u in ["a:9092", "b:9092"])
+    assert resolve_mesh_url(gen) == ["a:9092", "b:9092"]
+
+
+def test_none_falls_back_to_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(MESH_URL_ENV_VAR, "env-kafka:9092")
+    assert resolve_mesh_url(None) == ["env-kafka:9092"]
+
+
+def test_none_falls_back_to_localhost_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(MESH_URL_ENV_VAR, raising=False)
+    assert resolve_mesh_url(None) == [DEFAULT_MESH_URL]
+
+
+def test_empty_env_var_falls_through_to_localhost(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A set-but-empty env var is falsy and must not become a bogus "" server.
+    monkeypatch.setenv(MESH_URL_ENV_VAR, "")
+    assert resolve_mesh_url(None) == [DEFAULT_MESH_URL]

--- a/tests/test_run_serve.py
+++ b/tests/test_run_serve.py
@@ -51,7 +51,7 @@ def test_serve_resolves_nodes_and_runs_worker(captured: dict) -> None:
 
 def test_serve_no_host_delegates_to_client_default(captured: dict) -> None:
     """With no --host, serve passes server_urls=None so Client.connect applies
-    its CALF_HOST_URL -> localhost fallback."""
+    its CALFKIT_MESH_URL -> localhost fallback."""
     from calfkit.cli._run import serve
 
     serve([f"{_FIXTURE}:single"], host=None, provision=False, group_id=None, env_file=None, app_dir=".")
@@ -113,10 +113,10 @@ def test_serve_empty_resolution_exits_2(captured: dict) -> None:
 
 def test_serve_prints_banner_with_node_details(captured: dict, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
     """The banner names the node, its kind, its topics, provisioning state, and
-    the effective broker (localhost when --host and CALF_HOST_URL are unset)."""
+    the effective broker (localhost when --host and CALFKIT_MESH_URL are unset)."""
     from calfkit.cli._run import serve
 
-    monkeypatch.delenv("CALF_HOST_URL", raising=False)
+    monkeypatch.delenv("CALFKIT_MESH_URL", raising=False)
     serve([f"{_FIXTURE}:single"], host=None, provision=False, group_id=None, env_file=None, app_dir=".")
     out = capsys.readouterr().out
     assert "echo" in out
@@ -128,10 +128,10 @@ def test_serve_prints_banner_with_node_details(captured: dict, capsys: pytest.Ca
 
 
 def test_serve_banner_shows_env_host_when_no_flag(captured: dict, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
-    """With no --host, the banner reflects CALF_HOST_URL (the effective broker)."""
+    """With no --host, the banner reflects CALFKIT_MESH_URL (the effective broker)."""
     from calfkit.cli._run import serve
 
-    monkeypatch.setenv("CALF_HOST_URL", "envhost:9092")
+    monkeypatch.setenv("CALFKIT_MESH_URL", "envhost:9092")
     serve([f"{_FIXTURE}:single"], host=None, provision=False, group_id=None, env_file=None, app_dir=".")
     out = capsys.readouterr().out
     assert "envhost:9092" in out


### PR DESCRIPTION
## Summary

Renames the `CALF_HOST_URL` environment variable to **`CALFKIT_MESH_URL`** and extracts the broker-address resolution into a single shared helper.

Previously the `arg → env → localhost` resolution (plus the list normalization aiokafka needs) was duplicated in two places — `Client.connect` (the real one) and the `ck run` startup banner (a cosmetic mirror that could silently drift from the actual connection target). A third `"localhost"` literal lived on the broker subclass's constructor default.

This PR collapses all of that into **`calfkit/client/_mesh.py`**:

- `MESH_URL_ENV_VAR = "CALFKIT_MESH_URL"`, `DEFAULT_MESH_URL = "localhost"`
- `resolve_mesh_url(mesh_url)` — resolves `arg > $CALFKIT_MESH_URL > localhost` (a set-but-empty env var is ignored) and normalizes to the `list[str]` form the broker needs (a one-shot generator is materialized once).

## What changed

- **`Client.connect`** (`caller.py`) — collapsed to `server_list = resolve_mesh_url(server_urls)`; dropped the now-unused `import os`.
- **`ck run` banner** (`cli/_run.py`) — resolves through the same helper, so it always reports the exact broker the client connects to. Deferred import preserves the file's lazy-import pattern.
- **`_PreStartHookBroker`** (`client/_broker.py`) — default `bootstrap_servers` references `DEFAULT_MESH_URL`, collapsing the last duplicated `"localhost"`.
- Help text, docstrings, tests, and docs (`cli.md`, `api.md`, mcp-capability design spec) updated to the new var name.

## Scope

**Env var + internals only.** The public `Client.connect(server_urls=...)` parameter and the `ck run --host` / `-H` flag are unchanged.

## ⚠️ Breaking change

`CALF_HOST_URL` is no longer read. Set **`CALFKIT_MESH_URL`** instead (precedence unchanged: `--host` flag > `$CALFKIT_MESH_URL` > `localhost`).

## Testing (TDD)

- New `tests/test_mesh.py` (9 cases): precedence branches, str/iterable normalization, one-shot generator, empty-env fall-through, constants. Written RED-first (`ModuleNotFoundError`) → GREEN.
- Flipped existing behavioral tests (`Client.connect` env fallback, `ck run` banner env) RED → GREEN against the renamed source.
- `make check` (lint + format + mypy) clean; `make test` → **3585 passed, 6 skipped, 105 deselected**.

## Notes for reviewers

- Pre-existing drift left untouched (out of scope): `docs/designs/mcp-capability-discovery-spec.md` still references `base.py:144` (now `caller.py`) and "does not retain it" (retention has since shipped). Only the env-var token was updated there.