### PR TITLE
feat: add `--provision` to ck chat

### DIFF
--- a/calfkit/cli/_chat.py
+++ b/calfkit/cli/_chat.py
@@ -21,6 +21,7 @@ from calfkit.cli._chat_io import make_reader
 from calfkit.cli._chat_render import _error_line, _render_answer, _render_fault, _render_step, format_picker
 from calfkit.client import Client, RunCompleted, RunFailed
 from calfkit.exceptions import NodeFaultError
+from calfkit.provisioning import ProvisioningConfig
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Mapping
@@ -42,15 +43,20 @@ def _emit(lines: list[str]) -> None:
         print(line)
 
 
-async def run_chat_session(name: str | None, server_urls: str | list[str] | None, timeout: float | None) -> None:
+async def run_chat_session(name: str | None, server_urls: str | list[str] | None, timeout: float | None, provision: bool = False) -> None:
     """Connect, discover the online agents, resolve the target, and run the REPL.
 
     A not-ready mesh raises ``MeshUnavailableError`` from ``get_agents()`` — left to
     bubble to the ``chat.py`` boundary (F2). The ``async with`` closes the client
     (mesh views then broker) on every exit path.
+
+    ``provision`` (``--provision``) opt-in creates this client's reply inbox topic at broker
+    start — needed on brokers that don't auto-create topics (e.g. Tansu). The agent's own topics
+    are provisioned by its worker (``ck run --provision``), not here.
     """
     read_line = make_reader(asyncio.get_running_loop())
-    async with Client.connect(server_urls) as client:
+    provisioning = ProvisioningConfig(enabled=True) if provision else None
+    async with Client.connect(server_urls, provisioning=provisioning) as client:
         print("Discovering agents...")
         agents = await client.mesh.get_agents()
         if not agents:  # ready, but zero live agents

--- a/calfkit/cli/chat.py
+++ b/calfkit/cli/chat.py
@@ -41,6 +41,11 @@ def chat(
         "-H",
         help="Kafka bootstrap server(s), comma-separated. Precedence: this flag > $CALFKIT_MESH_URL > localhost.",
     ),
