### PR TITLE
feat: make producer idempotence opt-in

### DIFF
--- a/calfkit/cli/_run.py
+++ b/calfkit/cli/_run.py
@@ -19,7 +19,7 @@ from calfkit.cli._loader import load_nodes
 from calfkit.client._mesh_url import resolve_mesh_url
 
 
-def _print_banner(nodes: list[Any], server_urls: str | list[str] | None, provision: bool) -> None:
+def _print_banner(nodes: list[Any], server_urls: str | list[str] | None, provision: bool, enable_idempotence: bool) -> None:
     """Print a concise startup banner describing what is being served."""
     # Resolve through the same helper Client.connect uses, so the banner reports
     # the exact broker the client connects to (its arg > $CALFKIT_MESH_URL >
@@ -28,6 +28,7 @@ def _print_banner(nodes: list[Any], server_urls: str | list[str] | None, provisi
     typer.echo("🐮 Calfkit — starting dev worker")
     typer.echo(f"   broker: {broker}")
     typer.echo(f"   topic provisioning: {'on' if provision else 'off'}")
+    typer.echo(f"   producer idempotence: {'on' if enable_idempotence else 'off'}")
     for node in nodes:
         node_id = getattr(node, "node_id", None) or repr(node)
         kind = getattr(node, "_node_kind", "node")
@@ -48,6 +49,7 @@ def serve(
     group_id: str | None,
     env_file: str | None,
     app_dir: str,
+    enable_idempotence: bool = False,
 ) -> None:
     """Resolve targets and run them in a single Worker until stopped.
 
@@ -58,6 +60,11 @@ def serve(
         group_id: Optional Kafka consumer-group override (defaults per-node).
         env_file: Optional dotenv path (``./.env`` is auto-loaded otherwise).
         app_dir: Directory inserted on ``sys.path`` for import resolution.
+        enable_idempotence: Turn idempotent producers on (``--enable-idempotence``).
+            Off by default so the worker runs against brokers without producer-id
+            support; when set it flows to ``Client.connect`` as the single knob that
+            hardens every producer (broker + control-plane + fan-out writers). Absent,
+            calfkit sets nothing (``enable_idempotence=None``).
 
     Raises:
         typer.Exit: (code 2) on a bad spec, import failure, non-node object, or
@@ -74,8 +81,10 @@ def serve(
 
     server_urls = _parse_host(host)
     provisioning = ProvisioningConfig(enabled=True) if provision else None
-    client = Client.connect(server_urls, provisioning=provisioning)
+    # The CLI flag is opt-in only: absent -> None so calfkit imposes nothing (library defaults);
+    # --enable-idempotence -> True threads idempotence to every producer via the client.
+    client = Client.connect(server_urls, provisioning=provisioning, enable_idempotence=True if enable_idempotence else None)
     worker = Worker(client, nodes=nodes, group_id=group_id)
 
-    _print_banner(nodes, server_urls, provision)
+    _print_banner(nodes, server_urls, provision, enable_idempotence)
     asyncio.run(worker.run())

--- a/calfkit/cli/run.py
+++ b/calfkit/cli/run.py
@@ -51,6 +51,11 @@ def run(
         "--provision",
         help="Opt-in dev topic auto-creation (EXPERIMENTAL; rf=1, no ACLs). Off by default.",
     ),
+    enable_idempotence: bool = typer.Option(
+        False,
+        "--enable-idempotence",
+        help="Turn on idempotent producers across every producer (needs a broker with producer-id support). Off by default.",
+    ),
     reload: bool = typer.Option(
         False,
         "--reload",
@@ -98,12 +103,12 @@ def run(
         run_process(
             *dirs,
             target=serve,
-            args=(list(targets), host, provision, group_id, env_file, abs_app_dir),
+            args=(list(targets), host, provision, group_id, env_file, abs_app_dir, enable_idempotence),
             watch_filter=PythonFilter(),
         )
     else:
         try:
-            serve(list(targets), host, provision, group_id, env_file, abs_app_dir)
+            serve(list(targets), host, provision, group_id, env_file, abs_app_dir, enable_idempotence)
         except KeyboardInterrupt:
             # Ctrl-C in a window where FastStream's own SIGINT handler isn't
             # active yet (startup/teardown), or on a platform whose event loop

--- a/calfkit/client/caller.py
+++ b/calfkit/client/caller.py
@@ -64,6 +64,7 @@ class Client:
         startup_ensurer: StartupTopicEnsurer,
         server_urls: str | None,
         mesh_config: MeshViewConfig | None = None,
+        enable_idempotence: bool | None = None,
     ) -> None:
         self._broker = broker
         self._hub = hub
@@ -71,6 +72,11 @@ class Client:
         self._emitter_id = emitter_id
         self._firehose_buffer_size = firehose_buffer_size
         self._deps_factory = deps_factory
+        # The resolved producer idempotence posture, tri-state: None = calfkit sets nothing (the
+        # library default applies), True/False = force it. Stored so a co-located Worker + its nodes
+        # wire their control-plane / fan-out writers to the SAME posture — one knob, single source
+        # (worker.py / agent.py read self._client._enable_idempotence).
+        self._enable_idempotence = enable_idempotence
         self._server_urls = server_urls
         self._mesh_config = mesh_config
         self._mesh: Mesh | None = None  # the cached client.mesh singleton (created lazily, zero-I/O)
@@ -96,6 +102,7 @@ class Client:
         firehose_buffer_size: int = DEFAULT_FIREHOSE_BUFFER_SIZE,
         provisioning: ProvisioningConfig | None = None,
         mesh_config: MeshViewConfig | None = None,
+        enable_idempotence: bool | None = None,
         **broker_kwargs: Any,
     ) -> Client:
         """Build the client — **sync, lazy, no I/O** (spec §2.1/§2.7). Registers the hub's groupless
@@ -107,9 +114,13 @@ class Client:
         Security is configured the broker's way (a FastStream ``security=`` object in ``broker_kwargs``);
         raw security kwargs are rejected with an actionable error.
 
-        The shared producer is hardened to ``acks="all"`` + ``enable_idempotence=True`` by default (so a
-        broker-acked publish survives leader failover and retries can't duplicate/reorder, per the fault
-        rail). Override either via ``broker_kwargs`` if you must.
+        calfkit imposes **no** producer posture by default: with ``enable_idempotence`` left unset
+        (``None``) the SDK sets neither ``acks`` nor ``enable_idempotence``, so the library defaults
+        apply (aiokafka ``acks=1``, no idempotence) — which keeps the SDK working against brokers
+        without producer-id support (e.g. Tansu rejects ``InitProducerIdRequest``). Pass
+        ``enable_idempotence=True`` (or ``ck run --enable-idempotence``) to turn idempotence on
+        consistently across the shared producer **and** a co-located worker's control-plane / fan-out
+        writers (one knob). ``acks`` stays overridable via ``broker_kwargs``.
 
         ``provisioning`` is an **experimental** opt-in (issue #180; default disabled): when enabled,
         topics are auto-created at broker start. It is a separate, removable concern from the §2.7
@@ -138,11 +149,11 @@ class Client:
             )
 
         hub = _Hub()
-        # The broker hardens the shared producer (acks=all + idempotence) so a broker-acked publish
-        # survives leader failover and retries can't duplicate/reorder. Defaults only — a user may
-        # override via broker_kwargs. The decode floor is OUTERMOST, carrying the undecodable-sink
+        # calfkit sets no producer posture by default (idempotence unset -> library default). Only when
+        # the caller opts in does enable_idempotence reach the broker producer; acks is never hardcoded
+        # (override via broker_kwargs). The decode floor is OUTERMOST, carrying the undecodable-sink
         # registry {inbox -> hub.fail_run} (spec §5.8); ContextInjection populates correlation_id.
-        producer_posture = {"acks": "all", "enable_idempotence": True}
+        producer_posture: dict[str, Any] = {} if enable_idempotence is None else {"enable_idempotence": enable_idempotence}
         middlewares = [DecodeFloorMiddleware.builder({inbox_topic: hub.fail_run}), ContextInjectionMiddleware]
         broker, ensurer, provisioning = cls._make_provisioned_broker(
             server_list, middlewares, {**producer_posture, **broker_kwargs}, inbox_topic, provisioning
@@ -156,6 +167,7 @@ class Client:
             emitter_id=_new_client_emitter_id(client_id),
             firehose_buffer_size=firehose_buffer_size,
             deps_factory=deps_factory,
+            enable_idempotence=enable_idempotence,
             provisioning=provisioning,
             startup_ensurer=ensurer,
             server_urls=",".join(server_list),

--- a/calfkit/nodes/_fanout_store.py
+++ b/calfkit/nodes/_fanout_store.py
@@ -276,6 +276,7 @@ class KtablesFanoutBatchStore:
         reader_tuning: KTableReaderTuning | None = None,
         catchup_timeout: float | None = None,
         barrier_timeout: float = 30.0,
+        enable_idempotence: bool | None = None,
     ) -> None:
         import ktables  # lazy: keep ktables off the offline import path (only a real store touches it)
 
@@ -285,17 +286,20 @@ class KtablesFanoutBatchStore:
         reader_kwargs: dict[str, Any] = {"ensure_topic": True, **(reader_tuning.as_kwargs() if reader_tuning else {})}
         if catchup_timeout is not None:
             reader_kwargs["catchup_timeout"] = catchup_timeout
+        # Producer posture is the client's single knob (threaded via agent.py): None => set nothing
+        # (the ktables writer default applies), True/False => force it on both writers.
+        writer_idempotence: dict[str, Any] = {} if enable_idempotence is None else {"enable_idempotence": enable_idempotence}
         self._state_reader: KafkaTable[FanoutState] = ktables.KafkaTable.json(
             bootstrap_servers=bootstrap_servers, topic=state_topic, model=FanoutState, **reader_kwargs
         )
         self._state_writer: KafkaTableWriter[FanoutState] = ktables.KafkaTableWriter.json(
-            bootstrap_servers=bootstrap_servers, topic=state_topic, model=FanoutState, ensure_topic=True, enable_idempotence=True
+            bootstrap_servers=bootstrap_servers, topic=state_topic, model=FanoutState, ensure_topic=True, **writer_idempotence
         )
         self._base_reader: KafkaTable[FanoutBaseState] = ktables.KafkaTable.json(
             bootstrap_servers=bootstrap_servers, topic=basestate_topic, model=FanoutBaseState, **reader_kwargs
         )
         self._base_writer: KafkaTableWriter[FanoutBaseState] = ktables.KafkaTableWriter.json(
-            bootstrap_servers=bootstrap_servers, topic=basestate_topic, model=FanoutBaseState, ensure_topic=True, enable_idempotence=True
+            bootstrap_servers=bootstrap_servers, topic=basestate_topic, model=FanoutBaseState, ensure_topic=True, **writer_idempotence
         )
 
     async def start(self) -> None:

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -211,6 +211,8 @@ class BaseAgentNodeDef(
             reader_tuning=fcfg.reader_tuning,
             catchup_timeout=fcfg.catchup_timeout,
             barrier_timeout=fcfg.barrier_timeout,
+            # One knob: the fan-out writers inherit the client's producer idempotence posture.
+            enable_idempotence=worker._client._enable_idempotence,
         )
         await store.start()
         try:

--- a/calfkit/worker/worker.py
+++ b/calfkit/worker/worker.py
@@ -324,11 +324,17 @@ class Worker(LifecycleHookMixin):
                     f"cannot derive Kafka bootstrap servers for control-plane topic {topic!r} "
                     "(client built without connect()?); set ControlPlaneConfig(bootstrap_servers=...)."
                 )
