### PR TITLE
feat(cli): add ck chat interactive agent REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,24 +80,8 @@ ck run finance_help:finance finance_help:lookup_account_balance
 
 Ask the general assistant a question. Notice it's able to dynamically discover and consult the `finance` agent for help without any hard-coded configuration of `finance` agent's existence.
 
-```python
-import asyncio
-from calfkit import Client
-
-async def main():
-    async with Client.connect() as client:
-        result = await client.agent(name="general").execute(
-            "Do I have enough money to afford a new car?"
-        )
-        print(result.output)
-        # LOL nah twin
-
-if __name__ == "__main__":
-    asyncio.run(main())
-```
-
 ```bash
-python ask.py
+ck chat
 ```
 
 Calfkit agents discover and communicate over an agent mesh, provided by either Calfkit Cloud (in alpha) or your own self-hosted version. 
@@ -142,6 +126,7 @@ In-repo documentation lives under [`docs/`](docs/).
 **How-to guides** — goal-oriented walkthroughs:
 
 - **[How to call agents from a client](docs/client-features.md)** — the `agent(name)` gateway and its `send` / `start` / `execute` triad, multi-turn conversations, runtime dependency injection (`deps`), temporary instructions, streaming a run's intermediate steps live with `handle.stream()`, the `events()` firehose, and the typed client errors.
+- **[How to chat with an agent from the terminal](docs/chat-with-agents.md)** — discover the agents online, pick one (or name it), and hold a multi-turn conversation in an interactive `ck chat` REPL, watching each turn's tool calls and results stream live.
 - **[How to tap a topic with a consumer node](docs/consumer-nodes.md)** — terminal sinks that run arbitrary Python against every event on a topic; tap an agent's `publish_topic` to log, persist, or fan out.
 - **[How to guard and transform node invocations](docs/policy-seams.md)** — guard an invocation with `before_node` (transform the input, short-circuit the body, or raise to block), and validate or reshape its output with `after_node`.
 - **[How to handle errors and faults](docs/error-handling.md)** — recover from a failed node or callee with `on_node_error` / `on_callee_error`, mint typed faults with `NodeFaultError`, and inspect an `ErrorReport`.
@@ -153,7 +138,7 @@ In-repo documentation lives under [`docs/`](docs/).
 **Reference:**
 
 - **[API reference](docs/api.md)** — the public surface re-exported from the top-level `calfkit` package, with the key entry-point signatures.
-- **[CLI reference](docs/cli.md)** — the `ck run` and `ck topics` commands.
+- **[CLI reference](docs/cli.md)** — the `ck run`, `ck chat`, and `ck topics` commands.
 - **[Topic provisioning](docs/topic-provisioning.md)** — the experimental, opt-in topic-creation helper for dev/CI.
 
 ## Contributing

--- a/calfkit/cli/__init__.py
+++ b/calfkit/cli/__init__.py
@@ -21,12 +21,14 @@ def _build_app() -> Any:
     """
     import typer
 
+    from calfkit.cli.chat import chat as chat_command
     from calfkit.cli.run import run as run_command
     from calfkit.cli.topics import app as topics_app
 
     app = typer.Typer(name="ck", help="Calfkit SDK command-line tools.", no_args_is_help=True)
     app.add_typer(topics_app, name="topics")
     app.command(name="run")(run_command)
+    app.command(name="chat")(chat_command)
     return app
 
 

--- a/calfkit/cli/_chat.py
+++ b/calfkit/cli/_chat.py
@@ -1,0 +1,155 @@
+"""``ck chat`` orchestration (plan §6/§7/§9): discover -> pick -> REPL.
+
+This module owns every ``print`` and the per-turn streaming; the renderer
+(:mod:`calfkit.cli._chat_render`) is pure and the stdin reader
+(:mod:`calfkit.cli._chat_io`) is the one isolated I/O primitive. A turn is
+``start().stream()`` (the live work-log) followed by ``result()`` (the projected
+answer + the message history threaded into the next turn); ``--timeout`` bounds the
+response wait (``stream()`` + ``result()``, which have no internal timeout) — the
+dispatch (``start()``) is not under it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+from typing import TYPE_CHECKING, Any
+
+import typer
+
+from calfkit.cli._chat_io import make_reader
+from calfkit.cli._chat_render import _error_line, _render_answer, _render_fault, _render_step, format_picker
+from calfkit.client import Client, RunCompleted, RunFailed
+from calfkit.exceptions import NodeFaultError
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Mapping
+
+    from calfkit._vendor.pydantic_ai.messages import ModelMessage
+    from calfkit.client import AgentGateway
+    from calfkit.client.hub import InvocationHandle
+    from calfkit.client.mesh import AgentInfo
+
+    ReadLine = Callable[[str], Awaitable[str]]
+
+
+def _width() -> int:
+    return shutil.get_terminal_size().columns
+
+
+def _emit(lines: list[str]) -> None:
+    for line in lines:
+        print(line)
+
+
+async def run_chat_session(name: str | None, server_urls: str | list[str] | None, timeout: float | None) -> None:
+    """Connect, discover the online agents, resolve the target, and run the REPL.
+
+    A not-ready mesh raises ``MeshUnavailableError`` from ``get_agents()`` — left to
+    bubble to the ``chat.py`` boundary (F2). The ``async with`` closes the client
+    (mesh views then broker) on every exit path.
+    """
+    read_line = make_reader(asyncio.get_running_loop())
+    async with Client.connect(server_urls) as client:
+        print("Discovering agents...")
+        agents = await client.mesh.get_agents()
+        if not agents:  # ready, but zero live agents
+            print("No agents are online on the mesh.")
+            return
+        picked = await _resolve_target(name, agents, read_line)
+        if picked is None:  # user quit at the picker
+            return
+        await _chat_loop(client, picked, timeout, read_line)
+
+
+async def _resolve_target(name: str | None, agents: Mapping[str, AgentInfo], read_line: ReadLine) -> str | None:
+    """The named agent (erroring if it isn't online), or the user's picker choice
+    (``None`` if they quit)."""
+    if name is not None:
+        if name in agents:
+            return name
+        typer.echo(f"Agent {name!r} is not online. Online agents: {', '.join(sorted(agents))}.", err=True)
+        raise typer.Exit(2)
+
+    names = sorted(agents)  # sort ONCE — the displayed numbering and the index->name selection share it
+    _emit(format_picker(names, agents))
+    while True:
+        try:
+            choice = (await read_line(f"\nSelect an agent [1-{len(names)}, q to quit]: ")).strip()
+        except EOFError:
+            print()
+            return None
+        if choice.lower() == "q":
+            return None
+        if choice.isdigit() and 1 <= int(choice) <= len(names):
+            return names[int(choice) - 1]
+        print(f"Enter a number from 1 to {len(names)}, or q to quit.")
+
+
+async def _chat_loop(client: Client, agent_name: str, timeout: float | None, read_line: ReadLine) -> None:
+    """The multi-turn REPL with one agent. ``message_history`` is threaded turn to
+    turn — the only continuity mechanism."""
+    gw = client.agent(agent_name)
+    history: list[ModelMessage] = []
+    print(f"\nChatting with {agent_name}. Type /exit or press Ctrl-D to leave.")
+    print("-" * _width())
+    while True:
+        try:
+            line = (await read_line("\nyou > ")).strip()
+        except EOFError:  # Ctrl-D
+            print()
+            break
+        if line in {"/exit", "/quit"}:
+            break
+        if not line:
+            continue
+        new_history = await _run_turn(gw, agent_name, line, history, timeout)
+        if new_history is not None:  # None == the turn failed / timed out: keep the old history
+            history = new_history
+
+
+async def _run_turn(
+    gw: AgentGateway[Any],
+    agent_name: str,
+    prompt: str,
+    history: list[ModelMessage],
+    timeout: float | None,
+) -> list[ModelMessage] | None:
+    """Dispatch one turn, render it, and return the next history — or ``None`` if the
+    dispatch failed, the turn faulted, or it exceeded ``--timeout`` (the REPL keeps
+    going either way)."""
+    try:
+        handle = await gw.start(prompt, message_history=history)
+    except Exception as exc:  # the turn could not be dispatched (broker I/O, or building/serializing the request): surface it, keep the REPL alive
+        _emit(_error_line(agent_name, f"turn could not be started ({type(exc).__name__}: {exc})"))
+        return None
+    collect = _render_and_collect(handle, agent_name)
+    try:
+        if timeout is None:
+            return await collect  # no timeout: a real TimeoutError here propagates, never mislabelled
+        try:
+            return await asyncio.wait_for(collect, timeout)
+        except asyncio.TimeoutError:  # scoped to the wait_for path only
+            print("\n(no response within the timeout)")
+            return None
+    except NodeFaultError as exc:
+        _emit(_render_fault(agent_name, exc))
+        return None
+
+
+async def _render_and_collect(handle: InvocationHandle, agent_name: str) -> list[ModelMessage]:
+    """Render the turn's live step events (the work-log) as they stream, then the
+    projected final answer; return the message history for the next turn."""
+    responder = agent_name
+    current_emitter: str | None = None
+    async for event in handle.stream():  # intermediates, then the terminal (last)
+        if isinstance(event, RunCompleted):
+            responder = event.agent or agent_name
+        elif isinstance(event, RunFailed):
+            pass  # surfaced by result() below as NodeFaultError
+        else:
+            lines, current_emitter = _render_step(event, current_emitter)
+            _emit(lines)
+    result = await handle.result()  # cached terminal: projects str + history (or raises NodeFaultError)
+    _emit(_render_answer(responder, result.output))
+    return result.message_history