+    provision: bool = typer.Option(
+        False,
+        "--provision",
+        help="Opt-in creation of this client's reply inbox topic (experimental); for brokers without topic auto-create (e.g. Tansu).",
+    ),
     env_file: str | None = typer.Option(
         None,
         "--env-file",
@@ -66,7 +71,7 @@ def chat(
     # ValidationError, which subclasses ValueError) is a real bug and must propagate with its
     # traceback — not be masked as a clean config-error Exit(2).
     try:
-        asyncio.run(run_chat_session(name, server_urls, timeout))
+        asyncio.run(run_chat_session(name, server_urls, timeout, provision))
     except KeyboardInterrupt:
         # Ctrl-C at a prompt or mid-turn: a clean stop, not a traceback (the
         # add_reader-based reader cancels cleanly — see _chat_io).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -215,6 +215,7 @@ mid-turn. Any other input is sent to the agent verbatim.
 | Flag | Default | Description |
 | --- | --- | --- |
 | `--host`, `-H` | `$CALFKIT_MESH_URL` → `localhost` | Kafka bootstrap server(s), comma-separated. Precedence: this flag **>** `$CALFKIT_MESH_URL` **>** `localhost`. |
+| `--provision` | off | Opt-in creation of this client's reply inbox topic (**experimental**). Needed on brokers that don't auto-create topics (e.g. Tansu). The agent's own topics are provisioned by *its* worker (`ck run --provision`), not here. See [Topic provisioning](topic-provisioning.md). |
 | `--env-file` | `./.env` if present | dotenv file to load before connecting. A *missing explicit* `--env-file` warns (it is not silently ignored). |
 | `--timeout` | wait indefinitely | Per-turn patience, in seconds. A turn that exceeds it prints a notice and the session continues. (Ctrl-C exits the whole session — see [Leaving](#leaving).) |
 

--- a/tests/test_chat_cli.py
+++ b/tests/test_chat_cli.py
@@ -33,6 +33,27 @@ def test_chat_mounted_with_options() -> None:
     assert "--host" in out
     assert "--timeout" in out
     assert "--env-file" in out
+    assert "--provision" in out
+
+
+def test_chat_provision_flag_forwarded_to_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--provision reaches run_chat_session as True; absent it is False (opt-in)."""
+    from calfkit.cli import _build_app
+
+    cap: dict = {}
+
+    async def fake_session(name: object, server_urls: object, timeout: object, provision: bool = False) -> None:
+        cap["provision"] = provision
+
+    monkeypatch.setattr("calfkit.cli._chat.run_chat_session", fake_session)
+
+    result_on = CliRunner().invoke(_build_app(), ["chat", "--provision"])
+    assert result_on.exit_code == 0, result_on.stdout + result_on.stderr
+    assert cap["provision"] is True
+
+    result_off = CliRunner().invoke(_build_app(), ["chat"])
+    assert result_off.exit_code == 0, result_off.stdout + result_off.stderr
+    assert cap["provision"] is False
 
 
 def test_chat_offline_name_exits_2(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -125,6 +125,34 @@ async def test_run_chat_session_no_agents_prints_and_returns(monkeypatch: pytest
     assert "No agents are online" in out
 
 
+def _spy_client_connect(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Spy ``Client.connect``, capturing its ``provisioning`` kwarg while keeping the real (lazy) connect."""
+    captured: dict = {}
+    real_connect = Client.connect
+
+    def spy(server_urls: object = None, **kwargs: object) -> object:
+        captured["provisioning"] = kwargs.get("provisioning")
+        return real_connect(server_urls, **kwargs)
+
+    monkeypatch.setattr(Client, "connect", spy)
+    return captured
+
+
+async def test_run_chat_session_provision_enables_provisioning(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get_agents(monkeypatch, result={})  # early return after connect — no broker I/O
+    captured = _spy_client_connect(monkeypatch)
+    await run_chat_session(None, "localhost:9092", None, provision=True)
+    assert captured["provisioning"] is not None
+    assert captured["provisioning"].enabled is True
+
+
+async def test_run_chat_session_default_passes_no_provisioning(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get_agents(monkeypatch, result={})
+    captured = _spy_client_connect(monkeypatch)
+    await run_chat_session(None, "localhost:9092", None, provision=False)
+    assert captured["provisioning"] is None
+
+
 async def test_run_chat_session_offline_name_exits_2(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
     _patch_get_agents(monkeypatch, result={"helpbot": _agent("helpbot", "x")})
     with pytest.raises(typer.Exit) as exc:


### PR DESCRIPTION
## What & why

`ck chat` connected with topic provisioning **off** and offered no way to turn it on. On a broker that doesn't auto-create topics (e.g. **Tansu**), the client's reply inbox topic `calf-client-inbox-<id>` was never created, so its inbox consumer (`[HandleReply, HandleStep]`) looped `Topic … not found in cluster metadata` forever and the agent's reply never arrived.

This adds `--provision` to `ck chat`, mirroring `ck run`.

## Change

- New `--provision` flag on `ck chat` (off by default), threaded `chat.py → run_chat_session → Client.connect(provisioning=ProvisioningConfig(enabled=True))`.
- With it on, the client's `StartupTopicEnsurer` creates the inbox topic (`ensurer.declare([inbox_topic], framework=True)`) at broker start, so replies flow on a non-auto-creating broker.

## Scope (important)

This provisions **only the client's inbox topic**. The agent's own topics — its name-scoped input topic (`agent.<name>.private.input`, ADR-0017), plus `calf.agents` / `calf.capabilities` — are the **worker's** job. To chat against Tansu end to end you need provisioning on both sides:

- `ck run --provision` (agent worker) → agent input + control-plane topics
- `ck chat --provision` (client) → reply inbox topic

…or point both at an auto-creating broker (Redpanda / Kafka), where neither flag is needed. The flag's help and the docs note this. `client.mesh` (used to list agents) stays naive-open (`ensure_topic=False`) — `--provision` does not create `calf.agents`.

## Tests (TDD)

- `test_chat_cli.py` — `--provision` appears in `--help`; the flag reaches `run_chat_session` as `True` (and `False` when absent).
- `test_chat_session.py` — `run_chat_session(provision=True)` calls `Client.connect(provisioning=<enabled>)`; default passes `provisioning=None`.

`make check` clean (lint + format + type); full offline suite green (3827 passed). No behaviour change when the flag is omitted.