### PR TITLE
feat: inject agent name into instructions

### DIFF
--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -160,7 +160,7 @@ class BaseAgentNodeDef(
             name=self.name,
             output_type=[final_output_type, DeferredToolRequests],
             deps_type=dict,
-            instructions=system_prompt,
+            instructions=self._compose_instructions(self.name, system_prompt),
             model_settings=cast(ModelSettings | None, model_settings),
         )
 
@@ -173,6 +173,18 @@ class BaseAgentNodeDef(
             # @resource never runs under the synchronous TestKafkaBroker — offline, the test harness
             # injects a fake into the bag instead (tests/providers.py::prepare_worker).
             self.resource(name=FANOUT_STORE_KEY)(self._fanout_store_resource)
+
+    @staticmethod
+    def _compose_instructions(name: str, system_prompt: str) -> str:
+        """Bake the agent's identity into the leading line of its instructions.
+
+        Every agent's constructor ``name`` is injected as a leading ``You are {name}.`` line ahead of
+        the user's ``system_prompt``, so the model always knows its own identity on every invocation.
+        This is the construction-time literal (``self._instructions``), so it rides through the vendored
+        loop's additive instruction pipeline — ``temp_instructions``, ``@instructions`` functions, and the
+        handoff note all still compose after it (never replacing it, since calfkit never uses ``override``).
+        """
+        return f"You are {name}.\n\n{system_prompt}"
 
     @advertises(topic=AGENTS_TOPIC, record=AgentCard)
     def _agent_card_advert(self, stamp: ControlPlaneStamp) -> AgentCard:

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -8,7 +8,8 @@ from tests.providers import INSTRUCTIONS_TEST_SYSTEM_PROMPT, prepare_worker
 
 
 async def test_init_instructions_only(container, deploy_instructions_agent):
-    """When no temp_instructions or dynamic instructions are provided, the model should receive only the system_prompt."""
+    """With no temp_instructions or dynamic instructions, the model receives exactly the injected
+    identity line (``You are {name}.``) leading the system_prompt — and nothing else."""
     prepare_worker(container)
     broker = container.get(KafkaBroker)
     client = container.get(Client)
@@ -18,8 +19,26 @@ async def test_init_instructions_only(container, deploy_instructions_agent):
 
     assert result.output is not None
     assert isinstance(result.output, str)
-    assert INSTRUCTIONS_TEST_SYSTEM_PROMPT.strip().lower() == result.output.strip().lower()
+    identity = f"You are {deploy_instructions_agent.name}."
+    assert result.output.strip() == f"{identity}\n\n{INSTRUCTIONS_TEST_SYSTEM_PROMPT}"
     assert result.output.count(INSTRUCTIONS_TEST_SYSTEM_PROMPT) == 1
+
+
+async def test_name_injected_as_leading_line(container, deploy_instructions_agent):
+    """The constructor name is baked into the agent's instructions as the leading
+    ``You are {name}.`` line, ahead of the system_prompt, on every invocation."""
+    prepare_worker(container)
+    broker = container.get(KafkaBroker)
+    client = container.get(Client)
+
+    async with TestKafkaBroker(broker):
+        result = await client.agent(topic="test_instructions_agent.input").execute("hello")
+
+    assert result.output is not None and isinstance(result.output, str)
+    identity = f"You are {deploy_instructions_agent.name}."
+    assert result.output.startswith(identity)
+    assert result.output.index(identity) < result.output.index(INSTRUCTIONS_TEST_SYSTEM_PROMPT)
+    assert result.output.count(identity) == 1
 
 
 async def test_runtime_instructions_appended(container, deploy_instructions_agent):


### PR DESCRIPTION
## What

Bake each agent's constructor `name` into its instructions as a leading `You are {name}.` line, ahead of the user's `system_prompt`:

```
You are billing.

<system_prompt>
```

so the model always knows its own identity on **every** invocation.

## Why / how it composes

The injection is the construction-time instruction literal (`self._instructions`), so it rides through the vendored loop's **additive** instruction pipeline — `temp_instructions`, `@agent.instructions` functions, and the handoff note all still compose *after* it, never replacing it (only `agent.override(...)` replaces, which calfkit never uses). This keeps `self.system_prompt` pristine as "what the user passed"; the identity line is composed only for the loop.

Implementation is a small pure helper:

```python
@staticmethod
def _compose_instructions(name: str, system_prompt: str) -> str:
    return f"You are {name}.\n\n{system_prompt}"
```

## Scope

- **Name only** — no `description` injection (that field is authored as a peer-facing directory blurb, deliberately kept out of self-instructions for now).
- **Always-on** for every agent, no opt-in flag.
- **Code only** — no docs changes in this PR.

## Testing (TDD)

- Added `test_name_injected_as_leading_line` and updated `test_init_instructions_only` (RED → GREEN); the echo-model harness asserts on the *actual* resolved instruction string the model receives.
- Full offline suite: **3831 passed, 7 skipped** (kafka/live lanes deselected).
- `make check` (lint + format + type) passes.