--- a/calfkit/cli/_chat_io.py
+++ b/calfkit/cli/_chat_io.py
@@ -1,0 +1,102 @@
+"""The ``ck chat`` stdin line reader (plan §8.5).
+
+A cancellable single-line reader built on ``loop.add_reader`` — **no executor
+thread**, so Ctrl-C cancels the awaited read cleanly and there is no teardown
+join to hang on. The reader keeps a persistent buffer + incremental UTF-8 decoder
+in its closure, so a paste/pipe that delivers several lines (or splits a line, or
+a multibyte char, across reads) is handled correctly:
+
+- **Queue-first:** a call first serves any line already buffered; only when none
+  is buffered does it arm the reader and ``os.read``.
+- **Accumulate:** one ``add_reader`` per call (removed only in the ``finally``);
+  the callback reads and appends until a ``\\n`` is buffered (a partial line
+  leaves the reader armed, level-triggered) or EOF.
+- **EOF:** an empty read with a buffered partial returns that partial once, then
+  the next call (empty buffer) raises ``EOFError``.
+
+POSIX selector loop only (Windows ``ProactorEventLoop`` has no ``add_reader`` for
+stdin). ``read_line`` is the single primitive the orchestration injects, so it is
+unit-tested over an ``os.pipe()`` without a tty.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import codecs
+import io
+import os
+import sys
+from collections.abc import Awaitable, Callable
+
+_READ_SIZE = 4096
+
+
+def _resolve_stdin_fd() -> int:
+    """The stdin file descriptor, or a clear error if stdin isn't a real fd
+    (e.g. a ``CliRunner``/``BytesIO`` stream — those paths never read a line)."""
+    try:
+        return sys.stdin.fileno()
+    except (AttributeError, ValueError, io.UnsupportedOperation) as exc:
+        raise RuntimeError("ck chat needs an interactive terminal; stdin has no usable file descriptor.") from exc
+
+
+def make_reader(loop: asyncio.AbstractEventLoop, fd: int | None = None) -> Callable[[str], Awaitable[str]]:
+    """Build the line reader bound to ``loop``. ``fd`` defaults to stdin, resolved
+    lazily on the first read (so building the reader touches no fd — the no-reader
+    command paths stay usable); tests inject an ``os.pipe()`` read-end."""
+    # errors="replace": an invalid/truncated byte becomes U+FFFD rather than raising — a raise
+    # inside the add_reader callback would not reach the awaiter (it goes to the loop's exception
+    # handler) and the read would hang. Replacement is also the right UX for an interactive REPL.
+    decoder = codecs.getincrementaldecoder("utf-8")("replace")
+    buffer = ""
+    resolved_fd = fd
+
+    async def read_line(prompt: str) -> str:
+        nonlocal buffer, resolved_fd
+        sys.stdout.write(prompt)
+        sys.stdout.flush()
+
+        # Queue-first: serve a buffered line before touching the fd.
+        if "\n" in buffer:
+            line, _, buffer = buffer.partition("\n")
+            return line
+
+        if resolved_fd is None:
+            resolved_fd = _resolve_stdin_fd()
+        read_fd = resolved_fd
+
+        future: asyncio.Future[bool] = loop.create_future()
+
+        def _on_readable() -> None:
+            nonlocal buffer
+            if future.done():  # cancel/resolve already won the race
+                return  # pragma: no cover - asyncio cancel-vs-readable race; not deterministically reproducible
+            try:
+                chunk = os.read(read_fd, _READ_SIZE)
+            except OSError as exc:  # surface a read error (bad fd, etc.) to the awaiter
+                future.set_exception(exc)
+                return
+            if not chunk:  # EOF
+                future.set_result(False)
+                return
+            buffer += decoder.decode(chunk)
+            if "\n" in buffer:
+                future.set_result(True)
+            # else: partial — stay armed (level-triggered), accumulate on the next read
+
+        loop.add_reader(read_fd, _on_readable)
+        try:
+            has_line = await future
+        finally:
+            loop.remove_reader(read_fd)
+
+        if not has_line:  # EOF
+            buffer += decoder.decode(b"", final=True)  # flush a trailing truncated char (-> U+FFFD)
+            if buffer:  # a typed-ahead partial with no trailing newline: return it once
+                line, buffer = buffer, ""
+                return line
+            raise EOFError
+        line, _, buffer = buffer.partition("\n")
+        return line
+
+    return read_line

--- a/calfkit/cli/_chat_render.py
+++ b/calfkit/cli/_chat_render.py
@@ -1,0 +1,121 @@
+"""Pure rendering for ``ck chat`` (plan §8): step events / picker -> ``list[str]``.
+
+No ``print``, no I/O — ``_chat.py`` owns all output. Work-log layout: each line is
+``INDENT + tag.ljust(TAG_W) + TAG_GAP + content``; a multi-line content's
+continuation lines align to the content column. The final answer prints raw (no
+tag, no wrap).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from calfkit.models.payload import FilePart, ToolCallPart, render_parts_as_text
+from calfkit.models.step import AgentMessageEvent, HandoffEvent, ToolCallEvent, ToolResultEvent
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from calfkit.client.mesh import AgentInfo
+    from calfkit.exceptions import NodeFaultError
+    from calfkit.models.payload import ContentPart
+    from calfkit.models.step import RunStepEvent
+
+# One source of truth: each event TYPE -> its tag. Dispatch and TAG_W both read
+# this map, so a tag can never drift between the two. ``ToolResultEvent`` maps to
+# "[tool result]" or, when ``is_error``, the "[tool error]" override below.
+_TAGS: dict[type, str] = {
+    AgentMessageEvent: "[message]",
+    ToolCallEvent: "[tool call]",
+    ToolResultEvent: "[tool result]",
+    HandoffEvent: "[handoff]",
+}
+_TOOL_ERROR_TAG = "[tool error]"
+TAG_W = max(len(tag) for tag in (*_TAGS.values(), _TOOL_ERROR_TAG))  # 13, derived — never hardcoded
+INDENT = "  "
+TAG_GAP = "  "
+_CONTENT_COL = len(INDENT) + TAG_W + len(TAG_GAP)
+
+
+def _placeholder(part: ContentPart) -> str | None:
+    """``render_other`` for the work-log: a visible placeholder for the parts the
+    text renderer doesn't itself handle (File / ToolCall), so nothing is silently
+    dropped (D7). Any other part falls through to ``None`` (dropped)."""
+    if isinstance(part, FilePart):
+        return f"[file: {part.media_type}]"
+    if isinstance(part, ToolCallPart):
+        return f"[tool: {part.tool_name}]"
+    return None
+
+
+def _parts_text(parts: list[ContentPart]) -> str:
+    return render_parts_as_text(parts, render_other=_placeholder, empty="")
+
+
+def _format_args(args: str | dict[str, Any] | None) -> str:
+    """Render a tool call's args (the raw model emission) compactly."""
+    if args is None:
+        return ""
+    if isinstance(args, dict):
+        return ", ".join(f"{key}={value!r}" for key, value in args.items())
+    return args  # a raw (possibly unparsed) string, shown verbatim
+
+
+def _block(tag: str, content: str) -> list[str]:
+    """One work-log entry: ``tag`` + ``content``, with multi-line content's
+    continuation lines indented to the content column."""
+    head, *rest = content.split("\n")
+    lines = [f"{INDENT}{tag.ljust(TAG_W)}{TAG_GAP}{head}"]
+    lines.extend(f"{' ' * _CONTENT_COL}{line}" for line in rest)
+    return lines
+
+
+def _render_step(ev: RunStepEvent, current_emitter: str | None) -> tuple[list[str], str | None]:
+    """Render one step event to its work-log lines, prepending a blank line + the
+    emitter name when the emitter changes. An empty ``[message]`` is skipped
+    entirely (no header, no line) and leaves ``current_emitter`` unchanged."""
+    if isinstance(ev, AgentMessageEvent):
+        content = _parts_text(ev.parts)
+        if not content:
+            return [], current_emitter
+    elif isinstance(ev, ToolCallEvent):
+        content = f"{ev.name}({_format_args(ev.args)})"
+    elif isinstance(ev, ToolResultEvent):
+        content = _parts_text(ev.parts)
+    elif isinstance(ev, HandoffEvent):
+        content = f"{ev.target} ({ev.reason})"
+    else:  # defensive: an unmodeled/future surface step event
+        return [], current_emitter
+    tag = _TOOL_ERROR_TAG if isinstance(ev, ToolResultEvent) and ev.is_error else _TAGS[type(ev)]
+    lines = ["", ev.emitter] if ev.emitter != current_emitter else []
+    lines.extend(_block(tag, content))
+    return lines, ev.emitter
+
+
+def _render_answer(responder: str, output: str) -> list[str]:
+    """The final answer, raw (D8). An empty reply (e.g. a File/ToolCall-only
+    output) shows a placeholder rather than a bare ``responder >``."""
+    return ["", f"{responder} > {output or '(no text reply)'}"]
+
+
+def _error_line(agent_name: str, message: str) -> list[str]:
+    """The ``‹agent› > [error] …`` line — shared by faults and turn-level errors."""
+    return ["", f"{agent_name} > [error] {message}"]
+
+
+def _render_fault(agent_name: str, err: NodeFaultError) -> list[str]:
+    """The fault line for a turn whose ``result()`` raised ``NodeFaultError``."""
+    report = err.report
+    return _error_line(agent_name, report.message or report.error_type or "fault")
+
+
+def format_picker(names: list[str], agents: Mapping[str, AgentInfo]) -> list[str]:
+    """The numbered agent picker, rendering ``names`` in the given order (the caller
+    sorts) — ``index · name · description`` (``(no description)`` when absent) (D9)."""
+    idx_w = len(str(len(names)))
+    name_w = max((len(name) for name in names), default=0)
+    lines = ["Online agents", ""]
+    for index, name in enumerate(names, start=1):
+        description = agents[name].description or "(no description)"
+        lines.append(f"{INDENT}{str(index).rjust(idx_w)}{TAG_GAP}{name.ljust(name_w)}{TAG_GAP}{description}")
+    return lines

