### PR TITLE
docs: add intermediate-step streaming example; surface it in README + api.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ See [`examples/`](examples/) for more examples.
 - **[Agent, tool & consumer](examples/quickstart/)** — a weather agent and its `get_weather` tool deployed as separate services and invoked over the broker, with a consumer node tapping the agent's output stream.
 - **[Multi-agent panel](examples/multi_agent_panel/)** — three persona agents (`optimist`, `skeptic`, `pragmatist`) debate over one shared transcript, each automatically seeing the thread from its own point of view.
 - **[MCP toolbox](examples/quickstart_mcp/)** — give an agent a live web-`fetch` tool from an MCP server, deployed as its own node and referenced by name — the agent's code never imports it.
+- **[Streaming intermediate work](examples/streaming/)** — a trip-planner agent whose preamble, tool calls, and tool results stream to the caller hop by hop via `handle.stream()`, for a live view of a run's progress.
 
 ## Documentation
 
@@ -131,7 +132,7 @@ In-repo documentation lives under [`docs/`](docs/).
 
 **How-to guides** — goal-oriented walkthroughs:
 
-- **[How to call agents from a client](docs/client-features.md)** — the `agent(name)` gateway and its `send` / `start` / `execute` triad, multi-turn conversations, runtime dependency injection (`deps`), temporary instructions, the `events()` firehose, and the typed client errors.
+- **[How to call agents from a client](docs/client-features.md)** — the `agent(name)` gateway and its `send` / `start` / `execute` triad, multi-turn conversations, runtime dependency injection (`deps`), temporary instructions, streaming a run's intermediate steps live with `handle.stream()`, the `events()` firehose, and the typed client errors.
 - **[How to tap a topic with a consumer node](docs/consumer-nodes.md)** — terminal sinks that run arbitrary Python against every event on a topic; tap an agent's `publish_topic` to log, persist, or fan out.
 - **[How to guard and transform node invocations](docs/policy-seams.md)** — guard an invocation with `before_node` (transform the input, short-circuit the body, or raise to block), and validate or reshape its output with `after_node`.
 - **[How to handle errors and faults](docs/error-handling.md)** — recover from a failed node or callee with `on_node_error` / `on_callee_error`, mint typed faults with `NodeFaultError`, and inspect an `ErrorReport`.

