### PR TITLE
feat: follow handoffs across turns in `ck chat`

### DIFF
--- a/calfkit/cli/_chat.py
+++ b/calfkit/cli/_chat.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import shutil
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import typer
 
@@ -41,6 +41,16 @@ def _width() -> int:
 def _emit(lines: list[str]) -> None:
     for line in lines:
         print(line)
+
+
+class _TurnResult(NamedTuple):
+    """One turn's outcome threaded back to the REPL: the ``history`` for the next turn and the
+    ``responder`` — the agent that produced the answer. On a handoff the responder is the *target*
+    (control transferred), on a consult or a direct answer it stays the addressed agent. The loop
+    re-binds to ``responder`` so a handoff **sticks** across turns."""
+
+    history: list[ModelMessage]
+    responder: str
 
 
 async def run_chat_session(name: str | None, server_urls: str | list[str] | None, timeout: float | None, provision: bool = False) -> None:
@@ -93,11 +103,16 @@ async def _resolve_target(name: str | None, agents: Mapping[str, AgentInfo], rea
 
 
 async def _chat_loop(client: Client, agent_name: str, timeout: float | None, read_line: ReadLine) -> None:
-    """The multi-turn REPL with one agent. ``message_history`` is threaded turn to
-    turn — the only continuity mechanism."""
-    gw = client.agent(agent_name)
+    """The multi-turn REPL. Starts with the picked agent; a handoff **sticks** — when a turn's
+    answer comes from a different agent (the handoff target, ``RunCompleted.agent``), the REPL
+    re-binds to it so the *next* turn goes there, honoring the transfer (the handing agent
+    relinquishes and does not regain control). A consult (``message_agent``) keeps control, so its
+    responder is the current agent and nothing re-binds. ``message_history`` is threaded turn to
+    turn — the continuity mechanism across the (possibly changing) responder."""
+    active = agent_name
+    gw = client.agent(active)
     history: list[ModelMessage] = []
-    print(f"\nChatting with {agent_name}. Type /exit or press Ctrl-D to leave.")
+    print(f"\nChatting with {active}. Type /exit or press Ctrl-D to leave.")
     print("-" * _width())
     while True:
         try:
@@ -109,9 +124,14 @@ async def _chat_loop(client: Client, agent_name: str, timeout: float | None, rea
             break
         if not line:
             continue
-        new_history = await _run_turn(gw, agent_name, line, history, timeout)
-        if new_history is not None:  # None == the turn failed / timed out: keep the old history
-            history = new_history
+        outcome = await _run_turn(gw, active, line, history, timeout)
+        if outcome is None:  # the turn failed / timed out: keep the old history AND the current agent
+            continue
+        history = outcome.history
+        if outcome.responder != active:  # a handoff moved control — follow it so the transfer sticks
+            active = outcome.responder
+            gw = client.agent(active)
+            print(f"\n(now chatting with {active})")
 
 
 async def _run_turn(
@@ -120,10 +140,10 @@ async def _run_turn(
     prompt: str,
     history: list[ModelMessage],
     timeout: float | None,
-) -> list[ModelMessage] | None:
-    """Dispatch one turn, render it, and return the next history — or ``None`` if the
-    dispatch failed, the turn faulted, or it exceeded ``--timeout`` (the REPL keeps
-    going either way)."""
+) -> _TurnResult | None:
+    """Dispatch one turn, render it, and return its ``_TurnResult`` (next history + responder) —
+    or ``None`` if the dispatch failed, the turn faulted, or it exceeded ``--timeout`` (the REPL
+    keeps going, and keeps the current agent, either way)."""
     try:
         handle = await gw.start(prompt, message_history=history)
     except Exception as exc:  # the turn could not be dispatched (broker I/O, or building/serializing the request): surface it, keep the REPL alive
@@ -143,9 +163,11 @@ async def _run_turn(
         return None
 
 
-async def _render_and_collect(handle: InvocationHandle, agent_name: str) -> list[ModelMessage]:
-    """Render the turn's live step events (the work-log) as they stream, then the
-    projected final answer; return the message history for the next turn."""
+async def _render_and_collect(handle: InvocationHandle, agent_name: str) -> _TurnResult:
+    """Render the turn's live step events (the work-log) as they stream, then the projected final
+    answer; return the next-turn history plus the ``responder`` — who actually answered
+    (``RunCompleted.agent``: the handoff target when control moved, else ``agent_name``). The
+    responder heads the answer line AND is what the REPL re-binds to for the next turn."""
     responder = agent_name
     current_emitter: str | None = None
     async for event in handle.stream():  # intermediates, then the terminal (last)
@@ -158,4 +180,4 @@ async def _render_and_collect(handle: InvocationHandle, agent_name: str) -> list
             _emit(lines)
     result = await handle.result()  # cached terminal: projects str + history (or raises NodeFaultError)
     _emit(_render_answer(responder, result.output))
-    return result.message_history
+    return _TurnResult(result.message_history, responder)

--- a/docs/chat-with-agents.md
+++ b/docs/chat-with-agents.md
@@ -50,8 +50,27 @@ support-bot > Order #4471 shipped on the 24th and is in transit.
 ```
 
 The conversation is multi-turn — keep typing and the agent remembers the earlier
-turns. If it hands off to another agent mid-turn, that agent's name appears as its
-own header, so you can follow who did what.
+turns. If it **hands off** to another agent, that agent's name heads its part of the
+work log and the answer line, and the handoff **sticks**: because a handoff transfers
+control, your next message goes to the agent that took over — not back to the one you
+started with. When control moves, `ck chat` prints a short `(now chatting with …)`
+note so it's clear where your next message will go:
+
+```text
+you > I want to work directly with your billing specialist
+
+support-bot
+  [handoff]      billing (transferring the refund request)
+
+billing > Hi — I've got your refund request. What's the order number?
+
+(now chatting with billing)
+
+you > it's #4471            ← this goes to billing, not support-bot
+```
+
+A **consult** is different: when an agent quietly asks a peer for help and answers
+you itself, control never moves, so you stay with the same agent.
 
 ## Skip the picker
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -205,6 +205,13 @@ Each turn renders in three tiers: **your input** (`you >`), the agent's live
 which agent did the work; a mid-turn handoff prints the new agent's name as its
 own header.
 
+**Handoffs stick.** A handoff transfers control, so when a turn's answer comes from
+a different agent than you addressed, `ck chat` re-binds to that agent — your next
+message goes to it, not back to the one you started with — and prints a
+`(now chatting with ‹agent›)` note. A consult (`message_agent`) keeps control, so it
+does not move you. `message_history` is threaded across the change, so the agent that
+takes over has the full conversation.
+
 ### Leaving
 
 `/exit`, `/quit`, or Ctrl-D end the session; Ctrl-C exits at any time, including

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -343,17 +343,90 @@ async def test_render_and_collect_attributes_handoff_to_actual_responder(capsys:
     channel.push(_completed(agent="billing"))
     handle = InvocationHandle(correlation_id="c", _channel=channel)
 
-    history = await _render_and_collect(handle, "support-bot")
+    outcome = await _render_and_collect(handle, "support-bot")
     out = capsys.readouterr().out
     assert out.index("support-bot") < out.index("billing")  # the new emitter's header follows the handoff
     assert "billing > " in out  # the answer is attributed to the ACTUAL responder (billing)...
     assert "support-bot > " not in out  # ...not the addressed agent
-    assert isinstance(history, list)
+    assert isinstance(outcome.history, list)
+    assert outcome.responder == "billing"  # the responder the REPL re-binds to (sticky handoff)
 
 
 async def test_render_and_collect_falls_back_to_addressed_agent_when_responder_unknown(capsys: pytest.CaptureFixture[str]) -> None:
     channel = _RunChannel()
     channel.push(_completed(agent=None))  # terminal carries no emitter
     handle = InvocationHandle(correlation_id="c", _channel=channel)
-    await _render_and_collect(handle, "support-bot")
+    outcome = await _render_and_collect(handle, "support-bot")
     assert "support-bot > " in capsys.readouterr().out  # the `or agent_name` fallback
+    assert outcome.responder == "support-bot"  # no emitter -> stays with the addressed agent (no spurious re-bind)
+
+
+# --- sticky handoff: the REPL follows a transfer across turns --------------------
+# A handoff moves control to a peer that answers the original caller; the next turn should go
+# to THAT peer (the transfer sticks), not back to the originally-picked agent. A consult
+# (message_agent) keeps control, so the responder stays the current agent and nothing re-binds.
+
+
+class _ScriptedStickyGateway:
+    """A gateway bound to one agent name; each ``start()`` yields a handle whose terminal is
+    attributed to the responder the script maps this agent to (default: itself)."""
+
+    def __init__(self, name: str, responders: dict[str, str]) -> None:
+        self._name = name
+        self._responders = responders
+
+    async def start(self, _prompt: str, *, message_history: list[ModelMessage] | None = None) -> InvocationHandle:
+        channel = _RunChannel()
+        channel.push(_completed(agent=self._responders.get(self._name, self._name)))
+        return InvocationHandle(correlation_id="c", _channel=channel)
+
+
+class _RecordingStickyClient:
+    """Records every ``agent(name)`` bind and hands back a gateway scripted per name — so a
+    test can assert which agent each turn was dispatched to."""
+
+    def __init__(self, responders: dict[str, str]) -> None:
+        self._responders = responders
+        self.binds: list[str] = []
+
+    def agent(self, name: str) -> _ScriptedStickyGateway:
+        self.binds.append(name)
+        return _ScriptedStickyGateway(name, self._responders)
+
+
+async def test_chat_loop_sticks_to_handoff_target_on_next_turn(capsys: pytest.CaptureFixture[str]) -> None:
+    # Turn 1: support-bot hands off -> the answer comes from 'billing'. The REPL must re-bind to
+    # 'billing' so turn 2 dispatches THERE (billing then answers as itself -> no further re-bind).
+    client = _RecordingStickyClient({"support-bot": "billing", "billing": "billing"})
+    await _chat_loop(client, "support-bot", None, _scripted(["q1", "q2", "/exit"]))
+    assert client.binds == ["support-bot", "billing"]  # bound at start, re-bound to the handoff target
+    assert "(now chatting with billing)" in capsys.readouterr().out
+
+
+async def test_chat_loop_does_not_rebind_when_answer_stays_with_current_agent(capsys: pytest.CaptureFixture[str]) -> None:
+    # support-bot answers every turn itself (e.g. it consulted a peer but kept control): the
+    # responder equals the current agent, so the REPL never re-binds and prints no move notice.
+    client = _RecordingStickyClient({"support-bot": "support-bot"})
+    await _chat_loop(client, "support-bot", None, _scripted(["q1", "q2", "/exit"]))
+    assert client.binds == ["support-bot"]  # bound once, never re-bound
+    assert "now chatting with" not in capsys.readouterr().out
+
+
+async def test_chat_loop_keeps_current_agent_when_a_turn_fails(capsys: pytest.CaptureFixture[str]) -> None:
+    # A faulting turn returns None: the REPL keeps the current agent (no re-bind off a failed turn).
+    channel = _RunChannel()
+    channel.push(RunFailed(report=ErrorReport(error_type="x", message="boom"), correlation_id="c"))
+    handle = InvocationHandle(correlation_id="c", _channel=channel)
+
+    class _FaultingBindClient:
+        def __init__(self) -> None:
+            self.binds: list[str] = []
+
+        def agent(self, name: str) -> _FakeGateway:
+            self.binds.append(name)
+            return _FakeGateway(handle)
+
+    client = _FaultingBindClient()
+    await _chat_loop(client, "bot", None, _scripted(["boom", "/exit"]))
+    assert client.binds == ["bot"]  # never re-bound despite the fault
+    assert "bot > [error] boom" in capsys.readouterr().out


### PR DESCRIPTION
## What

Make `ck chat` **follow a handoff across turns**. A handoff transfers conversation control (ADR-0019: *"the handing agent relinquishes and does not regain it"*), but the REPL re-dispatched every turn to the originally-picked agent — so a transfer only lasted a single turn and your next message snapped back to the agent you started with.

Now the loop tracks the active agent and re-binds it to each successful turn's **responder** (`RunCompleted.agent`). When control moves it prints a `(now chatting with <agent>)` note; subsequent messages go to the agent that took over.

## Why

The old behavior contradicted the handoff's own semantics. Concretely: chat with a triage agent → it hands off to a specialist → the specialist answers → your follow-up went *back to triage*, not the specialist. Users reasonably expect the transfer to stick.

## How it distinguishes handoff from consult

`RunCompleted.agent` is the emitter of the terminal reply:
- **Handoff** (a `TailCall` transfer): the target produces the terminal → responder = target → re-bind. ✅
- **Consult** (`message_agent`, a `Call` that returns): the *addressed* agent folds the peer's reply and produces the terminal → responder = current agent → **no** re-bind. ✅

Verified live against a running mesh: `client.agent(name)` derives its topic via `derive_input_topic(name)` — the exact function the handoff `TailCall` targets — so re-binding hits precisely the agent the handoff transferred to. `message_history` was already threaded turn-to-turn, so the agent taking over gets the full conversation (POV-projected to its viewpoint).

## Changes

- `calfkit/cli/_chat.py`: `_chat_loop` tracks the `active` agent and re-binds on a responder change; `_run_turn` / `_render_and_collect` now return a small `_TurnResult(history, responder)` instead of history alone.
- `tests/test_chat_session.py`: sticky re-bind on handoff; no re-bind on consult/self-answer; keep the current agent when a turn fails; the two `_render_and_collect` tests assert the surfaced responder.
- `docs/cli.md`, `docs/chat-with-agents.md`: document sticky handoffs + the move notice.

## Testing

- TDD (red → green). Full offline suite: **3830 passed, 7 skipped**.
- `make fix` + `make check` clean (lint / format / type).

## Notes

- Scoped to the `ck chat` REPL — no framework/protocol change, so no ADR (it aligns the tool with the existing ADR-0019 handoff semantics).
- The move notice is a small UX default; easy to drop if you'd rather it stay silent.
- **Out of scope:** this does not address handoff *rings* (agents bouncing control back and forth, unbounded in v1 — #251) or the non-auto-create-broker requirement that `ck chat` use `--provision`. Those are separate from this cross-turn behavior.