--- a/calfkit/cli/_common.py
+++ b/calfkit/cli/_common.py
@@ -1,0 +1,49 @@
+"""Shared helpers for the calfkit CLI commands.
+
+``_load_env`` and ``_parse_host`` are used by more than one command (``ck run``'s
+``serve`` and ``ck chat``), so they live here rather than inside any single
+command's module.
+"""
+
+from __future__ import annotations
+
+import os
+
+import typer
+
+
+def _load_env(env_file: str | None) -> None:
+    """Load environment variables from a dotenv file.
+
+    An explicit ``env_file`` is loaded as given; otherwise ``./.env`` is loaded
+    if present. A development convenience so ``OPENAI_API_KEY`` and friends are
+    available without exporting them by hand.
+
+    An explicit ``env_file`` that does not exist is surfaced as a warning rather
+    than silently ignored (``load_dotenv`` no-ops on a missing path), so a typo'd
+    ``--env-file`` doesn't turn into a confusing "missing API key" failure later.
+    """
+    from dotenv import load_dotenv
+
+    if env_file:
+        if not os.path.exists(env_file):
+            typer.echo(f"Warning: --env-file {env_file!r} not found; continuing without it.", err=True)
+            return
+        load_dotenv(env_file)
+    elif os.path.exists(".env"):
+        load_dotenv(".env")
+
+
+def _parse_host(host: str | None) -> str | list[str] | None:
+    """Map the ``--host`` flag to a ``server_urls`` value for ``Client.connect``.
+
+    ``None`` (flag omitted) is passed through unchanged so ``Client.connect``
+    applies its ``CALFKIT_MESH_URL`` → ``localhost`` fallback — preserving the
+    flag > env > localhost precedence. A comma-separated value becomes a list.
+    """
+    if not host:
+        return None
+    parts = [s.strip() for s in host.split(",") if s.strip()]
+    if not parts:
+        return None
+    return parts if len(parts) > 1 else parts[0]

--- a/calfkit/cli/_run.py
+++ b/calfkit/cli/_run.py
@@ -10,50 +10,13 @@ it in a fresh process on every file change.
 from __future__ import annotations
 
 import asyncio
-import os
 from typing import Any
 
 import typer
 
+from calfkit.cli._common import _load_env, _parse_host
 from calfkit.cli._loader import load_nodes
 from calfkit.client._mesh_url import resolve_mesh_url
-
-
-def _load_env(env_file: str | None) -> None:
-    """Load environment variables from a dotenv file.
-
-    An explicit ``env_file`` is loaded as given; otherwise ``./.env`` is loaded
-    if present. A development convenience so ``OPENAI_API_KEY`` and friends are
-    available without exporting them by hand.
-
-    An explicit ``env_file`` that does not exist is surfaced as a warning rather
-    than silently ignored (``load_dotenv`` no-ops on a missing path), so a typo'd
-    ``--env-file`` doesn't turn into a confusing "missing API key" failure later.
-    """
-    from dotenv import load_dotenv
-
-    if env_file:
-        if not os.path.exists(env_file):
-            typer.echo(f"Warning: --env-file {env_file!r} not found; continuing without it.", err=True)
-            return
-        load_dotenv(env_file)
-    elif os.path.exists(".env"):
-        load_dotenv(".env")
-
-
-def _parse_host(host: str | None) -> str | list[str] | None:
-    """Map the ``--host`` flag to a ``server_urls`` value for ``Client.connect``.
-
-    ``None`` (flag omitted) is passed through unchanged so ``Client.connect``
-    applies its ``CALFKIT_MESH_URL`` → ``localhost`` fallback — preserving the
-    flag > env > localhost precedence. A comma-separated value becomes a list.
-    """
-    if not host:
-        return None
-    parts = [s.strip() for s in host.split(",") if s.strip()]
-    if not parts:
-        return None
-    return parts if len(parts) > 1 else parts[0]
 
 
 def _print_banner(nodes: list[Any], server_urls: str | list[str] | None, provision: bool) -> None:

--- a/calfkit/cli/chat.py
+++ b/calfkit/cli/chat.py
@@ -1,0 +1,79 @@
+"""``ck chat`` typer command — chat with an agent on the mesh (plan §5).
+
+Discovers the agents currently online (``client.mesh.get_agents()``), lets you pick
+one (or names it directly), then runs a multi-turn REPL that streams each turn's
+intermediate work (messages, tool calls/results, handoffs) live, then the answer.
+
+Exit codes:
+    0 — clean exit (``/exit``, ``/quit``, Ctrl-D, or Ctrl-C), or when no agents are online.
+    2 — an invalid config value, a named agent that isn't online, or an unusable mesh
+        directory (``MeshUnavailableError``). A bad ``--env-file`` warns and continues;
+        an unreachable broker surfaces as the mesh-unavailable path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import traceback
+
+import typer
+
+from calfkit.cli._common import _load_env, _parse_host
+from calfkit.exceptions import MeshUnavailableError
+
+# Reason -> remedy hint for an unusable mesh directory (the closed
+# MeshUnavailableError.reason set; ``.get`` degrades gracefully if it ever grows).
+_MESH_HINTS = {
+    "establishing": "still catching up — try again in a moment",
+    "open_failed": "no agents/tools are online yet, or the broker is unreachable",
+    "reader_dead": "the mesh reader failed — restart ck chat",
+}
+
+
+def chat(
+    name: str | None = typer.Argument(
+        None,
+        help="Agent to chat with. Omit to pick from the list of online agents.",
+    ),
+    host: str | None = typer.Option(
+        None,
+        "--host",
+        "-H",
+        help="Kafka bootstrap server(s), comma-separated. Precedence: this flag > $CALFKIT_MESH_URL > localhost.",
+    ),
+    env_file: str | None = typer.Option(
+        None,
+        "--env-file",
+        help="Path to a dotenv file to load. Defaults to ./.env if present.",
+    ),
+    timeout: float | None = typer.Option(
+        None,
+        "--timeout",
+        help="Per-turn patience in seconds. On timeout the turn is abandoned and the session continues. Default: wait indefinitely.",
+    ),
+) -> None:
+    """Chat with an agent on the mesh."""
+    from calfkit.cli._chat import run_chat_session
+
+    try:
+        _load_env(env_file)
+        server_urls = _parse_host(host)
+    except ValueError as exc:  # an invalid config value (defensive — the parsers don't raise today)
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(2) from exc
+
+    # The session runs in a SEPARATE try: a ValueError raised in here (e.g. a pydantic
+    # ValidationError, which subclasses ValueError) is a real bug and must propagate with its
+    # traceback — not be masked as a clean config-error Exit(2).
+    try:
+        asyncio.run(run_chat_session(name, server_urls, timeout))
+    except KeyboardInterrupt:
+        # Ctrl-C at a prompt or mid-turn: a clean stop, not a traceback (the
+        # add_reader-based reader cancels cleanly — see _chat_io).
+        raise typer.Exit(0) from None
+    except MeshUnavailableError as exc:
+        # Fail fast on an unusable mesh, but preserve the traceback so the cause is debuggable.
+        hint = _MESH_HINTS.get(exc.reason, "unavailable")
+        typer.echo(f"Error: mesh unavailable ({exc.reason}): {hint}", err=True)
+        typer.echo(traceback.format_exc(), err=True)
+        raise typer.Exit(2) from exc

--- a/docs/chat-with-agents.md
+++ b/docs/chat-with-agents.md
@@ -1,0 +1,91 @@
+# How to chat with an agent from the terminal
+
+`ck chat` opens an interactive REPL for talking to an agent running on your mesh —
+for trying an agent out, watching how it uses its tools, or a quick manual check
+without writing any client code.
+
+## Before you start
+
+You need a running mesh and at least one agent online (advertising itself on the
+control plane). Running locally, start your agent worker first — for example with
+[`ck run`](cli.md#ck-run):
+
+```console
+$ ck run support_desk:support_bot
+```
+
+`ck chat` connects to `$CALFKIT_MESH_URL` (or `localhost`) by default; point it at
+a different broker with `--host`.
+
+## Pick an agent and start chatting
+
+Run `ck chat` with no arguments to see who's online and choose one:
+
+```console
+$ ck chat
+Discovering agents...
+Online agents
+
+  1  researcher   Deep web research with citations
+  2  support-bot  Handles customer support tickets and refunds
+
+Select an agent [1-2, q to quit]: 2
+
+Chatting with support-bot. Type /exit or press Ctrl-D to leave.
+```
+
+Type a message at the `you >` prompt and press Enter. The reply streams in two
+parts — first the agent's **work log** (one indented, tagged line per step), then
+its **answer**:
+
+```text
+you > my order #4471 never arrived
+
+support-bot
+  [message]      Let me pull up that order for you.
+  [tool call]    lookup_order(id='4471')
+  [tool result]  shipped 2026-06-24, in transit
+
+support-bot > Order #4471 shipped on the 24th and is in transit.
+```
+
+The conversation is multi-turn — keep typing and the agent remembers the earlier
+turns. If it hands off to another agent mid-turn, that agent's name appears as its
+own header, so you can follow who did what.
+
+## Skip the picker
+
+If you already know the agent's name, pass it as an argument to go straight in:
+
+```console
+$ ck chat support-bot
+```
+
+This connects directly to `support-bot` (and exits with an error if it isn't
+online).
+
+## Leave the session
+
+End with `/exit`, `/quit`, or Ctrl-D. Ctrl-C also exits at any time, including
+mid-turn. To talk to a different agent, leave and run `ck chat` again — there is
+no in-session "back".
+
+## Cap how long a turn may take
+
+By default `ck chat` waits as long as the agent needs. To bound each turn, pass
+`--timeout` in seconds:
+
+```console
+$ ck chat researcher --timeout 120
+```
+
+A turn that exceeds the limit prints `(no response within the timeout)` and the
+session continues; your next message starts a fresh turn. (Pressing Ctrl-C instead
+exits the whole session — set `--timeout` if you want a stuck turn to abort while
+the session keeps going.)
+
+## Related
+
+- [CLI reference: `ck chat`](cli.md#ck-chat) — every option and exit code.
+- [How to call nodes from a client](client-features.md) — the programmatic way to
+  invoke agents, including typed structured output and streaming a run's steps.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -7,6 +7,7 @@ Commands:
 | Command | Purpose |
 | --- | --- |
 | [`ck run`](#ck-run) | Run node(s) as a worker for local development (no `Worker` boilerplate). |
+| [`ck chat`](#ck-chat) | Chat with an online agent from an interactive terminal REPL. |
 | [`ck topics`](#ck-topics) | Best-effort create the Kafka topics a set of nodes reference. |
 
 ---
@@ -149,6 +150,85 @@ if __name__ == "__main__":
 ```console
 $ python serve_tool.py
 ```
+
+---
+
+## `ck chat`
+
+Chat with an agent running on your mesh from an interactive REPL — discover the
+agents currently online, pick one (or name it directly), then hold a multi-turn
+conversation. Each turn streams the agent's intermediate work — its messages, tool
+calls and results, and any handoffs — live, followed by its answer.
+
+```text
+ck chat [NAME] [OPTIONS]
+```
+
+With no `NAME`, `ck chat` lists the agents online and prompts you to choose;
+`ck chat researcher` skips the picker and connects to that agent directly (and
+exits `2` if it isn't online). There is no "back" — leave and rerun to switch
+agents.
+
+### A session
+
+```console
+$ ck chat
+Discovering agents...
+Online agents
+
+  1  researcher   Deep web research with citations
+  2  support-bot  Handles customer support tickets and refunds
+
+Select an agent [1-2, q to quit]: 2
+
+Chatting with support-bot. Type /exit or press Ctrl-D to leave.
+----------------------------------------------------------------
+
+you > my order #4471 never arrived
+
+support-bot
+  [message]      Let me pull up that order for you.
+  [tool call]    lookup_order(id='4471')
+  [tool result]  shipped 2026-06-24, in transit
+
+support-bot > Order #4471 shipped on the 24th and is in transit.
+Estimated delivery is tomorrow. Want me to start a trace?
+
+you >
+```
+
+Each turn renders in three tiers: **your input** (`you >`), the agent's live
+**work log** (indented, one line per step, tagged `[message]` / `[tool call]` /
+`[tool result]` / `[tool error]` / `[handoff]`), and the agent's **answer**
+(`‹agent› >`). The work log is headed by the agent's name, so it is always clear
+which agent did the work; a mid-turn handoff prints the new agent's name as its
+own header.
+
+### Leaving
+
+`/exit`, `/quit`, or Ctrl-D end the session; Ctrl-C exits at any time, including
+mid-turn. Any other input is sent to the agent verbatim.
+
+### Options
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--host`, `-H` | `$CALFKIT_MESH_URL` → `localhost` | Kafka bootstrap server(s), comma-separated. Precedence: this flag **>** `$CALFKIT_MESH_URL` **>** `localhost`. |
+| `--env-file` | `./.env` if present | dotenv file to load before connecting. A *missing explicit* `--env-file` warns (it is not silently ignored). |
+| `--timeout` | wait indefinitely | Per-turn patience, in seconds. A turn that exceeds it prints a notice and the session continues. (Ctrl-C exits the whole session — see [Leaving](#leaving).) |
+
+### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Clean exit (`/exit`, `/quit`, Ctrl-D, or Ctrl-C), or when no agents are online. |
+| `2` | A named agent that isn't online, or an unusable mesh directory (`MeshUnavailableError`: still catching up, the directory topic absent, or the broker unreachable). A bad `--env-file` warns and continues. |
+
+> **Replies are rendered as text.** `ck chat` connects with a string output type,
+> so an agent whose output is structured data shows that data as JSON on the answer
+> line. It's a conversational tool for trying agents out and watching their work —
+> for typed structured output, call the agent from a client (see
+> [How to call nodes from a client](client-features.md)).
 
 ---
 

--- a/tests/integration/test_chat_discovery_kafka.py
+++ b/tests/integration/test_chat_discovery_kafka.py
@@ -1,0 +1,88 @@
+"""Real-broker (``kafka`` lane) discovery for ``ck chat``.
+
+A live worker advertises an ``Agent``; the CLI's discovery primitive
+(``client.mesh.get_agents()``) reads it back, and the CLI's own pure consumers —
+``format_picker`` and ``_resolve_target`` — render/resolve the *real* mesh output,
+proving the ``ck chat`` discovery path end to end against a live mesh.
+
+Opt-in (``-m kafka`` / ``make test-kafka``); skips cleanly without Docker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import Awaitable, Callable
+
+import pytest
+
+from calfkit import MeshUnavailableError
+from calfkit._vendor.pydantic_ai import models
+from calfkit.cli._chat import _resolve_target
+from calfkit.cli._chat_render import format_picker
+from calfkit.client import Client, MeshViewConfig
+from calfkit.nodes import Agent
+from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
+from calfkit.tuning import KTableReaderTuning
+from calfkit.worker import Worker
+from tests.integration._kafka_helpers import fast_control_plane
+
+pytestmark = pytest.mark.kafka
+models.ALLOW_MODEL_REQUESTS = True
+
+_EARLIEST = {"auto_offset_reset": "earliest"}
+_FAST_MESH = MeshViewConfig(reader_tuning=KTableReaderTuning(poll_timeout_ms=20, fetch_max_wait_ms=10))
+
+
+class FakeModel(PydanticModelClient):
+    """Advertise-only model: the agent is hosted to publish its AgentCard, never to run a turn."""
+
+    @property
+    def model_name(self) -> str:
+        return "fake"
+
+    @property
+    def system(self) -> str:
+        return "fake"
+
+    async def request(self, *args: object, **kwargs: object) -> object:
+        raise NotImplementedError
+
+
+def _eof_reader() -> Callable[[str], Awaitable[str]]:
+    async def read_line(_prompt: str) -> str:
+        raise EOFError  # a name-given resolution never reads a line
+
+    return read_line
+
+
+async def test_chat_discovers_and_resolves_a_live_agent(kafka_bootstrap: str, topic_namespace: str) -> None:
+    agent_name = f"{topic_namespace}-helpbot"
+    agent = Agent(agent_name, subscribe_topics=f"{agent_name}.in", model_client=FakeModel(), description="Helps with things")
+    worker = Worker(
+        Client.connect(kafka_bootstrap),
+        nodes=[agent],
+        control_plane=fast_control_plane(kafka_bootstrap),
+        extra_subscribe_kwargs=_EARLIEST,
+    )
+    client = Client.connect(kafka_bootstrap, mesh_config=_FAST_MESH)
+    try:
+        async with worker:
+            deadline = asyncio.get_event_loop().time() + 60
+            agents: dict = {}
+            while asyncio.get_event_loop().time() < deadline:
+                with contextlib.suppress(MeshUnavailableError):  # tolerate cold-start catch-up
+                    agents = dict(await client.mesh.get_agents())
+                    if agent_name in agents:
+                        break
+                await asyncio.sleep(0.2)
+            assert agent_name in agents, "the agent did not advertise within 60s"
+
+            # the CLI's discovery consumers render/resolve the real mesh output
+            assert agents[agent_name].description == "Helps with things"
+            picker = format_picker(sorted(agents), agents)
+            assert any(agent_name in line and "Helps with things" in line for line in picker)
+            assert await _resolve_target(agent_name, agents, _eof_reader()) == agent_name
+    finally:
+        await client.aclose()
+        await worker._client.aclose()