--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ Or skip the self-hosting with [Calfkit Cloud](https://forms.gle/Rk61GmHyJzequEPm
 
 See [`examples/`](examples/) for more examples.
 
+- **[Streaming intermediate work](examples/streaming/)** — a trip-planner agent whose preamble, tool calls, and tool results stream to the caller via `handle.stream()`, for a live view of a run's progress.
 - **[Agent, tool & consumer](examples/quickstart/)** — a weather agent and its `get_weather` tool deployed as separate services and invoked over the broker, with a consumer node tapping the agent's output stream.
 - **[Multi-agent panel](examples/multi_agent_panel/)** — three persona agents (`optimist`, `skeptic`, `pragmatist`) debate over one shared transcript, each automatically seeing the thread from its own point of view.
 - **[MCP toolbox](examples/quickstart_mcp/)** — give an agent a live web-`fetch` tool from an MCP server, deployed as its own node and referenced by name — the agent's code never imports it.
-- **[Streaming intermediate work](examples/streaming/)** — a trip-planner agent whose preamble, tool calls, and tool results stream to the caller hop by hop via `handle.stream()`, for a live view of a run's progress.
 
 ## Documentation
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -42,14 +42,14 @@ from calfkit import (
 
 Members of the `RunEvent` union, surfaced by `stream()` / `events()` as a run progresses (best-effort, at-most-once, **raw** — not `output_type`-coerced). All re-exported from `calfkit`.
 
-| Symbol | Emitted by | Carries |
-| --- | --- | --- |
-| `AgentMessageEvent` | an agent hop | `parts` — the hop's preamble text |
-| `ToolCallEvent` | an agent hop | `tool_call_id`, `name`, `args: str \| dict \| None` (raw model emission) |
-| `ToolResultEvent` | a tool node / consulted peer / rejected call | `tool_call_id`, `name`, `parts`, `is_error: bool` |
-| `HandoffEvent` | an agent hop | `target`, `reason` |
+| Symbol | `kind` | Emitted by | Carries |
+| --- | --- | --- | --- |
+| `AgentMessageEvent` | `"agent_message"` | an agent hop | `parts` — the hop's preamble text |
+| `ToolCallEvent` | `"tool_call"` | an agent hop | `tool_call_id`, `name`, `args: str \| dict \| None` (raw model emission) |
+| `ToolResultEvent` | `"tool_result"` | a tool node / consulted peer / rejected call | `tool_call_id`, `name`, `parts`, `is_error: bool` |
+| `HandoffEvent` | `"handoff"` | an agent hop | `target`, `reason` |
 
-Each also carries hop identity (`correlation_id`, `depth`, `frame_id`, `emitter`). A fifth type, `AgentThinkingEvent`, is **defined but not emitted in v1** — it is not in the `RunEvent` union and not top-level re-exported; it lives at `calfkit.models.step` for forward compatibility.
+Each is a **frozen** model discriminated on its `kind` literal, and also carries hop identity (`correlation_id`, `depth`, `frame_id`, `emitter`). A fifth type, `AgentThinkingEvent` (`kind="agent_thinking"`), is **defined but not emitted in v1** — it is not in the `RunEvent` union and not top-level re-exported; it lives at `calfkit.models.step` for forward compatibility.
 
 ### Node authoring
 

--- a/examples/multi_agent_panel/panel.py
+++ b/examples/multi_agent_panel/panel.py
@@ -25,7 +25,6 @@ def _panelist(name: str, persona: str) -> Agent:
             "Keep each contribution to 2-3 sentences, and address other panelists by "
             "name when you build on or push back against their points."
         ),
-        subscribe_topics=f"{name}.input",
         model_client=OpenAIResponsesModelClient(model_name=MODEL),
     )
 

--- a/examples/multi_agent_panel/panel.py
+++ b/examples/multi_agent_panel/panel.py
@@ -22,8 +22,9 @@ def _panelist(name: str, persona: str) -> Agent:
         name,
         system_prompt=(
             f"You are {name}, one panelist in a group discussion. {persona} "
-            "Keep each contribution to 2-3 sentences, and address other panelists by "
-            "name when you build on or push back against their points."
+            "Keep each contribution to 2-3 sentences. Address another panelist by name "
+            "only when responding to a specific point they actually made; do not invent "
+            "participants."
         ),
         model_client=OpenAIResponsesModelClient(model_name=MODEL),
     )

--- a/examples/multi_agent_panel/run.py
+++ b/examples/multi_agent_panel/run.py
@@ -5,7 +5,8 @@ the same transcript accumulates turns from all three agents. Once it holds more 
 one distinct agent identity, every subsequent invocation is automatically projected
 to that agent's point of view — its own turns stay assistant messages, the other
 panelists read as ``<optimist>`` / ``<skeptic>`` / ``<pragmatist>``, and the