+            # Producer posture is the client's single knob: None => set nothing (ktables writer
+            # default applies), True/False => force it. Same rule as the shared + fan-out producers.
+            writer_idempotence: dict[str, Any] = (
+                {} if self._client._enable_idempotence is None else {"enable_idempotence": self._client._enable_idempotence}
+            )
             writer: GroupedKafkaTableWriter[Any] = GroupedKafkaTableWriter.json(
                 bootstrap_servers=bootstrap,
                 topic=topic,
                 # Writers ensure only in dev/CI; production topics are ops-governed.
                 ensure_topic=self._client._provisioning.enabled,
+                **writer_idempotence,
             )
             await writer.start()
             yield writer

--- a/docs/api.md
+++ b/docs/api.md
@@ -144,11 +144,14 @@ Client.connect(
     deps_factory: Callable[[], dict] | None = None,
     firehose_buffer_size: int = DEFAULT_FIREHOSE_BUFFER_SIZE,
     provisioning: ProvisioningConfig | None = None,
+    enable_idempotence: bool | None = None,
     **broker_kwargs,
 ) -> Client
 ```
 
 Build a `Client` — **synchronous and lazy**: no I/O until the first dispatch / `events()`, so a connection error surfaces there, not from `connect()`. `server_urls` defaults to the `CALFKIT_MESH_URL` environment variable, then `"localhost"`. `inbox_topic` is the named topic this client receives its runs' replies on and routes callbacks to — `None` gives an ephemeral per-client inbox; set it for a durable, shareable one. `deps_factory` seeds ambient `deps` merged under each call's `deps`. `firehose_buffer_size` bounds each `events()` observer's drop-oldest buffer. Configure auth with a FastStream `security=` object in `broker_kwargs` (raw security kwargs are rejected).
+
+`enable_idempotence` is the single knob for producer idempotence across **every** producer this client drives — the shared broker producer and, for a co-located `Worker`, its control-plane and fan-out writers. Left unset (`None`), calfkit imposes nothing and the library defaults apply (no idempotence; aiokafka `acks=1`), which keeps the SDK working against brokers that lack producer-id support (e.g. Tansu). Set it to `True` to turn idempotence on consistently, or `False` to force it off. `acks` is not set by calfkit either; override it per-producer via `broker_kwargs` (e.g. `acks="all"`).
 
 ### `Client.agent`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -81,6 +81,7 @@ would block the import; keep it under the guard.)
 | --- | --- | --- |
 | `--host`, `-H` | `$CALFKIT_MESH_URL` → `localhost` | Kafka bootstrap server(s), comma-separated. Precedence: this flag **>** `$CALFKIT_MESH_URL` **>** `localhost`. |
 | `--provision` | off | Opt-in dev topic auto-creation (**experimental**; `replication_factor=1`, no ACLs). See [Topic provisioning](topic-provisioning.md). |
+| `--enable-idempotence` | off | Turn on idempotent producers across every producer the worker runs. Off by default so the worker runs against brokers without producer-id support; needs a broker that implements the producer-id / transaction coordinator to enable. |
 | `--reload` | off | Watch source files and restart the worker on change (see [Reload](#reload)). |
 | `--reload-dir` | current dir | Directory to watch with `--reload`. Repeatable. |
 | `--app-dir` | `.` (current dir) | Directory inserted on `sys.path` for resolving `module:attr` targets. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "typing-extensions>=4.15.0",
     "dishka>=1.9.1",
     "mcp>=1.27.2",
-    "ktables>=0.4.0",
+    "ktables>=1.1.0",
     # CLI (`ck`): typer powers the console script, watchfiles powers `ck run --reload`.
     "typer>=0.12",
     "watchfiles>=0.21",

--- a/tests/_fanout_fakes.py
+++ b/tests/_fanout_fakes.py
@@ -84,6 +84,7 @@ class OfflineFanoutBatchStore(FakeFanoutBatchStore):
         reader_tuning: object | None = None,
         catchup_timeout: float | None = None,
         barrier_timeout: float = 30.0,
+        enable_idempotence: bool | None = None,
     ) -> None:
         super().__init__()
 

--- a/tests/test_client_producer_config.py
+++ b/tests/test_client_producer_config.py
@@ -1,10 +1,12 @@
-"""PR-2: ``Client.connect()`` hardens the shared producer.
+"""``Client.connect()`` producer posture: calfkit imposes **no** ``acks`` / ``enable_idempotence``
+value by default, but exposes a unified opt-in override.
 
-aiokafka defaults the producer to ``acks=1`` with no idempotence — under which a
-broker-acked publish can vanish on leader failover and retries can duplicate or reorder.
-calfkit defaults the shared producer to ``acks=all`` + ``enable_idempotence=True`` for
-durable, non-duplicating publishes. A user may still override via
-``Client.connect(**broker_kwargs)`` (document-don't-police).
+The libraries supply the defaults (ktables writers and aiokafka both default to no idempotence;
+aiokafka defaults ``acks=1``). Passing ``enable_idempotence=True`` (or ``False``) via
+``Client.connect`` — or ``ck run --enable-idempotence`` — turns it on (off) consistently across the
+shared broker producer *and* the co-located worker's control-plane / fan-out writers. The resolved
+tri-state (``None`` = unset, ``True``, ``False``) is stored on the client so those writers wire to
+the same posture. ``acks`` stays overridable via ``broker_kwargs`` (document-don't-police).
 """
 
 from calfkit.client import Client
@@ -24,16 +26,25 @@ def _spy_broker_kwargs(monkeypatch) -> dict:  # noqa: ANN001
     return captured
 
 
-def test_connect_defaults_to_acks_all_and_idempotence(monkeypatch) -> None:  # noqa: ANN001
+def test_connect_sets_no_producer_posture_by_default(monkeypatch) -> None:  # noqa: ANN001
     captured = _spy_broker_kwargs(monkeypatch)
 
     Client.connect(server_urls="localhost:9092")
 
-    assert captured.get("acks") == "all"
+    # calfkit imposes nothing — the libraries' defaults apply (ktables/aiokafka: no idempotence).
+    assert "acks" not in captured
+    assert "enable_idempotence" not in captured
+
+
+def test_connect_opt_in_threads_idempotence_true(monkeypatch) -> None:  # noqa: ANN001
+    captured = _spy_broker_kwargs(monkeypatch)
+
+    Client.connect(server_urls="localhost:9092", enable_idempotence=True)
+
     assert captured.get("enable_idempotence") is True
 
 
-def test_connect_lets_user_override_producer_posture(monkeypatch) -> None:  # noqa: ANN001
+def test_connect_explicit_false_threads_idempotence_false(monkeypatch) -> None:  # noqa: ANN001
     captured = _spy_broker_kwargs(monkeypatch)
 
     Client.connect(server_urls="localhost:9092", enable_idempotence=False)
@@ -41,12 +52,19 @@ def test_connect_lets_user_override_producer_posture(monkeypatch) -> None:  # no
     assert captured.get("enable_idempotence") is False
 
 
-def test_connect_user_can_relax_acks_with_idempotence_off(monkeypatch) -> None:  # noqa: ANN001
-    # Both posture keys are overridable. Relaxing acks below "all" requires turning
-    # idempotence off too (aiokafka rejects acks<all with idempotence on).
+def test_connect_stores_resolved_idempotence_for_colocated_workers() -> None:
+    # A co-located worker/nodes read the resolved tri-state off the client
+    # (self._client._enable_idempotence) to wire their writers to the same posture — one knob.
+    assert Client.connect(server_urls="localhost:9092")._enable_idempotence is None
+    assert Client.connect(server_urls="localhost:9092", enable_idempotence=True)._enable_idempotence is True
+    assert Client.connect(server_urls="localhost:9092", enable_idempotence=False)._enable_idempotence is False
+
+
+def test_connect_acks_override_via_broker_kwargs(monkeypatch) -> None:  # noqa: ANN001
     captured = _spy_broker_kwargs(monkeypatch)
 
-    Client.connect(server_urls="localhost:9092", acks=1, enable_idempotence=False)
+    Client.connect(server_urls="localhost:9092", acks="all")
 
-    assert captured.get("acks") == 1
-    assert captured.get("enable_idempotence") is False
+    assert captured.get("acks") == "all"
+    # acks alone does not turn idempotence on.
+    assert "enable_idempotence" not in captured

--- a/tests/test_control_plane_writer_posture.py
+++ b/tests/test_control_plane_writer_posture.py
@@ -1,0 +1,60 @@
+"""The worker's control-plane advert writer (``calf.agents`` / ``calf.capabilities``) inherits the
+client's producer idempotence posture — the same single knob that drives the shared producer and the
+fan-out writers. Default (unset) => calfkit passes nothing to ktables (its writer default applies).
+
+The writer resource opens a real ``GroupedKafkaTableWriter`` under a live broker; here the ktables
+factory is patched so the wiring is exercised offline.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from calfkit.client import Client
+from calfkit.worker.worker import Worker
+
+
+class FakeWriter:
+    """Records the kwargs the control-plane writer resource passes to ``GroupedKafkaTableWriter.json``."""
+
+    last_kwargs: dict = {}
+
+    @classmethod
+    def json(cls, **kwargs: object) -> FakeWriter:
+        FakeWriter.last_kwargs = dict(kwargs)
+        return cls()
+
+    async def start(self) -> None: ...
+
+    async def stop(self) -> None: ...
+
+
+@pytest.fixture
+def fake_grouped_writer(monkeypatch: pytest.MonkeyPatch) -> None:
+    FakeWriter.last_kwargs = {}
+    monkeypatch.setattr("ktables.GroupedKafkaTableWriter", FakeWriter)
+
+
+async def _drive_writer_resource(worker: Worker) -> dict:
+    """Enter the control-plane writer resource once and return the captured writer kwargs."""
+    gen = worker._make_control_plane_writer_resource("calf.agents")(None)  # type: ignore[arg-type]
+    await anext(gen)
+    return FakeWriter.last_kwargs
+
+
+async def test_control_plane_writer_opts_in_from_client(fake_grouped_writer: None) -> None:
+    worker = Worker(Client.connect("kafka:9092", enable_idempotence=True))
+    kwargs = await _drive_writer_resource(worker)
+    assert kwargs["enable_idempotence"] is True
+
+
+async def test_control_plane_writer_explicit_false_from_client(fake_grouped_writer: None) -> None:
+    worker = Worker(Client.connect("kafka:9092", enable_idempotence=False))
+    kwargs = await _drive_writer_resource(worker)
+    assert kwargs["enable_idempotence"] is False
+
+
+async def test_control_plane_writer_default_sets_nothing(fake_grouped_writer: None) -> None:
+    worker = Worker(Client.connect("kafka:9092"))
+    kwargs = await _drive_writer_resource(worker)
+    assert "enable_idempotence" not in kwargs

--- a/tests/test_fanout_tuning.py
+++ b/tests/test_fanout_tuning.py
@@ -180,6 +180,78 @@ async def test_fanout_resource_passes_worker_fanout(monkeypatch: pytest.MonkeyPa
         await anext(gen)
 
 
+# ── enable_idempotence: one knob threaded from the client (default: calfkit sets nothing) ─────
+
+
+def test_store_forwards_enable_idempotence_to_both_writers(fake_ktables: None) -> None:
+    _store(enable_idempotence=True)
+    writers = FakeKafkaTableWriter.instances
+    assert len(writers) == 2  # state + basestate
+    for writer in writers:
+        assert writer.kwargs["enable_idempotence"] is True
+
+
+def test_store_forwards_explicit_false_idempotence(fake_ktables: None) -> None:
+    _store(enable_idempotence=False)
+    for writer in FakeKafkaTableWriter.instances:
+        assert writer.kwargs["enable_idempotence"] is False
+
+
+def test_store_default_omits_enable_idempotence(fake_ktables: None) -> None:
+    # Unset (None) -> calfkit passes nothing; the ktables writer default applies.
+    _store()
+    for writer in FakeKafkaTableWriter.instances:
+        assert "enable_idempotence" not in writer.kwargs
+
+
+async def test_fanout_resource_threads_client_idempotence_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class SpyStore:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        async def start(self) -> None: ...
+
+        async def stop(self) -> None: ...
+
+    monkeypatch.setattr("calfkit.nodes.agent.KtablesFanoutBatchStore", SpyStore)
+    from calfkit.nodes.agent import Agent
+
+    agent = Agent("a", subscribe_topics="a.in", model_client=_FakeModel())
+    worker = Worker(Client.connect("kafka:9092", enable_idempotence=True), nodes=[agent])
+    agent._worker = worker
+    gen = agent._fanout_store_resource(None)  # type: ignore[arg-type]
+    await anext(gen)
+    assert captured["enable_idempotence"] is True
+    with pytest.raises(StopAsyncIteration):
+        await anext(gen)
+
+
+async def test_fanout_resource_defaults_to_unset_idempotence(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class SpyStore:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        async def start(self) -> None: ...
+
+        async def stop(self) -> None: ...
+
+    monkeypatch.setattr("calfkit.nodes.agent.KtablesFanoutBatchStore", SpyStore)
+    from calfkit.nodes.agent import Agent
+
+    agent = Agent("a", subscribe_topics="a.in", model_client=_FakeModel())
+    worker = Worker(Client.connect("kafka:9092"), nodes=[agent])
+    agent._worker = worker
+    gen = agent._fanout_store_resource(None)  # type: ignore[arg-type]
+    await anext(gen)
+    assert captured["enable_idempotence"] is None
+    with pytest.raises(StopAsyncIteration):
+        await anext(gen)
+
+
 async def test_fanout_resource_boots_through_offline_store_mirror() -> None:
     # No SpyStore re-patch here: the autouse `_offline_fanout_store` fixture swaps in the real
     # `OfflineFanoutBatchStore`, so this exercises its signature mirror — it must accept the new

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -32,6 +32,7 @@ def test_run_mounted_on_top_level_cli() -> None:
     assert "--reload" in out
     assert "--host" in out
     assert "--provision" in out
+    assert "--enable-idempotence" in out
 
 
 def test_run_no_reload_calls_serve(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -41,7 +42,15 @@ def test_run_no_reload_calls_serve(monkeypatch: pytest.MonkeyPatch) -> None:
 
     cap: dict = {}
 
-    def fake_serve(targets: list[str], host: str | None, provision: bool, group_id: str | None, env_file: str | None, app_dir: str) -> None:
+    def fake_serve(
+        targets: list[str],
+        host: str | None,
+        provision: bool,
+        group_id: str | None,
+        env_file: str | None,
+        app_dir: str,
+        enable_idempotence: bool = False,
+    ) -> None:
         cap.update(targets=targets, host=host, provision=provision, group_id=group_id, env_file=env_file, app_dir=app_dir)
 
     monkeypatch.setattr(run_mod, "serve", fake_serve)
@@ -62,7 +71,15 @@ def test_run_forwards_flags_to_serve(monkeypatch: pytest.MonkeyPatch) -> None:
 
     cap: dict = {}
 
-    def fake_serve(targets: list[str], host: str | None, provision: bool, group_id: str | None, env_file: str | None, app_dir: str) -> None:
+    def fake_serve(
+        targets: list[str],
+        host: str | None,
+        provision: bool,
+        group_id: str | None,
+        env_file: str | None,
+        app_dir: str,
+        enable_idempotence: bool = False,
+    ) -> None:
         cap.update(host=host, provision=provision, group_id=group_id)
 
     monkeypatch.setattr(run_mod, "serve", fake_serve)
@@ -149,7 +166,15 @@ def test_run_multiple_targets_forwarded_to_serve(monkeypatch: pytest.MonkeyPatch
 
     cap: dict = {}
 
-    def fake_serve(targets: list[str], host: str | None, provision: bool, group_id: str | None, env_file: str | None, app_dir: str) -> None:
+    def fake_serve(
+        targets: list[str],
+        host: str | None,
+        provision: bool,
+        group_id: str | None,
+        env_file: str | None,
+        app_dir: str,
+        enable_idempotence: bool = False,
+    ) -> None:
         cap["targets"] = targets
 
     monkeypatch.setattr(run_mod, "serve", fake_serve)
@@ -166,7 +191,15 @@ def test_run_custom_app_dir_forwarded_to_serve(monkeypatch: pytest.MonkeyPatch, 
 
     cap: dict = {}
 
-    def fake_serve(targets: list[str], host: str | None, provision: bool, group_id: str | None, env_file: str | None, app_dir: str) -> None:
+    def fake_serve(
+        targets: list[str],
+        host: str | None,
+        provision: bool,
+        group_id: str | None,
+        env_file: str | None,
+        app_dir: str,
+        enable_idempotence: bool = False,
+    ) -> None:
         cap["app_dir"] = app_dir
 
     monkeypatch.setattr(run_mod, "serve", fake_serve)
@@ -175,6 +208,35 @@ def test_run_custom_app_dir_forwarded_to_serve(monkeypatch: pytest.MonkeyPatch, 
     result = CliRunner().invoke(_build_app(), ["run", "m:a", "--app-dir", target_dir])
     assert result.exit_code == 0, result.stdout + result.stderr
     assert cap["app_dir"] == os.path.abspath(target_dir)
+
+
+def test_run_enable_idempotence_flag_forwarded_to_serve(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--enable-idempotence reaches serve() as True; absent it is False (opt-in)."""
+    import calfkit.cli.run as run_mod
+    from calfkit.cli import _build_app
+
+    cap: dict = {}
+
+    def fake_serve(
+        targets: list[str],
+        host: str | None,
+        provision: bool,
+        group_id: str | None,
+        env_file: str | None,
+        app_dir: str,
+        enable_idempotence: bool = False,
+    ) -> None:
+        cap["enable_idempotence"] = enable_idempotence
+
+    monkeypatch.setattr(run_mod, "serve", fake_serve)
+
+    result_on = CliRunner().invoke(_build_app(), ["run", "mymod:agent", "--enable-idempotence"])
+    assert result_on.exit_code == 0, result_on.stdout + result_on.stderr
+    assert cap["enable_idempotence"] is True
+
+    result_off = CliRunner().invoke(_build_app(), ["run", "mymod:agent"])
+    assert result_off.exit_code == 0, result_off.stdout + result_off.stderr
+    assert cap["enable_idempotence"] is False
 
 
 def test_run_bad_spec_exits_2() -> None:

--- a/tests/test_run_serve.py
+++ b/tests/test_run_serve.py
@@ -24,6 +24,7 @@ def captured(monkeypatch: pytest.MonkeyPatch) -> dict:
         def connect(cls, server_urls: object = None, **kwargs: object) -> FakeClient:
             cap["server_urls"] = server_urls
             cap["provisioning"] = kwargs.get("provisioning")
+            cap["enable_idempotence"] = kwargs.get("enable_idempotence")
             return cls()
 
     class FakeWorker:
@@ -100,6 +101,30 @@ def test_serve_group_id_passthrough(captured: dict) -> None:
 
     serve([f"{_FIXTURE}:single"], host=None, provision=False, group_id="mygroup", env_file=None, app_dir=".")
     assert captured["group_id"] == "mygroup"
+
+
+def test_serve_default_sets_no_idempotence(captured: dict) -> None:
+    """Without --enable-idempotence, serve passes enable_idempotence=None (calfkit sets nothing)."""
+    from calfkit.cli._run import serve
+
+    serve([f"{_FIXTURE}:single"], host=None, provision=False, group_id=None, env_file=None, app_dir=".")
+    assert captured["enable_idempotence"] is None
+
+
+def test_serve_enable_idempotence_opts_in(captured: dict) -> None:
+    """--enable-idempotence forwards enable_idempotence=True to Client.connect."""
+    from calfkit.cli._run import serve
+
+    serve([f"{_FIXTURE}:single"], host=None, provision=False, group_id=None, env_file=None, app_dir=".", enable_idempotence=True)
+    assert captured["enable_idempotence"] is True
+
+
+def test_serve_banner_shows_idempotence_state(captured: dict, capsys: pytest.CaptureFixture[str]) -> None:
+    """The banner reports the producer idempotence posture (off by default)."""
+    from calfkit.cli._run import serve
+
+    serve([f"{_FIXTURE}:single"], host=None, provision=False, group_id=None, env_file=None, app_dir=".")
+    assert "idempotence: off" in capsys.readouterr().out
 
 
 def test_serve_empty_resolution_exits_2(captured: dict) -> None:


### PR DESCRIPTION
## What & why

calfkit hardcoded a producer posture (`acks="all"` + `enable_idempotence=True`) on **every** producer it drives. That made the SDK **unusable against Kafka-compatible brokers without a producer-id / transaction coordinator** — e.g. Tansu answers `InitProducerIdRequest` with `UNKNOWN(-1)`, which crashed worker startup (`ck run` never came up). It also imposed a durability posture the framework shouldn't police.

This PR makes calfkit **impose nothing by default** and exposes idempotence as a **single opt-in knob**.

## Behaviour

- **Default (unset):** calfkit sets neither `acks` nor `enable_idempotence` anywhere. The library defaults apply (ktables writers + aiokafka: no idempotence, `acks=1`). `ck run` now works against Tansu et al. out of the box.
- **Opt in:** `Client.connect(enable_idempotence=True)` or `ck run --enable-idempotence` turns idempotence on **consistently** across all three producer sites. Tri-state `bool | None`: `None` imposes nothing, `True`/`False` threads that value everywhere.
- **acks:** never hardcoded; override per-producer via `broker_kwargs` (e.g. `Client.connect(acks="all")`).

## One knob, single source

`Client.connect(enable_idempotence=…)` stores the resolved tri-state on the client; the three producer sites all read that one source:

| Site | Producer | Reads |
| --- | --- | --- |
| A | shared `KafkaBroker` producer (every publish) | folded into the broker producer posture |
| B | control-plane advert writer (`calf.agents` / `calf.capabilities`) | `self._client._enable_idempotence` |
| C | fan-out `state` / `basestate` writers | threaded via `agent.py` → `KtablesFanoutBatchStore` |

## Dependency

Requires **ktables ≥ 1.1.0** (writers now expose `enable_idempotence` + `acks`, and ktables' own writer default flipped to no-idempotence). Pin bumped in `pyproject.toml`.

## Tests (TDD)

- `test_client_producer_config.py` — default imposes nothing; opt-in True / explicit False; resolved tri-state stored on the client; `acks` override via `broker_kwargs`.
- `test_run_serve.py` / `test_run_cli.py` — `--enable-idempotence` flows `ck run → serve → Client.connect`; absent → `None`; banner reports the posture.
- `test_fanout_tuning.py` — the store forwards `enable_idempotence` to both writers (and omits it when unset); the agent resource threads the client's value.
- `test_control_plane_writer_posture.py` (new) — the advert writer inherits the client's posture.

`make check` clean (lint + format + type); full offline suite green (3824 passed). Kafka-lane behaviour (real idempotent/acks round-trip) runs in the `kafka` lane on main.