--- a/tests/test_chat_cli.py
+++ b/tests/test_chat_cli.py
@@ -1,0 +1,99 @@
+"""CliRunner smoke tests for the ``ck chat`` command (no-reader paths only).
+
+``CliRunner``'s ``BytesIO`` stdin has no usable ``fileno()``, so these exercise
+only the paths that never read a line: ``--help`` and the mocked-mesh offline-name
+``Exit(2)``. The interactive reader/transcript is covered by the unit/integration
+tests in ``test_chat_io`` / ``test_chat_session``.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+
+import pytest
+from typer.testing import CliRunner
+
+from calfkit.client.mesh import AgentInfo, Mesh
+from calfkit.exceptions import MeshUnavailableError
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
+def test_chat_mounted_with_options() -> None:
+    from calfkit.cli import _build_app
+
+    result = CliRunner().invoke(_build_app(), ["chat", "--help"])
+    assert result.exit_code == 0, result.stdout
+    out = _plain(result.stdout)
+    assert "--host" in out
+    assert "--timeout" in out
+    assert "--env-file" in out
+
+
+def test_chat_offline_name_exits_2(monkeypatch: pytest.MonkeyPatch) -> None:
+    from calfkit.cli import _build_app
+
+    async def _fake(_self: Mesh) -> dict[str, AgentInfo]:
+        return {"helpbot": AgentInfo(name="helpbot", description="x", last_seen=datetime(2026, 1, 1, tzinfo=timezone.utc))}
+
+    monkeypatch.setattr(Mesh, "get_agents", _fake)
+    result = CliRunner().invoke(_build_app(), ["chat", "missing"])
+    assert result.exit_code == 2, result.stdout + result.stderr
+    assert "is not online" in _plain(result.stdout + result.stderr)
+
+
+def test_chat_mesh_unavailable_exits_2_with_reason_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    from calfkit.cli import _build_app
+
+    async def _raise(_self: Mesh) -> dict[str, AgentInfo]:
+        raise MeshUnavailableError("down", reason="open_failed")
+
+    monkeypatch.setattr(Mesh, "get_agents", _raise)
+    result = CliRunner().invoke(_build_app(), ["chat"])
+    assert result.exit_code == 2, result.stdout + result.stderr
+    out = _plain(result.stdout + result.stderr)
+    assert "mesh unavailable (open_failed)" in out
+    assert "no agents/tools are online" in out  # the reason-aware hint
+
+
+def test_chat_session_value_error_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A ValueError from the running session (e.g. a pydantic ValidationError, which subclasses
+    # ValueError) is a real bug — it must NOT be masked as a clean config-error Exit(2).
+    from calfkit.cli import _build_app
+
+    async def _raise(*_a: object, **_k: object) -> None:
+        raise ValueError("a real bug")
+
+    monkeypatch.setattr("calfkit.cli._chat.run_chat_session", _raise)
+    result = CliRunner().invoke(_build_app(), ["chat"])
+    assert isinstance(result.exception, ValueError)  # propagated, not swallowed
+    assert result.exit_code != 2
+
+
+def test_chat_config_value_error_exits_2(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A ValueError while parsing config (the defensive --host arm) is a clean Exit(2), no traceback.
+    from calfkit.cli import _build_app
+
+    def _raise(_host: object) -> None:
+        raise ValueError("bad host value")
+
+    monkeypatch.setattr("calfkit.cli.chat._parse_host", _raise)
+    result = CliRunner().invoke(_build_app(), ["chat"])
+    assert result.exit_code == 2, result.stdout + result.stderr
+    assert "Error: bad host value" in _plain(result.stdout + result.stderr)
+
+
+def test_chat_keyboard_interrupt_exits_0(monkeypatch: pytest.MonkeyPatch) -> None:
+    from calfkit.cli import _build_app
+
+    async def _raise(*_a: object, **_k: object) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("calfkit.cli._chat.run_chat_session", _raise)
+    result = CliRunner().invoke(_build_app(), ["chat"])
+    assert result.exit_code == 0

--- a/tests/test_chat_io.py
+++ b/tests/test_chat_io.py
@@ -1,0 +1,199 @@
+"""Unit tests for the ``ck chat`` stdin line reader (``calfkit.cli._chat_io``).
+
+The reader is exercised over an ``os.pipe()`` (the plan's §11 transport) so the
+buffering contract — queue-first serving, partial accumulation, multibyte decode,
+and EOF — is asserted against a real fd without a tty.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import os
+from collections.abc import Awaitable
+from types import SimpleNamespace
+
+import pytest
+
+from calfkit.cli._chat_io import _resolve_stdin_fd, make_reader
+
+
+async def _drain(coro: Awaitable[str], timeout: float = 1.0) -> str:
+    return await asyncio.wait_for(coro, timeout)
+
+
+async def test_reads_one_line() -> None:
+    r, w = os.pipe()
+    try:
+        read_line = make_reader(asyncio.get_running_loop(), fd=r)
+        os.write(w, b"hi\n")
+        assert await _drain(read_line("")) == "hi"
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+async def test_multiline_one_write_served_from_buffer() -> None:
+    """A paste/pipe of several lines in one write: calls 2..N return from the
+    buffer with NO further write (the queue-first / no-re-read property)."""
+    r, w = os.pipe()
+    try:
+        read_line = make_reader(asyncio.get_running_loop(), fd=r)
+        os.write(w, b"a\nb\nc\n")
+        assert await _drain(read_line("")) == "a"
+        assert await _drain(read_line("")) == "b"  # no further write
+        assert await _drain(read_line("")) == "c"
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+async def test_partial_then_newline_accumulates() -> None:
+    r, w = os.pipe()
+    try:
+        read_line = make_reader(asyncio.get_running_loop(), fd=r)
+        task = asyncio.create_task(read_line(""))
+        os.write(w, b"hel")
+        await asyncio.sleep(0.05)
+        assert not task.done()  # partial line: still waiting, reader stays armed
+        os.write(w, b"lo\n")
+        assert await _drain(task) == "hello"
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+async def test_multibyte_char_split_across_writes() -> None:
+    r, w = os.pipe()
+    try:
+        read_line = make_reader(asyncio.get_running_loop(), fd=r)
+        task = asyncio.create_task(read_line(""))
+        os.write(w, b"\xe2\x9c")  # first two bytes of "✓"
+        await asyncio.sleep(0.05)
+        assert not task.done()  # incomplete char: decoder holds it, no line yet
+        os.write(w, b"\x93\n")  # final byte + newline
+        assert await _drain(task) == "✓"
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+async def test_eof_with_partial_returns_partial_then_raises() -> None:
+    r, w = os.pipe()
+    try:
+        read_line = make_reader(asyncio.get_running_loop(), fd=r)
+        os.write(w, b"par")
+        os.close(w)  # EOF with a partial (no trailing newline) buffered
+        assert await _drain(read_line("")) == "par"
+        with pytest.raises(EOFError):
+            await _drain(read_line(""))
+    finally:
+        os.close(r)
+
+
+async def test_bare_eof_raises() -> None:
+    r, w = os.pipe()
+    try:
+        read_line = make_reader(asyncio.get_running_loop(), fd=r)
+        os.close(w)  # EOF, no data
+        with pytest.raises(EOFError):
+            await _drain(read_line(""))
+    finally:
+        os.close(r)
+
+
+async def test_prompt_is_written_to_stdout(capsys: pytest.CaptureFixture[str]) -> None:
+    r, w = os.pipe()
+    try:
+        read_line = make_reader(asyncio.get_running_loop(), fd=r)
+        os.write(w, b"x\n")
+        await _drain(read_line("you > "))
+        assert "you > " in capsys.readouterr().out
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+def test_resolve_stdin_fd_returns_fileno(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.stdin", SimpleNamespace(fileno=lambda: 7))
+    assert _resolve_stdin_fd() == 7
+
+
+def test_resolve_stdin_fd_raises_when_no_real_fd(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _bad_fileno() -> int:
+        raise io.UnsupportedOperation
+
+    monkeypatch.setattr("sys.stdin", SimpleNamespace(fileno=_bad_fileno))
+    with pytest.raises(RuntimeError, match="interactive terminal"):
+        _resolve_stdin_fd()
+
+
+async def test_lazy_fd_resolution_reads_from_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    r, w = os.pipe()
+    try:
+        monkeypatch.setattr("sys.stdin", SimpleNamespace(fileno=lambda: r))
+        read_line = make_reader(asyncio.get_running_loop())  # fd=None -> resolve to r lazily
+        os.write(w, b"lazy\n")
+        assert await _drain(read_line("")) == "lazy"
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+async def test_os_read_error_is_surfaced(monkeypatch: pytest.MonkeyPatch) -> None:
+    r, w = os.pipe()
+    try:
+        read_line = make_reader(asyncio.get_running_loop(), fd=r)
+
+        def _boom(_fd: int, _n: int) -> bytes:
+            raise OSError("read failed")
+
+        monkeypatch.setattr("calfkit.cli._chat_io.os.read", _boom)
+        os.write(w, b"x\n")  # make the fd readable so the callback fires and hits os.read
+        with pytest.raises(OSError, match="read failed"):
+            await _drain(read_line(""))
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+async def test_invalid_utf8_byte_is_replaced_not_hung() -> None:
+    # An invalid UTF-8 byte must not raise inside the callback (which would hang the read).
+    r, w = os.pipe()
+    try:
+        read_line = make_reader(asyncio.get_running_loop(), fd=r)
+        os.write(w, b"\xff\n")  # invalid lead byte, then newline
+        assert await _drain(read_line("")) == "�"
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+async def test_truncated_multibyte_at_eof_is_replaced() -> None:
+    # A multibyte char cut off by EOF is surfaced as U+FFFD (flushed), not silently dropped.
+    r, w = os.pipe()
+    try:
+        read_line = make_reader(asyncio.get_running_loop(), fd=r)
+        os.write(w, b"\xe2\x9c")  # first 2 of the 3 bytes of "✓"
+        os.close(w)  # EOF before the char completes
+        assert await _drain(read_line("")) == "�"
+    finally:
+        os.close(r)
+
+
+async def test_cancel_in_flight_read_line_removes_reader_no_leak() -> None:
+    # The whole point of the add_reader reader: Ctrl-C cancels a parked read cleanly and the
+    # finally de-registers the reader (no fd/reader leak), unlike a to_thread(input) executor.
+    r, w = os.pipe()
+    try:
+        loop = asyncio.get_running_loop()
+        read_line = make_reader(loop, fd=r)
+        task = asyncio.create_task(read_line(""))  # arms the reader; no data -> parks
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert loop.remove_reader(r) is False  # the read's finally already removed it — no leak
+    finally:
+        os.close(r)
+        os.close(w)

--- a/tests/test_chat_render.py
+++ b/tests/test_chat_render.py
@@ -1,0 +1,189 @@
+"""Unit tests for the pure ``ck chat`` renderer (``calfkit.cli._chat_render``).
+
+The renderer returns ``list[str]`` and does no I/O, so every behavior is asserted
+directly on the produced lines — the alignment/indentation IS the contract.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from calfkit.cli._chat_render import _placeholder, _render_answer, _render_fault, _render_step, format_picker
+from calfkit.client.mesh import AgentInfo
+from calfkit.exceptions import NodeFaultError
+from calfkit.models.payload import DataPart, FilePart, TextPart, ToolCallPart
+from calfkit.models.step import AgentMessageEvent, AgentThinkingEvent, HandoffEvent, ToolCallEvent, ToolResultEvent
+
+# --- event/DTO builders (the base hop-identity fields are noise for rendering) ---
+
+
+def _msg(emitter: str, parts: list) -> AgentMessageEvent:
+    return AgentMessageEvent(correlation_id="c", depth=0, frame_id="f", emitter=emitter, parts=parts)
+
+
+def _call(emitter: str, name: str, args: object = None) -> ToolCallEvent:
+    return ToolCallEvent(correlation_id="c", depth=0, frame_id="f", emitter=emitter, tool_call_id="t1", name=name, args=args)
+
+
+def _result(emitter: str, name: str, parts: list, *, is_error: bool = False) -> ToolResultEvent:
+    return ToolResultEvent(correlation_id="c", depth=0, frame_id="f", emitter=emitter, tool_call_id="t1", name=name, parts=parts, is_error=is_error)
+
+
+def _handoff(emitter: str, target: str, reason: str) -> HandoffEvent:
+    return HandoffEvent(correlation_id="c", depth=0, frame_id="f", emitter=emitter, target=target, reason=reason)
+
+
+def _agent(name: str, desc: str | None) -> AgentInfo:
+    return AgentInfo(name=name, description=desc, last_seen=datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+
+# --- _render_step: tags, emitter header, block layout (content column = 17) ------
+
+
+def test_message_emits_header_then_block() -> None:
+    lines, emitter = _render_step(_msg("bot", [TextPart(text="Let me look.")]), None)
+    assert lines == ["", "bot", "  [message]      Let me look."]
+    assert emitter == "bot"
+
+
+def test_no_header_when_emitter_unchanged() -> None:
+    lines, emitter = _render_step(_call("bot", "lookup_order", {"id": "4471"}), "bot")
+    assert lines == ["  [tool call]    lookup_order(id='4471')"]
+    assert emitter == "bot"
+
+
+def test_emitter_change_emits_new_header() -> None:
+    lines, emitter = _render_step(_call("billing", "issue_refund"), "support-bot")
+    assert lines == ["", "billing", "  [tool call]    issue_refund()"]
+    assert emitter == "billing"
+
+
+def test_tool_result_success_tag() -> None:
+    lines, _ = _render_step(_result("bot", "lookup_order", [TextPart(text="in transit")]), "bot")
+    assert lines == ["  [tool result]  in transit"]
+
+
+def test_tool_result_error_tag() -> None:
+    lines, _ = _render_step(_result("bot", "issue_refund", [TextPart(text="declined")], is_error=True), "bot")
+    assert lines == ["  [tool error]   declined"]
+
+
+def test_handoff_tag_and_content() -> None:
+    lines, _ = _render_step(_handoff("bot", "billing", "refund authority required"), "bot")
+    assert lines == ["  [handoff]      billing (refund authority required)"]
+
+
+def test_multiline_content_block_indented_to_content_column() -> None:
+    parts = [TextPart(text="Refund policy:\n- within 30 days: full\n- after: store credit")]
+    lines, _ = _render_step(_result("bot", "search", parts), "bot")
+    assert lines == [
+        "  [tool result]  Refund policy:",
+        "                 - within 30 days: full",
+        "                 - after: store credit",
+    ]
+
+
+def test_multiline_message_is_also_block_indented() -> None:
+    lines, _ = _render_step(_msg("bot", [TextPart(text="line one\nline two")]), "bot")
+    assert lines == ["  [message]      line one", "                 line two"]
+
+
+# --- tool-call args: dict / str / None ------------------------------------------
+
+
+def test_tool_args_dict() -> None:
+    lines, _ = _render_step(_call("bot", "f", {"a": 1, "b": "x"}), "bot")
+    assert lines == ["  [tool call]    f(a=1, b='x')"]
+
+
+def test_tool_args_raw_str_verbatim() -> None:
+    lines, _ = _render_step(_call("bot", "f", '{"q": "x"}'), "bot")
+    assert lines == ['  [tool call]    f({"q": "x"})']
+
+
+def test_tool_args_none_is_empty_parens() -> None:
+    lines, _ = _render_step(_call("bot", "ping", None), "bot")
+    assert lines == ["  [tool call]    ping()"]
+
+
+# --- File / ToolCall parts -> visible placeholder (never dropped, D7) ------------
+
+
+def test_file_part_renders_placeholder() -> None:
+    lines, _ = _render_step(_result("bot", "gen", [FilePart(media_type="image/png")]), "bot")
+    assert lines == ["  [tool result]  [file: image/png]"]
+
+
+def test_toolcall_part_renders_placeholder() -> None:
+    lines, _ = _render_step(_msg("bot", [ToolCallPart(tool_call_id="t", tool_name="foo", kwargs={})]), "bot")
+    assert lines == ["  [message]      [tool: foo]"]
+
+
+def test_datapart_renders_as_json() -> None:
+    lines, _ = _render_step(_result("bot", "q", [DataPart(data={"k": 1})]), "bot")
+    assert lines == ['  [tool result]  {"k":1}']
+
+
+# --- empty [message] is skipped entirely (no header, no line, emitter unchanged) -
+
+
+def test_empty_message_skipped_emitter_unchanged() -> None:
+    lines, emitter = _render_step(_msg("newbot", []), "oldbot")
+    assert lines == []
+    assert emitter == "oldbot"
+
+
+# --- final answer (raw) and fault ------------------------------------------------
+
+
+def test_render_answer_raw() -> None:
+    assert _render_answer("support-bot", "Order shipped.") == ["", "support-bot > Order shipped."]
+
+
+def test_render_answer_empty_is_placeholder() -> None:
+    assert _render_answer("bot", "") == ["", "bot > (no text reply)"]
+
+
+def test_render_fault_uses_report_message() -> None:
+    err = NodeFaultError("billing.denied", message="quota exceeded")
+    assert _render_fault("bot", err) == ["", "bot > [error] quota exceeded"]
+
+
+def test_render_fault_falls_back_to_error_type() -> None:
+    err = NodeFaultError("billing.denied")
+    assert _render_fault("bot", err) == ["", "bot > [error] billing.denied"]
+
+
+# --- picker: alphabetical, (no description), numbered ----------------------------
+
+
+def test_format_picker_renders_given_order_and_no_description() -> None:
+    agents = {
+        "support-bot": _agent("support-bot", "Support"),
+        "researcher": _agent("researcher", "Deep research"),
+        "summarizer": _agent("summarizer", None),
+    }
+    names = ["researcher", "summarizer", "support-bot"]  # the caller sorts; the picker renders this order
+    assert format_picker(names, agents) == [
+        "Online agents",
+        "",
+        "  1  researcher   Deep research",
+        "  2  summarizer   (no description)",
+        "  3  support-bot  Support",
+    ]
+
+
+def test_format_picker_empty_does_not_crash() -> None:
+    assert format_picker([], {}) == ["Online agents", ""]
+
+
+def test_placeholder_drops_unhandled_part() -> None:
+    # render_other only sees File/ToolCall in practice; anything else falls through to None (dropped).
+    assert _placeholder(TextPart(text="x")) is None
+
+
+def test_render_step_skips_unmodeled_event() -> None:
+    # AgentThinkingEvent is a defined-but-not-emitted surface event: not one of the four rendered
+    # kinds, so it is skipped with the emitter left unchanged.
+    ev = AgentThinkingEvent(correlation_id="c", depth=0, frame_id="f", emitter="bot", parts=[TextPart(text="hmm")])
+    assert _render_step(ev, "prev") == ([], "prev")

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -1,0 +1,331 @@
+"""Tests for the ``ck chat`` orchestration (``calfkit.cli._chat``).
+
+Three layers, each as real as the broker allows:
+- discovery / picker / offline-name: ``client.mesh.get_agents`` patched, the rest real;
+- the fault & timeout turn paths: a **real** ``InvocationHandle`` + ``_RunChannel`` (a
+  synchronous test broker cannot produce a client-side timeout), injected via a thin gateway;
+- the happy multi-turn transcript: a full offline ``TestKafkaBroker`` run of a ``FunctionModel``
+  agent, driving ``_chat_loop`` with a scripted reader.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+
+import pytest
+import typer
+from faststream.kafka import KafkaBroker, TestKafkaBroker
+
+from calfkit._vendor.pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, TextPart, ToolCallPart, ToolReturnPart
+from calfkit._vendor.pydantic_ai.models.function import AgentInfo as _FnAgentInfo
+from calfkit._vendor.pydantic_ai.models.function import FunctionModel
+from calfkit.cli._chat import _chat_loop, _render_and_collect, _resolve_target, _run_turn, run_chat_session
+from calfkit.client import Client
+from calfkit.client.events import RunCompleted, RunFailed
+from calfkit.client.hub import InvocationHandle, _RunChannel
+from calfkit.client.mesh import AgentInfo, Mesh
+from calfkit.exceptions import MeshUnavailableError
+from calfkit.models import CallFrameStack, Envelope, SessionRunContext, WorkflowState
+from calfkit.models.error_report import ErrorReport
+from calfkit.models.payload import TextPart as _WireTextPart
+from calfkit.models.state import State
+from calfkit.models.step import AgentMessageEvent, HandoffEvent
+from calfkit.models.tool_context import ToolContext
+from calfkit.nodes import Agent, agent_tool
+from calfkit.worker import Worker
+from tests.providers import prepare_worker
+
+
+def _agent(name: str, desc: str | None) -> AgentInfo:
+    return AgentInfo(name=name, description=desc, last_seen=datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+
+def _scripted(lines: list[str]) -> Callable[[str], Awaitable[str]]:
+    """A reader that returns the scripted lines in order, then raises ``EOFError``."""
+    it = iter(lines)
+
+    async def read_line(_prompt: str) -> str:
+        try:
+            return next(it)
+        except StopIteration:
+            raise EOFError from None
+
+    return read_line
+
+
+def _patch_get_agents(monkeypatch: pytest.MonkeyPatch, *, result: object = None, raises: Exception | None = None) -> None:
+    async def _fake(_self: Mesh) -> object:
+        if raises is not None:
+            raise raises
+        return result
+
+    monkeypatch.setattr(Mesh, "get_agents", _fake)
+
+
+class _FakeGateway:
+    """A thin ``client.agent(...)`` stand-in: ``start`` returns a pre-built handle so the
+    fault / timeout branches of ``_run_turn`` can be driven with a controlled terminal."""
+
+    def __init__(self, handle: InvocationHandle) -> None:
+        self._handle = handle
+
+    async def start(self, _prompt: str, *, message_history: list[ModelMessage] | None = None) -> InvocationHandle:
+        return self._handle
+
+
+# --- _resolve_target: name online / offline, picker selection -------------------
+
+
+async def test_resolve_target_name_online_returns_it() -> None:
+    agents = {"helpbot": _agent("helpbot", "x")}
+    assert await _resolve_target("helpbot", agents, _scripted([])) == "helpbot"
+
+
+async def test_resolve_target_name_offline_exits_2_listing_online(capsys: pytest.CaptureFixture[str]) -> None:
+    agents = {"helpbot": _agent("helpbot", "x"), "researcher": _agent("researcher", "y")}
+    with pytest.raises(typer.Exit) as exc:
+        await _resolve_target("missing", agents, _scripted([]))
+    assert exc.value.exit_code == 2
+    err = capsys.readouterr().err
+    assert "is not online" in err
+    assert "helpbot, researcher" in err  # alphabetical online list
+
+
+async def test_resolve_target_picker_selects_by_index() -> None:
+    agents = {"beta": _agent("beta", "x"), "alpha": _agent("alpha", "y")}  # sorted: alpha, beta
+    assert await _resolve_target(None, agents, _scripted(["2"])) == "beta"
+
+
+async def test_resolve_target_picker_quit_returns_none() -> None:
+    agents = {"alpha": _agent("alpha", "x")}
+    assert await _resolve_target(None, agents, _scripted(["q"])) is None
+
+
+async def test_resolve_target_picker_eof_returns_none() -> None:
+    agents = {"alpha": _agent("alpha", "x")}
+    assert await _resolve_target(None, agents, _scripted([])) is None
+
+
+async def test_resolve_target_picker_invalid_then_valid(capsys: pytest.CaptureFixture[str]) -> None:
+    agents = {"alpha": _agent("alpha", "x")}
+    picked = await _resolve_target(None, agents, _scripted(["9", "notanumber", "1"]))
+    assert picked == "alpha"
+    assert "Enter a number from 1 to 1" in capsys.readouterr().out
+
+
+# --- run_chat_session discovery paths (mesh.get_agents patched) ------------------
+
+
+async def test_run_chat_session_no_agents_prints_and_returns(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    _patch_get_agents(monkeypatch, result={})
+    await run_chat_session(None, "localhost:9092", None)
+    out = capsys.readouterr().out
+    assert "Discovering agents" in out
+    assert "No agents are online" in out
+
+
+async def test_run_chat_session_offline_name_exits_2(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    _patch_get_agents(monkeypatch, result={"helpbot": _agent("helpbot", "x")})
+    with pytest.raises(typer.Exit) as exc:
+        await run_chat_session("missing", "localhost:9092", None)
+    assert exc.value.exit_code == 2
+    assert "is not online" in capsys.readouterr().err
+
+
+async def test_run_chat_session_propagates_mesh_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get_agents(monkeypatch, raises=MeshUnavailableError("down", reason="open_failed"))
+    with pytest.raises(MeshUnavailableError):
+        await run_chat_session(None, "localhost:9092", None)
+
+
+# --- _run_turn: fault + timeout (real handle + channel, thin injected gateway) ---
+
+
+async def test_run_turn_fault_renders_error_and_keeps_history(capsys: pytest.CaptureFixture[str]) -> None:
+    channel = _RunChannel()
+    channel.push(RunFailed(report=ErrorReport(error_type="billing.denied", message="over limit"), correlation_id="c"))
+    handle = InvocationHandle(correlation_id="c", _channel=channel)
+    result = await _run_turn(_FakeGateway(handle), "bot", "hi", ["OLD"], None)
+    assert result is None  # turn failed -> caller keeps the old history
+    out = capsys.readouterr().out
+    assert "bot > [error] over limit" in out
+    assert out.count("bot > ") == 1  # ONLY the error line — the normal answer is suppressed
+
+
+async def test_run_turn_timeout_prints_notice_and_keeps_history(capsys: pytest.CaptureFixture[str]) -> None:
+    channel = _RunChannel()  # never terminated -> stream() parks
+    handle = InvocationHandle(correlation_id="c", _channel=channel)
+    result = await _run_turn(_FakeGateway(handle), "bot", "hi", ["OLD"], 0.05)
+    assert result is None
+    assert "no response within the timeout" in capsys.readouterr().out
+
+
+class _FailingStartGateway:
+    """A gateway whose dispatch (start) fails — e.g. a transient broker/publish error."""
+
+    async def start(self, _prompt: str, *, message_history: list[ModelMessage] | None = None) -> InvocationHandle:
+        raise ConnectionError("broker unreachable")
+
+
+async def test_run_turn_dispatch_failure_keeps_repl_alive(capsys: pytest.CaptureFixture[str]) -> None:
+    # A dispatch failure (gw.start) must be surfaced per-turn and return None (keep history),
+    # not propagate out and tear down the whole REPL.
+    result = await _run_turn(_FailingStartGateway(), "bot", "hi", ["OLD"], None)
+    assert result is None
+    out = capsys.readouterr().out
+    assert "bot >" in out and "turn could not be started" in out and "ConnectionError" in out
+
+
+# --- happy multi-turn transcript over a real (offline) TestKafkaBroker -----------
+
+
+@agent_tool
+def _lookup_year(_ctx: ToolContext) -> str:
+    return "1967"
+
+
+_seen: list[list[ModelMessage]] = []
+
+
+def _preamble_call_then_final(messages: list[ModelMessage], _info: _FnAgentInfo) -> ModelResponse:
+    _seen.append(list(messages))
+    last = messages[-1]
+    if isinstance(last, ModelRequest) and any(isinstance(p, ToolReturnPart) for p in last.parts):
+        returned = next(p for p in last.parts if isinstance(p, ToolReturnPart))
+        return ModelResponse(parts=[TextPart(f"answer: {returned.content}")])
+    return ModelResponse(parts=[TextPart("checking the records"), ToolCallPart("_lookup_year")])
+
+
+async def test_chat_loop_renders_transcript_and_threads_history(container: object, capsys: pytest.CaptureFixture[str]) -> None:
+    _seen.clear()
+    worker = container.get(Worker)  # type: ignore[attr-defined]
+    agent = Agent(
+        "helpbot",
+        system_prompt="x",
+        subscribe_topics="agent.helpbot.private.input",  # == derive_input_topic("helpbot")
+        model_client=FunctionModel(_preamble_call_then_final),
+        tools=[_lookup_year],
+        sequential_only_mode=True,
+    )
+    worker.add_nodes(agent, _lookup_year)
+    prepare_worker(container)
+    broker = container.get(KafkaBroker)  # type: ignore[attr-defined]
+    client = container.get(Client)  # type: ignore[attr-defined]
+
+    async with TestKafkaBroker(broker):
+        await _chat_loop(client, "helpbot", 10.0, _scripted(["what year", "what else", "/exit"]))
+
+    out = capsys.readouterr().out
+    assert "helpbot" in out  # the emitter header attributes the work to the agent
+    assert "[message]" in out and "checking the records" in out  # preamble step
+    assert "[tool call]" in out and "_lookup_year()" in out  # tool call step
+    assert "[tool result]" in out and "1967" in out  # tool result step
+    assert "helpbot > answer: 1967" in out  # the final answer line
+    # the work log streams BEFORE the answer, in step order (first occurrences = turn 1)
+    assert out.index("[message]") < out.index("[tool call]") < out.index("[tool result]") < out.index("helpbot > answer: 1967")
+    assert out.count("answer: 1967") == 2  # both turns completed
+    # threading: turn 2's first model call saw the accumulated turn-1 history (more messages).
+    assert len(_seen[2]) > len(_seen[0])
+
+
+# --- loop & dispatch edge branches (no turn dispatched, so no broker needed) -----
+
+
+class _FakeClient:
+    """A client whose gateway is never used: the loop branches under test break before any turn."""
+
+    def agent(self, _name: str) -> object:
+        return None
+
+
+async def test_chat_loop_eof_breaks_immediately(capsys: pytest.CaptureFixture[str]) -> None:
+    await _chat_loop(_FakeClient(), "bot", None, _scripted([]))  # Ctrl-D at the first prompt
+    assert "Chatting with bot" in capsys.readouterr().out
+
+
+async def test_chat_loop_empty_line_is_skipped() -> None:
+    # an empty line is skipped (D6); /quit ends — neither dispatches a turn, so the gateway is unused.
+    await _chat_loop(_FakeClient(), "bot", None, _scripted(["", "/quit"]))
+
+
+async def test_run_chat_session_picker_quit_returns(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    _patch_get_agents(monkeypatch, result={"alpha": _agent("alpha", "x"), "beta": _agent("beta", "y")})
+    monkeypatch.setattr("calfkit.cli._chat.make_reader", lambda _loop: _scripted(["q"]))
+    await run_chat_session(None, "localhost:9092", None)
+    assert "Online agents" in capsys.readouterr().out  # picker shown, then quit -> clean return
+
+
+async def test_run_chat_session_dispatches_to_chat_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get_agents(monkeypatch, result={"helpbot": _agent("helpbot", "x")})
+    called: list[str] = []
+
+    async def _record(_client: object, agent_name: str, _timeout: object, _read_line: object) -> None:
+        called.append(agent_name)
+
+    monkeypatch.setattr("calfkit.cli._chat._chat_loop", _record)
+    await run_chat_session("helpbot", "localhost:9092", None)
+    assert called == ["helpbot"]
+
+
+async def test_chat_loop_survives_a_faulting_turn(capsys: pytest.CaptureFixture[str]) -> None:
+    """A turn that faults renders an [error] line and the REPL keeps going (reaches /exit)."""
+    channel = _RunChannel()
+    channel.push(RunFailed(report=ErrorReport(error_type="billing.denied", message="boom"), correlation_id="c"))
+    handle = InvocationHandle(correlation_id="c", _channel=channel)
+
+    class _FaultingClient:
+        def agent(self, _name: str) -> _FakeGateway:
+            return _FakeGateway(handle)
+
+    await _chat_loop(_FaultingClient(), "bot", None, _scripted(["trigger a fault", "/exit"]))
+    # the fault rendered, and reaching /exit (no raise) proves the loop survived it
+    out = capsys.readouterr().out
+    assert "bot > [error] boom" in out
+    assert out.count("bot > ") == 1  # only the error line — no answer line printed
+
+
+# --- handoff / multi-emitter attribution (real channel, fed before close) --------
+# Output PROJECTION is covered by the integration + caller-surface tests; here we assert only the
+# ATTRIBUTION — which emitter heads each block, and who the answer is attributed to — so the
+# terminal carries no reply (the answer projects to the empty-reply "(no text reply)" placeholder).
+
+
+def _completed(agent: str | None) -> RunCompleted:
+    envelope = Envelope(
+        context=SessionRunContext(state=State(), deps={}),
+        internal_workflow_state=WorkflowState(call_stack=CallFrameStack()),
+    )
+    return RunCompleted(output="", correlation_id="c", agent=agent, _envelope=envelope)
+
+
+def _amsg(emitter: str, text: str) -> AgentMessageEvent:
+    return AgentMessageEvent(correlation_id="c", depth=1, frame_id="f", emitter=emitter, parts=[_WireTextPart(text=text)])
+
+
+def _handoff(emitter: str, target: str, reason: str) -> HandoffEvent:
+    return HandoffEvent(correlation_id="c", depth=1, frame_id="f", emitter=emitter, target=target, reason=reason)
+
+
+async def test_render_and_collect_attributes_handoff_to_actual_responder(capsys: pytest.CaptureFixture[str]) -> None:
+    channel = _RunChannel()
+    channel.push_intermediate(_amsg("support-bot", "handing this to billing"))
+    channel.push_intermediate(_handoff("support-bot", "billing", "refund authority"))
+    channel.push_intermediate(_amsg("billing", "processing the refund"))
+    channel.push(_completed(agent="billing"))
+    handle = InvocationHandle(correlation_id="c", _channel=channel)
+
+    history = await _render_and_collect(handle, "support-bot")
+    out = capsys.readouterr().out
+    assert out.index("support-bot") < out.index("billing")  # the new emitter's header follows the handoff
+    assert "billing > " in out  # the answer is attributed to the ACTUAL responder (billing)...
+    assert "support-bot > " not in out  # ...not the addressed agent
+    assert isinstance(history, list)
+
+
+async def test_render_and_collect_falls_back_to_addressed_agent_when_responder_unknown(capsys: pytest.CaptureFixture[str]) -> None:
+    channel = _RunChannel()
+    channel.push(_completed(agent=None))  # terminal carries no emitter
+    handle = InvocationHandle(correlation_id="c", _channel=channel)
+    await _render_and_collect(handle, "support-bot")
+    assert "support-bot > " in capsys.readouterr().out  # the `or agent_name` fallback

--- a/tests/test_run_serve.py
+++ b/tests/test_run_serve.py
@@ -143,13 +143,13 @@ def test_serve_banner_shows_env_host_when_no_flag(captured: dict, capsys: pytest
 
 
 def test_parse_host_none_returns_none() -> None:
-    from calfkit.cli._run import _parse_host
+    from calfkit.cli._common import _parse_host
 
     assert _parse_host(None) is None
 
 
 def test_parse_host_empty_returns_none() -> None:
-    from calfkit.cli._run import _parse_host
+    from calfkit.cli._common import _parse_host
 
     assert _parse_host("") is None
 
@@ -157,19 +157,19 @@ def test_parse_host_empty_returns_none() -> None:
 def test_parse_host_separators_only_returns_none() -> None:
     """A non-empty value that strips to nothing falls back to None (so env/
     localhost still win), not an empty/garbage server list."""
-    from calfkit.cli._run import _parse_host
+    from calfkit.cli._common import _parse_host
 
     assert _parse_host(" , ") is None
 
 
 def test_parse_host_single_returns_str() -> None:
-    from calfkit.cli._run import _parse_host
+    from calfkit.cli._common import _parse_host
 
     assert _parse_host("h:9092") == "h:9092"
 
 
 def test_parse_host_comma_returns_list() -> None:
-    from calfkit.cli._run import _parse_host
+    from calfkit.cli._common import _parse_host
 
     assert _parse_host("a:9092, b:9092") == ["a:9092", "b:9092"]
 
@@ -183,14 +183,14 @@ def test_load_env_explicit_file_is_loaded(monkeypatch: pytest.MonkeyPatch, tmp_p
     """An explicit --env-file that exists is passed to load_dotenv."""
     import dotenv
 
-    import calfkit.cli._run as run_mod
+    import calfkit.cli._common as common_mod
 
     env_path = tmp_path / "custom.env"  # type: ignore[operator]
     env_path.write_text("FOO=bar\n")
     calls: list[str] = []
     monkeypatch.setattr(dotenv, "load_dotenv", lambda p: calls.append(p) or True)
 
-    run_mod._load_env(str(env_path))
+    common_mod._load_env(str(env_path))
     assert calls == [str(env_path)]
 
 
@@ -198,12 +198,12 @@ def test_load_env_missing_explicit_file_warns_and_skips(monkeypatch: pytest.Monk
     """A missing explicit --env-file warns (not silent) and does not load."""
     import dotenv
 
-    import calfkit.cli._run as run_mod
+    import calfkit.cli._common as common_mod
 
     calls: list[str] = []
     monkeypatch.setattr(dotenv, "load_dotenv", lambda p: calls.append(p) or True)
 
-    run_mod._load_env("/no/such/file.env")
+    common_mod._load_env("/no/such/file.env")
     assert calls == []
     assert "not found" in capsys.readouterr().err
 
@@ -212,14 +212,14 @@ def test_load_env_autoloads_dotenv_when_present(monkeypatch: pytest.MonkeyPatch,
     """With no explicit file, ./.env is auto-loaded when it exists."""
     import dotenv
 
-    import calfkit.cli._run as run_mod
+    import calfkit.cli._common as common_mod
 
     monkeypatch.chdir(tmp_path)  # type: ignore[arg-type]
     (tmp_path / ".env").write_text("FOO=bar\n")  # type: ignore[operator]
     calls: list[str] = []
     monkeypatch.setattr(dotenv, "load_dotenv", lambda p: calls.append(p) or True)
 
-    run_mod._load_env(None)
+    common_mod._load_env(None)
     assert calls == [".env"]
 
 
@@ -227,11 +227,11 @@ def test_load_env_no_file_no_autoload(monkeypatch: pytest.MonkeyPatch, tmp_path:
     """With no explicit file and no ./.env, load_dotenv is not called."""
     import dotenv
 
-    import calfkit.cli._run as run_mod
+    import calfkit.cli._common as common_mod
 
     monkeypatch.chdir(tmp_path)  # type: ignore[arg-type]
     calls: list[str] = []
     monkeypatch.setattr(dotenv, "load_dotenv", lambda p: calls.append(p) or True)
 
-    run_mod._load_env(None)
+    common_mod._load_env(None)
     assert calls == []


### PR DESCRIPTION
## Summary

Adds a `ck chat [NAME]` CLI command — an interactive REPL for talking to an agent running on the mesh. Discover the agents currently online, pick one (or name it directly), then hold a multi-turn conversation. Each turn streams the agent's intermediate work — messages, tool calls and results, handoffs — live, then its answer, attributed to the agent.

```text
$ ck chat
Discovering agents...

Online agents

  1  researcher    Deep web research with citations
  2  support-bot   Handles customer support tickets and refunds

Select an agent [1-2, q to quit]: 2

Chatting with support-bot. Type /exit or press Ctrl-D to leave.
----------------------------------------------------------------

you > my order #4471 never arrived

support-bot
  [message]      Let me pull up that order for you.
  [tool call]    lookup_order(id='4471')
  [tool result]  shipped 2026-06-24, in transit

support-bot > Order #4471 shipped on the 24th and is in transit.
```

## What's included

- **`cli/_chat_render.py`** — pure renderer (`event -> list[str]`): work-log type tags, multi-line block-indent, the picker. No I/O.
- **`cli/_chat_io.py`** — a cancellable `loop.add_reader` stdin reader (no executor thread → clean Ctrl-C, no teardown hang) with a full line buffer for paste / partial / split-multibyte / EOF.
- **`cli/_chat.py`** — orchestration: discover → pick → REPL; `start().stream()` for the live work-log + `result()` for the projected answer + multi-turn history threading; per-turn `--timeout` via `asyncio.wait_for`.
- **`cli/chat.py`** — the Typer command (registered lazily); fail-fast on an unusable mesh with a reason-aware `MeshUnavailableError` message + a preserved traceback.
- **`cli/_common.py`** — `_load_env` / `_parse_host` extracted from `_run.py` (shared by `ck run` and `ck chat`).
- **Docs** — how-to (`docs/chat-with-agents.md`), CLI reference entry (`docs/cli.md`), README mentions.

Stdlib-only — no new runtime dependencies. Codes against the real `client.mesh` surface from #307.

## Testing

TDD throughout (red → green per module):
- Pure-renderer units (every tag kind, block-indent, picker, defensive branches).
- `os.pipe()` reader units (one line, multi-line-in-one-write, partial, split-multibyte, EOF).
- Offline `TestKafkaBroker` integration: a `FunctionModel` agent's full transcript + multi-turn `message_history` threading; fault path; `--timeout`.
- `CliRunner` smoke tests (`--help`, offline-name, the exception handlers).
- A CI-gated (`kafka` lane) real-broker discovery test.

**100% coverage** on the five new/changed modules; `make check` clean; full offline suite green (3802 passed).