-moderator prompts read as ``<user>``. There are no flags to set; it just works.
+moderator's prompts read as ``<user:Moderator>`` (attributed via ``author=``). There
+are no flags to set; it just works.
 
 Start ``service.py`` first, then run this.
 """
@@ -31,6 +32,7 @@ async def main() -> None:
             result = await client.agent(agent.name).execute(
                 prompt,
                 message_history=history,  # every panelist sees the same growing transcript
+                author="Moderator",  # attribute the human prompt so panelists address "Moderator", not an invented name
             )
             history = result.message_history  # accumulate this panelist's response
             print(f"\n[{agent.name}] {result.output}")

--- a/examples/quickstart_mcp/README.md
+++ b/examples/quickstart_mcp/README.md
@@ -18,7 +18,7 @@ agent one tool — `fetch` (URL → markdown) — so it can read the live web.
 
 ## Prerequisites
 
-- A running [Calfkit broker](../../README.md#start-a-calfkit-broker) on `localhost:9092`.
+- A running [Calfkit broker](../../README.md#running-your-agents) on `localhost:9092`.
 - calfkit installed: `pip install calfkit`.
 - [`uv`](https://docs.astral.sh/uv/) on your PATH — the toolbox runs the fetch
   server with `uvx`, which fetches it on first use (no manual install).

--- a/examples/streaming/README.md
+++ b/examples/streaming/README.md
@@ -1,0 +1,69 @@
+# Streaming intermediate work
+
+Watch an agent's progress **live**, hop by hop, instead of waiting for the final
+answer. As the run unfolds, the caller receives **step events** — the agent's
+preamble, each tool call, and each tool result — and prints them as they arrive.
+This is the runnable version of the
+[How to call agents from a client](../../docs/client-features.md#observing-results)
+guide's "Observing results" section.
+
+The agent is a small trip planner: given a city, it checks the weather, finds
+activities, then gives a short plan — so one run produces several intermediate
+steps before it completes.
+
+## What's here
+
+| File | Role |
+| --- | --- |
+| `trip_tools.py` | Two tool nodes — `get_weather` and `find_activities` (canned, offline returns). |
+| `planner_agent.py` | The `trip_planner` agent; calls both tools, narrates each step. |
+| `service.py` | Deploys the agent **and** both tools on one worker. |
+| `stream.py` | Calls the agent with `start()` and prints each step from `handle.stream()` live. |
+
+## Prerequisites
+
+- A running [Calfkit broker](../../README.md#running-your-agents) on `localhost:9092`.
+- calfkit installed: `pip install calfkit`.
+- An LLM API key: `export OPENAI_API_KEY=sk-...`.
+
+## Run it (two terminals)
+
+```console
+# 1) the agent + its tools, on one worker
+$ python service.py
+
+# 2) call the agent and watch its work stream in
+$ python stream.py
+```
+
+You'll see the steps print as the run progresses, then the final plan:
+
+```text
+── live progress ─────────────────────────────
+  💬 Let me check tomorrow's weather in Kyoto.
+  🔧 calling get_weather({'city': 'Kyoto'})
+  ✅ get_weather → Tomorrow in Kyoto: cloudy with light rain, 14°C.
+  🔧 calling find_activities({'city': 'Kyoto'})
+  ✅ find_activities → In Kyoto: temple tours, a covered food market, and a tea ceremony.
+  🏁 run completed
+──────────────────────────────────────────────
+
+Final plan:
+...
+```
+
+The exact preamble text and the order of the tool calls are up to the model, so
+your output will vary.
+
+## Things to try
+
+- **Stop early.** To break out of the loop before the terminal, wrap the stream
+  in `contextlib.aclosing(handle.stream())` so its guard releases promptly — a
+  handle allows only one live `stream()` at a time
+  ([guide](../../docs/client-features.md#observing-results)).
+- **Observe across runs.** `handle.stream()` follows one run; `client.events()`
+  is a firehose over **every** run on the client's inbox (and the only way to
+  observe a `send()` run). It is best-effort — see the guide.
+- **See handoffs and sub-agents.** A `HandoffEvent`, and tool/peer steps at
+  `depth > 1`, appear once an agent hands off or consults a peer — add a peer
+  with [`Messaging` / `Handoff`](../../docs/agent-peers.md).

--- a/examples/streaming/README.md
+++ b/examples/streaming/README.md
@@ -1,6 +1,6 @@
 # Streaming intermediate work
 
-Watch an agent's progress **live**, hop by hop, instead of waiting for the final
+Watch an agent's progress **live**, instead of waiting for the final
 answer. As the run unfolds, the caller receives **step events** — the agent's
 preamble, each tool call, and each tool result — and prints them as they arrive.
 This is the runnable version of the

--- a/examples/streaming/planner_agent.py
+++ b/examples/streaming/planner_agent.py
@@ -1,0 +1,28 @@
+"""A trip-planner agent that does its work in several hops.
+
+The system prompt steers it to say what it's about to do, call the two tools,
+then summarise — so a run produces a stream of intermediate steps (a preamble,
+tool calls, tool results) before the final answer. ``service.py`` deploys this
+agent together with its tools; ``stream.py`` calls it and prints the steps live.
+
+Note there is no ``publish_topic`` here: step events flow to the *caller's* inbox
+(the run's reply channel), not the agent's broadcast topic.
+"""
+
+from trip_tools import find_activities, get_weather
+
+from calfkit.nodes import Agent
+from calfkit.providers import OpenAIResponsesModelClient
+
+# Run it with:  ck run planner_agent:agent
+agent = Agent(
+    "trip_planner",
+    system_prompt=(
+        "You are a trip planner. When asked about a destination, first check the weather, "
+        "then find activities, then give a short plan that suits the weather. Before each "
+        "tool call, briefly say what you are about to do."
+    ),
+    subscribe_topics="trip_planner.input",
+    model_client=OpenAIResponsesModelClient(model_name="gpt-5.4-nano"),
+    tools=[get_weather, find_activities],
+)

--- a/examples/streaming/service.py
+++ b/examples/streaming/service.py
@@ -1,0 +1,25 @@
+"""Deploy the trip planner and its two tools on a single worker.
+
+Run this first (it blocks), then run ``stream.py`` in another terminal. Requires
+a running Calfkit broker on ``localhost:9092`` (see the repo README, "Start a
+Calfkit Broker") and ``export OPENAI_API_KEY=sk-...``.
+"""
+
+import asyncio
+
+from planner_agent import agent
+from trip_tools import find_activities, get_weather
+
+from calfkit.client import Client
+from calfkit.worker import Worker
+
+
+async def main() -> None:
+    client = Client.connect("localhost:9092")
+    # Agent + both tool nodes on one worker — the agent's tool Calls are served in-process.
+    worker = Worker(client, nodes=[agent, get_weather, find_activities])
+    await worker.run()  # (blocking) serve the trip planner
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/streaming/stream.py
+++ b/examples/streaming/stream.py
@@ -1,0 +1,67 @@
+"""Stream an agent's intermediate work to the caller as it happens.
+
+``start()`` dispatches the run and returns a handle. ``handle.stream()`` yields
+this run's events in order — zero or more intermediate **step events** (the
+agent's preamble, each tool call, each tool result) and then the terminal
+(``RunCompleted`` / ``RunFailed``) as the last element. The terminal is cached,
+so ``handle.result()`` afterwards replays it as the typed final answer.
+
+Step events are best-effort and carry **raw** parts (not the run's typed
+output); the held handle is the lossless path. See
+``docs/client-features.md`` → "Observing results" for the full contract.
+
+Run it with:  python stream.py
+(Start ``service.py`` first — see this folder's README.)
+"""
+
+import asyncio
+
+from calfkit import (
+    AgentMessageEvent,
+    HandoffEvent,
+    RunCompleted,
+    RunFailed,
+    ToolCallEvent,
+    ToolResultEvent,
+)
+from calfkit.client import Client
+
+
+def _text(parts) -> str:
+    """Join the text of any TextParts in a step event's raw parts (for display)."""
+    return " ".join(p.text for p in parts if p.kind == "text").strip()
+
+
+async def main() -> None:
+    async with Client.connect("localhost:9092") as client:
+        handle = await client.agent("trip_planner").start("I'm visiting Kyoto tomorrow — what should I do?")
+
+        print("── live progress ─────────────────────────────")
+        # The stream yields intermediates in order, then the terminal as its last
+        # element; the loop ends naturally after the terminal (no break needed).
+        async for event in handle.stream():
+            match event:
+                case AgentMessageEvent(parts=parts):
+                    print(f"  💬 {_text(parts)}")
+                case ToolCallEvent(name=name, args=args):
+                    print(f"  🔧 calling {name}({args})")
+                case ToolResultEvent(name=name, parts=parts, is_error=is_error):
+                    mark = "⚠️ error" if is_error else "✅"
+                    print(f"  {mark} {name} → {_text(parts)}")
+                case HandoffEvent(target=target, reason=reason):
+                    # Not emitted by this single-agent run — appears when an agent hands
+                    # off or consults a peer (see docs/agent-peers.md).
+                    print(f"  🤝 handoff → {target}: {reason}")
+                case RunCompleted():
+                    print("  🏁 run completed")
+                case RunFailed():
+                    print("  🛑 run failed")
+        print("──────────────────────────────────────────────")
+
+        # Same channel as the stream: the cached terminal, projected to the typed output.
+        result = await handle.result()
+        print(f"\nFinal plan:\n{result.output}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/streaming/trip_tools.py
+++ b/examples/streaming/trip_tools.py
@@ -1,0 +1,22 @@
+"""Two tools the trip planner calls — each is its own deployable tool node.
+
+The agent reaches them by name over the broker (it publishes a tool Call to each
+tool's inbox); ``service.py`` co-hosts them with the agent on one worker. The
+canned returns keep the demo deterministic and offline (no external API).
+"""
+
+from calfkit.nodes import agent_tool
+
+
+# Run it with:  ck run trip_tools:get_weather
+@agent_tool
+def get_weather(city: str) -> str:
+    """Get tomorrow's weather forecast for a city."""
+    return f"Tomorrow in {city}: cloudy with light rain, 14°C."
+
+
+# Run it with:  ck run trip_tools:find_activities
+@agent_tool
+def find_activities(city: str) -> str:
+    """Find notable things to do in a city."""
+    return f"In {city}: temple tours, a covered food market, and a tea ceremony."


### PR DESCRIPTION
## What

Follow-up docs/example work for the **intermediate step streaming** feature (PR #302). The feature shipped with reference + how-to coverage, but a review found it under-surfaced for discovery and missing a runnable example. This PR addresses that.

## Changes

- **New `examples/streaming/`** — a `trip_planner` agent that checks the weather and finds activities (two tool nodes), so a run produces a real stream of steps. `stream.py` calls it with `start()` and prints each step — preamble, tool calls, tool results — live from `handle.stream()`, then replays the cached terminal via `result()` as the typed final answer. The agent and both tool nodes are co-hosted on one `Worker`, so it's a **2-terminal** demo. The `match/case` covers all six `RunEvent` members (including `HandoffEvent`, with a note on when it appears).
- **`README.md`** — adds the example to the **Examples** list, and names live step streaming (`handle.stream()`) in the **"How to call agents from a client"** index entry, which previously mentioned only the `events()` firehose.
- **`docs/api.md`** — adds the per-event `kind` discriminator column to the intermediate-step-events table and notes the events are **frozen** (reference completeness).
- **Fix a pre-existing broken link** — `examples/quickstart_mcp/README.md` pointed at `../../README.md#start-a-calfkit-broker`, which has no matching heading; repointed to `#running-your-agents` (the section that actually documents broker startup).

## Verification

- `make check` clean (lint / format / type).
- All example files compile; the agent, tool nodes, and `Worker` construct cleanly (`agent.node_id == "trip_planner"`, worker hosts 3 nodes).
- `stream.py`'s `match/case` + text helper were exercised against the real surface event types.
- Deployment model confirmed against source: `tools=[...]` publishes tool Calls to each tool's inbox; tool nodes override `project_steps` to emit `ToolResultStep`, so the stream genuinely carries tool results.
- Docs-only + example-only change — no library code touched.