### PR TITLE
feat: `ck dev` agent lifecycle — detached daemons, session workers, status/stop/down

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,24 @@ general = Agent(
 
 ### Run it and chat
 
-```bash
-# Starts the agent (and a local mesh if one isn't running):
-#   ck dev run <file>:<agent>
-ck dev run general:general
+One line launches the agent in the background (spinning up the local mesh if
+needed) and drops you into a chat with it:
 
-# In a second terminal, chat with the agent:
-ck dev chat
+```console
+$ ck dev run -d general:general && ck dev chat
+ck dev: managed broker at 127.0.0.1:9092 (pid 51234)
+ck dev: launched agent 'general' (pid 51288) — runs until 'ck dev stop general' — logs: ~/.calfkit/logs/agents-....log
+Discovering agents...
+
+Online agents:
+  1  general  Answers simple questions and routes requests to whoever can handle it.
+
+Select an agent [1-1, q to quit]: 1
 ```
+
+`-d` detaches the agent as a managed background daemon — it keeps running
+(reloading on your edits) after the command returns, so the chat lands on a
+mesh where the agent already exists.
 
 ### Add another agent — and watch them discover each other
 
@@ -79,11 +89,21 @@ finance = Agent(
 )
 ```
 
+From a second terminal — while your chat is still open:
+
 ```bash
-ck dev run finance:finance
+ck dev run -d finance:finance
 ```
 
-Now ask a finance question in `ck dev chat` — `general` discovers `finance` at runtime and hands off automatically. No wiring, no orchestrator.
+Now ask a finance question in the chat — `general` discovers `finance` at
+runtime and hands off automatically. No wiring, no orchestrator: two separate
+processes finding each other over the mesh.
+
+When you're done, one command stops every launched agent and the broker:
+
+```bash
+ck dev down
+```
 
 ## Running an agent mesh
 

--- a/README.md
+++ b/README.md
@@ -55,25 +55,14 @@ general = Agent(
 
 ### Run it and chat
 
-One line launches the agent in the background (spinning up the local mesh if
-needed) and drops you into a chat with it:
+```bash
+# Starts the agent (and a local mesh if one isn't running):
+#   ck dev run <file>:<agent>
+ck dev run general:general
 
-```console
-$ ck dev run -d general:general && ck dev chat
-ck dev: managed broker at 127.0.0.1:9092 (pid 51234)
-ck dev: launched agent 'general' (pid 51288) — runs until 'ck dev stop general' — logs: /Users/you/.calfkit/logs/agents-127.0.0.1_9092-general_general.log
-ck dev: managed broker at 127.0.0.1:9092 (pid 51234)
-Discovering agents...
-Online agents
-
-  1  general  Answers simple questions and routes requests to whoever can handle it.
-
-Select an agent [1-1, q to quit]: 1
+# In a second terminal, chat with the agent:
+ck dev chat
 ```
-
-`-d` detaches the agent as a managed background daemon — it keeps running
-(reloading on your edits) after the command returns, so the chat lands on a
-mesh where the agent already exists.
 
 ### Add another agent — and watch them discover each other
 
@@ -90,21 +79,11 @@ finance = Agent(
 )
 ```
 
-From a second terminal — while your chat is still open:
-
 ```bash
-ck dev run -d finance:finance
+ck dev run finance:finance
 ```
 
-Now ask a finance question in the chat — `general` discovers `finance` at
-runtime and hands off automatically. No wiring, no orchestrator: two separate
-processes finding each other over the mesh.
-
-When you're done, one command stops every launched agent and the broker:
-
-```bash
-ck dev down
-```
+Now ask a finance question in `ck dev chat` — `general` discovers `finance` at runtime and hands off automatically. No wiring, no orchestrator.
 
 ## Running an agent mesh
 

--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ needed) and drops you into a chat with it:
 ```console
 $ ck dev run -d general:general && ck dev chat
 ck dev: managed broker at 127.0.0.1:9092 (pid 51234)
-ck dev: launched agent 'general' (pid 51288) — runs until 'ck dev stop general' — logs: ~/.calfkit/logs/agents-....log
+ck dev: launched agent 'general' (pid 51288) — runs until 'ck dev stop general' — logs: /Users/you/.calfkit/logs/agents-127.0.0.1_9092-general_general.log
+ck dev: managed broker at 127.0.0.1:9092 (pid 51234)
 Discovering agents...
+Online agents
 
-Online agents:
   1  general  Answers simple questions and routes requests to whoever can handle it.
 
 Select an agent [1-1, q to quit]: 1

--- a/calfkit/cli/__main__.py
+++ b/calfkit/cli/__main__.py
@@ -1,0 +1,11 @@
+"""``python -m calfkit.cli`` — the module entry point.
+
+The ``ck dev run -d`` daemon spawn re-invokes the CLI as
+``[sys.executable, "-m", "calfkit.cli", "run", ...]`` (dev-agent-lifecycle plan §3.1): a child
+process must not depend on the ``ck`` console script being on PATH — ``sys.executable`` plus this
+module is resolvable from whatever environment the parent runs in.
+"""
+
+from calfkit.cli import main
+
+main()

--- a/calfkit/cli/_chat.py
+++ b/calfkit/cli/_chat.py
@@ -64,6 +64,7 @@ async def run_chat_session(
     *,
     session_plan: list[TargetNodes] | None = None,
     session_host_key: str | None = None,
+    offline_daemon_hint: Callable[[str], str | None] | None = None,
 ) -> None:
     """Connect, discover the online agents, resolve the target, and run the REPL.
 
@@ -79,26 +80,37 @@ async def run_chat_session(
     non-reused targets on an in-process Worker sharing THIS session's client, gate on their
     presence readiness, then enter the normal picker; the worker is stopped on every session end
     (before the client closes). ``session_host_key`` scopes the connect-or-spawn evaluation.
+
+    ``offline_daemon_hint`` (spec §7, dev-layer only): called with a named agent that turned out
+    offline; a returned line (e.g. "a managed daemon for 'x' exists but its agents are offline —
+    logs: …") is appended to the shipped not-online error.
     """
     read_line = make_reader(asyncio.get_running_loop())
     provisioning = ProvisioningConfig(enabled=True) if provision else None
     async with Client.connect(server_urls, provisioning=provisioning) as client:
         if session_plan is None:
-            await _attach(client, name, timeout, read_line)
+            await _attach(client, name, timeout, read_line, offline_hint=offline_daemon_hint)
             return
         if session_host_key is None:
             raise ValueError("session_plan requires session_host_key (the connect-or-spawn address scope)")
         await _target_session(client, session_plan, session_host_key, timeout, read_line)
 
 
-async def _attach(client: Client, name: str | None, timeout: float | None, read_line: ReadLine) -> None:
+async def _attach(
+    client: Client,
+    name: str | None,
+    timeout: float | None,
+    read_line: ReadLine,
+    *,
+    offline_hint: Callable[[str], str | None] | None = None,
+) -> None:
     """Today's attach flow: discover -> pick (or resolve the name) -> REPL."""
     print("Discovering agents...")
     agents = await client.mesh.get_agents()
     if not agents:  # ready, but zero live agents
         print("No agents are online on the mesh.")
         return
-    picked = await _resolve_target(name, agents, read_line)
+    picked = await _resolve_target(name, agents, read_line, offline_hint=offline_hint)
     if picked is None:  # user quit at the picker
         return
     await _chat_loop(client, picked, timeout, read_line)
@@ -116,8 +128,9 @@ async def _target_session(
     Under the agent-layer flock (released before the REPL opens): connect-or-spawn evaluation —
     reused targets are excluded — then the non-reused nodes are hosted on an in-process
     ``Worker`` **sharing this session's Client** (the co-located contract ``client/caller.py``
-    documents: the start-lock serializes the co-located ``app.start()``, and the worker stops
-    before the client closes), with the 5s dev heartbeat preset set explicitly at construction.
+    documents: ``_ensure_started`` gates on ``broker.running`` so a co-located Worker's completed
+    ``app.start()`` is honored, and the worker stops before the client closes), with the 5s dev
+    heartbeat preset set explicitly at construction.
     The worker dies with this process by construction — no reload, no child to orphan. Worker
     logs stay on this terminal (v1). On any session end the worker is stopped and the §3.2 exit
     narration prints.
@@ -178,13 +191,22 @@ def _print_session_narration(launched_names: list[str], reused_names: list[str])
         print(f"✦ still running: {', '.join(reused_names)} — 'ck dev chat' to rejoin, 'ck dev down' to stop everything")
 
 
-async def _resolve_target(name: str | None, agents: Mapping[str, AgentInfo], read_line: ReadLine) -> str | None:
-    """The named agent (erroring if it isn't online), or the user's picker choice
-    (``None`` if they quit)."""
+async def _resolve_target(
+    name: str | None,
+    agents: Mapping[str, AgentInfo],
+    read_line: ReadLine,
+    *,
+    offline_hint: Callable[[str], str | None] | None = None,
+) -> str | None:
+    """The named agent (erroring if it isn't online — plus the dev layer's daemon hint when one
+    applies, spec §7), or the user's picker choice (``None`` if they quit)."""
     if name is not None:
         if name in agents:
             return name
         typer.echo(f"Agent {name!r} is not online. Online agents: {', '.join(sorted(agents))}.", err=True)
+        hint = offline_hint(name) if offline_hint is not None else None
+        if hint:
+            typer.echo(hint, err=True)
         raise typer.Exit(2)
 
     names = sorted(agents)  # sort ONCE — the displayed numbering and the index->name selection share it

--- a/calfkit/cli/_chat.py
+++ b/calfkit/cli/_chat.py
@@ -109,6 +109,12 @@ async def _attach(
     agents = await client.mesh.get_agents()
     if not agents:  # ready, but zero live agents
         print("No agents are online on the mesh.")
+        # The PRIMARY §7 moment (round 2, Ryan-approved minimal shape): a single crashed daemon
+        # leaves the roster EMPTY — a named lookup still gets the daemon diagnosis, same exit.
+        if name is not None and offline_hint is not None:
+            hint = offline_hint(name)
+            if hint:
+                print(hint)
         return
     picked = await _resolve_target(name, agents, read_line, offline_hint=offline_hint)
     if picked is None:  # user quit at the picker

--- a/calfkit/cli/_chat.py
+++ b/calfkit/cli/_chat.py
@@ -13,10 +13,12 @@ from __future__ import annotations
 
 import asyncio
 import shutil
+import traceback
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 import typer
 
+from calfkit.cli import _dev_agents
 from calfkit.cli._chat_io import make_reader
 from calfkit.cli._chat_render import _error_line, _render_answer, _render_fault, _render_step, format_picker
 from calfkit.client import Client, RunCompleted, RunFailed
@@ -27,6 +29,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Mapping
 
     from calfkit._vendor.pydantic_ai.messages import ModelMessage
+    from calfkit.cli._dev_agents import TargetNodes, TargetOutcome
     from calfkit.client import AgentGateway
     from calfkit.client.hub import InvocationHandle
     from calfkit.client.mesh import AgentInfo
@@ -53,7 +56,15 @@ class _TurnResult(NamedTuple):
     responder: str
 
 
-async def run_chat_session(name: str | None, server_urls: str | list[str] | None, timeout: float | None, provision: bool = False) -> None:
+async def run_chat_session(
+    name: str | None,
+    server_urls: str | list[str] | None,
+    timeout: float | None,
+    provision: bool = False,
+    *,
+    session_plan: list[TargetNodes] | None = None,
+    session_host_key: str | None = None,
+) -> None:
     """Connect, discover the online agents, resolve the target, and run the REPL.
 
     A not-ready mesh raises ``MeshUnavailableError`` from ``get_agents()`` — left to
@@ -63,19 +74,108 @@ async def run_chat_session(name: str | None, server_urls: str | list[str] | None
     ``provision`` (``--provision``) opt-in creates this client's reply inbox topic at broker
     start — needed on brokers that don't auto-create topics (e.g. Tansu). The agent's own topics
     are provisioned by its worker (``ck run --provision``), not here.
+
+    ``session_plan`` is ``ck dev chat TARGET...`` (agent-lifecycle spec §3.2): host the plan's
+    non-reused targets on an in-process Worker sharing THIS session's client, gate on their
+    presence readiness, then enter the normal picker; the worker is stopped on every session end
+    (before the client closes). ``session_host_key`` scopes the connect-or-spawn evaluation.
     """
     read_line = make_reader(asyncio.get_running_loop())
     provisioning = ProvisioningConfig(enabled=True) if provision else None
     async with Client.connect(server_urls, provisioning=provisioning) as client:
-        print("Discovering agents...")
-        agents = await client.mesh.get_agents()
-        if not agents:  # ready, but zero live agents
-            print("No agents are online on the mesh.")
+        if session_plan is None:
+            await _attach(client, name, timeout, read_line)
             return
-        picked = await _resolve_target(name, agents, read_line)
-        if picked is None:  # user quit at the picker
-            return
-        await _chat_loop(client, picked, timeout, read_line)
+        if session_host_key is None:
+            raise ValueError("session_plan requires session_host_key (the connect-or-spawn address scope)")
+        await _target_session(client, session_plan, session_host_key, timeout, read_line)
+
+
+async def _attach(client: Client, name: str | None, timeout: float | None, read_line: ReadLine) -> None:
+    """Today's attach flow: discover -> pick (or resolve the name) -> REPL."""
+    print("Discovering agents...")
+    agents = await client.mesh.get_agents()
+    if not agents:  # ready, but zero live agents
+        print("No agents are online on the mesh.")
+        return
+    picked = await _resolve_target(name, agents, read_line)
+    if picked is None:  # user quit at the picker
+        return
+    await _chat_loop(client, picked, timeout, read_line)
+
+
+async def _target_session(
+    client: Client,
+    plan: list[TargetNodes],
+    host_key: str,
+    timeout: float | None,
+    read_line: ReadLine,
+) -> None:
+    """The ``ck dev chat TARGET...`` session (agent-lifecycle spec §3.2).
+
+    Under the agent-layer flock (released before the REPL opens): connect-or-spawn evaluation —
+    reused targets are excluded — then the non-reused nodes are hosted on an in-process
+    ``Worker`` **sharing this session's Client** (the co-located contract ``client/caller.py``
+    documents: the start-lock serializes the co-located ``app.start()``, and the worker stops
+    before the client closes), with the 5s dev heartbeat preset set explicitly at construction.
+    The worker dies with this process by construction — no reload, no child to orphan. Worker
+    logs stay on this terminal (v1). On any session end the worker is stopped and the §3.2 exit
+    narration prints.
+    """
+    from calfkit.controlplane import ControlPlaneConfig
+    from calfkit.worker import Worker
+
+    worker: Any = None
+    reused: list[TargetOutcome] = []
+    launched: list[TargetNodes] = []
+    repl_entered = False
+    try:
+        with _dev_agents.agents_lock():
+            reused, to_launch = await _dev_agents.evaluate_targets(plan, host_key, client.mesh)
+            session_agents = [n for t in to_launch for n in t.agent_names] + [n for o in reused for n in o.target.agent_names]
+            if not session_agents:  # §7: a precondition over the launched+reused set only
+                raise _dev_agents.DevAgentError(
+                    "the given targets resolve to no agents (tools only) — nobody to chat with. "
+                    "Launch tools with 'ck dev run -d' and chat with an agent that uses them."
+                )
+            if to_launch:
+                worker = Worker(
+                    client,  # the SHARED session client — caller.py's documented co-located mode
+                    nodes=[node for target in to_launch for node in target.nodes],
+                    control_plane=ControlPlaneConfig(heartbeat_interval=_dev_agents.DEV_HEARTBEAT_INTERVAL),
+                )
+                try:
+                    await worker.start()
+                except Exception as exc:
+                    traceback.print_exc()  # §7: surface directly — it IS this process
+                    raise _dev_agents.DevAgentError(f"the session worker failed to start: {exc}") from exc
+                launched = list(to_launch)
+                await _dev_agents.wait_agents_ready(
+                    None,  # the chat variant: no process arm — a failed start already raised above
+                    [n for t in to_launch for n in t.agent_names],
+                    [n for t in to_launch for n in t.tool_names],
+                    client.mesh,
+                    log_path=None,
+                )
+        repl_entered = True
+        await _attach(client, None, timeout, read_line)
+    finally:
+        if worker is not None:
+            await worker.stop()  # BEFORE the client closes (caller.py's aclose ordering)
+        if repl_entered:  # a launch that never reached the REPL reports its error, not narration
+            _print_session_narration(
+                [name for target in launched for name in target.names],
+                [name for outcome in reused for name in outcome.target.names],
+            )
+
+
+def _print_session_narration(launched_names: list[str], reused_names: list[str]) -> None:
+    """§3.2 exit narration — only when the session launched or reused something; attach-only
+    sessions exit silently."""
+    if launched_names:
+        print(f"✦ stopped '{', '.join(launched_names)}' (ran in this session)")
+    if reused_names:
+        print(f"✦ still running: {', '.join(reused_names)} — 'ck dev chat' to rejoin, 'ck dev down' to stop everything")
 
 
 async def _resolve_target(name: str | None, agents: Mapping[str, AgentInfo], read_line: ReadLine) -> str | None:

--- a/calfkit/cli/_dev_agents.py
+++ b/calfkit/cli/_dev_agents.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from subprocess import Popen
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from calfkit.cli._dev_broker import (
     _MESH_EXTRA_HINT,
@@ -45,6 +45,9 @@ from calfkit.cli._loader import load_nodes
 from calfkit.exceptions import MeshUnavailableError
 from calfkit.models.agents import AGENTS_TOPIC
 from calfkit.models.capability import CAPABILITY_TOPIC
+
+if TYPE_CHECKING:
+    from calfkit.client.mesh import AgentInfo, ToolInfo
 
 MARKER_FLAG = "--dev-daemon"
 """The argv ownership marker (spec §5.4): an *agent daemon* is a live process whose cmdline
@@ -67,9 +70,9 @@ _DEFAULT_HOST_KEY = _format_address("127.0.0.1", DEFAULT_PORT)
 class PresenceReader(Protocol):
     """The slice of ``client.mesh`` the supervisor reads: fresh name-keyed snapshots per kind."""
 
-    async def get_agents(self) -> Mapping[str, Any]: ...
+    async def get_agents(self) -> Mapping[str, AgentInfo]: ...
 
-    async def get_tools(self) -> Mapping[str, Any]: ...
+    async def get_tools(self) -> Mapping[str, ToolInfo]: ...
 
 
 @contextmanager
@@ -77,7 +80,14 @@ def agents_lock() -> Iterator[None]:
     """The agent-layer flock (spec §5.1): ``run -d`` holds it across check→spawn→readiness and
     ``chat TARGET`` across evaluate→start→readiness (released before the REPL opens) — without
     it, two concurrent launches of one target both see "none online" and double-spawn (the exact
-    hazard the broker lock exists for; agents have no port-bind exclusivity to save them)."""
+    hazard the broker lock exists for; agents have no port-bind exclusivity to save them).
+
+    Acquisition is a BLOCKING ``fcntl.flock`` on the calling thread. Both acquisition sites sit
+    inside async functions, which is safe TODAY only because nothing async is live before the
+    lock is taken (the clients are lazy; no mesh view or broker connection is open yet), so a
+    contended wait cannot stall an event loop with running consumers. Keep it that way: never
+    open a connection, start the broker, or read the mesh before taking this lock.
+    """
     with _spawn_lock(filename="dev-agents.lock", waiting_message="waiting for another ck dev agent launch to finish…"):
         yield
 
@@ -295,8 +305,8 @@ class _Presence:
     """One captured point-in-time snapshot, kinds kept apart (a name is checked against its own
     kind's view, never a cross-kind union)."""
 
-    agents: Mapping[str, Any]
-    tools: Mapping[str, Any]
+    agents: Mapping[str, AgentInfo]
+    tools: Mapping[str, ToolInfo]
 
 
 async def _read_presence(mesh: PresenceReader, *, want_agents: bool, want_tools: bool) -> _Presence | MeshUnavailableError:
@@ -588,7 +598,7 @@ async def ensure_agents(
         return EnsureReport(outcomes=outcomes, pid=proc.pid, log_path=str(log_path))
 
 
-def _spawn_daemon(to_launch: Sequence[TargetNodes], target: Target, log_path: Path, options: RunOptions) -> Any:
+def _spawn_daemon(to_launch: Sequence[TargetNodes], target: Target, log_path: Path, options: RunOptions) -> Popen[bytes]:
     """Spawn the daemon tree — the broker's shipped ``Popen`` pattern verbatim (detached session
     leader, real log-file fd, ``DEVNULL`` stdin) around the §5.1 argv: the child re-invokes the
     CLI (``-m calfkit.cli run``) with the normalized host, the caller's options, the ownership
@@ -621,6 +631,7 @@ def _spawn_daemon(to_launch: Sequence[TargetNodes], target: Target, log_path: Pa
         raise DevAgentError(f"cannot write the agent daemon log at {log_path}: {exc}") from exc
     with log_file:
         try:
-            return Popen(cmd, stdin=subprocess.DEVNULL, stdout=log_file, stderr=log_file, **_detach_kwargs())  # type: ignore[call-overload]
+            proc: Popen[bytes] = Popen(cmd, stdin=subprocess.DEVNULL, stdout=log_file, stderr=log_file, **_detach_kwargs())  # type: ignore[call-overload]
+            return proc
         except OSError as exc:
             raise DevAgentError(f"failed to launch the agent daemon: {exc}") from exc

--- a/calfkit/cli/_dev_agents.py
+++ b/calfkit/cli/_dev_agents.py
@@ -13,13 +13,12 @@ extra and is imported lazily by the process scan.
 from __future__ import annotations
 
 import asyncio
-import os
 import re
 import signal
 import subprocess
 import sys
 import time
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Collection, Iterator, Mapping, Sequence
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -36,7 +35,9 @@ from calfkit.cli._dev_broker import (
     _detach_kwargs,
     _flag_value,
     _format_address,
+    _killpg,
     _log_tail,
+    _signal,
     _spawn_lock,
     normalize,
 )
@@ -67,14 +68,6 @@ class PresenceReader(Protocol):
     async def get_agents(self) -> Mapping[str, Any]: ...
 
     async def get_tools(self) -> Mapping[str, Any]: ...
-
-
-def _killpg(pgid: int, sig: int) -> None:
-    """Signal a whole process group — the ``-d`` spawn is a session leader, so its pid is the
-    pgid and one signal reaps supervisor + worker + multiprocessing helpers together (spec §3.4).
-    A call-time ``os`` lookup (``killpg`` does not exist on Windows, and module import must stay
-    platform-safe) and the test seam — tests replace this, never a live signal."""
-    os.killpg(pgid, sig)
 
 
 @contextmanager
@@ -428,6 +421,62 @@ async def evaluate_targets(
                 "invocation can neither reuse nor launch it. Stop the partial set or rename the collision."
             )
     return reused, to_launch
+
+
+# --- stop: whole-daemon, group-signalled, narrated by the caller (spec §3.4) --------------------------
+
+DAEMON_GRACE = 8.0
+"""Teardown grace for daemon trees (spec §3.4, ≥ 8s): the reload supervisor's own teardown budget
+is ~6s (SIGINT to the worker → join(5) → SIGKILL → join(1)), so a shorter grace would SIGKILL it
+mid-shutdown and orphan the worker. Parameterized per call site — the broker keeps its 5s
+default (R4)."""
+
+
+def stop_daemon(hit: DaemonHit, *, grace: float = DAEMON_GRACE) -> bool:
+    """SIGTERM → *grace* → SIGKILL the daemon's whole **process group** (the ``-d`` spawn is a
+    session leader, so one signal reaps supervisor + worker + multiprocessing helpers together).
+    Whole-daemon by design: co-hosted names go down together — the caller narrates every one.
+    ``False`` = access denied (someone else's daemon)."""
+    return _signal(hit.proc, pid=hit.pid, label=f"the agent daemon (pid {hit.pid})", grace=grace, group=True)
+
+
+def resolve_stop(
+    names: Sequence[str],
+    daemons: Sequence[DaemonHit],
+    *,
+    host_key: str,
+    online: Collection[str],
+) -> list[DaemonHit]:
+    """Resolve ``stop NAME...`` to the daemons owning those names within one address scope
+    (spec §3.4) — deduped (co-hosted names share a daemon; it is stopped once, narrated whole),
+    order of first mention.
+
+    Raises:
+        DevAgentError: an unknown name (listing what IS running at this address, and how to look
+            elsewhere); a name that is online but not a marker daemon (a session worker, a
+            foreground run, anything external — stop it where it runs); or two same-named hits at
+            one address (hand-run markers, dead-broker windows) — both pids listed, never a guess.
+    """
+    resolved: list[DaemonHit] = []
+    seen_pids: set[int] = set()
+    for name in names:
+        owners = [hit for hit in daemons if name in hit.names]
+        if len(owners) > 1:
+            pids = ", ".join(str(hit.pid) for hit in sorted(owners, key=lambda h: h.pid))
+            raise DevAgentError(
+                f"two ck dev daemons at {host_key} claim '{name}' (pids {pids}) — refusing to guess. "
+                "Stop them directly by pid, or 'ck dev down' to clear everything."
+            )
+        if not owners:
+            if name in online:
+                raise DevAgentError(f"'{name}' is not a ck dev daemon — stop it where it runs.")
+            live = ", ".join(sorted({n for hit in daemons for n in hit.names})) or "none"
+            raise DevAgentError(f"no ck dev daemon owns '{name}' (running at {host_key}: {live}; use --host for other meshes).")
+        (owner,) = owners
+        if owner.pid not in seen_pids:
+            seen_pids.add(owner.pid)
+            resolved.append(owner)
+    return resolved
 
 
 # --- the -d daemon spawn + ensure orchestration (spec §5.1) -------------------------------------------

--- a/calfkit/cli/_dev_agents.py
+++ b/calfkit/cli/_dev_agents.py
@@ -12,9 +12,222 @@ extra and is imported lazily by the process scan.
 
 from __future__ import annotations
 
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from calfkit.cli._dev_broker import (
+    _MESH_EXTRA_HINT,
+    DEFAULT_PORT,
+    MeshExtraMissingError,
+    _calfkit_dir,
+    _flag_value,
+    _format_address,
+    normalize,
+)
+from calfkit.cli._loader import load_nodes
+from calfkit.models.agents import AGENTS_TOPIC
+from calfkit.models.capability import CAPABILITY_TOPIC
+
+MARKER_FLAG = "--dev-daemon"
+"""The argv ownership marker (spec §5.4): an *agent daemon* is any live process whose cmdline
+carries this flag. Internal — humans launch daemons via ``ck dev run -d``, never by hand-setting
+the marker (a hand-set marker IS managed, though: "whoever started it", the broker rule)."""
+
+_DEFAULT_HOST_KEY = _format_address("127.0.0.1", DEFAULT_PORT)
+
 DEV_HEARTBEAT_INTERVAL = 5.0
 """The dev heartbeat preset (spec §5.6): every worker ``ck dev`` launches — foreground runs,
 ``-d`` daemons, and in-process chat session workers alike — heartbeats every 5s instead of the
 30s production default, so crash-staleness detection (3 × interval) is ~15s. Writer-side only:
 the reader's ``stale_after`` derives from the interval stamped on each record and must never be
 shortened below the writer's cadence (live agents would flap offline between heartbeats)."""
+
+
+class DevAgentError(Exception):
+    """An agent-daemon supervise/manage failure (usage errors at preflight, spawn/readiness
+    failures, stop-resolution errors, …).
+
+    The ``ck dev`` commands surface it and exit ``2`` — the :class:`DevBrokerError` contract, one
+    layer up.
+    """
+
+
+# --- preflight (spec §5.1): per-target names by kind, fail-fast at the prompt ------------------------
+
+
+@dataclass(frozen=True)
+class TargetNodes:
+    """One preflighted ``module:attr`` target: its resolved node defs and their advertised names
+    by presence kind. ``chat TARGET`` hosts ``nodes`` in-process; ``run -d`` re-imports the spec
+    in the daemon child and uses only the names."""
+
+    spec: str
+    nodes: tuple[Any, ...]
+    agent_names: tuple[str, ...]
+    tool_names: tuple[str, ...]
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        """The readiness/marker set: the union of both advertising kinds (spec §5.1)."""
+        return self.agent_names + self.tool_names
+
+
+def preflight(targets: Sequence[str], *, app_dir: str | None = None) -> list[TargetNodes]:
+    """Resolve and classify ``targets``, fail-fast at the prompt (spec §5.1).
+
+    Each target resolves through the shipped ``load_nodes`` (its import/validation failures keep
+    their ``typer.Exit(2)`` contract). Per node, agent-ness is the shipped predicate —
+    ``AGENTS_TOPIC in control_plane_adverts()`` — tools advertise on ``CAPABILITY_TOPIC``, and the
+    advertised name is ``node_id``.
+
+    Raises:
+        DevAgentError: on a target with zero presence-advertising nodes (an invisible,
+            name-unstoppable daemon — Ryan's ruling, 2026-07-02), or a node name arriving via two
+            targets (never a silent dedupe).
+        typer.Exit: (code 2) on the loader's own failures (bad spec, import error, non-node,
+            zero nodes).
+    """
+    plan: list[TargetNodes] = []
+    seen: dict[str, str] = {}  # advertised-or-not node name -> the spec that brought it
+    for spec in targets:
+        nodes = load_nodes([spec], app_dir=app_dir, source_label="target")
+        agent_names: list[str] = []
+        tool_names: list[str] = []
+        for node in nodes:
+            name = str(node.node_id)
+            owner = seen.get(name)
+            if owner is not None:
+                raise DevAgentError(
+                    f"duplicate node name {name!r} across targets {owner!r} and {spec!r} — one invocation "
+                    "launches each name once, and same-named nodes from different files are ambiguous. "
+                    "Launch them separately or rename one."
+                )
+            seen[name] = spec
+            adverts = node.control_plane_adverts()
+            if AGENTS_TOPIC in adverts:
+                agent_names.append(name)
+            elif CAPABILITY_TOPIC in adverts:
+                tool_names.append(name)
+        if not agent_names and not tool_names:
+            raise DevAgentError(
+                f"target {spec!r} resolves to no agents or tools — 'ck dev' launch targets need at least "
+                "one presence-advertising node (a daemon with no presence names would be invisible to "
+                "'ck dev status' and unstoppable by name). Run plain consumer nodes with foreground "
+                "'ck dev run' instead."
+            )
+        plan.append(TargetNodes(spec=spec, nodes=tuple(nodes), agent_names=tuple(agent_names), tool_names=tuple(tool_names)))
+    return plan
+
+
+# --- the stateless argv-marker scan (spec §5.4) -------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DaemonHit:
+    """A running agent daemon found in the process table, with its live psutil handle (typed
+    ``Any`` — psutil ships no type stubs) so callers signal the same process the scan verified.
+
+    The scan matches exactly one process per daemon — the supervisor (the session leader
+    ``stop`` group-signals): watchfiles/multiprocessing descendants carry ``spawn_main``-shaped
+    argv without the marker. Everything here derives from that one argv: ``names`` from the
+    marker value, ``host_key`` from the adjacent ``--host`` (normalized for the address join;
+    absent = the default address), ``targets`` from the positional block, and ``log_path``
+    re-derived through :func:`daemon_log_path` — the same function the spawn writes with.
+    """
+
+    proc: Any
+    pid: int
+    names: tuple[str, ...]
+    host_key: str
+    targets: tuple[str, ...]
+    log_path: str
+    started_at: str
+
+
+def daemon_log_path(host_key: str, targets: Sequence[str]) -> Path:
+    """The daemon's log file (spec §5.1: ``~/.calfkit/logs/agents-<slug>.log``, overwritten per
+    spawn). The slug is the normalized address key plus the launched targets, each sanitized —
+    derived identically at spawn and scan time so management commands can point at the log
+    without any saved state."""
+    slug = f"{_sanitize(host_key)}-{_sanitize('-'.join(targets))}"
+    return _calfkit_dir() / "logs" / f"agents-{slug}.log"
+
+
+def _sanitize(part: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]", "_", part)
+
+
+def _daemon_hit(proc: Any, cmd: list[str]) -> DaemonHit | None:
+    """Project one process's argv to a :class:`DaemonHit`, or ``None`` if it is not a manageable
+    agent daemon (no marker, an empty marker, or an address that cannot be normalized for the
+    join)."""
+    marker = _flag_value(cmd, MARKER_FLAG, "")
+    names = tuple(name for name in marker.split(",") if name)
+    if not names:
+        return None
+    host = _flag_value(cmd, "--host", "")
+    if host:
+        try:
+            host_key = normalize([host]).key
+        except ValueError:
+            return None  # an unjoinable address is not a daemon we can manage
+    else:
+        host_key = _DEFAULT_HOST_KEY
+    targets = _positional_targets(cmd)
+    started = datetime.fromtimestamp(proc.create_time(), tz=timezone.utc)
+    return DaemonHit(
+        proc=proc,
+        pid=proc.pid,
+        names=names,
+        host_key=host_key,
+        targets=targets,
+        log_path=str(daemon_log_path(host_key, targets)),
+        started_at=started.isoformat(timespec="seconds"),
+    )
+
+
+def _positional_targets(cmd: list[str]) -> tuple[str, ...]:
+    """The ``module:attr`` block of a daemon argv: the contiguous non-flag tokens after ``run``.
+
+    The ``-d`` spawn always emits ``run *targets --host …``, so this is exact for managed
+    daemons; for a hand-run marker with interleaved flags it is best-effort (R3)."""
+    try:
+        start = cmd.index("run") + 1
+    except ValueError:
+        return ()
+    targets: list[str] = []
+    for token in cmd[start:]:
+        if token.startswith("-"):
+            break
+        targets.append(token)
+    return tuple(targets)
+
+
+def scan_daemons() -> list[DaemonHit]:
+    """Scan the live process table for agent daemons (spec §5.4) — the broker scan's discipline,
+    one layer up. Raises :class:`MeshExtraMissingError` when ``psutil`` (the ``[mesh]`` extra) is
+    not installed."""
+    try:
+        import psutil  # type: ignore[import-untyped]
+    except ModuleNotFoundError as exc:
+        raise MeshExtraMissingError(_MESH_EXTRA_HINT) from exc
+
+    hits: list[DaemonHit] = []
+    for proc in psutil.process_iter():
+        try:
+            hit = _daemon_hit(proc, proc.cmdline())
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            continue  # vanished or unreadable mid-scan — by definition not a daemon we can manage
+        if hit is not None:
+            hits.append(hit)
+    return hits
+
+
+def find_daemons(host_key: str | None) -> list[DaemonHit]:
+    """The scan, host-scoped: hits whose argv-derived address key equals *host_key* (``None`` =
+    every address — the ``stop --all``/``down`` sweep scope)."""
+    return [hit for hit in scan_daemons() if host_key is None or hit.host_key == host_key]

--- a/calfkit/cli/_dev_agents.py
+++ b/calfkit/cli/_dev_agents.py
@@ -1,0 +1,20 @@
+"""Agent-daemon supervisor for ``ck dev`` (dev-agent-lifecycle spec §5).
+
+The agent-layer sibling of :mod:`calfkit.cli._dev_broker`, one layer up: preflight ``module:attr``
+targets, connect-or-spawn detached agent daemons (identified statelessly by the ``--dev-daemon``
+argv marker), gate on presence-plane readiness, and provide the stop/status data the ``ck dev``
+management commands render.
+
+Import hygiene (load-bearing, the ``_dev_broker`` rule): ``ck dev`` imports this module on every
+invocation, so nothing here may import ``psutil`` at module top — it ships only in the ``[mesh]``
+extra and is imported lazily by the process scan.
+"""
+
+from __future__ import annotations
+
+DEV_HEARTBEAT_INTERVAL = 5.0
+"""The dev heartbeat preset (spec §5.6): every worker ``ck dev`` launches — foreground runs,
+``-d`` daemons, and in-process chat session workers alike — heartbeats every 5s instead of the
+30s production default, so crash-staleness detection (3 × interval) is ~15s. Writer-side only:
+the reader's ``stale_after`` derives from the interval stamped on each record and must never be
+shortened below the writer's cadence (live agents would flap offline between heartbeats)."""

--- a/calfkit/cli/_dev_agents.py
+++ b/calfkit/cli/_dev_agents.py
@@ -202,12 +202,24 @@ def _sanitize(part: str) -> str:
     return re.sub(r"[^A-Za-z0-9._-]", "_", part)
 
 
+def _daemon_marker_names(cmd: list[str]) -> tuple[str, ...]:
+    """The marker's names, matched ONLY in its emitted shape (review round 1, Ryan-approved):
+    a ``--dev-daemon=<names>`` token on a command line that also carries a ``run`` token — the
+    two anchors every real spawn (and hand-run ``ck run``) has. A bare ``--dev-daemon`` token or
+    the ``=``-form appearing as *data* in some other process's argv (``rg -- --dev-daemon …``)
+    must never match: a false hit here is what ``stop``/``down`` group-kill."""
+    if "run" not in cmd:
+        return ()
+    prefix = f"{MARKER_FLAG}="
+    value = next((token[len(prefix) :] for token in cmd if token.startswith(prefix)), "")
+    return tuple(name for name in value.split(",") if name)
+
+
 def _daemon_hit(proc: Any, cmd: list[str]) -> DaemonHit | None:
     """Project one process's argv to a :class:`DaemonHit`, or ``None`` if it is not a manageable
-    agent daemon (no marker, an empty marker, or an address that cannot be normalized for the
-    join)."""
-    marker = _flag_value(cmd, MARKER_FLAG, "")
-    names = tuple(name for name in marker.split(",") if name)
+    agent daemon (no emitted-form marker on a ``run`` argv, an empty marker, or an address that
+    cannot be normalized for the join)."""
+    names = _daemon_marker_names(cmd)
     if not names:
         return None
     host = _flag_value(cmd, "--host", "")
@@ -235,11 +247,9 @@ def _positional_targets(cmd: list[str]) -> tuple[str, ...]:
     """The ``module:attr`` block of a daemon argv: the contiguous non-flag tokens after ``run``.
 
     The ``-d`` spawn always emits ``run *targets --host …``, so this is exact for managed
-    daemons; for a hand-run marker with interleaved flags it is best-effort (R3)."""
-    try:
-        start = cmd.index("run") + 1
-    except ValueError:
-        return ()
+    daemons; for a hand-run marker with interleaved flags it is best-effort (R3). A ``run``
+    token is guaranteed present: the marker anchor already required it."""
+    start = cmd.index("run") + 1
     targets: list[str] = []
     for token in cmd[start:]:
         if token.startswith("-"):
@@ -286,18 +296,20 @@ class _Presence:
     tools: Mapping[str, Any]
 
 
-async def _read_presence(mesh: PresenceReader, *, want_agents: bool, want_tools: bool) -> _Presence | None:
-    """One capture of the requested kinds, or ``None`` while the mesh is not usable yet.
+async def _read_presence(mesh: PresenceReader, *, want_agents: bool, want_tools: bool) -> _Presence | MeshUnavailableError:
+    """One capture of the requested kinds, or the ``MeshUnavailableError`` that prevented it.
 
-    Any ``MeshUnavailableError`` is *not ready yet*: ``open_failed`` is the fresh-broker race the
-    loop is specified to absorb (spec §5.5), and the other reasons are the same transient class —
-    a bounded deadline turns a persistent one into the honest exit-2 anyway.
+    The failure is returned (not swallowed) so each caller can branch on ``reason`` — the reasons
+    are NOT one class (review round 1): ``open_failed`` is the fresh-broker race the readiness
+    loop is specified to absorb (spec §5.5), ``establishing`` is a transient catch-up, and
+    ``reader_dead`` is documented terminal for the view's lifetime — misreporting it as "agents
+    offline" blames the wrong side.
     """
     try:
         agents = dict(await mesh.get_agents()) if want_agents else {}
         tools = dict(await mesh.get_tools()) if want_tools else {}
-    except MeshUnavailableError:
-        return None
+    except MeshUnavailableError as exc:
+        return exc
     return _Presence(agents=agents, tools=tools)
 
 
@@ -329,17 +341,36 @@ async def wait_agents_ready(
         DevAgentError: the supervisor died, or the deadline passed.
     """
     deadline = time.monotonic() + timeout
+    last_read_failure: MeshUnavailableError | None = None
     while True:
         if proc is not None and proc.poll() is not None:
             code = proc.returncode
             cause = f"killed by a signal ({code})" if code is not None and code < 0 else f"exit code {code}"
             raise DevAgentError(f"the agent daemon exited during startup ({cause}){_tail_suffix(log_path)}")
-        presence = await _read_presence(mesh, want_agents=bool(agent_names), want_tools=bool(tool_names))
-        if presence is not None and not _missing_names(agent_names, tool_names, presence):
-            return
+        result = await _read_presence(mesh, want_agents=bool(agent_names), want_tools=bool(tool_names))
+        if isinstance(result, MeshUnavailableError):
+            if result.reason == "reader_dead":
+                # Terminal for this client's view — retrying burns the deadline to then blame a
+                # healthy daemon's log. Name the real (client-side) culprit immediately.
+                if proc is not None:
+                    _kill_spawn_group(proc)
+                raise DevAgentError(
+                    f"the presence view died while waiting for the agents ({result}) — a client-side "
+                    f"read failure, not the agents{_tail_suffix(log_path)}"
+                ) from result
+            last_read_failure = result  # open_failed / establishing: not ready yet, keep polling
+        else:
+            last_read_failure = None
+            if not _missing_names(agent_names, tool_names, result):
+                return
         if time.monotonic() >= deadline:
             if proc is not None:
                 _kill_spawn_group(proc)
+            if last_read_failure is not None:
+                raise DevAgentError(
+                    f"the presence view never became readable within {timeout:.1f}s "
+                    f"({last_read_failure.reason}: {last_read_failure}){_tail_suffix(log_path)}"
+                ) from last_read_failure
             raise DevAgentError(f"the launched agents did not come online within {timeout:.1f}s{_tail_suffix(log_path)}")
         await asyncio.sleep(poll_interval)
 
@@ -386,11 +417,24 @@ async def evaluate_targets(
     Returns:
         ``(reused, to_launch)``, both in plan order.
     """
-    presence = await _read_presence(
+    result = await _read_presence(
         mesh,
         want_agents=any(t.agent_names for t in plan),
         want_tools=any(t.tool_names for t in plan),
     )
+    if isinstance(result, MeshUnavailableError):
+        if result.reason != "open_failed":
+            # Only the fresh-broker open_failed is spec'd as none-online (§5.5). Classifying on
+            # an establishing/reader_dead capture could brand a HEALTHY daemon "broken" (and
+            # advise stopping it) or double-spawn — error naming the read failure instead
+            # (review round 1, Ryan-approved).
+            raise DevAgentError(
+                f"the presence view could not be read ({result.reason}): {result} — cannot evaluate "
+                "which agents are online. Try again in a moment; if it persists, restart the command."
+            ) from result
+        presence = None
+    else:
+        presence = result
     now = datetime.now(tz=timezone.utc)
     reused: list[TargetOutcome] = []
     to_launch: list[TargetNodes] = []

--- a/calfkit/cli/_dev_agents.py
+++ b/calfkit/cli/_dev_agents.py
@@ -12,23 +12,36 @@ extra and is imported lazily by the process scan.
 
 from __future__ import annotations
 
+import asyncio
+import os
 import re
-from collections.abc import Sequence
-from dataclasses import dataclass
+import signal
+import subprocess
+import sys
+import time
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from subprocess import Popen
+from typing import Any, Protocol
 
 from calfkit.cli._dev_broker import (
     _MESH_EXTRA_HINT,
     DEFAULT_PORT,
     MeshExtraMissingError,
+    Target,
     _calfkit_dir,
+    _detach_kwargs,
     _flag_value,
     _format_address,
+    _log_tail,
+    _spawn_lock,
     normalize,
 )
 from calfkit.cli._loader import load_nodes
+from calfkit.exceptions import MeshUnavailableError
 from calfkit.models.agents import AGENTS_TOPIC
 from calfkit.models.capability import CAPABILITY_TOPIC
 
@@ -37,7 +50,42 @@ MARKER_FLAG = "--dev-daemon"
 carries this flag. Internal — humans launch daemons via ``ck dev run -d``, never by hand-setting
 the marker (a hand-set marker IS managed, though: "whoever started it", the broker rule)."""
 
+READY_TIMEOUT = 15.0
+"""The readiness gate's deadline (spec §5.2, Ryan-confirmed): how long a launch waits for every
+preflighted name to be online on the presence plane."""
+
+_POLL_INTERVAL = 0.25
+"""The readiness gate's sample cadence: a bounded one-shot startup gate over the in-memory mesh
+snapshot (a local dict read — sanctioned by spec N4), never steady-state polling."""
+
 _DEFAULT_HOST_KEY = _format_address("127.0.0.1", DEFAULT_PORT)
+
+
+class PresenceReader(Protocol):
+    """The slice of ``client.mesh`` the supervisor reads: fresh name-keyed snapshots per kind."""
+
+    async def get_agents(self) -> Mapping[str, Any]: ...
+
+    async def get_tools(self) -> Mapping[str, Any]: ...
+
+
+def _killpg(pgid: int, sig: int) -> None:
+    """Signal a whole process group — the ``-d`` spawn is a session leader, so its pid is the
+    pgid and one signal reaps supervisor + worker + multiprocessing helpers together (spec §3.4).
+    A call-time ``os`` lookup (``killpg`` does not exist on Windows, and module import must stay
+    platform-safe) and the test seam — tests replace this, never a live signal."""
+    os.killpg(pgid, sig)
+
+
+@contextmanager
+def agents_lock() -> Iterator[None]:
+    """The agent-layer flock (spec §5.1): ``run -d`` holds it across check→spawn→readiness and
+    ``chat TARGET`` across evaluate→start→readiness (released before the REPL opens) — without
+    it, two concurrent launches of one target both see "none online" and double-spawn (the exact
+    hazard the broker lock exists for; agents have no port-bind exclusivity to save them)."""
+    with _spawn_lock(filename="dev-agents.lock", waiting_message="waiting for another ck dev agent launch to finish…"):
+        yield
+
 
 DEV_HEARTBEAT_INTERVAL = 5.0
 """The dev heartbeat preset (spec §5.6): every worker ``ck dev`` launches — foreground runs,
@@ -231,3 +279,249 @@ def find_daemons(host_key: str | None) -> list[DaemonHit]:
     """The scan, host-scoped: hits whose argv-derived address key equals *host_key* (``None`` =
     every address — the ``stop --all``/``down`` sweep scope)."""
     return [hit for hit in scan_daemons() if host_key is None or hit.host_key == host_key]
+
+
+# --- the bounded readiness poll (spec §5.2): the broker loop, one layer up ----------------------------
+
+
+@dataclass(frozen=True)
+class _Presence:
+    """One captured point-in-time snapshot, kinds kept apart (a name is checked against its own
+    kind's view, never a cross-kind union)."""
+
+    agents: Mapping[str, Any]
+    tools: Mapping[str, Any]
+
+
+async def _read_presence(mesh: PresenceReader, *, want_agents: bool, want_tools: bool) -> _Presence | None:
+    """One capture of the requested kinds, or ``None`` while the mesh is not usable yet.
+
+    Any ``MeshUnavailableError`` is *not ready yet*: ``open_failed`` is the fresh-broker race the
+    loop is specified to absorb (spec §5.5), and the other reasons are the same transient class —
+    a bounded deadline turns a persistent one into the honest exit-2 anyway.
+    """
+    try:
+        agents = dict(await mesh.get_agents()) if want_agents else {}
+        tools = dict(await mesh.get_tools()) if want_tools else {}
+    except MeshUnavailableError:
+        return None
+    return _Presence(agents=agents, tools=tools)
+
+
+def _missing_names(agent_names: Sequence[str], tool_names: Sequence[str], presence: _Presence) -> list[str]:
+    """The names not yet online, each checked against ITS kind's view within the one capture."""
+    return [n for n in agent_names if n not in presence.agents] + [n for n in tool_names if n not in presence.tools]
+
+
+async def wait_agents_ready(
+    proc: Any | None,
+    agent_names: Sequence[str],
+    tool_names: Sequence[str],
+    mesh: PresenceReader,
+    *,
+    log_path: str | None,
+    timeout: float = READY_TIMEOUT,
+    poll_interval: float = _POLL_INTERVAL,
+) -> None:
+    """Wait until every name is online, bounded (spec §5.2) — the broker readiness loop's shape.
+
+    Each iteration: (1) ``proc.poll()`` FIRST, so child death always wins a tie (fires mainly for
+    ``--no-reload``/supervisor-level failures — under reload-ON the supervisor survives worker
+    crashes and the deadline is the normal failure path); (2) one captured mesh snapshot, checked
+    whole (an unusable mesh = not ready); (3) all online → return; (4) deadline → group-kill the
+    spawn and raise with the log tail. *proc* ``None`` is the chat variant: the same loop minus
+    the process arms (a failed in-process ``Worker.start()`` raises directly instead).
+
+    Raises:
+        DevAgentError: the supervisor died, or the deadline passed.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        if proc is not None and proc.poll() is not None:
+            code = proc.returncode
+            cause = f"killed by a signal ({code})" if code is not None and code < 0 else f"exit code {code}"
+            raise DevAgentError(f"the agent daemon exited during startup ({cause}){_tail_suffix(log_path)}")
+        presence = await _read_presence(mesh, want_agents=bool(agent_names), want_tools=bool(tool_names))
+        if presence is not None and not _missing_names(agent_names, tool_names, presence):
+            return
+        if time.monotonic() >= deadline:
+            if proc is not None:
+                _kill_spawn_group(proc)
+            raise DevAgentError(f"the launched agents did not come online within {timeout:.1f}s{_tail_suffix(log_path)}")
+        await asyncio.sleep(poll_interval)
+
+
+def _tail_suffix(log_path: str | None) -> str:
+    return f"; log tail from {log_path}:\n{_log_tail(Path(log_path))}" if log_path else ""
+
+
+def _kill_spawn_group(proc: Any) -> None:
+    """Tear down a spawn that never became ready: SIGKILL its whole process group (the spawn is a
+    session leader) and reap the leader — best-effort, the readiness error is what surfaces."""
+    with suppress(ProcessLookupError, PermissionError):
+        _killpg(proc.pid, signal.SIGKILL)
+    with suppress(Exception):
+        proc.wait(timeout=5.0)
+
+
+# --- connect-or-spawn at the agent layer (spec §5.5) --------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TargetOutcome:
+    """One target's connect-or-spawn verdict: reused (never owned; ``ages`` carries the
+    heartbeat age per name for the honesty line) or launched by this invocation."""
+
+    target: TargetNodes
+    reused: bool
+    ages: dict[str, float] = field(default_factory=dict)
+
+
+async def evaluate_targets(
+    plan: Sequence[TargetNodes],
+    host_key: str,
+    mesh: PresenceReader,
+) -> tuple[list[TargetOutcome], list[TargetNodes]]:
+    """Classify every preflighted target against one presence capture (spec §5.5): all names
+    online → reuse (name-identity, never code identity); none online → launch, unless a live
+    marker daemon at this address owns overlapping names (a broken daemon is an error, never
+    silently doubled); partially online → error naming the collision.
+
+    An unopenable presence view counts as **none online** — the launched worker's provisioning
+    then creates the topics and the readiness gate absorbs the race.
+
+    Returns:
+        ``(reused, to_launch)``, both in plan order.
+    """
+    presence = await _read_presence(
+        mesh,
+        want_agents=any(t.agent_names for t in plan),
+        want_tools=any(t.tool_names for t in plan),
+    )
+    now = datetime.now(tz=timezone.utc)
+    reused: list[TargetOutcome] = []
+    to_launch: list[TargetNodes] = []
+    daemons: list[DaemonHit] | None = None  # scanned lazily: only an offline target needs it
+    for target in plan:
+        missing = list(target.names) if presence is None else _missing_names(target.agent_names, target.tool_names, presence)
+        if not missing:
+            assert presence is not None  # not missing anything implies a usable capture
+            ages = {name: (now - presence.agents[name].last_seen).total_seconds() for name in target.agent_names}
+            ages |= {name: (now - presence.tools[name].last_seen).total_seconds() for name in target.tool_names}
+            reused.append(TargetOutcome(target=target, reused=True, ages=ages))
+        elif len(missing) == len(target.names):
+            if daemons is None:
+                daemons = find_daemons(host_key)
+            owner = next((hit for hit in daemons if set(hit.names) & set(target.names)), None)
+            if owner is not None:
+                name = next(n for n in target.names if n in owner.names)
+                raise DevAgentError(
+                    f"a daemon for '{name}' already exists (pid {owner.pid}; its agents are offline — broken "
+                    f"code or mid-restart). Logs: {owner.log_path}. Use 'ck dev stop {name}' to replace it."
+                )
+            to_launch.append(target)
+        else:
+            online = [n for n in target.names if n not in missing]
+            raise DevAgentError(
+                f"target {target.spec!r} is partially online: {', '.join(online)} already online while "
+                f"{', '.join(missing)} is not — a worker hosts all its targets' nodes together, so this "
+                "invocation can neither reuse nor launch it. Stop the partial set or rename the collision."
+            )
+    return reused, to_launch
+
+
+# --- the -d daemon spawn + ensure orchestration (spec §5.1) -------------------------------------------
+
+
+@dataclass(frozen=True)
+class RunOptions:
+    """The ``ck dev run`` options a ``-d`` daemon child inherits (spec §3.1: everything
+    ``ck dev run`` is today, with the attachment cut). Defaults mirror the ``dev run`` presets."""
+
+    provision: bool = True
+    reload: bool = True
+    reload_dir: Sequence[str] | None = None
+    app_dir: str = "."
+    group_id: str | None = None
+    env_file: str | None = None
+    enable_idempotence: bool = False
+
+
+@dataclass(frozen=True)
+class EnsureReport:
+    """What one ``run -d`` ensured: the per-target verdicts (plan order), and — when something
+    was spawned — the supervisor pid (the process ``stop`` signals) and its log."""
+
+    outcomes: tuple[TargetOutcome, ...]
+    pid: int | None
+    log_path: str | None
+
+
+async def ensure_agents(
+    plan: Sequence[TargetNodes],
+    target: Target,
+    mesh: PresenceReader,
+    *,
+    run_args: RunOptions,
+    timeout: float = READY_TIMEOUT,
+    poll_interval: float = _POLL_INTERVAL,
+) -> EnsureReport:
+    """Connect-or-spawn the plan's targets as ONE detached daemon (spec §5.1), returning only
+    once its names are online. The whole check→spawn→readiness section runs under the
+    agent-layer flock."""
+    with agents_lock():
+        reused, to_launch = await evaluate_targets(plan, target.key, mesh)
+        if not to_launch:
+            return EnsureReport(outcomes=tuple(reused), pid=None, log_path=None)
+        log_path = daemon_log_path(target.key, tuple(t.spec for t in to_launch))
+        proc = _spawn_daemon(to_launch, target, log_path, run_args)
+        await wait_agents_ready(
+            proc,
+            [n for t in to_launch for n in t.agent_names],
+            [n for t in to_launch for n in t.tool_names],
+            mesh,
+            log_path=str(log_path),
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
+        by_spec = {outcome.target.spec: outcome for outcome in reused}
+        outcomes = tuple(by_spec.get(t.spec, TargetOutcome(target=t, reused=False)) for t in plan)
+        return EnsureReport(outcomes=outcomes, pid=proc.pid, log_path=str(log_path))
+
+
+def _spawn_daemon(to_launch: Sequence[TargetNodes], target: Target, log_path: Path, options: RunOptions) -> Any:
+    """Spawn the daemon tree — the broker's shipped ``Popen`` pattern verbatim (detached session
+    leader, real log-file fd, ``DEVNULL`` stdin) around the §5.1 argv: the child re-invokes the
+    CLI (``-m calfkit.cli run``) with the normalized host, the caller's options, the ownership
+    marker, and the 5s heartbeat preset."""
+    cmd = [sys.executable, "-m", "calfkit.cli", "run", *(t.spec for t in to_launch)]
+    cmd += ["--host", target.listener if target.is_single else target.bootstrap]
+    if options.provision:
+        cmd.append("--provision")
+    if options.reload:
+        cmd.append("--reload")
+    for directory in options.reload_dir or ():
+        cmd += ["--reload-dir", directory]
+    if options.app_dir != ".":
+        cmd += ["--app-dir", options.app_dir]
+    if options.group_id:
+        cmd += ["--group-id", options.group_id]
+    if options.env_file:
+        cmd += ["--env-file", options.env_file]
+    if options.enable_idempotence:
+        cmd.append("--enable-idempotence")
+    names = [name for t in to_launch for name in t.names]
+    cmd.append(f"{MARKER_FLAG}={','.join(names)}")
+    cmd += ["--heartbeat-interval", str(DEV_HEARTBEAT_INTERVAL)]
+    # Overwritten each spawn — bounded logs, consult them BEFORE relaunching (spec §9). A real
+    # file fd, never PIPE: an unread pipe would deadlock the worker once its buffer fills.
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_file = log_path.open("wb")
+    except OSError as exc:
+        raise DevAgentError(f"cannot write the agent daemon log at {log_path}: {exc}") from exc
+    with log_file:
+        try:
+            return Popen(cmd, stdin=subprocess.DEVNULL, stdout=log_file, stderr=log_file, **_detach_kwargs())  # type: ignore[call-overload]
+        except OSError as exc:
+            raise DevAgentError(f"failed to launch the agent daemon: {exc}") from exc

--- a/calfkit/cli/_dev_agents.py
+++ b/calfkit/cli/_dev_agents.py
@@ -47,9 +47,11 @@ from calfkit.models.agents import AGENTS_TOPIC
 from calfkit.models.capability import CAPABILITY_TOPIC
 
 MARKER_FLAG = "--dev-daemon"
-"""The argv ownership marker (spec §5.4): an *agent daemon* is any live process whose cmdline
-carries this flag. Internal — humans launch daemons via ``ck dev run -d``, never by hand-setting
-the marker (a hand-set marker IS managed, though: "whoever started it", the broker rule)."""
+"""The argv ownership marker (spec §5.4): an *agent daemon* is a live process whose cmdline
+carries this flag in its emitted ``--dev-daemon=<names>`` form alongside a ``run`` token (the
+two anchors — see :func:`_daemon_marker_names`). Internal — humans launch daemons via
+``ck dev run -d``, never by hand-setting the marker (a hand-set marker on a real ``run`` command
+line IS managed, though: "whoever started it", the broker rule)."""
 
 READY_TIMEOUT = 15.0
 """The readiness gate's deadline (spec §5.2, Ryan-confirmed): how long a launch waits for every
@@ -207,7 +209,8 @@ def _daemon_marker_names(cmd: list[str]) -> tuple[str, ...]:
     a ``--dev-daemon=<names>`` token on a command line that also carries a ``run`` token — the
     two anchors every real spawn (and hand-run ``ck run``) has. A bare ``--dev-daemon`` token or
     the ``=``-form appearing as *data* in some other process's argv (``rg -- --dev-daemon …``)
-    must never match: a false hit here is what ``stop``/``down`` group-kill."""
+    does not match — both anchors are required (a false hit here is what ``stop``/``down``
+    group-kill; an argv carrying BOTH anchors as data remains a theoretical residual)."""
     if "run" not in cmd:
         return ()
     prefix = f"{MARKER_FLAG}="
@@ -367,9 +370,12 @@ async def wait_agents_ready(
             if proc is not None:
                 _kill_spawn_group(proc)
             if last_read_failure is not None:
+                # Claim only what is known — the LAST read (the view may have been readable for
+                # most of the wait before a late failure; round-2 wording fix).
                 raise DevAgentError(
-                    f"the presence view never became readable within {timeout:.1f}s "
-                    f"({last_read_failure.reason}: {last_read_failure}){_tail_suffix(log_path)}"
+                    f"the launched agents did not come online within {timeout:.1f}s and the last "
+                    f"presence read failed ({last_read_failure.reason}: {last_read_failure})"
+                    f"{_tail_suffix(log_path)}"
                 ) from last_read_failure
             raise DevAgentError(f"the launched agents did not come online within {timeout:.1f}s{_tail_suffix(log_path)}")
         await asyncio.sleep(poll_interval)

--- a/calfkit/cli/_dev_broker.py
+++ b/calfkit/cli/_dev_broker.py
@@ -527,19 +527,34 @@ def _signal(proc: Any, *, pid: int, label: str, grace: float, group: bool = Fals
     def _send(sig: int) -> None:
         # The group path signals via killpg (ProcessLookupError/PermissionError are the OS-level
         # twins of psutil's NoSuchProcess/AccessDenied, handled below); the single path keeps
-        # psutil's own calls so the scan-verified handle is what gets signalled.
+        # psutil's own calls so the scan-verified handle is what gets signalled. Before a raw
+        # killpg, the identity-checked handle must still be running (live or unreaped-zombie —
+        # either way the pgid cannot have been recycled): a daemon that exited between scan and
+        # signal may have had its pid reused by an innocent process GROUP (review round 1).
         if group:
+            if not proc.is_running():
+                raise psutil.NoSuchProcess(pid)
             _killpg(pid, sig)
         elif sig == signal_module.SIGTERM:
             proc.terminate()
         else:
             proc.kill()
 
+    def _final_group_sweep() -> None:
+        # Leader death says nothing about the rest of the group: a SIGTERM-surviving descendant
+        # (a node's own subprocess) would otherwise outlive the 'stopped' report — markerless,
+        # so unmanageable forever (review round 1). One unconditional SIGKILL sweeps the
+        # now-headless tree; an already-empty or zombie-only group absorbs it as a no-op.
+        with suppress(ProcessLookupError, PermissionError):
+            _killpg(pid, signal_module.SIGKILL)
+
     try:
         _send(signal_module.SIGTERM)
         if _wait_or_gone():
+            if group:
+                _final_group_sweep()
             return True
-        _send(signal_module.SIGKILL)
+        _send(signal_module.SIGKILL)  # group mode: this already swept the whole group
         if not _wait_or_gone():
             raise DevBrokerError(f"{label} survived SIGKILL for {grace:.1f}s.")
     except (psutil.NoSuchProcess, ProcessLookupError):

--- a/calfkit/cli/_dev_broker.py
+++ b/calfkit/cli/_dev_broker.py
@@ -524,6 +524,8 @@ def _signal(proc: Any, *, pid: int, label: str, grace: float, group: bool = Fals
                 if remaining <= 0.1:
                     return False
 
+    group_signal_delivered = False
+
     def _send(sig: int) -> None:
         # The group path signals via killpg (ProcessLookupError/PermissionError are the OS-level
         # twins of psutil's NoSuchProcess/AccessDenied, handled below); the single path keeps
@@ -531,10 +533,12 @@ def _signal(proc: Any, *, pid: int, label: str, grace: float, group: bool = Fals
         # killpg, the identity-checked handle must still be running (live or unreaped-zombie —
         # either way the pgid cannot have been recycled): a daemon that exited between scan and
         # signal may have had its pid reused by an innocent process GROUP (review round 1).
+        nonlocal group_signal_delivered
         if group:
             if not proc.is_running():
                 raise psutil.NoSuchProcess(pid)
             _killpg(pid, sig)
+            group_signal_delivered = True
         elif sig == signal_module.SIGTERM:
             proc.terminate()
         else:
@@ -558,7 +562,13 @@ def _signal(proc: Any, *, pid: int, label: str, grace: float, group: bool = Fals
         if not _wait_or_gone():
             raise DevBrokerError(f"{label} survived SIGKILL for {grace:.1f}s.")
     except (psutil.NoSuchProcess, ProcessLookupError):
-        pass  # exited between the scan and the signal — the goal state (stopped) is reached
+        # Exited between the scan and the signal — the goal state (stopped) is reached. Group
+        # mode, round 2: if a group signal WAS already delivered this call (the leader died
+        # mid-ladder), descendants may remain and any survivor keeps the pgid reserved — sweep.
+        # If nothing was ever delivered (the identity gate refused the first send), the pid may
+        # belong to a recycled, innocent group: never sweep.
+        if group and group_signal_delivered:
+            _final_group_sweep()
     except (psutil.AccessDenied, PermissionError):
         return False  # someone else's process — never signalled further; callers decide how to report
     return True

--- a/calfkit/cli/_dev_broker.py
+++ b/calfkit/cli/_dev_broker.py
@@ -457,7 +457,7 @@ def stop(target: Target, *, grace: float = DEFAULT_GRACE) -> bool:
     hit = _find_dev_broker(target.listener)
     if hit is None:
         return False
-    if not _signal(hit, grace):
+    if not _signal(hit.proc, pid=hit.pid, label=f"the dev broker at {hit.listener} (pid {hit.pid})", grace=grace):
         raise DevBrokerError(f"cannot stop the dev broker at {hit.listener} (pid {hit.pid}) — it is owned by another user.")
     return True
 
@@ -472,39 +472,51 @@ def stop_all(*, grace: float = DEFAULT_GRACE) -> list[str]:
     stopped: list[str] = []
     for hit in _scan_dev_brokers():
         try:
-            if _signal(hit, grace):
+            if _signal(hit.proc, pid=hit.pid, label=f"the dev broker at {hit.listener} (pid {hit.pid})", grace=grace):
                 stopped.append(hit.listener)
         except DevBrokerError as exc:
             print(f"warning: {exc}", file=sys.stderr)
     return stopped
 
 
-def _signal(hit: _ScanHit, grace: float) -> bool:
-    """SIGTERM → *grace* → SIGKILL one scan hit. ``True`` = stopped, ``False`` = access denied.
+def _killpg(pgid: int, sig: int) -> None:
+    """Signal a whole process group — the agent-daemon ``-d`` spawn is a session leader, so its
+    pid is the pgid and one signal reaps supervisor + worker + multiprocessing helpers together
+    (dev-agent-lifecycle spec §3.4). A call-time ``os`` attribute lookup (``killpg`` does not
+    exist on Windows, and module import must stay platform-safe) and the test seam — tests
+    replace this, never deliver a live group signal."""
+    os.killpg(pgid, sig)
 
-    A broker whose spawning ``ck dev run`` is still alive dies into an **unreaped zombie** (spec
-    §5.8: the parent reaps only at its own exit), and psutil's non-child ``wait`` never returns
-    for a zombie — so a post-wait timeout with ``status() == zombie`` IS the stopped state, not
-    a failure.
+
+def _signal(proc: Any, *, pid: int, label: str, grace: float, group: bool = False) -> bool:
+    """SIGTERM → *grace* → SIGKILL one scanned process — or, with ``group=True``, its whole
+    process group (the agent-daemon path: the leader's pid IS the pgid). ``True`` = stopped,
+    ``False`` = access denied; *label* names the process in the survived-SIGKILL error.
+
+    A process whose spawning parent is still alive dies into an **unreaped zombie** (the parent
+    reaps only at its own exit), and psutil's non-child ``wait`` never returns for a zombie — so
+    a post-wait timeout with ``status() == zombie`` IS the stopped state, not a failure.
     """
-    import psutil  # already importable: the scan produced the hit (mypy flags the module once, on the scan's import)
+    import signal as signal_module
+
+    import psutil  # already importable: the scan produced the process handle (mypy flags the module once, on the scan's import)
 
     def _is_gone() -> bool:
         try:
-            zombie: bool = hit.proc.status() == psutil.STATUS_ZOMBIE
+            zombie: bool = proc.status() == psutil.STATUS_ZOMBIE
         except psutil.NoSuchProcess:
             return True
         return zombie
 
     def _wait_or_gone() -> bool:
         # psutil's non-child wait polls pid_exists, which a zombie passes — it would eat the
-        # whole grace for an already-dead broker. Wait in short slices, checking the zombie
-        # status between them, so the common case (stop while `ck dev run` is alive) is instant.
+        # whole grace for an already-dead process. Wait in short slices, checking the zombie
+        # status between them, so the common case (stop while the spawner is alive) is instant.
         deadline = time.monotonic() + grace
         while True:
             remaining = deadline - time.monotonic()
             try:
-                hit.proc.wait(min(0.1, max(0.01, remaining)))
+                proc.wait(min(0.1, max(0.01, remaining)))
                 return True
             except psutil.TimeoutExpired:
                 if _is_gone():
@@ -512,17 +524,28 @@ def _signal(hit: _ScanHit, grace: float) -> bool:
                 if remaining <= 0.1:
                     return False
 
+    def _send(sig: int) -> None:
+        # The group path signals via killpg (ProcessLookupError/PermissionError are the OS-level
+        # twins of psutil's NoSuchProcess/AccessDenied, handled below); the single path keeps
+        # psutil's own calls so the scan-verified handle is what gets signalled.
+        if group:
+            _killpg(pid, sig)
+        elif sig == signal_module.SIGTERM:
+            proc.terminate()
+        else:
+            proc.kill()
+
     try:
-        hit.proc.terminate()
+        _send(signal_module.SIGTERM)
         if _wait_or_gone():
             return True
-        hit.proc.kill()
+        _send(signal_module.SIGKILL)
         if not _wait_or_gone():
-            raise DevBrokerError(f"the dev broker at {hit.listener} (pid {hit.pid}) survived SIGKILL for {grace:.1f}s.")
-    except psutil.NoSuchProcess:
+            raise DevBrokerError(f"{label} survived SIGKILL for {grace:.1f}s.")
+    except (psutil.NoSuchProcess, ProcessLookupError):
         pass  # exited between the scan and the signal — the goal state (stopped) is reached
-    except psutil.AccessDenied:
-        return False  # someone else's broker — never signalled further; callers decide how to report
+    except (psutil.AccessDenied, PermissionError):
+        return False  # someone else's process — never signalled further; callers decide how to report
     return True
 
 

--- a/calfkit/cli/_dev_broker.py
+++ b/calfkit/cli/_dev_broker.py
@@ -277,26 +277,31 @@ def _calfkit_dir() -> Path:
 
 
 @contextmanager
-def _spawn_lock() -> Iterator[None]:
-    """Hold a blocking, exclusive advisory lock over the spawn critical section.
+def _spawn_lock(
+    filename: str = "dev-mesh.lock",
+    waiting_message: str = "waiting for the dev broker to start…",
+) -> Iterator[None]:
+    """Hold a blocking, exclusive advisory lock over a spawn critical section.
 
     Exists ONLY for the double-spawn race (spec §5.3); ``stop``/``status`` never take it. Released
     by the OS if the holder dies, so a crashed process never deadlocks the file. A contended lock
-    announces itself ("waiting for the dev broker to start…") before blocking.
+    announces itself (*waiting_message*) before blocking. The defaults are the broker's; the
+    agent-daemon layer reuses the pattern verbatim with its own lock file (dev-agent-lifecycle
+    spec §5.1).
     """
     import fcntl
 
     root = _calfkit_dir()
     try:
         root.mkdir(parents=True, exist_ok=True)
-        fd = os.open(root / "dev-mesh.lock", os.O_CREAT | os.O_RDWR, 0o644)
+        fd = os.open(root / filename, os.O_CREAT | os.O_RDWR, 0o644)
     except OSError as exc:
         raise DevBrokerError(f"cannot access the calfkit state dir {root}: {exc}") from exc
     try:
         try:
             fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except BlockingIOError:
-            print("waiting for the dev broker to start…", file=sys.stderr)
+            print(waiting_message, file=sys.stderr)
             fcntl.flock(fd, fcntl.LOCK_EX)
         except OSError as exc:  # e.g. ENOLCK on an NFS home — exit-2 material, not a crash
             raise DevBrokerError(f"cannot lock the calfkit state dir {root}: {exc}") from exc

--- a/calfkit/cli/_run.py
+++ b/calfkit/cli/_run.py
@@ -50,6 +50,7 @@ def serve(
     env_file: str | None,
     app_dir: str,
     enable_idempotence: bool = False,
+    heartbeat_interval: float | None = None,
 ) -> None:
     """Resolve targets and run them in a single Worker until stopped.
 
@@ -65,6 +66,11 @@ def serve(
             support; when set it flows to ``Client.connect`` as the single knob that
             hardens every producer (broker + control-plane + fan-out writers). Absent,
             calfkit sets nothing (``enable_idempotence=None``).
+        heartbeat_interval: Control-plane heartbeat cadence override in seconds (the
+            hidden ``--heartbeat-interval`` — ``ck dev``'s 5s preset, dev-agent-lifecycle
+            spec §5.6). ``None`` (default) passes no ``ControlPlaneConfig`` so the
+            worker's production default applies. A plain float so the reload
+            supervisor's picklable-args contract holds.
 
     Raises:
         typer.Exit: (code 2) on a bad spec, import failure, non-node object, or
@@ -76,15 +82,17 @@ def serve(
     # Import the broker-facing modules only after the targets validate, so a
     # bad spec fails fast without paying these imports.
     from calfkit.client import Client
+    from calfkit.controlplane import ControlPlaneConfig
     from calfkit.provisioning import ProvisioningConfig
     from calfkit.worker import Worker
 
     server_urls = _parse_host(host)
     provisioning = ProvisioningConfig(enabled=True) if provision else None
+    control_plane = ControlPlaneConfig(heartbeat_interval=heartbeat_interval) if heartbeat_interval is not None else None
     # The CLI flag is opt-in only: absent -> None so calfkit imposes nothing (library defaults);
     # --enable-idempotence -> True threads idempotence to every producer via the client.
     client = Client.connect(server_urls, provisioning=provisioning, enable_idempotence=True if enable_idempotence else None)
-    worker = Worker(client, nodes=nodes, group_id=group_id)
+    worker = Worker(client, nodes=nodes, group_id=group_id, control_plane=control_plane)
 
     _print_banner(nodes, server_urls, provision, enable_idempotence)
     asyncio.run(worker.run())

--- a/calfkit/cli/chat.py
+++ b/calfkit/cli/chat.py
@@ -15,11 +15,15 @@ from __future__ import annotations
 
 import asyncio
 import traceback
+from typing import TYPE_CHECKING, Any
 
 import typer
 
 from calfkit.cli._common import _load_env, _parse_host
 from calfkit.exceptions import MeshUnavailableError
+
+if TYPE_CHECKING:
+    from collections.abc import Coroutine
 
 # Reason -> remedy hint for an unusable mesh directory (the closed
 # MeshUnavailableError.reason set; ``.get`` degrades gracefully if it ever grows).
@@ -67,11 +71,18 @@ def chat(
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(2) from exc
 
-    # The session runs in a SEPARATE try: a ValueError raised in here (e.g. a pydantic
-    # ValidationError, which subclasses ValueError) is a real bug and must propagate with its
-    # traceback — not be masked as a clean config-error Exit(2).
+    run_session_command(run_chat_session(name, server_urls, timeout, provision))
+
+
+def run_session_command(session: Coroutine[Any, Any, None]) -> None:
+    """The shared command boundary around a chat session (``ck chat`` and ``ck dev chat``).
+
+    Runs the session in a try SEPARATE from any config parsing: a ValueError raised in here
+    (e.g. a pydantic ValidationError, which subclasses ValueError) is a real bug and must
+    propagate with its traceback — not be masked as a clean config-error Exit(2).
+    """
     try:
-        asyncio.run(run_chat_session(name, server_urls, timeout, provision))
+        asyncio.run(session)
     except KeyboardInterrupt:
         # Ctrl-C at a prompt or mid-turn: a clean stop, not a traceback (the
         # add_reader-based reader cancels cleanly — see _chat_io).

--- a/calfkit/cli/dev.py
+++ b/calfkit/cli/dev.py
@@ -268,9 +268,11 @@ def _format_age(seconds: float) -> str:
 
 @dev_app.command(name="chat")
 def dev_chat(
-    name: str | None = typer.Argument(
+    args: list[str] | None = typer.Argument(
         None,
-        help="Agent to chat with. Omit to pick from the list of online agents.",
+        help="An agent NAME to attach to, or 'module:attr' TARGET(s) to run as a session worker "
+        "inside this chat process (they stop when the session ends). Omit to pick from the "
+        "online agents.",
     ),
     host: str | None = typer.Option(None, "--host", "-H", help=_HOST_HELP),
     provision: bool = typer.Option(
@@ -291,16 +293,59 @@ def dev_chat(
 ) -> None:
     """Chat with an agent on the local dev mesh, spawning its broker if needed."""
     _load_env(env_file)
+    # The §3.2 grammar: an argument containing ':' is a module:attr target; a bare word is an
+    # agent name. Mixing them, or more than one bare name, is a usage error.
+    values = list(args or [])
+    target_specs = [value for value in values if ":" in value]
+    names = [value for value in values if ":" not in value]
+    if target_specs and names:
+        typer.echo(
+            "Error: cannot mix agent names and 'module:attr' targets — attach to ONE online agent by name, or launch target(s) for this session.",
+            err=True,
+        )
+        raise typer.Exit(2)
+    if len(names) > 1:
+        typer.echo(
+            f"Error: chat attaches to one agent, got {len(names)} names ({', '.join(names)}); pass one name or omit it to pick.",
+            err=True,
+        )
+        raise typer.Exit(2)
+    if target_specs:
+        _chat_targets(target_specs, host=host, provision=provision, env_file=env_file, timeout=timeout)
+        return
     servers = resolve_mesh_url(_parse_host(host))
     target = _normalize_or_exit(servers)
     _ensure_or_exit(target)
     _chat_command(
-        name=name,
+        name=names[0] if names else None,
         host=_forward_host(target),
         provision=provision,
         env_file=env_file,
         timeout=timeout,
     )
+
+
+def _chat_targets(targets: list[str], *, host: str | None, provision: bool, env_file: str | None, timeout: float | None) -> None:
+    """The ``chat TARGET...`` session mode (agent-lifecycle spec §3.2): ensure the broker,
+    preflight the targets, then run the in-process session — the worker lives inside the chat
+    process and dies with it, atomically, by construction. No reload (an in-process worker
+    cannot re-import user code): the edit loop is save → /exit → rerun."""
+    target = _normalize_or_exit(resolve_mesh_url(_parse_host(host)))
+    _ensure_or_exit(target)
+    try:
+        plan = _dev_agents.preflight(targets, app_dir=".")
+    except _dev_agents.DevAgentError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(2) from exc
+    from calfkit.cli import chat as chat_module
+    from calfkit.cli._chat import run_chat_session
+
+    session = run_chat_session(None, _forward_host(target), timeout, provision, session_plan=plan, session_host_key=target.key)
+    try:
+        chat_module.run_session_command(session)
+    except _dev_agents.DevAgentError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(2) from exc
 
 
 _ENV_FILE_HELP = "Path to a dotenv file to load. Defaults to ./.env if present."

--- a/calfkit/cli/dev.py
+++ b/calfkit/cli/dev.py
@@ -1,13 +1,18 @@
 """The ``ck dev`` command group — a calfkit project against a zero-setup local mesh (spec §4).
 
-``ck dev run`` / ``ck dev chat`` are thin wrappers: load ``.env`` **first** (so a ``.env``-set
-``CALFKIT_MESH_URL`` is visible when the address is normalized), resolve + normalize the host,
-**ensure** a broker there via the connect-or-spawn supervisor, print the managed-vs-reused line,
-then delegate to the existing ``run()``/``chat()`` command functions forwarding every argument
-explicitly — with the **normalized** ``listen_ip:port`` as ``host`` (a multi-address borrow
-forwards the user's list unchanged). The preset: provisioning ON (Tansu has no topic auto-create),
-reload ON (``dev run`` only), idempotence OFF. ``ck dev broker`` controls the managed daemon
-directly.
+Every command loads ``.env`` **first** (so a ``.env``-set ``CALFKIT_MESH_URL`` is visible when
+the address is normalized), resolves + normalizes the host, and **ensures** a broker there via
+the connect-or-spawn supervisor with the managed-vs-reused line printed — with the **normalized**
+``listen_ip:port`` as ``host`` (a multi-address borrow forwards the user's list unchanged). The
+preset: provisioning ON (Tansu has no topic auto-create), reload ON (``dev run`` only),
+idempotence OFF.
+
+Four surfaces (agent-lifecycle spec §3): foreground ``dev run`` delegates to the top-level
+``run()`` command function forwarding every argument explicitly; ``dev run -d`` connect-or-spawns
+a detached agent daemon via :mod:`calfkit.cli._dev_agents`; ``dev chat`` attaches (or, given
+targets, runs an in-process session worker) through ``run_chat_session`` directly; and
+``status``/``stop``/``down`` manage the daemons the argv-marker scan owns. ``ck dev broker``
+controls the broker daemon directly.
 
 Import hygiene (load-bearing): ``_build_app()`` imports this module on **every** ``ck``
 invocation, so nothing here may import ``psutil`` or ``calfkit_mesh`` at module top — both belong
@@ -25,7 +30,6 @@ import typer
 from calfkit.cli import _dev_agents, _dev_broker
 from calfkit.cli._common import _load_env, _parse_host
 from calfkit.cli._dev_broker import BrokerInfo, DevBrokerError, Target, normalize
-from calfkit.cli.chat import chat as _chat_command
 from calfkit.cli.run import run as _run_command
 from calfkit.client._mesh_url import resolve_mesh_url
 
@@ -107,7 +111,7 @@ def dev_run(
         False,
         "--detach",
         "-d",
-        help="Launch as a detached agent daemon: return once the agents are online; they run until 'ck dev stop'.",
+        help="Launch as a detached agent daemon: return once the agents/tools are online; they run until 'ck dev stop'.",
     ),
     host: str | None = typer.Option(None, "--host", "-H", help=_HOST_HELP),
     provision: bool = typer.Option(
@@ -317,13 +321,43 @@ def dev_chat(
     servers = resolve_mesh_url(_parse_host(host))
     target = _normalize_or_exit(servers)
     _ensure_or_exit(target)
-    _chat_command(
-        name=names[0] if names else None,
-        host=_forward_host(target),
-        provision=provision,
-        env_file=env_file,
-        timeout=timeout,
+    _chat_attach(names[0] if names else None, target, provision=provision, timeout=timeout)
+
+
+def _chat_attach(name: str | None, target: Target, *, provision: bool, timeout: float | None) -> None:
+    """The attach path (no args / bare NAME): the plain chat session, plus the dev layer's §7
+    offline-daemon hint — a named agent that turns out offline gets the marker-scan diagnosis
+    (its daemon exists but stopped advertising: broken edit / mid-restart) appended to the
+    shipped not-online error."""
+    from calfkit.cli import chat as chat_module
+    from calfkit.cli._chat import run_chat_session
+
+    session = run_chat_session(
+        name,
+        _forward_host(target),
+        timeout,
+        provision,
+        offline_daemon_hint=_offline_daemon_hint(target.key),
     )
+    chat_module.run_session_command(session)
+
+
+def _offline_daemon_hint(host_key: str) -> Any:
+    """Build the §7 hint provider: scan the marker daemons at *host_key* for one owning the
+    offline name. Degrades to no hint on a core install (the scan needs the ``[mesh]`` extra) —
+    the shipped not-online error then stands alone."""
+
+    def hint(name: str) -> str | None:
+        try:
+            daemons = _dev_agents.find_daemons(host_key)
+        except DevBrokerError:  # incl. MeshExtraMissingError — never let the hint break the error
+            return None
+        owner = next((daemon for daemon in daemons if name in daemon.names), None)
+        if owner is None:
+            return None
+        return f"a managed daemon for '{name}' exists but its agents are offline — logs: {owner.log_path} (ck dev status)"
+
+    return hint
 
 
 def _chat_targets(targets: list[str], *, host: str | None, provision: bool, env_file: str | None, timeout: float | None) -> None:
@@ -344,7 +378,10 @@ def _chat_targets(targets: list[str], *, host: str | None, provision: bool, env_
     session = run_chat_session(None, _forward_host(target), timeout, provision, session_plan=plan, session_host_key=target.key)
     try:
         chat_module.run_session_command(session)
-    except _dev_agents.DevAgentError as exc:
+    except (_dev_agents.DevAgentError, DevBrokerError) as exc:
+        # DevBrokerError covers MeshExtraMissingError from the lazy daemon scan inside the
+        # session's connect-or-spawn evaluation (a core install): exit 2 with the install hint,
+        # never a raw traceback.
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(2) from exc
 
@@ -384,19 +421,31 @@ def dev_status(
 
 async def _read_presence_maps(target: Target) -> tuple[dict[str, Any], dict[str, Any]]:
     """One point-in-time presence snapshot per kind via a short-lived client; an unusable view
-    (not created yet / still establishing / reader died) degrades to empty, never errors."""
+    degrades to empty, never errors.
+
+    The degrade is silent only for ``open_failed`` (the spec'd first-run state: no presence
+    plane yet ⇒ zero online rows). Any other reason (``establishing``, ``reader_dead``) is a
+    read failure on a reachable mesh — rendered the same way, but announced on stderr so the
+    degraded table never masquerades as a healthy empty mesh (review round 1, Ryan-approved).
+    """
     from calfkit.client import Client
     from calfkit.exceptions import MeshUnavailableError
+
+    def _warn_unless_first_run(kind: str, exc: MeshUnavailableError) -> None:
+        if exc.reason != "open_failed":
+            typer.echo(f"warning: presence unreadable ({kind} view, {exc.reason}): {exc}", err=True)
 
     client = Client.connect(_forward_host(target))
     try:
         try:
             agents = dict(await client.mesh.get_agents())
-        except MeshUnavailableError:
+        except MeshUnavailableError as exc:
+            _warn_unless_first_run("agents", exc)
             agents = {}
         try:
             tools = dict(await client.mesh.get_tools())
-        except MeshUnavailableError:
+        except MeshUnavailableError as exc:
+            _warn_unless_first_run("tools", exc)
             tools = {}
     finally:
         await client.aclose()
@@ -497,13 +546,19 @@ def _echo_stopped(hit: _dev_agents.DaemonHit) -> None:
 
 
 def _stop_daemon_sweep(daemons: list[_dev_agents.DaemonHit]) -> None:
-    """Stop every given daemon, narrated; a denied one warns and never aborts the sweep (the
-    broker stop_all discipline)."""
+    """Stop every given daemon, narrated; a denied or stuck one warns and never aborts the sweep
+    (the broker stop_all discipline) — one bad daemon must not leave the rest running or skip
+    ``down``'s broker stop."""
     if not daemons:
         typer.echo("no agent daemons to stop")
         return
     for hit in daemons:
-        if _dev_agents.stop_daemon(hit):
+        try:
+            stopped = _dev_agents.stop_daemon(hit)
+        except DevBrokerError as exc:  # e.g. survived SIGKILL — warn and keep sweeping
+            typer.echo(f"warning: {exc}", err=True)
+            continue
+        if stopped:
             _echo_stopped(hit)
         else:
             typer.echo(f"warning: cannot stop the agent daemon (pid {hit.pid}) — it is owned by another user.", err=True)

--- a/calfkit/cli/dev.py
+++ b/calfkit/cli/dev.py
@@ -101,6 +101,18 @@ def _forward_host(target: Target) -> str:
     return target.listener if target.is_single else target.bootstrap
 
 
+def _session_servers(target: Target) -> str | list[str]:
+    """The bootstrap value for a client/session opened DIRECTLY by this module (review round 2,
+    R2-M1): ``resolve_mesh_url`` never comma-splits a bare string, so a multi-address borrow must
+    hand over the user's elements as a list (``target.servers`` — the same value the reachability
+    probe uses); handing it the comma-joined ``bootstrap`` would dial one malformed element. The
+    single-address case stays the normalized listener string, byte-identical to before.
+
+    Distinct from :func:`_forward_host`, which feeds delegated COMMANDS (``ck run``'s ``--host``
+    string / the daemon argv) whose own ``_parse_host`` does the splitting."""
+    return target.listener if target.is_single else list(target.servers)
+
+
 @dev_app.command(name="run")
 def dev_run(
     targets: list[str] = typer.Argument(
@@ -240,7 +252,7 @@ async def _ensure_agents_with_client(
     snapshot source; closed on every path so the CLI never leaks a consumer."""
     from calfkit.client import Client
 
-    client = Client.connect(_forward_host(target))
+    client = Client.connect(_session_servers(target))
     try:
         return await _dev_agents.ensure_agents(plan, target, client.mesh, run_args=run_args)
     finally:
@@ -334,7 +346,7 @@ def _chat_attach(name: str | None, target: Target, *, provision: bool, timeout: 
 
     session = run_chat_session(
         name,
-        _forward_host(target),
+        _session_servers(target),
         timeout,
         provision,
         offline_daemon_hint=_offline_daemon_hint(target.key),
@@ -375,7 +387,7 @@ def _chat_targets(targets: list[str], *, host: str | None, provision: bool, env_
     from calfkit.cli import chat as chat_module
     from calfkit.cli._chat import run_chat_session
 
-    session = run_chat_session(None, _forward_host(target), timeout, provision, session_plan=plan, session_host_key=target.key)
+    session = run_chat_session(None, _session_servers(target), timeout, provision, session_plan=plan, session_host_key=target.key)
     try:
         chat_module.run_session_command(session)
     except (_dev_agents.DevAgentError, DevBrokerError) as exc:
@@ -435,7 +447,7 @@ async def _read_presence_maps(target: Target) -> tuple[dict[str, Any], dict[str,
         if exc.reason != "open_failed":
             typer.echo(f"warning: presence unreadable ({kind} view, {exc.reason}): {exc}", err=True)
 
-    client = Client.connect(_forward_host(target))
+    client = Client.connect(_session_servers(target))
     try:
         try:
             agents = dict(await client.mesh.get_agents())

--- a/calfkit/cli/dev.py
+++ b/calfkit/cli/dev.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import typer
 
-from calfkit.cli import _dev_broker
+from calfkit.cli import _dev_agents, _dev_broker
 from calfkit.cli._common import _load_env, _parse_host
 from calfkit.cli._dev_broker import BrokerInfo, DevBrokerError, Target, normalize
 from calfkit.cli.chat import chat as _chat_command
@@ -152,6 +152,12 @@ def dev_run(
         app_dir=app_dir,
         group_id=group_id,
         env_file=env_file,
+        # The hidden internals, forwarded explicitly with their dev presets so the
+        # forwards-every-parameter guard keeps its equality contract: the 5s heartbeat applies
+        # to foreground dev runs too (agent-lifecycle spec §5.6); a foreground run is never a
+        # daemon, so no ownership marker.
+        dev_daemon=None,
+        heartbeat_interval=_dev_agents.DEV_HEARTBEAT_INTERVAL,
     )
 
 

--- a/calfkit/cli/dev.py
+++ b/calfkit/cli/dev.py
@@ -18,6 +18,7 @@ the supervisor's spawn branch.
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 import typer
 
@@ -344,6 +345,188 @@ def _chat_targets(targets: list[str], *, host: str | None, provision: bool, env_
     try:
         chat_module.run_session_command(session)
     except _dev_agents.DevAgentError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(2) from exc
+
+
+# --- status / stop / down: the agent-daemon management surface (agent-lifecycle spec §3.3/§3.4) --------
+
+_STATUS_HEADER = ("KIND", "NAME", "STATE", "PID", "SINCE", "TARGET", "LOGS")
+_EMPTY = "—"
+
+
+@dev_app.command(name="status")
+def dev_status(
+    host: str | None = typer.Option(None, "--host", "-H", help=_HOST_HELP),
+    env_file: str | None = typer.Option(None, "--env-file", help="Path to a dotenv file to load. Defaults to ./.env if present."),
+) -> None:
+    """Show the broker, every online node, and the managed agent daemons — unfiltered.
+
+    Never errors on a down mesh: the broker line degrades, presence columns read
+    'unknown (mesh unreachable)', and daemon rows still render from the process scan.
+    """
+    target = _target_or_exit(host, env_file)
+    try:
+        broker_report = _dev_broker.status(target)
+        daemons = _dev_agents.find_daemons(target.key)
+    except DevBrokerError as exc:  # the scan needs the [mesh] extra — without it there is no answer
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(2) from exc
+    agents: dict[str, Any] = {}
+    tools: dict[str, Any] = {}
+    if broker_report.reachable:
+        # An unusable presence plane (open_failed on a fresh broker) reads as ZERO online rows —
+        # only an unreachable broker degrades the presence columns (spec §3.3).
+        agents, tools = asyncio.run(_read_presence_maps(target))
+    for line in _render_table(_status_rows(broker_report, daemons, agents, tools)):
+        typer.echo(line)
+
+
+async def _read_presence_maps(target: Target) -> tuple[dict[str, Any], dict[str, Any]]:
+    """One point-in-time presence snapshot per kind via a short-lived client; an unusable view
+    (not created yet / still establishing / reader died) degrades to empty, never errors."""
+    from calfkit.client import Client
+    from calfkit.exceptions import MeshUnavailableError
+
+    client = Client.connect(_forward_host(target))
+    try:
+        try:
+            agents = dict(await client.mesh.get_agents())
+        except MeshUnavailableError:
+            agents = {}
+        try:
+            tools = dict(await client.mesh.get_tools())
+        except MeshUnavailableError:
+            tools = {}
+    finally:
+        await client.aclose()
+    return agents, tools
+
+
+def _status_rows(
+    report: _dev_broker.MeshStatus,
+    daemons: list[_dev_agents.DaemonHit],
+    agents: dict[str, Any],
+    tools: dict[str, Any],
+) -> list[tuple[str, ...]]:
+    """The §3.3 join: broker row(s), then managed-daemon rows (scan ⋈ presence by name), then
+    every remaining online node — nothing online is ever filtered out (Ryan's transparency rule)."""
+    rows: list[tuple[str, ...]] = [_STATUS_HEADER]
+    target_elements = set(report.target_key.split(","))
+    managed_brokers = [broker for broker in report.brokers if broker.listener in target_elements]
+    for broker in managed_brokers:
+        rows.append(("broker", broker.listener, "running", str(broker.pid), broker.started_at or _EMPTY, _EMPTY, _EMPTY))
+    if not managed_brokers:
+        state = "reachable, not managed by calfkit" if report.reachable else "no broker reachable"
+        rows.append(("broker", report.target_key, state, _EMPTY, _EMPTY, _EMPTY, _EMPTY))
+    for hit in daemons:
+        for name in hit.names:
+            if name in agents:
+                kind, state = "agent", f"online (last seen {_format_age(_age_of(agents[name]))} ago)"
+            elif name in tools:
+                kind, state = "tool", f"online (last seen {_format_age(_age_of(tools[name]))} ago)"
+            elif not report.reachable:
+                kind, state = "unknown", "unknown (mesh unreachable)"
+            else:
+                # Daemon process alive, no presence record: crashed on a broken edit, mid-restart,
+                # or still booting — statelessly indistinguishable, so honestly unknown (Ryan,
+                # 2026-07-02), pointing at the LOGS column.
+                kind, state = "unknown", "unknown (see logs)"
+            rows.append((kind, name, state, str(hit.pid), hit.started_at, ",".join(hit.targets) or _EMPTY, hit.log_path))
+    managed_names = {name for hit in daemons for name in hit.names}
+    annotation = "not a ck dev daemon (stop it where it runs)"
+    for name, info in sorted(agents.items()):
+        if name not in managed_names:
+            rows.append(("agent", name, f"online (last seen {_format_age(_age_of(info))} ago) — {annotation}", _EMPTY, _EMPTY, _EMPTY, _EMPTY))
+    for name, info in sorted(tools.items()):
+        if name not in managed_names:
+            rows.append(("tool", name, f"online (last seen {_format_age(_age_of(info))} ago) — {annotation}", _EMPTY, _EMPTY, _EMPTY, _EMPTY))
+    return rows
+
+
+def _age_of(info: Any) -> float:
+    from datetime import datetime, timezone
+
+    age: float = (datetime.now(tz=timezone.utc) - info.last_seen).total_seconds()
+    return age
+
+
+def _render_table(rows: list[tuple[str, ...]]) -> list[str]:
+    widths = [max(len(row[column]) for row in rows) for column in range(len(rows[0]))]
+    return ["  ".join(cell.ljust(widths[column]) for column, cell in enumerate(row)).rstrip() for row in rows]
+
+
+@dev_app.command(name="stop")
+def dev_stop(
+    names: list[str] | None = typer.Argument(None, help="Agent/tool name(s) whose daemon to stop (whole-daemon: co-hosted names stop together)."),
+    stop_all: bool = typer.Option(False, "--all", help="Stop every ck dev agent daemon on every address (ignores --host)."),
+    host: str | None = typer.Option(None, "--host", "-H", help=_HOST_HELP),
+    env_file: str | None = typer.Option(None, "--env-file", help="Path to a dotenv file to load. Defaults to ./.env if present."),
+) -> None:
+    """Stop agent daemon(s) by name; the broker stays up."""
+    try:
+        if stop_all:
+            _stop_daemon_sweep(_dev_agents.find_daemons(None))
+            return
+        if not names:
+            typer.echo("Error: pass agent name(s) to stop, or --all ('ck dev status' lists what is running).", err=True)
+            raise typer.Exit(2)
+        target = _target_or_exit(host, env_file)
+        daemons = _dev_agents.find_daemons(target.key)
+        # The online set feeds only the not-a-daemon explanation; read it just when a name
+        # is not covered by any daemon (and degrade to empty if the mesh is unusable).
+        online: set[str] = set()
+        if any(name not in {n for hit in daemons for n in hit.names} for name in names):
+            online = asyncio.run(_online_name_set(target))
+        for hit in _dev_agents.resolve_stop(names, daemons, host_key=target.key, online=online):
+            if not _dev_agents.stop_daemon(hit):
+                raise _dev_agents.DevAgentError(f"cannot stop the agent daemon (pid {hit.pid}) — it is owned by another user.")
+            _echo_stopped(hit)
+    except (_dev_agents.DevAgentError, DevBrokerError) as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(2) from exc
+
+
+async def _online_name_set(target: Target) -> set[str]:
+    agents, tools = await _read_presence_maps(target)
+    return set(agents) | set(tools)
+
+
+def _echo_stopped(hit: _dev_agents.DaemonHit) -> None:
+    typer.echo(f"stopped daemon pid {hit.pid} (agents: {', '.join(hit.names)})")
+
+
+def _stop_daemon_sweep(daemons: list[_dev_agents.DaemonHit]) -> None:
+    """Stop every given daemon, narrated; a denied one warns and never aborts the sweep (the
+    broker stop_all discipline)."""
+    if not daemons:
+        typer.echo("no agent daemons to stop")
+        return
+    for hit in daemons:
+        if _dev_agents.stop_daemon(hit):
+            _echo_stopped(hit)
+        else:
+            typer.echo(f"warning: cannot stop the agent daemon (pid {hit.pid}) — it is owned by another user.", err=True)
+
+
+@dev_app.command(name="down")
+def dev_down(
+    host: str | None = typer.Option(None, "--host", "-H", help=_HOST_HELP),
+    env_file: str | None = typer.Option(None, "--env-file", help="Path to a dotenv file to load. Defaults to ./.env if present."),
+) -> None:
+    """Stop every agent daemon, then the broker at the resolved address.
+
+    Foreground and chat-session workers survive by design (they carry no marker) and will error
+    against the stopped broker — stop them where they run.
+    """
+    target = _target_or_exit(host, env_file)
+    try:
+        _stop_daemon_sweep(_dev_agents.find_daemons(None))
+        if _dev_broker.stop(target):
+            typer.echo(f"stopped {target.key}")
+        else:
+            typer.echo(f"no managed broker at {target.key} (no memory-engine tansu is bound there)")
+    except (_dev_agents.DevAgentError, DevBrokerError) as exc:
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(2) from exc
 

--- a/calfkit/cli/dev.py
+++ b/calfkit/cli/dev.py
@@ -23,7 +23,7 @@ the supervisor's spawn branch.
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import typer
 
@@ -32,6 +32,9 @@ from calfkit.cli._common import _load_env, _parse_host
 from calfkit.cli._dev_broker import BrokerInfo, DevBrokerError, Target, normalize
 from calfkit.cli.run import run as _run_command
 from calfkit.client._mesh_url import resolve_mesh_url
+
+if TYPE_CHECKING:
+    from calfkit.client.mesh import AgentInfo, ToolInfo
 
 dev_app = typer.Typer(
     name="dev",
@@ -62,7 +65,7 @@ def _resolve_bin() -> str:
         if not (os.path.isfile(override) and os.access(override, os.X_OK)):
             raise DevBrokerError(f"CALF_TANSU_BIN={override!r} does not point at an executable file.")
         return override
-    from calfkit_mesh import resolve_broker_bin  # type: ignore[import-not-found]
+    from calfkit_mesh import resolve_broker_bin
 
     path: str = resolve_broker_bin()
     return path
@@ -431,7 +434,7 @@ def dev_status(
         typer.echo(line)
 
 
-async def _read_presence_maps(target: Target) -> tuple[dict[str, Any], dict[str, Any]]:
+async def _read_presence_maps(target: Target) -> tuple[dict[str, AgentInfo], dict[str, ToolInfo]]:
     """One point-in-time presence snapshot per kind via a short-lived client; an unusable view
     degrades to empty, never errors.
 
@@ -467,8 +470,8 @@ async def _read_presence_maps(target: Target) -> tuple[dict[str, Any], dict[str,
 def _status_rows(
     report: _dev_broker.MeshStatus,
     daemons: list[_dev_agents.DaemonHit],
-    agents: dict[str, Any],
-    tools: dict[str, Any],
+    agents: dict[str, AgentInfo],
+    tools: dict[str, ToolInfo],
 ) -> list[tuple[str, ...]]:
     """The §3.3 join: broker row(s), then managed-daemon rows (scan ⋈ presence by name), then
     every remaining online node — nothing online is ever filtered out (Ryan's transparency rule)."""
@@ -496,16 +499,16 @@ def _status_rows(
             rows.append((kind, name, state, str(hit.pid), hit.started_at, ",".join(hit.targets) or _EMPTY, hit.log_path))
     managed_names = {name for hit in daemons for name in hit.names}
     annotation = "not a ck dev daemon (stop it where it runs)"
-    for name, info in sorted(agents.items()):
+    for name, agent_info in sorted(agents.items()):
         if name not in managed_names:
-            rows.append(("agent", name, f"online (last seen {_format_age(_age_of(info))} ago) — {annotation}", _EMPTY, _EMPTY, _EMPTY, _EMPTY))
-    for name, info in sorted(tools.items()):
+            rows.append(("agent", name, f"online (last seen {_format_age(_age_of(agent_info))} ago) — {annotation}", _EMPTY, _EMPTY, _EMPTY, _EMPTY))
+    for name, tool_info in sorted(tools.items()):
         if name not in managed_names:
-            rows.append(("tool", name, f"online (last seen {_format_age(_age_of(info))} ago) — {annotation}", _EMPTY, _EMPTY, _EMPTY, _EMPTY))
+            rows.append(("tool", name, f"online (last seen {_format_age(_age_of(tool_info))} ago) — {annotation}", _EMPTY, _EMPTY, _EMPTY, _EMPTY))
     return rows
 
 
-def _age_of(info: Any) -> float:
+def _age_of(info: AgentInfo | ToolInfo) -> float:
     from datetime import datetime, timezone
 
     age: float = (datetime.now(tz=timezone.utc) - info.last_seen).total_seconds()

--- a/calfkit/cli/dev.py
+++ b/calfkit/cli/dev.py
@@ -17,6 +17,8 @@ the supervisor's spawn branch.
 
 from __future__ import annotations
 
+import asyncio
+
 import typer
 
 from calfkit.cli import _dev_agents, _dev_broker
@@ -100,6 +102,12 @@ def dev_run(
         ...,
         help="One or more 'module:attr' targets. Each attr is a node or an iterable of nodes.",
     ),
+    detach: bool = typer.Option(
+        False,
+        "--detach",
+        "-d",
+        help="Launch as a detached agent daemon: return once the agents are online; they run until 'ck dev stop'.",
+    ),
     host: str | None = typer.Option(None, "--host", "-H", help=_HOST_HELP),
     provision: bool = typer.Option(
         True,
@@ -139,6 +147,19 @@ def dev_run(
 ) -> None:
     """Run node(s) against the local dev mesh, spawning its broker if needed."""
     _load_env(env_file)  # FIRST: a .env-set CALFKIT_MESH_URL must be visible to host resolution
+    if detach:
+        _detach_run(
+            targets,
+            host=host,
+            provision=provision,
+            enable_idempotence=enable_idempotence,
+            reload=reload,
+            reload_dir=reload_dir,
+            app_dir=app_dir,
+            group_id=group_id,
+            env_file=env_file,
+        )
+        return
     servers = resolve_mesh_url(_parse_host(host))
     target = _normalize_or_exit(servers)
     _ensure_or_exit(target)  # in the PARENT: reload children only ever connect (spec §4.3)
@@ -159,6 +180,90 @@ def dev_run(
         dev_daemon=None,
         heartbeat_interval=_dev_agents.DEV_HEARTBEAT_INTERVAL,
     )
+
+
+def _detach_run(
+    targets: list[str],
+    *,
+    host: str | None,
+    provision: bool,
+    enable_idempotence: bool,
+    reload: bool,
+    reload_dir: list[str] | None,
+    app_dir: str,
+    group_id: str | None,
+    env_file: str | None,
+) -> None:
+    """The ``run -d`` path (agent-lifecycle spec §3.1/§5.1): preflight fails fast at the prompt,
+    then broker ensure, then connect-or-spawn the agent daemon and return only once its names are
+    online — so ``... && ck dev chat`` lands on a mesh where the agents already exist."""
+    try:
+        plan = _dev_agents.preflight(targets, app_dir=app_dir)
+    except _dev_agents.DevAgentError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(2) from exc
+    target = _normalize_or_exit(resolve_mesh_url(_parse_host(host)))
+    _ensure_or_exit(target)
+    run_args = _dev_agents.RunOptions(
+        provision=provision,
+        reload=reload,
+        reload_dir=tuple(reload_dir) if reload_dir else None,
+        app_dir=app_dir,
+        group_id=group_id,
+        env_file=env_file,
+        enable_idempotence=enable_idempotence,
+    )
+    try:
+        report = asyncio.run(_ensure_agents_with_client(plan, target, run_args))
+    except KeyboardInterrupt:
+        # §3.4: the daemon (if one was spawned) is deliberately left running — recoverable state,
+        # never half-killed on an interrupted wait.
+        typer.echo("interrupted — a launched daemon may still be starting in the background; check 'ck dev status'.", err=True)
+        raise typer.Exit(130) from None
+    except (_dev_agents.DevAgentError, DevBrokerError) as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(2) from exc
+    _echo_detach_report(report)
+
+
+async def _ensure_agents_with_client(
+    plan: list[_dev_agents.TargetNodes],
+    target: Target,
+    run_args: _dev_agents.RunOptions,
+) -> _dev_agents.EnsureReport:
+    """Run the ensure under a short-lived readiness client: its ``mesh`` view is the §5.2 poll's
+    snapshot source; closed on every path so the CLI never leaks a consumer."""
+    from calfkit.client import Client
+
+    client = Client.connect(_forward_host(target))
+    try:
+        return await _dev_agents.ensure_agents(plan, target, client.mesh, run_args=run_args)
+    finally:
+        await client.aclose()
+
+
+def _echo_detach_report(report: _dev_agents.EnsureReport) -> None:
+    """§3.1's per-name lines: launched names state their lifetime + supervisor pid + log; reused
+    names state the heartbeat age (the staleness-window honesty device, spec §5.5)."""
+    for outcome in report.outcomes:
+        for kind_word, names in (("agent", outcome.target.agent_names), ("tool", outcome.target.tool_names)):
+            for name in names:
+                if outcome.reused:
+                    age = _format_age(outcome.ages.get(name, 0.0))
+                    typer.echo(f"ck dev: reusing {kind_word} '{name}' (online, last seen {age} ago)")
+                else:
+                    lifetime = f"runs until 'ck dev stop {name}'"
+                    typer.echo(f"ck dev: launched {kind_word} '{name}' (pid {report.pid}) — {lifetime} — logs: {report.log_path}")
+
+
+def _format_age(seconds: float) -> str:
+    """A compact heartbeat age: ``3s``, ``2m05s``, ``1h04m``."""
+    whole = max(0, int(seconds))
+    if whole < 60:
+        return f"{whole}s"
+    if whole < 3600:
+        return f"{whole // 60}m{whole % 60:02d}s"
+    return f"{whole // 3600}h{(whole % 3600) // 60:02d}m"
 
 
 @dev_app.command(name="chat")

--- a/calfkit/cli/run.py
+++ b/calfkit/cli/run.py
@@ -81,6 +81,21 @@ def run(
         "--env-file",
         help="Path to a dotenv file to load. Defaults to ./.env if present.",
     ),
+    dev_daemon: str | None = typer.Option(
+        None,
+        "--dev-daemon",
+        hidden=True,
+        help="Internal (`ck dev run -d` plumbing): the argv ownership marker naming the daemon's "
+        "advertised nodes. Accepted so it lands in the process cmdline for the stateless "
+        "management scan (dev-agent-lifecycle spec §5.4); it changes no behavior here.",
+    ),
+    heartbeat_interval: float | None = typer.Option(
+        None,
+        "--heartbeat-interval",
+        hidden=True,
+        help="Internal (`ck dev` plumbing): control-plane heartbeat cadence override in seconds "
+        "(the dev 5s preset, dev-agent-lifecycle spec §5.6). Unset, the worker default applies.",
+    ),
 ) -> None:
     """Run node(s) as a worker until stopped (Ctrl-C)."""
     abs_app_dir = os.path.abspath(app_dir)
@@ -103,12 +118,12 @@ def run(
         run_process(
             *dirs,
             target=serve,
-            args=(list(targets), host, provision, group_id, env_file, abs_app_dir, enable_idempotence),
+            args=(list(targets), host, provision, group_id, env_file, abs_app_dir, enable_idempotence, heartbeat_interval),
             watch_filter=PythonFilter(),
         )
     else:
         try:
-            serve(list(targets), host, provision, group_id, env_file, abs_app_dir, enable_idempotence)
+            serve(list(targets), host, provision, group_id, env_file, abs_app_dir, enable_idempotence, heartbeat_interval)
         except KeyboardInterrupt:
             # Ctrl-C in a window where FastStream's own SIGINT handler isn't
             # active yet (startup/teardown), or on a platform whose event loop

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -252,8 +252,11 @@ is spawned as a detached background daemon that persists until an explicit
 `ck dev broker stop`/`restart` or a reboot.
 
 ```text
-ck dev run TARGET [TARGET ...] [OPTIONS]
-ck dev chat [NAME] [OPTIONS]
+ck dev run  TARGET [TARGET ...] [--detach/-d] [OPTIONS]
+ck dev chat [NAME | TARGET ...] [OPTIONS]
+ck dev status [OPTIONS]
+ck dev stop (NAME [NAME ...] | --all) [OPTIONS]
+ck dev down [OPTIONS]
 ck dev broker (start | stop | status | restart) [OPTIONS]
 ```
 
@@ -297,6 +300,89 @@ workers only reconnect — and each command first prints whether the broker is
 **managed** (`ck dev: managed broker at 127.0.0.1:9092 (pid 51234)`) or
 **reused** (`… — not managed by calfkit`).
 
+### `ck dev run --detach/-d`
+
+Everything `ck dev run` is, with the attachment cut (the `docker compose up
+-d` gesture): the worker tree — the reload supervisor plus the worker it
+restarts on edits — is spawned as a **detached daemon** and the command
+returns only when its agents/tools are **online on the mesh** (bounded at
+15 s; a failure reports the daemon's log tail). Lifetime: until
+`ck dev stop <name>`, `ck dev down`, or a reboot.
+
+- Per launched name it prints the **supervisor pid** (the process `stop`
+  signals), the lifetime statement, and the log path
+  (`~/.calfkit/logs/agents-<address>-<targets>.log`, overwritten per launch).
+- If every name of a target is already online, the target is **reused**
+  (`ck dev: reusing agent '<name>' (online, last seen 3s ago)`) and nothing is
+  spawned. Reuse matches names **on the mesh**, never code identity.
+- If a daemon for a name exists but its agents are offline (broken code or
+  mid-restart), a relaunch is an **error** naming the pid, the logs, and the
+  `stop` command — never a second daemon over a broken first.
+- All targets of one invocation co-host in **one** worker (the `ck run`
+  rule); they still discover and communicate over the mesh, never in-process.
+- A target must resolve to at least one agent or tool (a plain consumer node
+  has no mesh presence to manage — run those in the foreground).
+- Ctrl-C during the readiness wait leaves the daemon running (recoverable —
+  `ck dev status`); exit `130`.
+
+Ownership is **stateless**: a daemon is recognized by an internal
+`--dev-daemon=<names>` marker in its command line (with its `--host` scoping
+it to an address), exactly like the broker's process scan — no registry file
+anywhere. The flag is internal `ck dev` plumbing; it is accepted (and ignored)
+by `ck run` purely so it lands in the daemon's argv.
+
+### `ck dev chat` targets — session workers
+
+An argument containing `:` is a `module:attr` **target**; a bare word is an
+agent **name** (mixing them, passing two names, or duplicate node names across
+targets: exit `2`). With targets, the chat runs them **inside its own
+process** — a *session worker* on the chat's own client — waits for them to be
+online, then opens the normal picker:
+
+- The session worker dies **with the chat process**, on any exit — there is no
+  child process to orphan. Its logs share the chat terminal.
+- **No reload in a chat session** (an in-process worker cannot re-import your
+  code): the edit loop is save → `/exit` → rerun, or use
+  `ck dev run -d … && ck dev chat` for live reload while chatting.
+- Targets already online are **reused**, not launched; if every target was
+  reused nothing is started at all. The exit narration says what was owned:
+  `✦ stopped '<names>' (ran in this session)` /
+  `✦ still running: <names> — 'ck dev chat' to rejoin, 'ck dev down' to stop
+  everything`.
+- The launched+reused set must contain at least one **agent** (tools alone are
+  nobody to chat with): exit `2`.
+
+### `ck dev status`
+
+One table, unfiltered, host-scoped (`--host` > `$CALFKIT_MESH_URL` >
+`localhost`): the broker, every managed daemon's names joined with a live mesh
+snapshot, and **every other online node** annotated `not a ck dev daemon (stop
+it where it runs)`. Heartbeat ages are always shown ("online" can lag a crash
+by up to the ~15 s staleness window — the age is the honesty device). A
+daemon-owned name with no mesh record reads `unknown (see logs)` (crashed
+edit, mid-restart, or still booting — indistinguishable from outside). A down
+broker never errors: its line reads `no broker reachable`, presence columns
+degrade to `unknown (mesh unreachable)`, daemon rows still render. Exit `0`
+always.
+
+### `ck dev stop` and `ck dev down`
+
+| Command | Behavior |
+| --- | --- |
+| `stop NAME…` | Stop the daemon(s) owning those names — **whole-daemon**: co-hosted names go down together and every one is narrated (`stopped daemon pid 51288 (agents: general, finance)`). SIGTERM → 8 s grace → SIGKILL, delivered to the daemon's whole **process group**. |
+| `stop --all` | Every `ck dev` agent daemon on **every** address (ignores `--host`). |
+| `down` | `stop --all`, then `broker stop` at the resolved address. |
+
+Names resolve **within the target address** while `--all`/`down` sweep
+globally — that is the one name-vs-address asymmetry in the family. An unknown
+name exits `2` listing what *is* running at the address (and hints at
+`--host`); a name that is online but not a daemon (a session worker, a
+foreground run, anything external) exits `2` with *stop it where it runs*; two
+same-named daemons at one address exit `2` listing both pids — never a guess.
+Foreground runs and chat-session workers **survive `down`** by design (they
+carry no marker) and will error against the stopped broker — stop them where
+they run. Finding nothing to stop is a messaged no-op, exit `0`.
+
 ### `ck dev broker`
 
 Direct control of the dev broker daemon, decoupled from any app run. Every
@@ -321,8 +407,9 @@ is never touched; no state is persisted anywhere to track this.
 
 | Code | Meaning |
 | --- | --- |
-| `0` | Clean exit (including a `stop`/`status` that found nothing to act on). |
-| `2` | Configuration or broker-ensure error — invalid address, unreachable non-loopback address, missing binary/`[mesh]` extra, spawn or readiness failure — plus everything that exits `2` in the delegated command. |
+| `0` | Clean exit (including a `stop`/`status`/`down` that found nothing to act on). |
+| `2` | Configuration or supervise error — invalid address, unreachable non-loopback address, missing binary/`[mesh]` extra, broker or agent spawn/readiness failure, a bad `chat` grammar, an unknown/unmanaged `stop` name — plus everything that exits `2` in the delegated command. |
+| `130` | Ctrl-C during a `run -d` readiness wait (the daemon is left running — `ck dev status`). |
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -267,10 +267,13 @@ Windows; the broker is Unix-only) and `psutil` (the ownership scan).
 extra installed (resolution order: `CALF_TANSU_BIN` → bundled → `tansu` on
 `PATH`). Without the extra, foreground `ck dev run` and the `ck dev chat`
 attach forms still work as pure clients against an already-reachable broker —
-but everything that manages agent daemons needs the extra's process scan:
-`ck dev run -d`, `ck dev chat TARGET…`, `ck dev status`, `ck dev stop`,
-`ck dev down`, and the `ck dev broker` management commands (each exits `2`
-with the install hint without it). See
+but everything that manages agent daemons needs the extra's process scan.
+`ck dev status`, `ck dev stop`, `ck dev down`, `ck dev broker stop`, and
+`ck dev broker status` exit `2` with the install hint without it;
+`ck dev run -d` and `ck dev chat TARGET…` need it to launch (they still
+succeed on a core install when every target is already online — pure reuse
+never scans); `ck dev broker start`/`restart` degrade gracefully (reuse/borrow
+still works; only the managed-vs-reused classification is lost). See
 [How to run a local mesh with `ck dev`](local-dev-mesh.md).
 
 ### Spawn rules
@@ -335,9 +338,9 @@ returns only when its agents/tools are **online on the mesh** (bounded at
 Ownership is **stateless**: a daemon is recognized by an internal
 `--dev-daemon=<names>` marker in its command line — matched only in that
 exact emitted form, and only on a `run` command line, so the flag merely
-*appearing as data* in some other process's argv (say, a grep of it) never
-matches — with its `--host` scoping it to an address, exactly like the
-broker's process scan; no registry file anywhere. The flag is internal
+*appearing as data* in some other process's argv (say, a grep of it) does not
+match (both anchors are required) — with its `--host` scoping it to an
+address, exactly like the broker's process scan; no registry file anywhere. The flag is internal
 `ck dev` plumbing; it is accepted (and ignored) by `ck run` purely so it
 lands in the daemon's argv.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -269,7 +269,9 @@ extra installed (resolution order: `CALF_TANSU_BIN` → bundled → `tansu` on
 attach forms still work as pure clients against an already-reachable broker —
 but everything that manages agent daemons needs the extra's process scan.
 `ck dev status`, `ck dev stop`, `ck dev down`, `ck dev broker stop`, and
-`ck dev broker status` exit `2` with the install hint without it;
+`ck dev broker status` exit `2` with the install hint without it (one edge:
+`ck dev broker stop` against a *multi-address* target is a messaged no-op —
+multi-address is never a spawn target, so there is nothing to scan);
 `ck dev run -d` and `ck dev chat TARGET…` need it to launch (they still
 succeed on a core install when every target is already online — pure reuse
 never scans); `ck dev broker start`/`restart` degrade gracefully (reuse/borrow

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -265,9 +265,12 @@ which ships the binary (Linux x86_64/aarch64 glibc+musl, macOS arm64/x86_64 — 
 Windows; the broker is Unix-only) and `psutil` (the ownership scan).
 `CALF_TANSU_BIN` overrides the bundled binary with your own, with or without the
 extra installed (resolution order: `CALF_TANSU_BIN` → bundled → `tansu` on
-`PATH`). Without the extra, `ck dev run`/`ck dev chat` still work as pure
-clients against an already-reachable broker; the `ck dev broker` management
-commands need the extra's process scan. See
+`PATH`). Without the extra, foreground `ck dev run` and the `ck dev chat`
+attach forms still work as pure clients against an already-reachable broker —
+but everything that manages agent daemons needs the extra's process scan:
+`ck dev run -d`, `ck dev chat TARGET…`, `ck dev status`, `ck dev stop`,
+`ck dev down`, and the `ck dev broker` management commands (each exits `2`
+with the install hint without it). See
 [How to run a local mesh with `ck dev`](local-dev-mesh.md).
 
 ### Spawn rules
@@ -318,6 +321,10 @@ returns only when its agents/tools are **online on the mesh** (bounded at
 - If a daemon for a name exists but its agents are offline (broken code or
   mid-restart), a relaunch is an **error** naming the pid, the logs, and the
   `stop` command — never a second daemon over a broken first.
+- If a target is **partially online** (some of its names online, others not),
+  launching it is an error naming the collision — a worker hosts all of a
+  target's nodes together, so it can neither be reused nor launched. Applies
+  to `chat TARGET…` too.
 - All targets of one invocation co-host in **one** worker (the `ck run`
   rule); they still discover and communicate over the mesh, never in-process.
 - A target must resolve to at least one agent or tool (a plain consumer node
@@ -326,10 +333,13 @@ returns only when its agents/tools are **online on the mesh** (bounded at
   `ck dev status`); exit `130`.
 
 Ownership is **stateless**: a daemon is recognized by an internal
-`--dev-daemon=<names>` marker in its command line (with its `--host` scoping
-it to an address), exactly like the broker's process scan — no registry file
-anywhere. The flag is internal `ck dev` plumbing; it is accepted (and ignored)
-by `ck run` purely so it lands in the daemon's argv.
+`--dev-daemon=<names>` marker in its command line — matched only in that
+exact emitted form, and only on a `run` command line, so the flag merely
+*appearing as data* in some other process's argv (say, a grep of it) never
+matches — with its `--host` scoping it to an address, exactly like the
+broker's process scan; no registry file anywhere. The flag is internal
+`ck dev` plumbing; it is accepted (and ignored) by `ck run` purely so it
+lands in the daemon's argv.
 
 ### `ck dev chat` targets — session workers
 
@@ -363,7 +373,15 @@ daemon-owned name with no mesh record reads `unknown (see logs)` (crashed
 edit, mid-restart, or still booting — indistinguishable from outside). A down
 broker never errors: its line reads `no broker reachable`, presence columns
 degrade to `unknown (mesh unreachable)`, daemon rows still render. Exit `0`
-always.
+whenever it can answer — a down broker or unreadable mesh never errors; only a
+missing `[mesh]` extra or an invalid address exits `2`, as everywhere in the
+family.
+
+Heartbeat cadence behind the ages: every worker `ck dev` launches (foreground
+runs, `-d` daemons, chat-session workers) heartbeats every **5 s**, so its
+crash-staleness window is ~15 s. A worker launched by plain `ck run` keeps the
+30 s production default — its "online" can lag a crash by up to ~90 s, ages
+shown all the same.
 
 ### `ck dev stop` and `ck dev down`
 

--- a/docs/local-dev-mesh.md
+++ b/docs/local-dev-mesh.md
@@ -110,9 +110,9 @@ no orchestrator, no restarts.
 
 ```console
 $ ck dev status
-KIND    NAME             STATE                          PID    SINCE                      TARGET           LOGS
-broker  127.0.0.1:9092   running                        51234  2026-07-02T14:00:12+00:00  —                     —
-agent   general          online (last seen 3s ago)      51288  2026-07-02T14:02:40+00:00  general:general  /Users/you/.calfkit/logs/agents-….log
+KIND    NAME            STATE                      PID    SINCE                      TARGET           LOGS
+broker  127.0.0.1:9092  running                    51234  2026-07-02T14:00:12+00:00  —                —
+agent   general         online (last seen 3s ago)  51288  2026-07-02T14:02:40+00:00  general:general  /Users/you/.calfkit/logs/agents-….log
 ```
 
 `ck dev status` shows everything, unfiltered: the broker, every managed

--- a/docs/local-dev-mesh.md
+++ b/docs/local-dev-mesh.md
@@ -41,9 +41,9 @@ share the same mesh.
 ## Launch agents in the background with `--detach`
 
 ```console
-$ ck dev run -d general_help:general
+$ ck dev run -d general:general
 ck dev: managed broker at 127.0.0.1:9092 (pid 51234)
-ck dev: launched agent 'general' (pid 51288) — runs until 'ck dev stop general' — logs: ~/.calfkit/logs/agents-127.0.0.1_9092-general_help_general.log
+ck dev: launched agent 'general' (pid 51288) — runs until 'ck dev stop general' — logs: /Users/you/.calfkit/logs/agents-127.0.0.1_9092-general_general.log
 ```
 
 `--detach/-d` (the `docker compose up -d` gesture) runs the same reload
@@ -76,7 +76,7 @@ session itself.
 process itself*, then opens the picker:
 
 ```console
-$ ck dev chat general_help:general
+$ ck dev chat general:general
 ```
 
 A session worker lives and dies with the chat — close the session (`/exit`,
@@ -96,9 +96,9 @@ want live reload while chatting. On exit the session narrates what it owned:
 The core lesson of the mesh — *agents are independent processes that discover
 each other at runtime* — is something you can watch happen:
 
-1. Terminal 1: `ck dev run -d general_help:general && ck dev chat` — launch
+1. Terminal 1: `ck dev run -d general:general && ck dev chat` — launch
    the generalist, start chatting.
-2. Terminal 2: `ck dev run -d finance_help:finance` — add a specialist to the
+2. Terminal 2: `ck dev run -d finance:finance` — add a specialist to the
    **live** team. The first agent's process is untouched.
 3. Back in the chat, ask a finance question — `general` discovers `finance`
    over the mesh and hands off to it, mid-conversation.
@@ -110,9 +110,9 @@ no orchestrator, no restarts.
 
 ```console
 $ ck dev status
-KIND    NAME             STATE                          PID    SINCE                      TARGET                LOGS
+KIND    NAME             STATE                          PID    SINCE                      TARGET           LOGS
 broker  127.0.0.1:9092   running                        51234  2026-07-02T14:00:12+00:00  —                     —
-agent   general          online (last seen 3s ago)      51288  2026-07-02T14:02:40+00:00  general_help:general  ~/.calfkit/logs/agents-….log
+agent   general          online (last seen 3s ago)      51288  2026-07-02T14:02:40+00:00  general:general  /Users/you/.calfkit/logs/agents-….log
 ```
 
 `ck dev status` shows everything, unfiltered: the broker, every managed
@@ -122,8 +122,10 @@ foreground run, a teammate's worker) annotated
 live mesh record shows `unknown (see logs)` — usually a broken edit mid-reload;
 its log path is right there in the row. When the broker itself is down, the
 presence columns degrade to `unknown (mesh unreachable)` and the daemon rows
-still render. Heartbeat ages are always shown: "online" can lag a crash by up
-to the ~15s staleness window, and the age is the honesty device.
+still render. Heartbeat ages are always shown: "online" can lag a crash — by
+up to ~15s for `ck dev`-launched workers (they heartbeat every 5s), and up to
+~90s for a plain `ck run` worker on the 30s production default — and the age
+is the honesty device.
 
 - `ck dev stop NAME…` — stop the daemon(s) owning those names. A stop is
   **whole-daemon**: co-hosted agents launched by one command go down together,

--- a/docs/local-dev-mesh.md
+++ b/docs/local-dev-mesh.md
@@ -38,6 +38,27 @@ The broker is a background daemon that **outlives the command** — Ctrl-C stops
 your worker, not the broker, so restarts reconnect instantly and other commands
 share the same mesh.
 
+## Launch agents in the background with `--detach`
+
+```console
+$ ck dev run -d general_help:general
+ck dev: managed broker at 127.0.0.1:9092 (pid 51234)
+ck dev: launched agent 'general' (pid 51288) — runs until 'ck dev stop general' — logs: ~/.calfkit/logs/agents-127.0.0.1_9092-general_help_general.log
+```
+
+`--detach/-d` (the `docker compose up -d` gesture) runs the same reload
+supervisor as a **managed background daemon** and returns only once the agent
+is **online on the mesh** — so `ck dev run -d … && ck dev chat` always lands
+on a mesh where the agent already exists. The daemon keeps reloading on your
+edits until an explicit `ck dev stop <name>` (or `ck dev down`, or a reboot).
+
+Launching the same target again while it is online **reuses** it instead
+(`ck dev: reusing agent 'general' (online, last seen 3s ago)`) — reuse matches
+the **name on the mesh**, so check `ck dev status` if you're unsure what is
+actually running. If a daemon for the name exists but its agents are offline
+(usually a broken edit), a relaunch errors and points at the logs and the
+`stop` command instead of stacking a second daemon.
+
 ## Chat with them from a second terminal
 
 ```console
@@ -49,6 +70,74 @@ and provisions its own reply inbox. This two-terminal loop — `ck dev run` in
 one, `ck dev chat` in the other — is the working local setup; see
 [How to chat with an agent from the terminal](chat-with-agents.md) for the chat
 session itself.
+
+`ck dev chat` can also **launch agents for the session**: give it
+`module:attr` target(s) instead of a name and it runs them *inside the chat
+process itself*, then opens the picker:
+
+```console
+$ ck dev chat general_help:general
+```
+
+A session worker lives and dies with the chat — close the session (`/exit`,
+Ctrl-D, Ctrl-C, or even killing the terminal) and it is gone with it, by
+construction. Because it runs in-process there is **no reload** in a chat
+session: the edit loop is save → `/exit` → rerun (the broker and any daemons
+persist, so this is seconds). Use `ck dev run -d … && ck dev chat` when you
+want live reload while chatting. On exit the session narrates what it owned:
+
+```text
+✦ stopped 'general' (ran in this session)
+✦ still running: finance — 'ck dev chat' to rejoin, 'ck dev down' to stop everything
+```
+
+## The team loop: watch two agents find each other
+
+The core lesson of the mesh — *agents are independent processes that discover
+each other at runtime* — is something you can watch happen:
+
+1. Terminal 1: `ck dev run -d general_help:general && ck dev chat` — launch
+   the generalist, start chatting.
+2. Terminal 2: `ck dev run -d finance_help:finance` — add a specialist to the
+   **live** team. The first agent's process is untouched.
+3. Back in the chat, ask a finance question — `general` discovers `finance`
+   over the mesh and hands off to it, mid-conversation.
+
+Separate commands, separate processes, discovery over the mesh — no wiring,
+no orchestrator, no restarts.
+
+## See and stop what you launched
+
+```console
+$ ck dev status
+KIND    NAME             STATE                          PID    SINCE                      TARGET                LOGS
+broker  127.0.0.1:9092   running                        51234  2026-07-02T14:00:12+00:00  —                     —
+agent   general          online (last seen 3s ago)      51288  2026-07-02T14:02:40+00:00  general_help:general  ~/.calfkit/logs/agents-….log
+```
+
+`ck dev status` shows everything, unfiltered: the broker, every managed
+daemon, and **every other node online on the mesh** (a chat-session worker, a
+foreground run, a teammate's worker) annotated
+`not a ck dev daemon (stop it where it runs)`. A daemon whose names have no
+live mesh record shows `unknown (see logs)` — usually a broken edit mid-reload;
+its log path is right there in the row. When the broker itself is down, the
+presence columns degrade to `unknown (mesh unreachable)` and the daemon rows
+still render. Heartbeat ages are always shown: "online" can lag a crash by up
+to the ~15s staleness window, and the age is the honesty device.
+
+- `ck dev stop NAME…` — stop the daemon(s) owning those names. A stop is
+  **whole-daemon**: co-hosted agents launched by one command go down together,
+  and every name is narrated (`stopped daemon pid 51288 (agents: general)`).
+  Stopping resolves names **at the target address** (`--host` for other
+  meshes); `--all` sweeps every daemon on every address.
+- `ck dev down` — stop **all** agent daemons, then the broker at the target
+  address. Foreground runs and chat-session workers survive `down` by design
+  (they are not daemons) — they will error against the stopped broker; stop
+  them where they run.
+
+Daemon logs live at `~/.calfkit/logs/agents-<address>-<targets>.log`,
+overwritten on each launch — consult them *before* relaunching over a broken
+daemon.
 
 ## Control the broker directly
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,13 @@ warn_return_any = true
 warn_unused_ignores = true
 exclude = ["calfkit/_vendor"]
 
+# calfkit_mesh ships no py.typed: absent (core install / CI) it is import-not-found, installed
+# (local kafka-lane runs) it is import-untyped — an inline ignore can only ever match one of the
+# two under warn_unused_ignores, so the suppression lives here, env-independent.
+[[tool.mypy.overrides]]
+module = "calfkit_mesh"
+ignore_missing_imports = true
+
 [tool.coverage.run]
 omit = ["calfkit/_vendor/*"]
 

--- a/tests/_dev_fakes.py
+++ b/tests/_dev_fakes.py
@@ -168,6 +168,35 @@ class CountingResolveBin:
         return self.path
 
 
+class FakeMesh:
+    """A drivable stand-in for ``client.mesh``: per-kind scripted frames, one consumed per read.
+
+    Each frame is a ``dict`` (the read's result, e.g. real ``AgentInfo``/``ToolNodeInfo`` DTOs)
+    or an ``Exception`` (raised — e.g. ``MeshUnavailableError``). The last frame repeats, so a
+    readiness loop can poll it forever (the ``scripted_probe`` convention).
+    """
+
+    def __init__(self, agents_frames: list[Any] | None = None, tools_frames: list[Any] | None = None) -> None:
+        self.agents_frames = agents_frames if agents_frames is not None else [{}]
+        self.tools_frames = tools_frames if tools_frames is not None else [{}]
+        self.reads: list[str] = []
+
+    @staticmethod
+    def _next(frames: list[Any]) -> Any:
+        frame = frames.pop(0) if len(frames) > 1 else frames[0]
+        if isinstance(frame, Exception):
+            raise frame
+        return frame
+
+    async def get_agents(self) -> Any:
+        self.reads.append("agents")
+        return self._next(self.agents_frames)
+
+    async def get_tools(self) -> Any:
+        self.reads.append("tools")
+        return self._next(self.tools_frames)
+
+
 def scripted_probe(*values: bool) -> Any:
     """A fake ``is_reachable``: yields *values* in order, repeating the last one; records calls."""
 

--- a/tests/_dev_fakes.py
+++ b/tests/_dev_fakes.py
@@ -74,6 +74,11 @@ class FakeProc:
             raise psutil.NoSuchProcess()  # type: ignore[attr-defined]
         return "zombie" if self.zombie else "running"
 
+    def is_running(self) -> bool:
+        """psutil semantics: identity-checked liveness; a zombie still 'is running' (unreaped,
+        so its pid — and pgid — cannot have been recycled)."""
+        return self.alive or self.zombie
+
     def terminate(self) -> None:
         self.events.append("terminate")
         psutil = sys.modules["psutil"]

--- a/tests/dev_agents_nodes.py
+++ b/tests/dev_agents_nodes.py
@@ -1,0 +1,64 @@
+"""Importable nodes for the ``ck dev`` agent-lifecycle tests (spec §5.1 preflight).
+
+Mirrors ``tests/provisioning_cli_nodes.py``: small, real node definitions the CLI resolves via
+``module:attr`` targets. Covers every preflight classification — an agent (advertises on
+``calf.agents``), a function tool (``calf.capabilities``), a mixed iterable, a same-named agent in
+a second attr (the cross-target duplicate), and a consumer node (advertises on neither plane).
+"""
+
+from __future__ import annotations
+
+from calfkit.nodes import ConsumerNode, ToolNodeDef, consumer
+from calfkit.nodes.agent import Agent
+from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
+
+
+class _FakeModel(PydanticModelClient):
+    """Constructor-only model stand-in: preflight never runs a model."""
+
+    @property
+    def model_name(self) -> str:
+        return "fake"
+
+    @property
+    def system(self) -> str:
+        return "fake"
+
+    async def request(self, *args: object, **kwargs: object) -> object:
+        raise NotImplementedError
+
+
+def _agent(name: str) -> Agent:
+    return Agent(name, subscribe_topics=f"{name}.in", model_client=_FakeModel())
+
+
+def _tool(name: str) -> ToolNodeDef:
+    def _fn(x: int) -> int:
+        return x
+
+    _fn.__name__ = name
+    return ToolNodeDef.create_tool_node(func=_fn, subscribe_topics=f"{name}.in", publish_topic=f"{name}.out")
+
+
+# One agent / one tool — the two advertising kinds.
+general = _agent("general")
+get_weather = _tool("get_weather")
+
+# A DIFFERENT attr resolving to the SAME advertised name: launching both targets in one
+# invocation must be a duplicate-name usage error, never a silent dedupe (spec §5.1).
+general_dupe = _agent("general")
+
+# A mixed iterable: one worker co-hosting an agent and a tool (union readiness set).
+support_team = [_agent("support"), _tool("get_time")]
+
+
+@consumer(subscribe_topics="audit.in", name="audit_log")
+def audit_log(ctx: object) -> None:
+    """A zero-advert node: no presence-plane record, so not a launchable ck dev target."""
+
+
+assert isinstance(audit_log, ConsumerNode)
+
+# A consumer co-hosted WITH an advertising node: legitimate — the daemon is visible and
+# stoppable via the agent's name; only an all-consumer target errors.
+desk_with_audit = [_agent("desk"), audit_log]

--- a/tests/integration/test_dev_agents_kafka.py
+++ b/tests/integration/test_dev_agents_kafka.py
@@ -109,9 +109,7 @@ def isolated_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     return tmp_path
 
 
-def test_run_detach_lifecycle_spawn_online_reuse_status_stop(
-    kafka_bootstrap: str, topic_namespace: str, isolated_home: Path, tmp_path: Path
-) -> None:
+def test_run_detach_lifecycle_spawn_online_reuse_status_stop(kafka_bootstrap: str, topic_namespace: str, isolated_home: Path, tmp_path: Path) -> None:
     """spawn → online → reuse-with-age → status → stop; the stop group-reaps the WHOLE daemon
     tree (supervisor + reload worker + multiprocessing helpers — no survivors)."""
     psutil = pytest.importorskip("psutil", reason="the [mesh] extra is not installed")
@@ -151,9 +149,7 @@ def test_run_detach_lifecycle_spawn_online_reuse_status_stop(
         _reap_tree(pid)
 
 
-def test_kill9_staleness_flip_and_no_flap_liveness_proof(
-    kafka_bootstrap: str, topic_namespace: str, isolated_home: Path, tmp_path: Path
-) -> None:
+def test_kill9_staleness_flip_and_no_flap_liveness_proof(kafka_bootstrap: str, topic_namespace: str, isolated_home: Path, tmp_path: Path) -> None:
     """Ryan's empirical gate (spec §5.6): a 5s-heartbeat daemon (a) never flaps offline while
     alive across many samples, and (b) after kill -9 (a crash: no tombstone) reads offline within
     the ~15–20s staleness window (3 × 5s from its last heartbeat)."""
@@ -193,7 +189,12 @@ def test_kill9_staleness_flip_and_no_flap_liveness_proof(
 
 
 async def test_chat_target_runs_an_in_process_session_worker(
-    kafka_bootstrap: str, topic_namespace: str, isolated_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    kafka_bootstrap: str,
+    topic_namespace: str,
+    isolated_home: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     """The §3.2 in-process session against a real broker: preflight → launch on the SHARED chat
     client → readiness → picker (the launched agent is listed) → exit narration; the worker is

--- a/tests/integration/test_dev_agents_kafka.py
+++ b/tests/integration/test_dev_agents_kafka.py
@@ -1,0 +1,276 @@
+"""Real-broker tests for the ``ck dev`` agent lifecycle (kafka lane, ADR-0007).
+
+Four slices from the impl plan's CG-C, each end to end with real processes:
+
+- the ``run -d`` lifecycle against the lane's broker: spawn → online → reuse-with-age →
+  ``status`` → ``stop`` (group-reap: no survivor from the daemon tree);
+- **the kill-9 liveness proof (Ryan's empirical gate, spec §5.6)**: a dev-preset (5s heartbeat)
+  daemon never flaps offline while alive, and flips offline within the ~15–20s staleness window
+  after a SIGKILL crash (no tombstone);
+- the ``chat TARGET`` in-process session against the real broker (shared-client co-location);
+- the fresh-broker first-run e2e (bundled Tansu): one command from nothing to an online agent —
+  the readiness gate absorbs the missing-presence-topic window — then ``ck dev down``.
+
+Daemon targets are generated per test as uniquely-named modules under ``tmp_path`` (resolved via
+``--app-dir``), so parallel tests on the shared broker never collide on names or import caches.
+The scan slices need ``psutil`` (the ``[mesh]`` extra) and skip cleanly without it — the shipped
+``test_dev_broker_kafka`` posture.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import signal
+import socket
+import time
+import uuid
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from calfkit.cli._dev_broker import normalize
+from calfkit.cli._dev_probe import is_reachable
+from calfkit.client import Client, MeshViewConfig
+from calfkit.tuning import KTableReaderTuning
+
+pytestmark = pytest.mark.kafka
+
+_FAST_MESH = MeshViewConfig(reader_tuning=KTableReaderTuning(poll_timeout_ms=20, fetch_max_wait_ms=10))
+
+_NODES_TEMPLATE = '''"""Generated ck dev daemon target (unique per test)."""
+
+from calfkit.nodes.agent import Agent
+from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
+
+
+class _FakeModel(PydanticModelClient):
+    """Advertise-only: the agent is hosted for presence, never to run a turn."""
+
+    @property
+    def model_name(self) -> str:
+        return "fake"
+
+    @property
+    def system(self) -> str:
+        return "fake"
+
+    async def request(self, *args: object, **kwargs: object) -> object:
+        raise NotImplementedError
+
+
+agent = Agent("{name}", subscribe_topics="{name}.in", model_client=_FakeModel())
+'''
+
+
+def _write_target(tmp_path: Path, agent_name: str) -> str:
+    """A uniquely-named importable module hosting one advertise-only agent; returns its spec."""
+    module = f"dev_nodes_{uuid.uuid4().hex[:10]}"
+    (tmp_path / f"{module}.py").write_text(_NODES_TEMPLATE.format(name=agent_name))
+    return f"{module}:agent"
+
+
+def _invoke(args: list[str]) -> Any:
+    from calfkit.cli import _build_app
+
+    return CliRunner().invoke(_build_app(), args)
+
+
+def _pid_of(launch_line_output: str) -> int:
+    """The DAEMON supervisor pid from the §3.1 launched line — never the managed-broker line's
+    pid, which precedes it when the broker was spawned too (the fresh-Tansu path)."""
+    match = re.search(r"launched (?:agent|tool) '[^']+' \(pid (\d+)\)", launch_line_output)
+    assert match, f"no launched-line pid in: {launch_line_output!r}"
+    return int(match.group(1))
+
+
+def _gone_or_zombie(psutil: Any, pid: int) -> bool:
+    try:
+        return bool(psutil.Process(pid).status() == psutil.STATUS_ZOMBIE)
+    except psutil.NoSuchProcess:
+        return True
+
+
+def _reap_tree(pid: int) -> None:
+    """Best-effort cleanup so a failed test never leaks a daemon tree."""
+    with suppress(ProcessLookupError, PermissionError):
+        os.killpg(pid, signal.SIGKILL)
+
+
+@pytest.fixture
+def isolated_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Locks + logs under tmp (inherited by spawned daemons); no ambient mesh URL."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CALFKIT_MESH_URL", raising=False)
+    return tmp_path
+
+
+def test_run_detach_lifecycle_spawn_online_reuse_status_stop(
+    kafka_bootstrap: str, topic_namespace: str, isolated_home: Path, tmp_path: Path
+) -> None:
+    """spawn → online → reuse-with-age → status → stop; the stop group-reaps the WHOLE daemon
+    tree (supervisor + reload worker + multiprocessing helpers — no survivors)."""
+    psutil = pytest.importorskip("psutil", reason="the [mesh] extra is not installed")
+    agent_name = f"{topic_namespace}-general"
+    spec = _write_target(tmp_path, agent_name)
+    base = ["--host", kafka_bootstrap, "--app-dir", str(tmp_path)]
+
+    result = _invoke(["dev", "run", "-d", spec, *base])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert f"launched agent '{agent_name}'" in result.stdout
+    pid = _pid_of(result.stdout)
+    try:
+        # Reuse: a second -d finds the names online and spawns nothing (the age is the honesty device).
+        again = _invoke(["dev", "run", "-d", spec, *base])
+        assert again.exit_code == 0, again.stdout + str(again.exception)
+        assert f"reusing agent '{agent_name}' (online, last seen" in again.stdout
+
+        status = _invoke(["dev", "status", "--host", kafka_bootstrap])
+        assert status.exit_code == 0, status.stdout + str(status.exception)
+        row = next(line for line in status.stdout.splitlines() if agent_name in line)
+        assert "online (last seen" in row
+        assert str(pid) in row
+        assert "not a ck dev daemon" not in row  # it IS managed
+
+        tree = [pid] + [child.pid for child in psutil.Process(pid).children(recursive=True)]
+        assert len(tree) >= 2, "the reload supervisor should have a worker child"
+
+        stop = _invoke(["dev", "stop", agent_name, "--host", kafka_bootstrap])
+        assert stop.exit_code == 0, stop.stdout + str(stop.exception)
+        assert f"stopped daemon pid {pid} (agents: {agent_name})" in stop.stdout
+
+        deadline = time.monotonic() + 15.0
+        while not all(_gone_or_zombie(psutil, member) for member in tree):
+            assert time.monotonic() < deadline, f"survivors from the daemon tree: {tree}"
+            time.sleep(0.2)
+    finally:
+        _reap_tree(pid)
+
+
+def test_kill9_staleness_flip_and_no_flap_liveness_proof(
+    kafka_bootstrap: str, topic_namespace: str, isolated_home: Path, tmp_path: Path
+) -> None:
+    """Ryan's empirical gate (spec §5.6): a 5s-heartbeat daemon (a) never flaps offline while
+    alive across many samples, and (b) after kill -9 (a crash: no tombstone) reads offline within
+    the ~15–20s staleness window (3 × 5s from its last heartbeat)."""
+    pytest.importorskip("psutil", reason="the [mesh] extra is not installed")
+    agent_name = f"{topic_namespace}-general"
+    spec = _write_target(tmp_path, agent_name)
+
+    result = _invoke(["dev", "run", "-d", spec, "--host", kafka_bootstrap, "--app-dir", str(tmp_path)])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    pid = _pid_of(result.stdout)
+
+    async def _observe() -> float:
+        client = Client.connect(kafka_bootstrap, mesh_config=_FAST_MESH)
+        try:
+            # (a) no flap: ~12s of continuous sampling (> 2 heartbeat gaps) — online in EVERY sample.
+            for _ in range(24):
+                agents = await client.mesh.get_agents()
+                assert agent_name in agents, "a live dev-preset agent flapped offline between heartbeats"
+                await asyncio.sleep(0.5)
+            # (b) crash: SIGKILL the whole tree — no graceful shutdown, no tombstone.
+            os.killpg(pid, signal.SIGKILL)
+            killed_at = time.monotonic()
+            while agent_name in (await client.mesh.get_agents()):
+                assert time.monotonic() - killed_at < 25.0, "the crashed agent never went stale"
+                await asyncio.sleep(0.5)
+            return time.monotonic() - killed_at
+        finally:
+            await client.aclose()
+
+    try:
+        flip_seconds = asyncio.run(_observe())
+        # Staleness = 3 x 5s from the LAST heartbeat, which was at most ~5s before the kill:
+        # the flip lands in ~10-15s; ~20s is the honest upper bound (spec: "within ~15-20s").
+        assert flip_seconds <= 21.0, f"staleness flip took {flip_seconds:.1f}s"
+    finally:
+        _reap_tree(pid)
+
+
+async def test_chat_target_runs_an_in_process_session_worker(
+    kafka_bootstrap: str, topic_namespace: str, isolated_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The §3.2 in-process session against a real broker: preflight → launch on the SHARED chat
+    client → readiness → picker (the launched agent is listed) → exit narration; the worker is
+    gone with the session (its tombstone lands — the agent reads offline right after)."""
+    pytest.importorskip("psutil", reason="the [mesh] extra is not installed")
+    from calfkit.cli._dev_agents import preflight
+
+    agent_name = f"{topic_namespace}-general"
+    spec = _write_target(tmp_path, agent_name)
+    plan = preflight([spec], app_dir=str(tmp_path))
+
+    async def _quit_reader(_prompt: str) -> str:
+        return "q"
+
+    monkeypatch.setattr("calfkit.cli._chat.make_reader", lambda _loop: _quit_reader)
+    from calfkit.cli._chat import run_chat_session
+
+    await run_chat_session(
+        None,
+        kafka_bootstrap,
+        None,
+        provision=True,
+        session_plan=plan,
+        session_host_key=normalize([kafka_bootstrap]).key,
+    )
+    out = capsys.readouterr().out
+    assert agent_name in out  # the launched agent reached the picker
+    assert f"✦ stopped '{agent_name}' (ran in this session)" in out
+
+    # Atomic lifetime: the worker stopped with the session — its graceful tombstone makes the
+    # agent read offline immediately (no staleness wait).
+    client = Client.connect(kafka_bootstrap, mesh_config=_FAST_MESH)
+    try:
+        deadline = time.monotonic() + 20.0
+        while agent_name in (await client.mesh.get_agents()):
+            assert time.monotonic() < deadline, "the session worker's tombstone never landed"
+            await asyncio.sleep(0.2)
+    finally:
+        await client.aclose()
+
+
+def test_fresh_broker_first_run_end_to_end(isolated_home: Path, tmp_path: Path) -> None:
+    """G1 from nothing (spec §1): one command spawns the bundled Tansu AND the agent daemon —
+    the readiness gate absorbs the missing-presence-topic window (open_failed = not ready,
+    provisioning creates the plane) — then the address-scoped teardown clears daemon and broker.
+
+    Teardown uses ``stop NAME`` + ``broker stop`` (both scoped to this test's address) rather
+    than ``ck dev down``: the down sweep is deliberately global across addresses (spec §3.4) and
+    would reap daemons belonging to parallel tests — its composition is covered offline.
+    """
+    pytest.importorskip("psutil", reason="the [mesh] extra is not installed")
+    pytest.importorskip("calfkit_mesh", reason="the [mesh] extra is not installed")
+
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    host = f"127.0.0.1:{port}"
+    agent_name = f"fresh-{uuid.uuid4().hex[:8]}-general"
+    spec = _write_target(tmp_path, agent_name)
+
+    result = _invoke(["dev", "run", "-d", spec, "--host", host, "--app-dir", str(tmp_path)])
+    pid: int | None = None
+    try:
+        assert result.exit_code == 0, result.stdout + str(result.exception)
+        assert "managed broker" in result.stdout  # Tansu spawned first
+        assert f"launched agent '{agent_name}'" in result.stdout
+        pid = _pid_of(result.stdout)
+
+        stop = _invoke(["dev", "stop", agent_name, "--host", host])
+        assert stop.exit_code == 0, stop.stdout + str(stop.exception)
+        assert f"stopped daemon pid {pid}" in stop.stdout
+
+        broker_stop = _invoke(["dev", "broker", "stop", "--host", host])
+        assert broker_stop.exit_code == 0, broker_stop.stdout + str(broker_stop.exception)
+        assert f"stopped {host}" in broker_stop.stdout
+        assert is_reachable(host, timeout=2.0) is False
+    finally:
+        if pid is not None:
+            _reap_tree(pid)
+        _invoke(["dev", "broker", "stop", "--host", host])  # belt-and-braces if the assert path bailed early

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -20,7 +20,9 @@ from faststream.kafka import KafkaBroker, TestKafkaBroker
 from calfkit._vendor.pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, TextPart, ToolCallPart, ToolReturnPart
 from calfkit._vendor.pydantic_ai.models.function import AgentInfo as _FnAgentInfo
 from calfkit._vendor.pydantic_ai.models.function import FunctionModel
+from calfkit.cli import _dev_agents
 from calfkit.cli._chat import _chat_loop, _render_and_collect, _resolve_target, _run_turn, run_chat_session
+from calfkit.cli._dev_agents import DevAgentError, TargetNodes, TargetOutcome
 from calfkit.client import Client
 from calfkit.client.events import RunCompleted, RunFailed
 from calfkit.client.hub import InvocationHandle, _RunChannel
@@ -430,3 +432,190 @@ async def test_chat_loop_keeps_current_agent_when_a_turn_fails(capsys: pytest.Ca
     await _chat_loop(client, "bot", None, _scripted(["boom", "/exit"]))
     assert client.binds == ["bot"]  # never re-bound despite the fault
     assert "bot > [error] boom" in capsys.readouterr().out
+
+
+# --- ck dev chat TARGET: the in-process session worker (agent-lifecycle spec §3.2) ---------------------
+
+
+@pytest.fixture
+def isolated_home(monkeypatch: pytest.MonkeyPatch, tmp_path: object) -> object:
+    """The session takes the agent-layer flock under ~/.calfkit — keep it out of the real home."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+def _target_nodes(spec: str = "app:agent", agent_names: tuple[str, ...] = ("general",), tool_names: tuple[str, ...] = ()) -> TargetNodes:
+    nodes = tuple(object() for _ in (*agent_names, *tool_names))
+    return TargetNodes(spec=spec, nodes=nodes, agent_names=agent_names, tool_names=tool_names)
+
+
+class _SessionWorker:
+    """Captures the in-process worker construction + lifecycle the session drives."""
+
+    instances: list[_SessionWorker] = []
+
+    def __init__(self, client: object, nodes: object = None, **kwargs: object) -> None:
+        self.client = client
+        self.nodes = nodes
+        self.kwargs = kwargs
+        self.started = False
+        self.stopped = False
+        _SessionWorker.instances.append(self)
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+@pytest.fixture
+def session_seams(monkeypatch: pytest.MonkeyPatch, isolated_home: object) -> dict:
+    """Default drivable seams: one launched target, readiness OK, picker quit immediately."""
+    seams: dict = {"evaluate": ([], [_target_nodes()]), "waits": []}
+    _SessionWorker.instances = []
+
+    async def fake_evaluate(plan: object, host_key: object, mesh: object) -> tuple:
+        seams["evaluate_args"] = (plan, host_key, mesh)
+        result: tuple = seams["evaluate"]
+        return result
+
+    async def fake_wait(proc: object, agent_names: object, tool_names: object, mesh: object, **kwargs: object) -> None:
+        seams["waits"].append({"proc": proc, "agent_names": agent_names, "tool_names": tool_names, **kwargs})
+
+    monkeypatch.setattr(_dev_agents, "evaluate_targets", fake_evaluate)
+    monkeypatch.setattr(_dev_agents, "wait_agents_ready", fake_wait)
+    monkeypatch.setattr("calfkit.worker.Worker", _SessionWorker)
+    _patch_get_agents(monkeypatch, result={"general": _agent("general", None)})
+    monkeypatch.setattr("calfkit.cli._chat.make_reader", lambda _loop: _scripted(["q"]))
+    return seams
+
+
+async def test_session_launches_the_worker_on_the_shared_client_and_stops_it(session_seams: dict, capsys: pytest.CaptureFixture[str]) -> None:
+    """The co-located contract (spec §9 'Session worker's Client'): the worker shares the chat
+    session's Client, carries the 5s dev heartbeat preset explicitly, hosts the launched nodes,
+    and is stopped before the client closes — on the session's normal end."""
+    from calfkit.controlplane import ControlPlaneConfig
+
+    plan = [_target_nodes()]
+    session_seams["evaluate"] = ([], plan)  # the worker hosts what the evaluation says to launch
+    await run_chat_session(None, "localhost:9092", None, session_plan=plan, session_host_key="127.0.0.1:9092")
+    (worker,) = _SessionWorker.instances
+    assert isinstance(worker.client, Client)
+    assert worker.started and worker.stopped
+    assert list(worker.nodes) == list(plan[0].nodes)  # type: ignore[call-overload]
+    assert worker.kwargs["control_plane"] == ControlPlaneConfig(heartbeat_interval=5.0)
+    out = capsys.readouterr().out
+    assert "✦ stopped 'general' (ran in this session)" in out
+    assert "still running" not in out
+    # The chat variant of the readiness gate: no process arm.
+    (wait,) = session_seams["waits"]
+    assert wait["proc"] is None
+    assert wait["agent_names"] == ["general"]
+
+
+async def test_session_all_reused_starts_no_worker(session_seams: dict, capsys: pytest.CaptureFixture[str]) -> None:
+    """All targets reused: attach-plus-narration only (spec §3.2) — nothing is started, and the
+    exit line's still-running names are the reused ones."""
+    target = _target_nodes()
+    session_seams["evaluate"] = ([TargetOutcome(target=target, reused=True, ages={"general": 2.0})], [])
+    await run_chat_session(None, "localhost:9092", None, session_plan=[target], session_host_key="127.0.0.1:9092")
+    assert _SessionWorker.instances == []
+    assert session_seams["waits"] == []
+    out = capsys.readouterr().out
+    assert "✦ still running: general — 'ck dev chat' to rejoin, 'ck dev down' to stop everything" in out
+    assert "ran in this session" not in out
+
+
+async def test_session_mixed_launch_and_reuse_narrates_both(session_seams: dict, capsys: pytest.CaptureFixture[str]) -> None:
+    launched = _target_nodes(spec="app:general", agent_names=("general",))
+    reused = _target_nodes(spec="app:finance", agent_names=("finance",))
+    session_seams["evaluate"] = ([TargetOutcome(target=reused, reused=True, ages={"finance": 1.0})], [launched])
+    await run_chat_session(None, "localhost:9092", None, session_plan=[launched, reused], session_host_key="127.0.0.1:9092")
+    out = capsys.readouterr().out
+    assert "✦ stopped 'general' (ran in this session)" in out
+    assert "✦ still running: finance" in out
+
+
+async def test_session_requires_an_agent_among_launched_and_reused(session_seams: dict) -> None:
+    """§7: tools-only launched+reused = nobody to chat with — a preflight-style error, NOT
+    softened into a picker over unrelated online agents; nothing is started."""
+    tools_only = _target_nodes(spec="tools:get_weather", agent_names=(), tool_names=("get_weather",))
+    session_seams["evaluate"] = ([], [tools_only])
+    with pytest.raises(DevAgentError, match=r"nobody to chat with"):
+        await run_chat_session(None, "localhost:9092", None, session_plan=[tools_only], session_host_key="127.0.0.1:9092")
+    assert _SessionWorker.instances == []
+
+
+async def test_session_worker_stopped_when_readiness_fails(session_seams: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Teardown on every exit path (§10): a readiness deadline after a successful start must
+    still stop the in-process worker."""
+
+    async def deadline(*args: object, **kwargs: object) -> None:
+        raise DevAgentError("the launched agents did not come online within 15.0s")
+
+    monkeypatch.setattr(_dev_agents, "wait_agents_ready", deadline)
+    with pytest.raises(DevAgentError, match="did not come online"):
+        await run_chat_session(None, "localhost:9092", None, session_plan=[_target_nodes()], session_host_key="127.0.0.1:9092")
+    (worker,) = _SessionWorker.instances
+    assert worker.started and worker.stopped
+
+
+async def test_session_worker_start_failure_surfaces_directly(
+    session_seams: dict, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """§7: an in-process Worker.start() failure surfaces in the terminal (same process) and is
+    exit-2 material for the command boundary."""
+
+    async def broken_start(self: object) -> None:
+        raise RuntimeError("kafka down")
+
+    monkeypatch.setattr(_SessionWorker, "start", broken_start)
+    with pytest.raises(DevAgentError, match="failed to start"):
+        await run_chat_session(None, "localhost:9092", None, session_plan=[_target_nodes()], session_host_key="127.0.0.1:9092")
+    assert "kafka down" in capsys.readouterr().err  # the traceback, surfaced directly
+
+
+async def test_session_holds_the_flock_through_readiness_and_releases_before_the_repl(
+    session_seams: dict, monkeypatch: pytest.MonkeyPatch, isolated_home: object
+) -> None:
+    """Chat flock scope (spec §9): evaluate→start→readiness under the agent-layer lock, released
+    before the REPL opens."""
+    import fcntl
+    from pathlib import Path
+
+    lock_path = Path(str(isolated_home)) / ".calfkit" / "dev-agents.lock"
+    states: dict[str, bool] = {}
+
+    def _held() -> bool:
+        with lock_path.open("rb") as fd:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                return True
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            return False
+
+    async def probing_wait(*args: object, **kwargs: object) -> None:
+        states["during_readiness"] = _held()
+
+    monkeypatch.setattr(_dev_agents, "wait_agents_ready", probing_wait)
+
+    def probing_reader(_loop: object) -> object:
+        async def read_line(_prompt: str) -> str:
+            states.setdefault("at_repl", _held())
+            return "q"
+
+        return read_line
+
+    monkeypatch.setattr("calfkit.cli._chat.make_reader", probing_reader)
+    await run_chat_session(None, "localhost:9092", None, session_plan=[_target_nodes()], session_host_key="127.0.0.1:9092")
+    assert states == {"during_readiness": True, "at_repl": False}
+
+
+async def test_attach_only_sessions_exit_silently(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """No session_plan = today's attach behavior exactly: no ✦ narration on exit (spec §3.2)."""
+    _patch_get_agents(monkeypatch, result={"alpha": _agent("alpha", "x")})
+    monkeypatch.setattr("calfkit.cli._chat.make_reader", lambda _loop: _scripted(["q"]))
+    await run_chat_session(None, "localhost:9092", None)
+    assert "✦" not in capsys.readouterr().out

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -94,6 +94,35 @@ async def test_resolve_target_name_offline_exits_2_listing_online(capsys: pytest
     assert "helpbot, researcher" in err  # alphabetical online list
 
 
+async def test_resolve_target_offline_name_appends_the_dev_daemon_hint(capsys: pytest.CaptureFixture[str]) -> None:
+    """Spec §7 (review round 1, Ryan-approved): when the dev layer knows a managed daemon owns
+    the offline name, the shipped not-online error gains the logs hint."""
+    agents = {"other": _agent("other", "x")}
+    hint_calls: list[str] = []
+
+    def hint(name: str) -> str | None:
+        hint_calls.append(name)
+        return f"a managed daemon for '{name}' exists but its agents are offline — logs: /tmp/agents-x.log (ck dev status)"
+
+    with pytest.raises(typer.Exit) as exc:
+        await _resolve_target("general", agents, _scripted([]), offline_hint=hint)
+    assert exc.value.exit_code == 2
+    err = capsys.readouterr().err
+    assert "is not online" in err
+    assert "a managed daemon for 'general' exists but its agents are offline — logs: /tmp/agents-x.log (ck dev status)" in err
+    assert hint_calls == ["general"]
+
+
+async def test_resolve_target_offline_name_hint_returning_none_adds_nothing(capsys: pytest.CaptureFixture[str]) -> None:
+    """No daemon owns the name (or the scan is unavailable on a core install): the shipped error
+    stands alone."""
+    with pytest.raises(typer.Exit):
+        await _resolve_target("general", {"other": _agent("other", "x")}, _scripted([]), offline_hint=lambda name: None)
+    err = capsys.readouterr().err
+    assert "is not online" in err
+    assert "managed daemon" not in err
+
+
 async def test_resolve_target_picker_selects_by_index() -> None:
     agents = {"beta": _agent("beta", "x"), "alpha": _agent("alpha", "y")}  # sorted: alpha, beta
     assert await _resolve_target(None, agents, _scripted(["2"])) == "beta"
@@ -619,3 +648,62 @@ async def test_attach_only_sessions_exit_silently(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr("calfkit.cli._chat.make_reader", lambda _loop: _scripted(["q"]))
     await run_chat_session(None, "localhost:9092", None)
     assert "✦" not in capsys.readouterr().out
+
+
+async def test_session_worker_stopped_when_the_repl_is_cancelled(session_seams: dict) -> None:
+    """E9 (review round 1, Ryan-approved): a real Ctrl-C reaches the session as task
+    cancellation while the reader is parked in the REPL — the finally must still stop the
+    in-process worker (and the cancellation must propagate)."""
+    import asyncio
+
+    parked = asyncio.Event()
+
+    def parked_reader(_loop: object) -> object:
+        async def read_line(_prompt: str) -> str:
+            parked.set()
+            await asyncio.Event().wait()  # park forever until cancelled
+            raise AssertionError("unreachable")
+
+        return read_line
+
+    import pytest as _pytest
+
+    with _pytest.MonkeyPatch.context() as mp:
+        mp.setattr("calfkit.cli._chat.make_reader", parked_reader)
+        task = asyncio.create_task(run_chat_session(None, "localhost:9092", None, session_plan=[_target_nodes()], session_host_key="127.0.0.1:9092"))
+        await asyncio.wait_for(parked.wait(), timeout=5.0)
+        task.cancel()
+        with _pytest.raises(asyncio.CancelledError):
+            await task
+    (worker,) = _SessionWorker.instances
+    assert worker.started and worker.stopped
+
+
+async def test_session_worker_stopped_when_the_repl_raises(session_seams: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+    """E9: a mid-REPL failure (e.g. the mesh dying under the picker) still stops the worker and
+    propagates to the command boundary."""
+    _patch_get_agents(monkeypatch, raises=MeshUnavailableError("died mid-session", reason="reader_dead"))
+    with pytest.raises(MeshUnavailableError):
+        await run_chat_session(None, "localhost:9092", None, session_plan=[_target_nodes()], session_host_key="127.0.0.1:9092")
+    (worker,) = _SessionWorker.instances
+    assert worker.started and worker.stopped
+
+
+async def test_session_failed_launch_prints_no_narration(
+    session_seams: dict, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """E11: a launch that never reached the REPL reports its error, not ✦ narration (the
+    repl_entered gate)."""
+
+    async def deadline(*args: object, **kwargs: object) -> None:
+        raise DevAgentError("the launched agents did not come online within 15.0s")
+
+    monkeypatch.setattr(_dev_agents, "wait_agents_ready", deadline)
+    with pytest.raises(DevAgentError):
+        await run_chat_session(None, "localhost:9092", None, session_plan=[_target_nodes()], session_host_key="127.0.0.1:9092")
+    assert "✦" not in capsys.readouterr().out
+
+
+async def test_session_plan_without_host_key_is_a_programming_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    with pytest.raises(ValueError, match="session_host_key"):
+        await run_chat_session(None, "localhost:9092", None, session_plan=[])

--- a/tests/test_dev_agents.py
+++ b/tests/test_dev_agents.py
@@ -1,0 +1,238 @@
+"""Offline tests for the ``ck dev`` agent-daemon supervisor (``calfkit.cli._dev_agents``).
+
+The agent-layer sibling of ``test_dev_broker.py``: preflight classification, the stateless
+argv-marker scan, the bounded readiness poll, connect-or-spawn, and the stop/status data — all at
+the supervisor seams (fake psutil / fake mesh views / FakePopen), no broker, no subprocesses.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import typer
+
+from calfkit.cli import _dev_agents
+from calfkit.cli._dev_agents import DevAgentError
+from calfkit.cli._dev_broker import MeshExtraMissingError
+from tests._dev_fakes import FAKE_CREATE_TIME, FakeProc, install_fake_psutil
+
+_NODES = "tests.dev_agents_nodes"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """No test touches the real ``~/.calfkit`` or inherits a mesh URL from the session env."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CALFKIT_MESH_URL", raising=False)
+
+
+def _daemon_argv(
+    *,
+    targets: tuple[str, ...] = ("app:agent",),
+    host: str | None = "127.0.0.1:9092",
+    marker: str | None = "--dev-daemon=general",
+) -> list[str]:
+    """The exact ``-d`` spawn argv shape (plan §3.1)."""
+    argv = [sys.executable, "-m", "calfkit.cli", "run", *targets]
+    if host is not None:
+        argv += ["--host", host]
+    argv += ["--provision", "--reload"]
+    if marker is not None:
+        argv.append(marker)
+    argv += ["--heartbeat-interval", "5.0"]
+    return argv
+
+
+# --- preflight (spec §5.1): per-target names by kind, fail-fast usage errors --------------------------
+
+
+def test_preflight_classifies_agent_and_tool_names_per_target() -> None:
+    plan = _dev_agents.preflight([f"{_NODES}:general", f"{_NODES}:get_weather"])
+    assert [t.spec for t in plan] == [f"{_NODES}:general", f"{_NODES}:get_weather"]
+    assert plan[0].agent_names == ("general",)
+    assert plan[0].tool_names == ()
+    assert plan[1].agent_names == ()
+    assert plan[1].tool_names == ("get_weather",)
+
+
+def test_preflight_names_is_the_union_of_both_kinds() -> None:
+    """The readiness set is the union of agent + tool names (spec §5.1) — a mixed target
+    contributes both kinds."""
+    (target,) = _dev_agents.preflight([f"{_NODES}:support_team"])
+    assert target.agent_names == ("support",)
+    assert target.tool_names == ("get_time",)
+    assert target.names == ("support", "get_time")
+
+
+def test_preflight_carries_the_node_objects() -> None:
+    """``chat TARGET`` hosts the (non-reused) targets in-process — preflight must yield the
+    resolved node defs themselves, not just their names."""
+    (target,) = _dev_agents.preflight([f"{_NODES}:general"])
+    assert [node.node_id for node in target.nodes] == ["general"]
+
+
+def test_preflight_duplicate_names_across_targets_is_a_usage_error() -> None:
+    """Never a silent dedupe (spec §5.1): the same advertised name arriving via two targets is
+    ambiguous and errors naming the collision."""
+    with pytest.raises(DevAgentError, match=r"general"):
+        _dev_agents.preflight([f"{_NODES}:general", f"{_NODES}:general_dupe"])
+
+
+def test_preflight_same_target_listed_twice_is_a_usage_error() -> None:
+    with pytest.raises(DevAgentError, match=r"general"):
+        _dev_agents.preflight([f"{_NODES}:general", f"{_NODES}:general"])
+
+
+def test_preflight_zero_advert_target_is_a_usage_error() -> None:
+    """Ryan's ruling (2026-07-02): a target with no presence-advertising node would be an
+    invisible, unstoppable daemon (no status row, no name for stop) — fail fast instead and
+    point at foreground ``ck dev run``."""
+    with pytest.raises(DevAgentError, match=r"no agents or tools"):
+        _dev_agents.preflight([f"{_NODES}:audit_log"])
+
+
+def test_preflight_zero_advert_error_names_the_target() -> None:
+    with pytest.raises(DevAgentError, match=r"audit_log"):
+        _dev_agents.preflight([f"{_NODES}:audit_log"])
+
+
+def test_preflight_consumer_co_hosted_with_an_advertising_node_is_fine() -> None:
+    """A consumer node co-hosted WITH an advertising node rides along (the daemon is visible and
+    stoppable via the advertised names); only an all-consumer target errors."""
+    (target,) = _dev_agents.preflight([f"{_NODES}:desk_with_audit"])
+    assert target.agent_names == ("desk",)
+    assert target.names == ("desk",)  # the consumer contributes no presence name
+
+
+def test_preflight_zero_advert_target_among_advertising_targets_still_errors() -> None:
+    """The rule is per target: a consumer-only TARGET errors even when another target in the same
+    invocation advertises fine."""
+    with pytest.raises(DevAgentError, match=r"audit_log"):
+        _dev_agents.preflight([f"{_NODES}:general", f"{_NODES}:audit_log"])
+
+
+def test_preflight_bad_spec_exits_2_via_the_shipped_loader() -> None:
+    """Import/spec failures keep the shipped ``load_nodes`` fail-fast contract (typer.Exit 2)."""
+    with pytest.raises(typer.Exit) as exc:
+        _dev_agents.preflight(["no_colon_here"])
+    assert exc.value.exit_code == 2
+
+
+# --- the stateless argv-marker scan (spec §5.4) -------------------------------------------------------
+
+
+def test_scan_finds_a_marker_daemon_with_names_host_and_targets(monkeypatch: pytest.MonkeyPatch) -> None:
+    argv = _daemon_argv(targets=("app:agent", "tools:all"), marker="--dev-daemon=general,get_weather")
+    install_fake_psutil(monkeypatch, [FakeProc(4055, argv)])
+    (hit,) = _dev_agents.scan_daemons()
+    assert hit.pid == 4055
+    assert hit.names == ("general", "get_weather")
+    assert hit.host_key == "127.0.0.1:9092"
+    assert hit.targets == ("app:agent", "tools:all")
+    assert hit.started_at  # iso from create_time — the SINCE column source
+
+
+def test_scan_started_at_comes_from_process_create_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    from datetime import datetime, timezone
+
+    install_fake_psutil(monkeypatch, [FakeProc(4055, _daemon_argv())])
+    (hit,) = _dev_agents.scan_daemons()
+    assert hit.started_at == datetime.fromtimestamp(FAKE_CREATE_TIME, tz=timezone.utc).isoformat(timespec="seconds")
+
+
+def test_scan_matches_only_the_supervisor_never_spawn_main_descendants(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The C3 test (spec §5.4): the reload/multiprocessing descendants carry ``spawn_main``-shaped
+    argv without the marker — exactly one process per daemon matches."""
+    supervisor = FakeProc(4055, _daemon_argv())
+    worker_child = FakeProc(
+        4056,
+        [sys.executable, "-c", "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=6, pipe_handle=8)", "--multiprocessing-fork"],
+    )
+    install_fake_psutil(monkeypatch, [supervisor, worker_child])
+    hits = _dev_agents.scan_daemons()
+    assert [hit.pid for hit in hits] == [4055]
+
+
+def test_scan_accepts_the_space_separated_flag_form(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A hand-run ``ck run … --dev-daemon general`` is managed too (R3: whoever started it)."""
+    argv = [sys.executable, "-m", "calfkit.cli", "run", "app:agent", "--dev-daemon", "general"]
+    install_fake_psutil(monkeypatch, [FakeProc(4055, argv)])
+    (hit,) = _dev_agents.scan_daemons()
+    assert hit.names == ("general",)
+
+
+def test_scan_without_host_scopes_to_the_default_address(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Spec §3.4: a marker hit whose argv lacks ``--host`` scopes to the default address."""
+    install_fake_psutil(monkeypatch, [FakeProc(4055, _daemon_argv(host=None))])
+    (hit,) = _dev_agents.scan_daemons()
+    assert hit.host_key == "127.0.0.1:9092"
+
+
+def test_scan_normalizes_the_host_for_the_address_join(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A hand-run ``--host localhost`` must compare equal to the normalized ``127.0.0.1:9092``."""
+    install_fake_psutil(monkeypatch, [FakeProc(4055, _daemon_argv(host="localhost"))])
+    (hit,) = _dev_agents.scan_daemons()
+    assert hit.host_key == "127.0.0.1:9092"
+
+
+def test_scan_skips_an_unparseable_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An address that does not parse cannot be joined with presence — not a daemon we can manage."""
+    install_fake_psutil(monkeypatch, [FakeProc(4055, _daemon_argv(host="bad:port:extra:99999999"))])
+    assert _dev_agents.scan_daemons() == []
+
+
+def test_scan_skips_an_empty_marker_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A hand-run empty ``--dev-daemon=`` names nothing: invisible to status-by-name and
+    unstoppable by name — not a daemon we can manage."""
+    install_fake_psutil(monkeypatch, [FakeProc(4055, _daemon_argv(marker="--dev-daemon="))])
+    assert _dev_agents.scan_daemons() == []
+
+
+def test_scan_skips_unmarked_processes(monkeypatch: pytest.MonkeyPatch) -> None:
+    tansu = FakeProc(4021, ["tansu", "broker", "--storage-engine=memory://tansu/", "--kafka-listener-url=tcp://127.0.0.1:9092"])
+    install_fake_psutil(monkeypatch, [tansu, FakeProc(1, ["init"])])
+    assert _dev_agents.scan_daemons() == []
+
+
+def test_scan_skips_processes_that_vanish_or_deny_mid_scan(monkeypatch: pytest.MonkeyPatch) -> None:
+    install_fake_psutil(
+        monkeypatch,
+        [FakeProc(1, raises="nosuch"), FakeProc(2, raises="denied"), FakeProc(3, raises="zombie"), FakeProc(4055, _daemon_argv())],
+    )
+    assert [hit.pid for hit in _dev_agents.scan_daemons()] == [4055]
+
+
+def test_scan_without_psutil_raises_the_mesh_extra_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "psutil", None)  # forces ModuleNotFoundError on import
+    with pytest.raises(MeshExtraMissingError, match=r"\[mesh\]"):
+        _dev_agents.scan_daemons()
+
+
+def test_find_daemons_filters_by_host_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    here = FakeProc(4055, _daemon_argv(marker="--dev-daemon=general"))
+    elsewhere = FakeProc(4102, _daemon_argv(host="127.0.0.1:19092", marker="--dev-daemon=finance"))
+    install_fake_psutil(monkeypatch, [here, elsewhere])
+    assert [hit.pid for hit in _dev_agents.find_daemons("127.0.0.1:9092")] == [4055]
+    assert [hit.pid for hit in _dev_agents.find_daemons(None)] == [4055, 4102]
+
+
+# --- the log slug: derived identically at spawn and scan time (handoff rule) --------------------------
+
+
+def test_scan_derives_the_same_log_path_the_spawn_writes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    targets = ("general_help:general",)
+    spawn_side = _dev_agents.daemon_log_path("127.0.0.1:9092", targets)
+    install_fake_psutil(monkeypatch, [FakeProc(4055, _daemon_argv(targets=targets))])
+    (hit,) = _dev_agents.scan_daemons()
+    assert hit.log_path == str(spawn_side)
+    assert str(tmp_path) in hit.log_path  # under the isolated HOME's ~/.calfkit/logs
+    assert Path(hit.log_path).name.startswith("agents-")
+
+
+def test_daemon_log_path_sanitizes_path_hostile_characters() -> None:
+    path = _dev_agents.daemon_log_path("127.0.0.1:9092", ("pkg.mod:attr", "other:one"))
+    name = Path(path).name
+    assert name.endswith(".log")
+    assert ":" not in name and "/" not in name and "," not in name

--- a/tests/test_dev_agents.py
+++ b/tests/test_dev_agents.py
@@ -15,6 +15,7 @@ from typing import Any
 import pytest
 import typer
 
+import calfkit.cli._dev_broker as dev_broker_module
 from calfkit.cli import _dev_agents
 from calfkit.cli._dev_agents import DevAgentError
 from calfkit.cli._dev_broker import MeshExtraMissingError, normalize
@@ -239,6 +240,27 @@ def test_find_daemons_filters_by_host_key(monkeypatch: pytest.MonkeyPatch) -> No
     install_fake_psutil(monkeypatch, [here, elsewhere])
     assert [hit.pid for hit in _dev_agents.find_daemons("127.0.0.1:9092")] == [4055]
     assert [hit.pid for hit in _dev_agents.find_daemons(None)] == [4055, 4102]
+
+
+def test_scan_handles_a_marker_on_a_non_run_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A hand-set marker on an argv with no ``run`` verb still scans (whoever started it): no
+    positional targets, so the derived log slug is targets-less — best-effort, R3."""
+    argv = [sys.executable, "-m", "calfkit.cli", "--dev-daemon=general", "--host", "127.0.0.1:9092"]
+    install_fake_psutil(monkeypatch, [FakeProc(4055, argv)])
+    (hit,) = _dev_agents.scan_daemons()
+    assert hit.targets == ()
+    assert hit.names == ("general",)
+
+
+def test_killpg_seam_delivers_via_os_killpg(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The seam's body is the one real ``os.killpg`` call site (call-time lookup so module import
+    stays platform-safe); everything else in the suite replaces the seam itself."""
+    import os as os_module
+
+    calls: list[tuple[int, int]] = []
+    monkeypatch.setattr(os_module, "killpg", lambda pgid, sig: calls.append((pgid, sig)))
+    dev_broker_module._killpg(123, 15)
+    assert calls == [(123, 15)]
 
 
 # --- the log slug: derived identically at spawn and scan time (handoff rule) --------------------------
@@ -541,6 +563,172 @@ async def test_ensure_readiness_failure_propagates_after_the_group_kill(monkeypa
         await _dev_agents.ensure_agents([_target("general")], normalize([_KEY]), mesh, run_args=_run_args(), **_fast_wait())
     assert len(spawned) == 1
     assert killed and killed[0][0] == spawned[0].pid
+
+
+# --- stop: whole-daemon group signalling (spec §3.4) --------------------------------------------------
+
+
+def _hit(proc: FakeProc, names: tuple[str, ...] = ("general",), host_key: str = _KEY) -> _dev_agents.DaemonHit:
+    return _dev_agents.DaemonHit(
+        proc=proc,
+        pid=proc.pid,
+        names=names,
+        host_key=host_key,
+        targets=("app:agent",),
+        log_path="/tmp/agents-x.log",
+        started_at="2026-07-02T00:00:00+00:00",
+    )
+
+
+def _group_killer(monkeypatch: pytest.MonkeyPatch, procs: list[FakeProc], *, dies_on: int | None = None) -> list[tuple[int, int]]:
+    """Replace the killpg seam with a recorder that flips the leader's FakeProc state, modelling
+    the group signal reaching the tree. ``dies_on`` = the signal that actually kills (None = both)."""
+    import signal as signal_module
+
+    calls: list[tuple[int, int]] = []
+
+    def fake_killpg(pgid: int, sig: int) -> None:
+        calls.append((pgid, sig))
+        for proc in procs:
+            if proc.pid == pgid and (dies_on is None or sig == dies_on):
+                proc.alive = False
+
+    monkeypatch.setattr(dev_broker_module, "_killpg", fake_killpg)
+    assert signal_module.SIGTERM  # keep the import obviously used
+    return calls
+
+
+def test_stop_daemon_signals_the_process_group_term_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    import signal as signal_module
+
+    install_fake_psutil(monkeypatch, [])
+    proc = FakeProc(4055)
+    calls = _group_killer(monkeypatch, [proc])
+    assert _dev_agents.stop_daemon(_hit(proc), grace=0.3) is True
+    assert calls == [(4055, signal_module.SIGTERM)]
+
+
+def test_stop_daemon_escalates_to_group_sigkill_after_grace(monkeypatch: pytest.MonkeyPatch) -> None:
+    import signal as signal_module
+
+    install_fake_psutil(monkeypatch, [])
+    proc = FakeProc(4055, survives_sigterm=True)
+    calls = _group_killer(monkeypatch, [proc], dies_on=signal_module.SIGKILL)
+    assert _dev_agents.stop_daemon(_hit(proc), grace=0.3) is True
+    assert calls == [(4055, signal_module.SIGTERM), (4055, signal_module.SIGKILL)]
+
+
+def test_stop_daemon_denied_group_signal_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    install_fake_psutil(monkeypatch, [])
+    proc = FakeProc(4055)
+
+    def deny(pgid: int, sig: int) -> None:
+        raise PermissionError("not yours")
+
+    monkeypatch.setattr(dev_broker_module, "_killpg", deny)
+    assert _dev_agents.stop_daemon(_hit(proc), grace=0.3) is False
+
+
+def test_stop_daemon_vanished_group_is_the_goal_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    install_fake_psutil(monkeypatch, [])
+    proc = FakeProc(4055)
+
+    def gone(pgid: int, sig: int) -> None:
+        raise ProcessLookupError("already gone")
+
+    monkeypatch.setattr(dev_broker_module, "_killpg", gone)
+    assert _dev_agents.stop_daemon(_hit(proc), grace=0.3) is True
+
+
+def test_stop_daemon_zombie_leader_counts_as_stopped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The broker's zombie discipline holds one layer up: a dead-but-unreaped leader (its
+    spawning shell still alive) IS the stopped state, not a failure."""
+    import signal as signal_module
+
+    install_fake_psutil(monkeypatch, [])
+    proc = FakeProc(4055)
+    calls: list[tuple[int, int]] = []
+
+    def zombify(pgid: int, sig: int) -> None:
+        calls.append((pgid, sig))
+        proc.zombie = True
+
+    monkeypatch.setattr(dev_broker_module, "_killpg", zombify)
+    assert _dev_agents.stop_daemon(_hit(proc), grace=0.3) is True
+    assert calls == [(4055, signal_module.SIGTERM)]
+
+
+def test_daemon_grace_is_at_least_eight_seconds() -> None:
+    """Spec §3.4: the reload supervisor's own teardown budget is ~6s (SIGINT→join(5)→SIGKILL→
+    join(1)); a shorter grace would SIGKILL it mid-shutdown and orphan the worker. The broker's
+    own 5s default stays untouched (R4: parameterized per call site)."""
+    import inspect
+
+    assert _dev_agents.DAEMON_GRACE >= 8.0
+    assert inspect.signature(_dev_agents.stop_daemon).parameters["grace"].default == _dev_agents.DAEMON_GRACE
+    assert dev_broker_module.DEFAULT_GRACE == 5.0
+
+
+# --- stop resolution: names -> daemons at one address (spec §3.4) -------------------------------------
+
+
+def test_resolve_stop_dedupes_co_hosted_names_to_one_daemon(monkeypatch: pytest.MonkeyPatch) -> None:
+    daemon = _hit(FakeProc(4055), names=("general", "finance"))
+    hits = _dev_agents.resolve_stop(["general", "finance"], [daemon], host_key=_KEY, online=set())
+    assert [h.pid for h in hits] == [4055]
+
+
+def test_resolve_stop_multiple_names_across_daemons(monkeypatch: pytest.MonkeyPatch) -> None:
+    first = _hit(FakeProc(4055), names=("general",))
+    second = _hit(FakeProc(4102), names=("finance",))
+    hits = _dev_agents.resolve_stop(["finance", "general"], [first, second], host_key=_KEY, online=set())
+    assert [h.pid for h in hits] == [4102, 4055]
+
+
+def test_resolve_stop_unknown_name_lists_the_address_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exit-2 material naming what IS running at the target address and how to look elsewhere."""
+    daemon = _hit(FakeProc(4055), names=("general",))
+    with pytest.raises(DevAgentError, match=r"(?s)'nope'.*running at 127\.0\.0\.1:9092: general.*--host"):
+        _dev_agents.resolve_stop(["nope"], [daemon], host_key=_KEY, online=set())
+
+
+def test_resolve_stop_unknown_name_with_no_daemons_says_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    with pytest.raises(DevAgentError, match=r"(?s)running at 127\.0\.0\.1:9092: none.*--host"):
+        _dev_agents.resolve_stop(["nope"], [], host_key=_KEY, online=set())
+
+
+def test_resolve_stop_online_but_unmanaged_name_explains_why(monkeypatch: pytest.MonkeyPatch) -> None:
+    with pytest.raises(DevAgentError, match=r"'support' is not a ck dev daemon — stop it where it runs"):
+        _dev_agents.resolve_stop(["support"], [], host_key=_KEY, online={"support"})
+
+
+def test_resolve_stop_two_same_named_hits_lists_both_pids_never_guesses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hand-run markers / dead-broker windows can leave two same-named daemons at one address —
+    exit 2 listing both pids, never a guess (spec §3.4)."""
+    first = _hit(FakeProc(4055), names=("general",))
+    second = _hit(FakeProc(4102), names=("general",))
+    with pytest.raises(DevAgentError, match=r"(?s)4055.*4102"):
+        _dev_agents.resolve_stop(["general"], [first, second], host_key=_KEY, online=set())
+
+
+async def test_ensure_unwritable_log_location_is_exit_2_material(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    install_fake_psutil(monkeypatch, [])
+    blocker = tmp_path / "blocker"
+    blocker.write_text("a file where a directory must go")
+    monkeypatch.setattr(_dev_agents, "daemon_log_path", lambda key, targets: blocker / "logs" / "agents-x.log")
+    with pytest.raises(DevAgentError, match=r"cannot write the agent daemon log"):
+        await _dev_agents.ensure_agents([_target("general")], normalize([_KEY]), FakeMesh(), run_args=_run_args(), **_fast_wait())
+
+
+async def test_ensure_exec_failure_is_exit_2_material(monkeypatch: pytest.MonkeyPatch) -> None:
+    install_fake_psutil(monkeypatch, [])
+
+    def boom(cmd: list[str], **kwargs: object) -> FakePopen:
+        raise OSError("exec format error")
+
+    monkeypatch.setattr(_dev_agents, "Popen", boom)
+    with pytest.raises(DevAgentError, match=r"failed to launch the agent daemon"):
+        await _dev_agents.ensure_agents([_target("general")], normalize([_KEY]), FakeMesh(), run_args=_run_args(), **_fast_wait())
 
 
 async def test_ensure_holds_the_agents_flock_across_its_critical_section(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_dev_agents.py
+++ b/tests/test_dev_agents.py
@@ -179,11 +179,26 @@ def test_scan_matches_only_the_supervisor_never_spawn_main_descendants(monkeypat
     assert [hit.pid for hit in hits] == [4055]
 
 
-def test_scan_accepts_the_space_separated_flag_form(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A hand-run ``ck run … --dev-daemon general`` is managed too (R3: whoever started it)."""
-    argv = [sys.executable, "-m", "calfkit.cli", "run", "app:agent", "--dev-daemon", "general"]
-    install_fake_psutil(monkeypatch, [FakeProc(4055, argv)])
+def test_scan_requires_the_emitted_marker_form_never_the_bare_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Review round 1 (Ryan-approved): the marker matches ONLY its emitted ``--dev-daemon=<names>``
+    form — a bare ``--dev-daemon`` token appearing as *data* in some other process's argv (e.g.
+    ``rg -- --dev-daemon docs/``) must never be claimed as a daemon, or ``ck dev down`` would
+    group-kill an innocent process."""
+    searcher = FakeProc(6001, ["rg", "--", "--dev-daemon", "docs/"])
+    space_form = FakeProc(6002, [sys.executable, "-m", "calfkit.cli", "run", "app:agent", "--dev-daemon", "general"])
+    install_fake_psutil(monkeypatch, [searcher, space_form])
+    assert _dev_agents.scan_daemons() == []
+
+
+def test_scan_requires_a_run_token_alongside_the_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Second anchor (review round 1, Ryan-approved): the emitted marker only ever rides a
+    ``run`` command line, so a process merely *mentioning* the ``=``-form (e.g. a grep of a log
+    line) is still not a daemon."""
+    grepper = FakeProc(6003, ["rg", "--", "--dev-daemon=general", "notes.md"])
+    hand_run_ck = FakeProc(6004, ["/venv/bin/ck", "run", "app:agent", "--dev-daemon=general"])
+    install_fake_psutil(monkeypatch, [grepper, hand_run_ck])
     (hit,) = _dev_agents.scan_daemons()
+    assert hit.pid == 6004  # the hand-run `ck run` form stays managed (R3: whoever started it)
     assert hit.names == ("general",)
 
 
@@ -242,14 +257,12 @@ def test_find_daemons_filters_by_host_key(monkeypatch: pytest.MonkeyPatch) -> No
     assert [hit.pid for hit in _dev_agents.find_daemons(None)] == [4055, 4102]
 
 
-def test_scan_handles_a_marker_on_a_non_run_command(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A hand-set marker on an argv with no ``run`` verb still scans (whoever started it): no
-    positional targets, so the derived log slug is targets-less — best-effort, R3."""
+def test_scan_skips_a_marker_on_a_non_run_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ``run`` anchor is required (review round 1): a marker on an argv with no ``run`` verb
+    is data, not a daemon — unmatchable, so unmanageable, so never signalled."""
     argv = [sys.executable, "-m", "calfkit.cli", "--dev-daemon=general", "--host", "127.0.0.1:9092"]
     install_fake_psutil(monkeypatch, [FakeProc(4055, argv)])
-    (hit,) = _dev_agents.scan_daemons()
-    assert hit.targets == ()
-    assert hit.names == ("general",)
+    assert _dev_agents.scan_daemons() == []
 
 
 def test_killpg_seam_delivers_via_os_killpg(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -368,6 +381,40 @@ async def test_wait_ready_reads_only_the_kinds_the_targets_advertise() -> None:
     assert set(mesh.reads) == {"agents"}
 
 
+async def test_wait_ready_reader_dead_fails_fast_naming_the_client_side_failure() -> None:
+    """Review round 1 (Ryan-approved): ``reader_dead`` is terminal for the view's lifetime —
+    polling it for 15s and then blaming the daemon's healthy log misdiagnoses a client-side
+    failure. Fail fast, naming the real culprit."""
+    dead = MeshUnavailableError("the agents reader died", reason="reader_dead")
+    mesh = FakeMesh(agents_frames=[dead])
+    with pytest.raises(DevAgentError, match=r"(?s)presence view died.*not the agents") as exc:
+        await _dev_agents.wait_agents_ready(None, ("general",), (), mesh, log_path=None, **_fast_wait())
+    assert exc.value.__cause__ is dead
+
+
+async def test_wait_ready_reader_dead_still_tears_down_the_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The fail-fast arm must not strand a half-started spawn: the group is killed exactly as on
+    the deadline path."""
+    import signal
+
+    killed = _record_killpg(monkeypatch)
+    proc = FakePopen(["cmd"], stdout=None)
+    mesh = FakeMesh(agents_frames=[MeshUnavailableError("died", reason="reader_dead")])
+    with pytest.raises(DevAgentError, match="presence view died"):
+        await _dev_agents.wait_agents_ready(proc, ("general",), (), mesh, log_path=None, **_fast_wait())
+    assert killed == [(proc.pid, signal.SIGKILL)]
+
+
+async def test_wait_ready_deadline_names_the_unreadable_reason(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A deadline that never saw a readable view must say so — 'did not come online' would point
+    the user at their agent when the presence read itself was the problem."""
+    _record_killpg(monkeypatch)
+    establishing = MeshUnavailableError("catching up", reason="establishing")
+    mesh = FakeMesh(agents_frames=[establishing])
+    with pytest.raises(DevAgentError, match=r"(?s)never became readable.*establishing"):
+        await _dev_agents.wait_agents_ready(None, ("general",), (), mesh, log_path=None, **_fast_wait())
+
+
 # --- connect-or-spawn evaluation (spec §5.5) ----------------------------------------------------------
 
 
@@ -402,6 +449,19 @@ async def test_evaluate_unopenable_view_counts_as_none_online(monkeypatch: pytes
     mesh = FakeMesh(agents_frames=[_unavailable()])
     _, to_launch = await _dev_agents.evaluate_targets([_target("general")], _KEY, mesh)
     assert [t.spec for t in to_launch] == [f"{_NODES}:general"]
+
+
+async def test_evaluate_non_open_failed_read_failures_error_instead_of_classifying(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Spec §5.5 pins only ``open_failed`` as none-online. ``establishing``/``reader_dead`` are a
+    different class: classifying on them could brand a HEALTHY daemon 'broken' (and advise
+    'ck dev stop' against it) or double-spawn — error naming the read failure instead (review
+    round 1, Ryan-approved)."""
+    daemon = FakeProc(4055, _daemon_argv(marker="--dev-daemon=general"))
+    install_fake_psutil(monkeypatch, [daemon])
+    for reason in ("establishing", "reader_dead"):
+        mesh = FakeMesh(agents_frames=[MeshUnavailableError("unreadable", reason=reason)])
+        with pytest.raises(DevAgentError, match=rf"(?s)could not be read.*{reason}"):
+            await _dev_agents.evaluate_targets([_target("general")], _KEY, mesh)
 
 
 async def test_evaluate_broken_daemon_errors_instead_of_a_second_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -493,9 +553,16 @@ async def test_ensure_spawns_one_daemon_for_all_offline_targets(monkeypatch: pyt
     assert "--dev-daemon=general,get_weather" in proc.cmd
     heartbeat_index = proc.cmd.index("--heartbeat-interval")
     assert proc.cmd[heartbeat_index + 1] == "5.0"
-    # The detach + log-fd contract (the broker Popen pattern verbatim).
+    # The detach + log-fd contract (the broker Popen pattern verbatim): stdout and stderr share
+    # the REAL log-file fd (never PIPE — an unread pipe would deadlock a chatty worker), stdin is
+    # detached, and the parent closes its copy of the fd after the spawn.
+    import subprocess as subprocess_module
+
     assert proc.kwargs["start_new_session"] is True
-    assert proc.kwargs["stdin"] is not None
+    assert proc.kwargs["stdin"] is subprocess_module.DEVNULL
+    assert proc.kwargs["stdout"] is proc.kwargs["stderr"]
+    assert Path(proc.kwargs["stdout"].name) == Path(str(report.log_path))
+    assert proc.kwargs["stdout"].closed  # the parent's copy — the daemon holds its own
     assert report.pid == proc.pid
     assert report.log_path is not None and Path(report.log_path).exists()
     assert [o.reused for o in report.outcomes] == [False, False]
@@ -598,14 +665,51 @@ def _group_killer(monkeypatch: pytest.MonkeyPatch, procs: list[FakeProc], *, die
     return calls
 
 
-def test_stop_daemon_signals_the_process_group_term_first(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_stop_daemon_signals_the_group_term_then_a_final_kill_sweep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Review round 1 (Ryan-approved): leader death alone must not declare the GROUP dead — a
+    SIGTERM-surviving grandchild (a node's own subprocess) would silently outlive the 'stopped'
+    report, markerless and unmanageable. After the leader is gone, one unconditional group
+    SIGKILL sweeps the now-headless tree."""
     import signal as signal_module
 
     install_fake_psutil(monkeypatch, [])
     proc = FakeProc(4055)
     calls = _group_killer(monkeypatch, [proc])
     assert _dev_agents.stop_daemon(_hit(proc), grace=0.3) is True
-    assert calls == [(4055, signal_module.SIGTERM)]
+    assert calls == [(4055, signal_module.SIGTERM), (4055, signal_module.SIGKILL)]
+
+
+def test_stop_daemon_final_sweep_tolerates_an_already_empty_group(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The final sweep is best-effort: a fully-dead group raises ProcessLookupError — the goal
+    state, not a failure."""
+    import signal as signal_module
+
+    install_fake_psutil(monkeypatch, [])
+    proc = FakeProc(4055)
+    calls: list[tuple[int, int]] = []
+
+    def killpg_then_gone(pgid: int, sig: int) -> None:
+        calls.append((pgid, sig))
+        if sig == signal_module.SIGTERM:
+            proc.alive = False
+        else:
+            raise ProcessLookupError("group already empty")
+
+    monkeypatch.setattr(dev_broker_module, "_killpg", killpg_then_gone)
+    assert _dev_agents.stop_daemon(_hit(proc), grace=0.3) is True
+    assert [sig for _, sig in calls] == [signal_module.SIGTERM, signal_module.SIGKILL]
+
+
+def test_stop_daemon_never_signals_a_recycled_pid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Review round 1 (Ryan-approved): the group path must keep psutil's identity guard — if the
+    scanned daemon exited between scan and signal (its pid possibly recycled by an unrelated
+    process group), no raw killpg may ever be sent; the exit IS the goal state."""
+    install_fake_psutil(monkeypatch, [])
+    proc = FakeProc(4055)
+    proc.alive = False  # exited after the scan; pid may now belong to an innocent group
+    calls = _group_killer(monkeypatch, [proc])
+    assert _dev_agents.stop_daemon(_hit(proc), grace=0.3) is True
+    assert calls == []  # no signal was ever delivered to the (possibly recycled) pgid
 
 
 def test_stop_daemon_escalates_to_group_sigkill_after_grace(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -655,7 +759,9 @@ def test_stop_daemon_zombie_leader_counts_as_stopped(monkeypatch: pytest.MonkeyP
 
     monkeypatch.setattr(dev_broker_module, "_killpg", zombify)
     assert _dev_agents.stop_daemon(_hit(proc), grace=0.3) is True
-    assert calls == [(4055, signal_module.SIGTERM)]
+    # The zombie leader is the stopped state; the final group sweep still fires (a zombie-only
+    # group absorbs it harmlessly, a straggler member gets reaped).
+    assert calls == [(4055, signal_module.SIGTERM), (4055, signal_module.SIGKILL)]
 
 
 def test_daemon_grace_is_at_least_eight_seconds() -> None:

--- a/tests/test_dev_agents.py
+++ b/tests/test_dev_agents.py
@@ -8,17 +8,40 @@ the supervisor seams (fake psutil / fake mesh views / FakePopen), no broker, no 
 from __future__ import annotations
 
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Any
 
 import pytest
 import typer
 
 from calfkit.cli import _dev_agents
 from calfkit.cli._dev_agents import DevAgentError
-from calfkit.cli._dev_broker import MeshExtraMissingError
-from tests._dev_fakes import FAKE_CREATE_TIME, FakeProc, install_fake_psutil
+from calfkit.cli._dev_broker import MeshExtraMissingError, normalize
+from calfkit.client.mesh import AgentInfo, ToolNodeInfo
+from calfkit.exceptions import MeshUnavailableError
+from tests._dev_fakes import FAKE_CREATE_TIME, FakeMesh, FakePopen, FakeProc, install_fake_psutil
 
 _NODES = "tests.dev_agents_nodes"
+
+
+def _agent_info(name: str, *, age: float = 0.0) -> AgentInfo:
+    return AgentInfo(name=name, description=None, last_seen=datetime.now(tz=timezone.utc) - timedelta(seconds=age))
+
+
+def _tool_info(name: str, *, age: float = 0.0) -> ToolNodeInfo:
+    return ToolNodeInfo(name=name, description=None, parameters_schema={}, last_seen=datetime.now(tz=timezone.utc) - timedelta(seconds=age))
+
+
+def _unavailable() -> MeshUnavailableError:
+    return MeshUnavailableError("no plane yet", reason="open_failed")
+
+
+def _record_killpg(monkeypatch: pytest.MonkeyPatch) -> list[tuple[int, int]]:
+    """Never let a test signal a real process group: replace the killpg seam with a recorder."""
+    calls: list[tuple[int, int]] = []
+    monkeypatch.setattr(_dev_agents, "_killpg", lambda pgid, sig: calls.append((pgid, sig)))
+    return calls
 
 
 @pytest.fixture(autouse=True)
@@ -236,3 +259,318 @@ def test_daemon_log_path_sanitizes_path_hostile_characters() -> None:
     name = Path(path).name
     assert name.endswith(".log")
     assert ":" not in name and "/" not in name and "," not in name
+
+
+# --- the bounded readiness poll (spec §5.2): the broker loop, one layer up ----------------------------
+
+
+def _fast_wait(**kwargs: Any) -> dict[str, Any]:
+    """Tight loop parameters so deadline tests run in real milliseconds."""
+    return {"timeout": kwargs.pop("timeout", 0.25), "poll_interval": 0.01, **kwargs}
+
+
+async def test_wait_ready_returns_once_every_name_is_online(tmp_path: Path) -> None:
+    mesh = FakeMesh(agents_frames=[{}, {"general": _agent_info("general")}])
+    await _dev_agents.wait_agents_ready(None, ("general",), (), mesh, log_path=None, **_fast_wait())
+
+
+async def test_wait_ready_child_death_is_checked_first_and_wins_ties(tmp_path: Path) -> None:
+    """The supervisor died: even with the mesh reporting the names online, the child-exit arm
+    fires first (spec §5.2 arm 1) with the log tail."""
+    log = tmp_path / "dead.log"
+    log.write_text("boom: broker rejected the connection")
+    proc = FakePopen(["cmd"], stdout=None)
+    proc.returncode = 2
+    mesh = FakeMesh(agents_frames=[{"general": _agent_info("general")}])
+    with pytest.raises(DevAgentError, match=r"(?s)exited.*boom: broker rejected") as exc:
+        await _dev_agents.wait_agents_ready(proc, ("general",), (), mesh, log_path=str(log), **_fast_wait())
+    assert "exit code 2" in str(exc.value)
+
+
+async def test_wait_ready_open_failed_counts_as_not_ready_and_retries(tmp_path: Path) -> None:
+    """The fresh-broker race (spec §5.5): an unopenable presence view is 'not ready yet', absorbed
+    inside the deadline — the spawned worker's provisioning creates the topics meanwhile."""
+    mesh = FakeMesh(agents_frames=[_unavailable(), _unavailable(), {"general": _agent_info("general")}])
+    await _dev_agents.wait_agents_ready(None, ("general",), (), mesh, log_path=None, **_fast_wait())
+
+
+async def test_wait_ready_mixed_kinds_need_both_views(tmp_path: Path) -> None:
+    """The readiness set is the union across kinds: an online agent alone must not satisfy a
+    target that also advertises a tool."""
+    mesh = FakeMesh(
+        agents_frames=[{"support": _agent_info("support")}],
+        tools_frames=[{}, {}, {"get_time": _tool_info("get_time")}],
+    )
+    await _dev_agents.wait_agents_ready(None, ("support",), ("get_time",), mesh, log_path=None, **_fast_wait())
+
+
+async def test_wait_ready_deadline_group_kills_the_spawn_and_reports_the_log_tail(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    killed = _record_killpg(monkeypatch)
+    log = tmp_path / "slow.log"
+    log.write_text("still importing torch...")
+    proc = FakePopen(["cmd"], stdout=None)  # never exits (returncode None)
+    mesh = FakeMesh(agents_frames=[{}])  # never online
+    with pytest.raises(DevAgentError, match=r"(?s)did not come online.*still importing torch"):
+        await _dev_agents.wait_agents_ready(proc, ("general",), (), mesh, log_path=str(log), **_fast_wait())
+    import signal
+
+    assert killed == [(proc.pid, signal.SIGKILL)]
+
+
+async def test_wait_ready_deadline_without_a_process_raises_without_killing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The chat variant (proc=None): the same loop minus the process arms — a deadline raises,
+    nothing is signalled (the in-process worker is the caller's to stop)."""
+    killed = _record_killpg(monkeypatch)
+    mesh = FakeMesh(agents_frames=[{}])
+    with pytest.raises(DevAgentError, match=r"did not come online"):
+        await _dev_agents.wait_agents_ready(None, ("general",), (), mesh, log_path=None, **_fast_wait())
+    assert killed == []
+
+
+async def test_wait_ready_checks_names_against_one_captured_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The raced-record protocol: each iteration captures the snapshot once and checks every name
+    against that capture — alternating single-name reads must never add up to 'ready'."""
+    killed = _record_killpg(monkeypatch)
+    frames: list[Any] = [{"a": _agent_info("a")}, {"b": _agent_info("b")}] * 40
+    mesh = FakeMesh(agents_frames=frames)
+    with pytest.raises(DevAgentError, match=r"did not come online"):
+        await _dev_agents.wait_agents_ready(None, ("a", "b"), (), mesh, log_path=None, **_fast_wait())
+    assert killed == []
+
+
+async def test_wait_ready_reads_only_the_kinds_the_targets_advertise() -> None:
+    """An agents-only launch must not open/read the tools view at all (plan §3.4: per the
+    target's kinds)."""
+    mesh = FakeMesh(agents_frames=[{"general": _agent_info("general")}])
+    await _dev_agents.wait_agents_ready(None, ("general",), (), mesh, log_path=None, **_fast_wait())
+    assert set(mesh.reads) == {"agents"}
+
+
+# --- connect-or-spawn evaluation (spec §5.5) ----------------------------------------------------------
+
+
+def _target(spec_attr: str) -> _dev_agents.TargetNodes:
+    (target,) = _dev_agents.preflight([f"{_NODES}:{spec_attr}"])
+    return target
+
+
+_KEY = "127.0.0.1:9092"
+
+
+async def test_evaluate_all_names_online_reuses_with_heartbeat_ages(monkeypatch: pytest.MonkeyPatch) -> None:
+    install_fake_psutil(monkeypatch, [])
+    mesh = FakeMesh(agents_frames=[{"general": _agent_info("general", age=3.0)}])
+    reused, to_launch = await _dev_agents.evaluate_targets([_target("general")], _KEY, mesh)
+    assert to_launch == []
+    (outcome,) = reused
+    assert outcome.target.spec == f"{_NODES}:general"
+    assert 2.5 <= outcome.ages["general"] <= 10.0
+
+
+async def test_evaluate_none_online_no_marker_spawns(monkeypatch: pytest.MonkeyPatch) -> None:
+    install_fake_psutil(monkeypatch, [])
+    mesh = FakeMesh()
+    reused, to_launch = await _dev_agents.evaluate_targets([_target("general")], _KEY, mesh)
+    assert reused == []
+    assert [t.spec for t in to_launch] == [f"{_NODES}:general"]
+
+
+async def test_evaluate_unopenable_view_counts_as_none_online(monkeypatch: pytest.MonkeyPatch) -> None:
+    install_fake_psutil(monkeypatch, [])
+    mesh = FakeMesh(agents_frames=[_unavailable()])
+    _, to_launch = await _dev_agents.evaluate_targets([_target("general")], _KEY, mesh)
+    assert [t.spec for t in to_launch] == [f"{_NODES}:general"]
+
+
+async def test_evaluate_broken_daemon_errors_instead_of_a_second_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Never a second daemon over a broken first (Ryan's ruling, spec §5.5): offline names owned
+    by a live marker daemon error with pid, the offline explanation, logs, and the stop hint."""
+    daemon = FakeProc(4055, _daemon_argv(targets=("general_help:general",), marker="--dev-daemon=general"))
+    install_fake_psutil(monkeypatch, [daemon])
+    mesh = FakeMesh()  # nothing online
+    with pytest.raises(DevAgentError, match=r"already exists \(pid 4055.*offline.*ck dev stop general") as exc:
+        await _dev_agents.evaluate_targets([_target("general")], _KEY, mesh)
+    assert "agents-" in str(exc.value)  # the log path is named
+
+
+async def test_evaluate_broken_daemon_on_another_address_does_not_block(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Address scoping: a marker daemon for the same names on a DIFFERENT mesh is unrelated."""
+    elsewhere = FakeProc(4055, _daemon_argv(host="127.0.0.1:19092", marker="--dev-daemon=general"))
+    install_fake_psutil(monkeypatch, [elsewhere])
+    mesh = FakeMesh()
+    _, to_launch = await _dev_agents.evaluate_targets([_target("general")], _KEY, mesh)
+    assert [t.spec for t in to_launch] == [f"{_NODES}:general"]
+
+
+async def test_evaluate_partial_online_within_one_target_errors_naming_the_collision(monkeypatch: pytest.MonkeyPatch) -> None:
+    install_fake_psutil(monkeypatch, [])
+    mesh = FakeMesh(agents_frames=[{"support": _agent_info("support")}])  # get_time offline
+    with pytest.raises(DevAgentError, match=r"support.*online.*get_time"):
+        await _dev_agents.evaluate_targets([_target("support_team")], _KEY, mesh)
+
+
+async def test_evaluate_mixed_invocation_splits_reuse_and_launch(monkeypatch: pytest.MonkeyPatch) -> None:
+    install_fake_psutil(monkeypatch, [])
+    mesh = FakeMesh(agents_frames=[{"general": _agent_info("general")}])
+    reused, to_launch = await _dev_agents.evaluate_targets([_target("general"), _target("get_weather")], _KEY, mesh)
+    assert [o.target.spec for o in reused] == [f"{_NODES}:general"]
+    assert [t.spec for t in to_launch] == [f"{_NODES}:get_weather"]
+
+
+async def test_evaluate_tool_targets_reuse_via_the_tools_view(monkeypatch: pytest.MonkeyPatch) -> None:
+    install_fake_psutil(monkeypatch, [])
+    mesh = FakeMesh(tools_frames=[{"get_weather": _tool_info("get_weather", age=2.0)}])
+    reused, to_launch = await _dev_agents.evaluate_targets([_target("get_weather")], _KEY, mesh)
+    assert to_launch == []
+    assert "get_weather" in reused[0].ages
+
+
+# --- ensure_agents: the -d orchestration under the agent-layer flock (spec §5.1) ----------------------
+
+
+def _capture_spawns(monkeypatch: pytest.MonkeyPatch) -> list[FakePopen]:
+    spawned: list[FakePopen] = []
+
+    def factory(cmd: list[str], **kwargs: object) -> FakePopen:
+        proc = FakePopen(cmd, **kwargs)
+        spawned.append(proc)
+        return proc
+
+    monkeypatch.setattr(_dev_agents, "Popen", factory)
+    return spawned
+
+
+def _run_args(**overrides: Any) -> _dev_agents.RunOptions:
+    return _dev_agents.RunOptions(**overrides)
+
+
+async def test_ensure_spawns_one_daemon_for_all_offline_targets(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """One worker per invocation (spec §4): both targets co-host in a single spawn whose argv is
+    the pinned §5.1 shape — targets, normalized --host, presets, the marker, the 5s heartbeat."""
+    install_fake_psutil(monkeypatch, [])
+    spawned = _capture_spawns(monkeypatch)
+    mesh = FakeMesh(
+        agents_frames=[{}, {"general": _agent_info("general")}],
+        tools_frames=[{}, {}, {"get_weather": _tool_info("get_weather")}],
+    )
+    report = await _dev_agents.ensure_agents(
+        [_target("general"), _target("get_weather")],
+        normalize([_KEY]),
+        mesh,
+        run_args=_run_args(),
+        **_fast_wait(timeout=5.0),
+    )
+    (proc,) = spawned
+    assert proc.cmd[:2] == [sys.executable, "-m"]
+    assert proc.cmd[2:4] == ["calfkit.cli", "run"]
+    assert proc.cmd[4:6] == [f"{_NODES}:general", f"{_NODES}:get_weather"]
+    host_index = proc.cmd.index("--host")
+    assert proc.cmd[host_index + 1] == _KEY
+    assert "--provision" in proc.cmd
+    assert "--reload" in proc.cmd
+    assert "--dev-daemon=general,get_weather" in proc.cmd
+    heartbeat_index = proc.cmd.index("--heartbeat-interval")
+    assert proc.cmd[heartbeat_index + 1] == "5.0"
+    # The detach + log-fd contract (the broker Popen pattern verbatim).
+    assert proc.kwargs["start_new_session"] is True
+    assert proc.kwargs["stdin"] is not None
+    assert report.pid == proc.pid
+    assert report.log_path is not None and Path(report.log_path).exists()
+    assert [o.reused for o in report.outcomes] == [False, False]
+
+
+async def test_ensure_all_reused_spawns_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    install_fake_psutil(monkeypatch, [])
+    spawned = _capture_spawns(monkeypatch)
+    mesh = FakeMesh(agents_frames=[{"general": _agent_info("general", age=1.0)}])
+    report = await _dev_agents.ensure_agents([_target("general")], normalize([_KEY]), mesh, run_args=_run_args(), **_fast_wait())
+    assert spawned == []
+    assert report.pid is None and report.log_path is None
+    assert [o.reused for o in report.outcomes] == [True]
+
+
+async def test_ensure_forwards_the_users_run_options_into_the_daemon_argv(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """'Everything ck dev run is today' (spec §3.1): the daemon child receives the caller's
+    non-default options; --no-provision / --no-reload drop their presets."""
+    install_fake_psutil(monkeypatch, [])
+    spawned = _capture_spawns(monkeypatch)
+    mesh = FakeMesh(agents_frames=[{}, {"general": _agent_info("general")}])
+    await _dev_agents.ensure_agents(
+        [_target("general")],
+        normalize([_KEY]),
+        mesh,
+        run_args=_run_args(
+            provision=False,
+            reload=False,
+            reload_dir=["src", "lib"],
+            app_dir=str(tmp_path),
+            group_id="g1",
+            env_file="custom.env",
+            enable_idempotence=True,
+        ),
+        **_fast_wait(timeout=5.0),
+    )
+    (proc,) = spawned
+    assert "--provision" not in proc.cmd
+    assert "--reload" not in proc.cmd
+    assert proc.cmd[proc.cmd.index("--app-dir") + 1] == str(tmp_path)
+    assert proc.cmd[proc.cmd.index("--group-id") + 1] == "g1"
+    assert proc.cmd[proc.cmd.index("--env-file") + 1] == "custom.env"
+    assert "--enable-idempotence" in proc.cmd
+    reload_dirs = [proc.cmd[i + 1] for i, tok in enumerate(proc.cmd) if tok == "--reload-dir"]
+    assert reload_dirs == ["src", "lib"]
+
+
+async def test_ensure_overwrites_the_log_per_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    install_fake_psutil(monkeypatch, [])
+    monkeypatch.setattr(_dev_agents, "Popen", FakePopen)
+    log_path = _dev_agents.daemon_log_path(_KEY, (f"{_NODES}:general",))
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("old contents from the previous spawn")
+    mesh = FakeMesh(agents_frames=[{}, {"general": _agent_info("general")}])
+    await _dev_agents.ensure_agents([_target("general")], normalize([_KEY]), mesh, run_args=_run_args(), **_fast_wait(timeout=5.0))
+    assert log_path.read_text() == ""  # truncated by the fresh open
+
+
+async def test_ensure_readiness_failure_propagates_after_the_group_kill(monkeypatch: pytest.MonkeyPatch) -> None:
+    install_fake_psutil(monkeypatch, [])
+    killed = _record_killpg(monkeypatch)
+    spawned = _capture_spawns(monkeypatch)
+    mesh = FakeMesh()  # never online
+    with pytest.raises(DevAgentError, match=r"did not come online"):
+        await _dev_agents.ensure_agents([_target("general")], normalize([_KEY]), mesh, run_args=_run_args(), **_fast_wait())
+    assert len(spawned) == 1
+    assert killed and killed[0][0] == spawned[0].pid
+
+
+async def test_ensure_holds_the_agents_flock_across_its_critical_section(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The double-spawn race (spec §5.1): the whole check→spawn→readiness section holds
+    ~/.calfkit/dev-agents.lock exclusively; a concurrent ensure would block until release."""
+    import fcntl
+
+    install_fake_psutil(monkeypatch, [])
+    monkeypatch.setattr(_dev_agents, "Popen", FakePopen)
+    lock_state: dict[str, Any] = {}
+
+    class ProbingMesh(FakeMesh):
+        async def get_agents(self) -> Any:
+            if "held" not in lock_state:
+                fd = (tmp_path / ".calfkit" / "dev-agents.lock").open("rb")
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    lock_state["held"] = True  # the supervisor holds it mid-section
+                else:
+                    lock_state["held"] = False
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                finally:
+                    fd.close()
+            return await super().get_agents()
+
+    mesh = ProbingMesh(agents_frames=[{}, {"general": _agent_info("general")}])
+    await _dev_agents.ensure_agents([_target("general")], normalize([_KEY]), mesh, run_args=_run_args(), **_fast_wait(timeout=5.0))
+    assert lock_state["held"] is True
+    # Released after: an exclusive claim now succeeds.
+    with (tmp_path / ".calfkit" / "dev-agents.lock").open("rb") as fd:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(fd, fcntl.LOCK_UN)

--- a/tests/test_dev_agents.py
+++ b/tests/test_dev_agents.py
@@ -406,13 +406,26 @@ async def test_wait_ready_reader_dead_still_tears_down_the_spawn(monkeypatch: py
 
 
 async def test_wait_ready_deadline_names_the_unreadable_reason(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A deadline that never saw a readable view must say so — 'did not come online' would point
-    the user at their agent when the presence read itself was the problem."""
+    """A deadline whose LAST read failed must say so — 'did not come online' would point the user
+    at their agent when the presence read itself was the problem. Round-2 minor 2: the message
+    claims only what is known (the last read), never 'never became readable' — the view may have
+    been readable for most of the wait before a late failure."""
     _record_killpg(monkeypatch)
     establishing = MeshUnavailableError("catching up", reason="establishing")
     mesh = FakeMesh(agents_frames=[establishing])
-    with pytest.raises(DevAgentError, match=r"(?s)never became readable.*establishing"):
+    with pytest.raises(DevAgentError, match=r"(?s)did not come online.*last presence read failed.*establishing"):
         await _dev_agents.wait_agents_ready(None, ("general",), (), mesh, log_path=None, **_fast_wait())
+
+
+async def test_wait_ready_deadline_after_a_late_read_failure_stays_accurate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Readable for most of the wait (names just offline), then the broker dies at the end: the
+    message must not claim the view was 'never readable'."""
+    _record_killpg(monkeypatch)
+    frames: list[Any] = [{}, {}, {}, MeshUnavailableError("gone", reason="open_failed")]
+    mesh = FakeMesh(agents_frames=frames)
+    with pytest.raises(DevAgentError, match=r"(?s)did not come online.*last presence read failed \(open_failed") as exc:
+        await _dev_agents.wait_agents_ready(None, ("general",), (), mesh, log_path=None, **_fast_wait())
+    assert "never" not in str(exc.value)
 
 
 # --- connect-or-spawn evaluation (spec §5.5) ----------------------------------------------------------
@@ -762,6 +775,43 @@ def test_stop_daemon_zombie_leader_counts_as_stopped(monkeypatch: pytest.MonkeyP
     # The zombie leader is the stopped state; the final group sweep still fires (a zombie-only
     # group absorbs it harmlessly, a straggler member gets reaped).
     assert calls == [(4055, signal_module.SIGTERM), (4055, signal_module.SIGKILL)]
+
+
+def test_stop_daemon_sweeps_when_the_leader_dies_mid_escalation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Round-2 minor 1: leader survives TERM through the grace, then dies just before the KILL
+    send — the identity gate raises NoSuchProcess, but a group signal WAS already delivered this
+    call, so descendants may remain: the final sweep must still fire (the pgid stays reserved by
+    any survivor, so it is safe)."""
+    import signal as signal_module
+
+    install_fake_psutil(monkeypatch, [])
+
+    class _DiesBeforeKill(FakeProc):
+        def __init__(self, pid: int) -> None:
+            super().__init__(pid, survives_sigterm=True)
+            self._running_answers = [True, False]  # TERM gate: alive; KILL gate: just died
+
+        def is_running(self) -> bool:
+            return self._running_answers.pop(0) if self._running_answers else False
+
+    proc = _DiesBeforeKill(4055)
+    calls: list[tuple[int, int]] = []
+    monkeypatch.setattr(dev_broker_module, "_killpg", lambda pgid, sig: calls.append((pgid, sig)))
+    assert _dev_agents.stop_daemon(_hit(proc), grace=0.3) is True
+    assert calls == [(4055, signal_module.SIGTERM), (4055, signal_module.SIGKILL)]
+
+
+def test_stop_daemon_no_sweep_when_no_signal_was_ever_delivered(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The counter-case pinning the guard: the identity gate refusing the FIRST send (recycled
+    pid) must not be followed by a sweep — no signal was delivered, and killpg could hit an
+    innocent recycled group. (Same assertion as the recycled-pid test, restated against the
+    sweep specifically.)"""
+    install_fake_psutil(monkeypatch, [])
+    proc = FakeProc(4055)
+    proc.alive = False
+    calls = _group_killer(monkeypatch, [proc])
+    assert _dev_agents.stop_daemon(_hit(proc), grace=0.3) is True
+    assert calls == []
 
 
 def test_daemon_grace_is_at_least_eight_seconds() -> None:

--- a/tests/test_dev_cli.py
+++ b/tests/test_dev_cli.py
@@ -590,6 +590,76 @@ def test_dev_run_detach_closes_the_readiness_client(detach_seams: dict[str, Any]
     assert detach_seams["ensure"]["mesh"] is client.mesh
 
 
+# --- dev chat grammar: names attach, targets launch in-process (agent-lifecycle spec §3.2) -------------
+
+
+def test_dev_chat_bare_name_attaches_via_the_delegate(ensure_calls: list[dict[str, Any]], chat_calls: list[dict[str, Any]]) -> None:
+    result = _invoke(["dev", "chat", "general"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert chat_calls[0]["name"] == "general"
+
+
+def test_dev_chat_mixing_names_and_targets_is_a_usage_error(chat_calls: list[dict[str, Any]]) -> None:
+    result = _invoke(["dev", "chat", "general", "app:agent"])
+    assert result.exit_code == 2
+    assert "mix" in _plain(result.stderr)
+    assert chat_calls == []
+
+
+def test_dev_chat_more_than_one_bare_name_is_a_usage_error(chat_calls: list[dict[str, Any]]) -> None:
+    result = _invoke(["dev", "chat", "general", "finance"])
+    assert result.exit_code == 2
+    assert chat_calls == []
+
+
+def test_dev_chat_targets_dispatch_to_the_session_launcher_not_the_delegate(
+    monkeypatch: pytest.MonkeyPatch, chat_calls: list[dict[str, Any]]
+) -> None:
+    launched: dict[str, Any] = {}
+
+    def fake_chat_targets(targets: list[str], **kwargs: Any) -> None:
+        launched["targets"] = targets
+        launched.update(kwargs)
+
+    monkeypatch.setattr(dev_cli, "_chat_targets", fake_chat_targets)
+    result = _invoke(["dev", "chat", "app:agent", "tools:all", "--timeout", "7"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert launched["targets"] == ["app:agent", "tools:all"]
+    assert launched["timeout"] == 7.0
+    assert chat_calls == []
+
+
+def test_dev_chat_target_session_ensures_broker_then_preflights(detach_seams: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    """§3.2 order: ensure the broker, preflight the targets, then run the session."""
+    session_runs: list[Any] = []
+    monkeypatch.setattr("calfkit.cli.chat.run_session_command", lambda coro: (coro.close(), session_runs.append(coro))[1])
+    result = _invoke(["dev", "chat", "app:agent"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert detach_seams["order"][:2] == ["ensure_broker", "preflight"]
+    assert len(session_runs) == 1
+
+
+def test_dev_chat_target_preflight_error_exits_2(detach_seams: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    def broken_preflight(targets: list[str], *, app_dir: str | None = None) -> list[TargetNodes]:
+        raise DevAgentError("duplicate node name 'general'")
+
+    monkeypatch.setattr(dev_agents, "preflight", broken_preflight)
+    result = _invoke(["dev", "chat", "app:agent"])
+    assert result.exit_code == 2
+    assert "duplicate node name" in _plain(result.stderr)
+
+
+def test_dev_chat_target_session_supervisor_error_exits_2(detach_seams: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    def raising_run(coro: Any) -> None:
+        coro.close()
+        raise DevAgentError("no agents among the given targets")
+
+    monkeypatch.setattr("calfkit.cli.chat.run_session_command", raising_run)
+    result = _invoke(["dev", "chat", "app:agent"])
+    assert result.exit_code == 2
+    assert "no agents among" in _plain(result.stderr)
+
+
 def test_dev_run_forwards_the_hidden_internals_explicitly(ensure_calls: list[dict[str, Any]], run_calls: list[dict[str, Any]]) -> None:
     """The parity-guard contract (impl plan CG-B): `dev run` forwards the hidden internals with
     their preset values — the 5s dev heartbeat (spec §5.6 covers foreground dev runs too) and no

--- a/tests/test_dev_cli.py
+++ b/tests/test_dev_cli.py
@@ -17,8 +17,10 @@ from typing import Any
 import pytest
 from typer.testing import CliRunner
 
+import calfkit.cli._dev_agents as dev_agents
 import calfkit.cli._dev_broker as dev_broker
 import calfkit.cli.dev as dev_cli
+from calfkit.cli._dev_agents import DevAgentError, EnsureReport, TargetNodes, TargetOutcome
 from calfkit.cli._dev_broker import BrokerInfo, DevBrokerError, MeshStatus
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
@@ -426,6 +428,166 @@ def test_dev_run_forwards_every_parameter_of_run(ensure_calls: list[dict[str, An
     result = _invoke(["dev", "run", "app:agent"])
     assert result.exit_code == 0, result.stdout + str(result.exception)
     assert set(run_calls[0]) == set(inspect.signature(run_command).parameters)
+
+
+# --- dev run --detach: launch agent daemons (agent-lifecycle spec §3.1) --------------------------------
+
+
+def _plan(agent_names: tuple[str, ...] = ("general",), tool_names: tuple[str, ...] = (), spec: str = "app:agent") -> list[TargetNodes]:
+    return [TargetNodes(spec=spec, nodes=(), agent_names=agent_names, tool_names=tool_names)]
+
+
+class _FakeMeshHandle:
+    pass
+
+
+class _FakeDetachClient:
+    """Stands in for the short-lived readiness Client the -d path opens."""
+
+    instances: list[_FakeDetachClient] = []
+
+    def __init__(self) -> None:
+        self.mesh = _FakeMeshHandle()
+        self.closed = False
+        _FakeDetachClient.instances.append(self)
+
+    @classmethod
+    def connect(cls, server_urls: object = None, **kwargs: object) -> _FakeDetachClient:
+        client = cls()
+        client.server_urls_arg = server_urls  # type: ignore[attr-defined]
+        return client
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def detach_seams(monkeypatch: pytest.MonkeyPatch, ensure_calls: list[dict[str, Any]]) -> dict[str, Any]:
+    """Fake the supervisor seams for the -d path; records call order and arguments."""
+    seams: dict[str, Any] = {"order": [], "plan": _plan()}
+    _FakeDetachClient.instances = []
+
+    def fake_preflight(targets: list[str], *, app_dir: str | None = None) -> list[TargetNodes]:
+        seams["order"].append("preflight")
+        seams["preflight"] = {"targets": targets, "app_dir": app_dir}
+        plan: list[TargetNodes] = seams["plan"]
+        return plan
+
+    async def fake_ensure(plan: list[TargetNodes], target: Any, mesh: Any, *, run_args: Any, **kwargs: Any) -> EnsureReport:
+        seams["order"].append("ensure_agents")
+        seams["ensure"] = {"plan": plan, "target": target, "mesh": mesh, "run_args": run_args}
+        report: EnsureReport = seams.get("report") or EnsureReport(
+            outcomes=tuple(TargetOutcome(target=t, reused=False) for t in plan),
+            pid=4055,
+            log_path="/tmp/agents-x.log",
+        )
+        return report
+
+    original_ensure_broker = dev_broker.ensure_broker
+
+    def ordered_ensure_broker(*args: Any, **kwargs: Any) -> BrokerInfo:
+        seams["order"].append("ensure_broker")
+        result: BrokerInfo = original_ensure_broker(*args, **kwargs)
+        return result
+
+    monkeypatch.setattr(dev_broker, "ensure_broker", ordered_ensure_broker)
+    monkeypatch.setattr(dev_agents, "preflight", fake_preflight)
+    monkeypatch.setattr(dev_agents, "ensure_agents", fake_ensure)
+    monkeypatch.setattr("calfkit.client.Client", _FakeDetachClient)
+    return seams
+
+
+def test_dev_run_detach_prints_the_launched_line(detach_seams: dict[str, Any], run_calls: list[dict[str, Any]]) -> None:
+    """§3.1: per launched agent — the SUPERVISOR pid (what stop signals), the lifetime statement,
+    and the log path; the foreground delegation never runs."""
+    result = _invoke(["dev", "run", "-d", "app:agent"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    out = _plain(result.stdout)
+    assert "ck dev: launched agent 'general' (pid 4055) — runs until 'ck dev stop general' — logs: /tmp/agents-x.log" in out
+    assert run_calls == []
+
+
+def test_dev_run_detach_prints_the_reusing_line_with_age(detach_seams: dict[str, Any]) -> None:
+    plan = detach_seams["plan"]
+    detach_seams["report"] = EnsureReport(outcomes=(TargetOutcome(target=plan[0], reused=True, ages={"general": 3.2}),), pid=None, log_path=None)
+    result = _invoke(["dev", "run", "--detach", "app:agent"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert "ck dev: reusing agent 'general' (online, last seen 3s ago)" in _plain(result.stdout)
+
+
+def test_dev_run_detach_tool_names_use_the_tool_word(detach_seams: dict[str, Any]) -> None:
+    """Tools-only targets are legitimate daemons (spec §5.1) — their lines say what they are."""
+    detach_seams["plan"] = _plan(agent_names=(), tool_names=("get_weather",), spec="tools:get_weather")
+    result = _invoke(["dev", "run", "-d", "tools:get_weather"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert "ck dev: launched tool 'get_weather' (pid 4055)" in _plain(result.stdout)
+
+
+def test_dev_run_detach_preflights_before_the_broker_ensure(detach_seams: dict[str, Any]) -> None:
+    """Spec §5.1 order: preflight fails fast at the prompt BEFORE any broker work."""
+    result = _invoke(["dev", "run", "-d", "app:agent"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert detach_seams["order"] == ["preflight", "ensure_broker", "ensure_agents"]
+
+
+def test_dev_run_detach_supervisor_error_exits_2(detach_seams: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    async def broken(*args: Any, **kwargs: Any) -> EnsureReport:
+        raise DevAgentError("a daemon for 'general' already exists (pid 4055)")
+
+    monkeypatch.setattr(dev_agents, "ensure_agents", broken)
+    result = _invoke(["dev", "run", "-d", "app:agent"])
+    assert result.exit_code == 2
+    assert "Error: a daemon for 'general' already exists" in _plain(result.stderr)
+    assert _FakeDetachClient.instances[0].closed is True  # the readiness client never leaks
+
+
+def test_dev_run_detach_interrupt_leaves_the_daemon_and_hints(detach_seams: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    """§3.4: Ctrl-C during the readiness wait leaves the daemon running (recoverable) and says so."""
+
+    async def interrupted(*args: Any, **kwargs: Any) -> EnsureReport:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(dev_agents, "ensure_agents", interrupted)
+    result = _invoke(["dev", "run", "-d", "app:agent"])
+    assert result.exit_code == 130
+    assert "ck dev status" in _plain(result.stderr)
+
+
+def test_dev_run_detach_forwards_the_run_options(detach_seams: dict[str, Any], tmp_path: Path) -> None:
+    result = _invoke(
+        [
+            "dev",
+            "run",
+            "-d",
+            "app:agent",
+            "--no-reload",
+            "--no-provision",
+            "--group-id",
+            "g1",
+            "--app-dir",
+            str(tmp_path),
+            "--reload-dir",
+            "src",
+            "--enable-idempotence",
+        ]
+    )
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    run_args = detach_seams["ensure"]["run_args"]
+    assert run_args.reload is False
+    assert run_args.provision is False
+    assert run_args.group_id == "g1"
+    assert run_args.app_dir == str(tmp_path)
+    assert list(run_args.reload_dir or []) == ["src"]
+    assert run_args.enable_idempotence is True
+    assert detach_seams["preflight"]["app_dir"] == str(tmp_path)
+
+
+def test_dev_run_detach_closes_the_readiness_client(detach_seams: dict[str, Any]) -> None:
+    result = _invoke(["dev", "run", "-d", "app:agent"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    (client,) = _FakeDetachClient.instances
+    assert client.closed is True
+    assert detach_seams["ensure"]["mesh"] is client.mesh
 
 
 def test_dev_run_forwards_the_hidden_internals_explicitly(ensure_calls: list[dict[str, Any]], run_calls: list[dict[str, Any]]) -> None:

--- a/tests/test_dev_cli.py
+++ b/tests/test_dev_cli.py
@@ -635,7 +635,88 @@ def test_dev_chat_targets_dispatch_to_the_session_launcher_not_the_attach_path(
     assert attach_calls == []
 
 
+# --- multi-address borrow: sessions/clients get the SPLIT server list (review round 2, R2-M1) ----------
+
+
+_MULTI = "kafka-a:9092,kafka-b:9092"
+
+
+@pytest.fixture
+def reachable_multi(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A reachable multi-address mesh: pure borrow (never a spawn target)."""
+    monkeypatch.setattr(dev_broker, "is_reachable", lambda servers, *, timeout: True)
+
+
+def test_dev_chat_attach_splits_a_multi_address_host(reachable_multi: None, attach_calls: list[dict[str, Any]]) -> None:
+    """R2-M1: resolve_mesh_url never comma-splits a bare string — the session must receive the
+    user's elements as a LIST, exactly as the old chat() delegation produced via _parse_host."""
+    result = _invoke(["dev", "chat", "--host", _MULTI])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert attach_calls[0]["server_urls"] == ["kafka-a:9092", "kafka-b:9092"]
+
+
+def test_dev_chat_attach_single_address_stays_the_normalized_listener(ensure_calls: list[dict[str, Any]], attach_calls: list[dict[str, Any]]) -> None:
+    result = _invoke(["dev", "chat"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert attach_calls[0]["server_urls"] == _KEY  # unchanged: the single normalized listener string
+
+
+def test_dev_chat_targets_split_a_multi_address_host(
+    reachable_multi: None, attach_calls: list[dict[str, Any]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(dev_agents, "preflight", lambda targets, *, app_dir=None: _plan())
+    result = _invoke(["dev", "chat", "app:agent", "--host", _MULTI])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert attach_calls[0]["server_urls"] == ["kafka-a:9092", "kafka-b:9092"]
+
+
+def test_dev_run_detach_readiness_client_splits_a_multi_address_host(reachable_multi: None, detach_seams: dict[str, Any]) -> None:
+    result = _invoke(["dev", "run", "-d", "app:agent", "--host", _MULTI])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    (client,) = _FakeDetachClient.instances
+    assert client.server_urls_arg == ["kafka-a:9092", "kafka-b:9092"]  # type: ignore[attr-defined]
+
+
+def test_dev_status_presence_client_splits_a_multi_address_host(real_presence_seams: dict[str, Any], reachable_multi: None) -> None:
+    real_presence_seams["broker"] = MeshStatus(target_key="kafka-a:9092,kafka-b:9092", reachable=True, brokers=())
+    result = _invoke(["dev", "status", "--host", _MULTI])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    (client,) = _FakeDetachClient.instances
+    assert client.server_urls_arg == ["kafka-a:9092", "kafka-b:9092"]  # type: ignore[attr-defined]
+
+
 # --- the §7 offline-daemon hint on `dev chat NAME` (review round 1, Ryan-approved) ---------------------
+
+
+def test_dev_chat_offline_name_hint_fires_on_an_empty_roster(ensure_calls: list[dict[str, Any]], monkeypatch: pytest.MonkeyPatch) -> None:
+    """R2-M2, minimal shape (Ryan-approved): the PRIMARY §7 moment is a single crashed daemon —
+    the mesh roster is then EMPTY, and the shipped 'No agents are online' exit-0 notice must
+    still carry the daemon hint when a name was asked for."""
+    from calfkit.client.mesh import Mesh
+
+    async def no_agents(_self: Mesh) -> dict[str, Any]:
+        return {}
+
+    monkeypatch.setattr(Mesh, "get_agents", no_agents)
+    monkeypatch.setattr(dev_agents, "find_daemons", lambda host_key: [_daemon_hit(4055, ("general",))])
+    result = _invoke(["dev", "chat", "general"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)  # the shipped empty-roster contract
+    out = _plain(result.stdout)
+    assert "No agents are online on the mesh." in out
+    assert "a managed daemon for 'general' exists but its agents are offline — logs: /tmp/agents-4055.log (ck dev status)" in out
+
+
+def test_dev_chat_empty_roster_without_a_name_gets_no_hint(ensure_calls: list[dict[str, Any]], monkeypatch: pytest.MonkeyPatch) -> None:
+    from calfkit.client.mesh import Mesh
+
+    async def no_agents(_self: Mesh) -> dict[str, Any]:
+        return {}
+
+    monkeypatch.setattr(Mesh, "get_agents", no_agents)
+    monkeypatch.setattr(dev_agents, "find_daemons", lambda host_key: [_daemon_hit(4055, ("general",))])
+    result = _invoke(["dev", "chat"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert "managed daemon" not in _plain(result.stdout)
 
 
 def test_dev_chat_offline_name_hint_names_the_daemon_and_logs(ensure_calls: list[dict[str, Any]], monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_dev_cli.py
+++ b/tests/test_dev_cli.py
@@ -428,6 +428,24 @@ def test_dev_run_forwards_every_parameter_of_run(ensure_calls: list[dict[str, An
     assert set(run_calls[0]) == set(inspect.signature(run_command).parameters)
 
 
+def test_dev_run_forwards_the_hidden_internals_explicitly(ensure_calls: list[dict[str, Any]], run_calls: list[dict[str, Any]]) -> None:
+    """The parity-guard contract (impl plan CG-B): `dev run` forwards the hidden internals with
+    their preset values — the 5s dev heartbeat (spec §5.6 covers foreground dev runs too) and no
+    ownership marker (a foreground run is not a daemon) — so the forwards-every-parameter guard
+    above keeps its simple equality contract."""
+    result = _invoke(["dev", "run", "app:agent"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert run_calls[0]["heartbeat_interval"] == 5.0
+    assert run_calls[0]["dev_daemon"] is None
+
+
+def test_dev_run_help_hides_the_internal_flags() -> None:
+    """R1 guard, dev side: the hidden internals must not leak into ck dev run --help either."""
+    out = _plain(_invoke(["dev", "run", "--help"]).stdout)
+    assert "--dev-daemon" not in out
+    assert "--heartbeat-interval" not in out
+
+
 def test_dev_chat_forwards_every_parameter_of_chat(ensure_calls: list[dict[str, Any]], chat_calls: list[dict[str, Any]]) -> None:
     import inspect
 

--- a/tests/test_dev_cli.py
+++ b/tests/test_dev_cli.py
@@ -660,6 +660,223 @@ def test_dev_chat_target_session_supervisor_error_exits_2(detach_seams: dict[str
     assert "no agents among" in _plain(result.stderr)
 
 
+# --- dev status: the unfiltered join (agent-lifecycle spec §3.3) ---------------------------------------
+
+
+def _daemon_hit(pid: int, names: tuple[str, ...], *, host_key: str = _KEY, targets: tuple[str, ...] = ("app:agent",)) -> Any:
+    return dev_agents.DaemonHit(
+        proc=None,
+        pid=pid,
+        names=names,
+        host_key=host_key,
+        targets=targets,
+        log_path=f"/tmp/agents-{pid}.log",
+        started_at="2026-07-02T14:02:40+00:00",
+    )
+
+
+def _mesh_info(name: str, *, age: float = 3.0) -> Any:
+    from datetime import datetime, timedelta, timezone
+
+    from calfkit.client.mesh import AgentInfo
+
+    return AgentInfo(name=name, description=None, last_seen=datetime.now(tz=timezone.utc) - timedelta(seconds=age))
+
+
+@pytest.fixture
+def status_seams(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    seams: dict[str, Any] = {
+        "broker": MeshStatus(target_key=_KEY, reachable=True, brokers=(_info(pid=4021),)),
+        "daemons": [],
+        "presence": ({}, {}),
+    }
+    monkeypatch.setattr(dev_broker, "status", lambda target, *, timeout=5.0: seams["broker"])
+    monkeypatch.setattr(dev_agents, "find_daemons", lambda host_key: list(seams["daemons"]))
+
+    async def fake_presence(target: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+        if seams.get("presence_forbidden"):
+            raise AssertionError("presence must not be read when the broker is unreachable")
+        result: tuple[dict[str, Any], dict[str, Any]] = seams["presence"]
+        return result
+
+    monkeypatch.setattr(dev_cli, "_read_presence_maps", fake_presence)
+    return seams
+
+
+def test_dev_status_renders_all_four_row_kinds(status_seams: dict[str, Any]) -> None:
+    """R5: broker + online managed + offline managed + unmanaged rows, unfiltered (Ryan's
+    transparency rule), heartbeat ages always shown."""
+    status_seams["daemons"] = [
+        _daemon_hit(4055, ("general",), targets=("general_help:general",)),
+        _daemon_hit(4102, ("finance",), targets=("finance_help:finance",)),
+    ]
+    status_seams["presence"] = (
+        {"general": _mesh_info("general"), "support": _mesh_info("support")},
+        {"get_weather": _mesh_info("get_weather", age=4.0)},
+    )
+    result = _invoke(["dev", "status"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    out = _plain(result.stdout)
+    for column in ("KIND", "NAME", "STATE", "PID", "SINCE", "TARGET", "LOGS"):
+        assert column in out
+    lines = {line.split()[1]: line for line in out.splitlines() if line and not line.startswith("KIND")}
+    assert lines[_KEY].startswith("broker")
+    assert "running" in lines[_KEY] and "4021" in lines[_KEY]
+    assert lines["general"].startswith("agent")
+    assert "online (last seen 3s ago)" in lines["general"]
+    assert "4055" in lines["general"] and "general_help:general" in lines["general"] and "/tmp/agents-4055.log" in lines["general"]
+    # The Ryan rulings (2026-07-02): a daemon-owned name with no presence record is honestly
+    # UNKNOWN — not 'offline', not mislabeled 'agent'.
+    assert lines["finance"].startswith("unknown")
+    assert "unknown (see logs)" in lines["finance"]
+    assert "4102" in lines["finance"]
+    assert "not a ck dev daemon (stop it where it runs)" in lines["support"]
+    assert lines["support"].startswith("agent")
+    assert lines["get_weather"].startswith("tool")
+    assert "not a ck dev daemon" in lines["get_weather"]
+
+
+def test_dev_status_broker_down_degrades_and_exits_0(status_seams: dict[str, Any]) -> None:
+    """§3.3: status never errors — the broker line reads no-broker, presence columns degrade,
+    daemon rows still render from the scan."""
+    status_seams["broker"] = MeshStatus(target_key=_KEY, reachable=False, brokers=())
+    status_seams["presence_forbidden"] = True
+    status_seams["daemons"] = [_daemon_hit(4055, ("general",))]
+    result = _invoke(["dev", "status"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    out = _plain(result.stdout)
+    assert "no broker reachable" in out
+    assert "unknown (mesh unreachable)" in out
+    assert "4055" in out
+
+
+def test_dev_status_reachable_but_empty_presence_shows_zero_online_rows(status_seams: dict[str, Any]) -> None:
+    """A reachable broker whose presence plane doesn't exist yet (open_failed) renders zero
+    online rows — only an unreachable broker degrades to 'unknown (mesh unreachable)'."""
+    status_seams["daemons"] = [_daemon_hit(4055, ("general",))]
+    result = _invoke(["dev", "status"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    out = _plain(result.stdout)
+    assert "online" not in out
+    assert "unknown (see logs)" in out
+    assert "mesh unreachable" not in out
+
+
+def test_dev_status_borrowed_broker_renders_the_shipped_shape(status_seams: dict[str, Any]) -> None:
+    status_seams["broker"] = MeshStatus(target_key=_KEY, reachable=True, brokers=())
+    result = _invoke(["dev", "status"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert "reachable, not managed by calfkit" in _plain(result.stdout)
+
+
+# --- dev stop / dev down (agent-lifecycle spec §3.4) ----------------------------------------------------
+
+
+@pytest.fixture
+def stop_seams(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    seams: dict[str, Any] = {"daemons": [], "online": set(), "stopped": [], "stop_result": True}
+    monkeypatch.setattr(dev_agents, "find_daemons", lambda host_key: [h for h in seams["daemons"] if host_key is None or h.host_key == host_key])
+
+    def fake_stop(hit: Any, *, grace: float = dev_agents.DAEMON_GRACE) -> bool:
+        seams["stopped"].append((hit.pid, grace))
+        result: bool = seams["stop_result"]
+        return result
+
+    monkeypatch.setattr(dev_agents, "stop_daemon", fake_stop)
+
+    async def fake_online(target: Any) -> set[str]:
+        online: set[str] = seams["online"]
+        return online
+
+    monkeypatch.setattr(dev_cli, "_online_name_set", fake_online)
+    return seams
+
+
+def test_dev_stop_narrates_the_whole_daemon(stop_seams: dict[str, Any]) -> None:
+    """Ryan's ruling: a co-hosted daemon is one process tree — naive whole-daemon stop, every
+    co-hosted name always printed."""
+    stop_seams["daemons"] = [_daemon_hit(4055, ("general", "finance"))]
+    result = _invoke(["dev", "stop", "general"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert "stopped daemon pid 4055 (agents: general, finance)" in _plain(result.stdout)
+    assert stop_seams["stopped"] == [(4055, dev_agents.DAEMON_GRACE)]
+
+
+def test_dev_stop_two_names_one_daemon_stops_once(stop_seams: dict[str, Any]) -> None:
+    stop_seams["daemons"] = [_daemon_hit(4055, ("general", "finance"))]
+    result = _invoke(["dev", "stop", "general", "finance"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert len(stop_seams["stopped"]) == 1
+
+
+def test_dev_stop_without_names_points_at_status(stop_seams: dict[str, Any]) -> None:
+    result = _invoke(["dev", "stop"])
+    assert result.exit_code == 2
+    assert "ck dev status" in _plain(result.stderr)
+
+
+def test_dev_stop_unknown_name_exits_2_with_the_address_scope(stop_seams: dict[str, Any]) -> None:
+    stop_seams["daemons"] = [_daemon_hit(4055, ("general",))]
+    result = _invoke(["dev", "stop", "nope"])
+    assert result.exit_code == 2
+    err = _plain(result.stderr)
+    assert "running at 127.0.0.1:9092: general" in err
+    assert "--host" in err
+
+
+def test_dev_stop_online_unmanaged_name_explains_itself(stop_seams: dict[str, Any]) -> None:
+    stop_seams["online"] = {"support"}
+    result = _invoke(["dev", "stop", "support"])
+    assert result.exit_code == 2
+    assert "not a ck dev daemon — stop it where it runs" in _plain(result.stderr)
+
+
+def test_dev_stop_denied_daemon_exits_2(stop_seams: dict[str, Any]) -> None:
+    stop_seams["daemons"] = [_daemon_hit(4055, ("general",))]
+    stop_seams["stop_result"] = False
+    result = _invoke(["dev", "stop", "general"])
+    assert result.exit_code == 2
+    assert "owned by another user" in _plain(result.stderr)
+
+
+def test_dev_stop_all_sweeps_every_address(stop_seams: dict[str, Any]) -> None:
+    stop_seams["daemons"] = [
+        _daemon_hit(4055, ("general",)),
+        _daemon_hit(4102, ("finance",), host_key="127.0.0.1:19092"),
+    ]
+    result = _invoke(["dev", "stop", "--all"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert [pid for pid, _ in stop_seams["stopped"]] == [4055, 4102]
+
+
+def test_dev_stop_all_with_nothing_is_a_messaged_noop(stop_seams: dict[str, Any]) -> None:
+    result = _invoke(["dev", "stop", "--all"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert "no agent daemons" in _plain(result.stdout)
+
+
+def test_dev_down_sweeps_daemons_then_stops_the_broker(stop_seams: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    stop_seams["daemons"] = [_daemon_hit(4055, ("general",))]
+    broker_stops: list[str] = []
+    monkeypatch.setattr(dev_broker, "stop", lambda target, *, grace=5.0: broker_stops.append(target.key) or True)
+    result = _invoke(["dev", "down"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    out = _plain(result.stdout)
+    assert "stopped daemon pid 4055" in out
+    assert f"stopped {_KEY}" in out
+    assert out.index("stopped daemon") < out.index(f"stopped {_KEY}")  # daemons first, then the broker
+    assert broker_stops == [_KEY]
+
+
+def test_dev_down_with_nothing_is_a_messaged_noop(stop_seams: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dev_broker, "stop", lambda target, *, grace=5.0: False)
+    result = _invoke(["dev", "down"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    out = _plain(result.stdout)
+    assert "no agent daemons" in out
+    assert "no managed broker" in out
+
+
 def test_dev_run_forwards_the_hidden_internals_explicitly(ensure_calls: list[dict[str, Any]], run_calls: list[dict[str, Any]]) -> None:
     """The parity-guard contract (impl plan CG-B): `dev run` forwards the hidden internals with
     their preset values — the 5s dev heartbeat (spec §5.6 covers foreground dev runs too) and no

--- a/tests/test_dev_cli.py
+++ b/tests/test_dev_cli.py
@@ -1,10 +1,11 @@
-"""CliRunner tests for the ``ck dev`` command group (spec §4).
+"""CliRunner tests for the ``ck dev`` command group (spec §4 + the agent-lifecycle surface).
 
-The supervisor is monkeypatched at its seams (``calfkit.cli._dev_broker.*`` for the broker
-commands, ``calfkit.cli.dev._run_command``/``_chat_command`` for delegation), so everything here
-is offline. The wrapper contract under test: ``.env`` loads **before** host resolution, the broker
-is ensured once in the parent with a lazy ``resolve_bin`` thunk, the managed-vs-reused line prints,
-and the delegate receives every argument explicitly with the **normalized** host.
+The supervisors are monkeypatched at their seams (``calfkit.cli._dev_broker.*`` /
+``calfkit.cli._dev_agents.*``; ``dev._run_command`` for the foreground-run delegation;
+``calfkit.cli._chat.run_chat_session`` for the attach path), so everything here is offline. The
+wrapper contract under test: ``.env`` loads **before** host resolution, the broker is ensured
+once in the parent with a lazy ``resolve_bin`` thunk, the managed-vs-reused line prints, and the
+delegate/session receives every argument explicitly with the **normalized** host.
 """
 
 from __future__ import annotations
@@ -76,9 +77,14 @@ def run_calls(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
 
 
 @pytest.fixture
-def chat_calls(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+def attach_calls(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Record the attach-path session launches (`run_chat_session` at its module seam)."""
     calls: list[dict[str, Any]] = []
-    monkeypatch.setattr(dev_cli, "_chat_command", lambda **kw: calls.append(kw))
+
+    async def fake_session(name: Any, server_urls: Any, timeout: Any, provision: bool = False, **kwargs: Any) -> None:
+        calls.append({"name": name, "server_urls": server_urls, "timeout": timeout, "provision": provision, **kwargs})
+
+    monkeypatch.setattr("calfkit.cli._chat.run_chat_session", fake_session)
     return calls
 
 
@@ -223,35 +229,35 @@ def test_dev_run_invalid_address_exits_2(run_calls: list[dict[str, Any]]) -> Non
 # --- dev chat (spec §4.1) ------------------------------------------------------------------------------
 
 
-def test_dev_chat_ensures_then_delegates_with_presets(ensure_calls: list[dict[str, Any]], chat_calls: list[dict[str, Any]]) -> None:
+def test_dev_chat_ensures_then_runs_the_session_with_presets(ensure_calls: list[dict[str, Any]], attach_calls: list[dict[str, Any]]) -> None:
     result = _invoke(["dev", "chat"])
     assert result.exit_code == 0, result.stdout + str(result.exception)
     assert len(ensure_calls) == 1
-    (call,) = chat_calls
+    (call,) = attach_calls
     assert call["name"] is None
-    assert call["host"] == _KEY
+    assert call["server_urls"] == _KEY  # the NORMALIZED listener
     assert call["provision"] is True
     assert call["timeout"] is None
-    assert call["env_file"] is None
+    assert callable(call["offline_daemon_hint"])  # the §7 dev-layer hint is wired
 
 
-def test_dev_chat_forwards_name_timeout_and_no_provision(ensure_calls: list[dict[str, Any]], chat_calls: list[dict[str, Any]]) -> None:
+def test_dev_chat_forwards_name_timeout_and_no_provision(ensure_calls: list[dict[str, Any]], attach_calls: list[dict[str, Any]]) -> None:
     result = _invoke(["dev", "chat", "helpdesk", "--no-provision", "--timeout", "12.5"])
     assert result.exit_code == 0, result.stdout + str(result.exception)
-    (call,) = chat_calls
+    (call,) = attach_calls
     assert call["name"] == "helpdesk"
     assert call["provision"] is False
     assert call["timeout"] == 12.5
 
 
-def test_dev_chat_broker_ensure_failure_exits_2(monkeypatch: pytest.MonkeyPatch, chat_calls: list[dict[str, Any]]) -> None:
+def test_dev_chat_broker_ensure_failure_exits_2(monkeypatch: pytest.MonkeyPatch, attach_calls: list[dict[str, Any]]) -> None:
     def boom(target: Any, *, resolve_bin: Any, timeout: float) -> BrokerInfo:
         raise DevBrokerError("nope")
 
     monkeypatch.setattr(dev_broker, "ensure_broker", boom)
     result = _invoke(["dev", "chat"])
     assert result.exit_code == 2
-    assert chat_calls == []
+    assert attach_calls == []
 
 
 # --- dev broker start/stop/status/restart (spec §4.2) ---------------------------------------------------
@@ -593,27 +599,27 @@ def test_dev_run_detach_closes_the_readiness_client(detach_seams: dict[str, Any]
 # --- dev chat grammar: names attach, targets launch in-process (agent-lifecycle spec §3.2) -------------
 
 
-def test_dev_chat_bare_name_attaches_via_the_delegate(ensure_calls: list[dict[str, Any]], chat_calls: list[dict[str, Any]]) -> None:
+def test_dev_chat_bare_name_attaches_via_the_session(ensure_calls: list[dict[str, Any]], attach_calls: list[dict[str, Any]]) -> None:
     result = _invoke(["dev", "chat", "general"])
     assert result.exit_code == 0, result.stdout + str(result.exception)
-    assert chat_calls[0]["name"] == "general"
+    assert attach_calls[0]["name"] == "general"
 
 
-def test_dev_chat_mixing_names_and_targets_is_a_usage_error(chat_calls: list[dict[str, Any]]) -> None:
+def test_dev_chat_mixing_names_and_targets_is_a_usage_error(attach_calls: list[dict[str, Any]]) -> None:
     result = _invoke(["dev", "chat", "general", "app:agent"])
     assert result.exit_code == 2
     assert "mix" in _plain(result.stderr)
-    assert chat_calls == []
+    assert attach_calls == []
 
 
-def test_dev_chat_more_than_one_bare_name_is_a_usage_error(chat_calls: list[dict[str, Any]]) -> None:
+def test_dev_chat_more_than_one_bare_name_is_a_usage_error(attach_calls: list[dict[str, Any]]) -> None:
     result = _invoke(["dev", "chat", "general", "finance"])
     assert result.exit_code == 2
-    assert chat_calls == []
+    assert attach_calls == []
 
 
-def test_dev_chat_targets_dispatch_to_the_session_launcher_not_the_delegate(
-    monkeypatch: pytest.MonkeyPatch, chat_calls: list[dict[str, Any]]
+def test_dev_chat_targets_dispatch_to_the_session_launcher_not_the_attach_path(
+    monkeypatch: pytest.MonkeyPatch, attach_calls: list[dict[str, Any]]
 ) -> None:
     launched: dict[str, Any] = {}
 
@@ -626,7 +632,60 @@ def test_dev_chat_targets_dispatch_to_the_session_launcher_not_the_delegate(
     assert result.exit_code == 0, result.stdout + str(result.exception)
     assert launched["targets"] == ["app:agent", "tools:all"]
     assert launched["timeout"] == 7.0
-    assert chat_calls == []
+    assert attach_calls == []
+
+
+# --- the §7 offline-daemon hint on `dev chat NAME` (review round 1, Ryan-approved) ---------------------
+
+
+def test_dev_chat_offline_name_hint_names_the_daemon_and_logs(ensure_calls: list[dict[str, Any]], monkeypatch: pytest.MonkeyPatch) -> None:
+    """The crashed-on-edit moment: the name is offline on the mesh but a marker daemon owns it —
+    the shipped not-online error gains the daemon + logs + status pointer."""
+    from calfkit.client.mesh import Mesh
+
+    async def other_agents(_self: Mesh) -> dict[str, Any]:
+        return {"other": _mesh_info("other")}  # SOME agents online, just not the named one
+
+    monkeypatch.setattr(Mesh, "get_agents", other_agents)
+    monkeypatch.setattr(dev_agents, "find_daemons", lambda host_key: [_daemon_hit(4055, ("general",))])
+    result = _invoke(["dev", "chat", "general"])
+    assert result.exit_code == 2
+    err = _plain(result.stderr)
+    assert "is not online" in err
+    assert "a managed daemon for 'general' exists but its agents are offline — logs: /tmp/agents-4055.log (ck dev status)" in err
+
+
+def test_dev_chat_offline_name_hint_degrades_without_the_mesh_extra(ensure_calls: list[dict[str, Any]], monkeypatch: pytest.MonkeyPatch) -> None:
+    """Core install: the scan cannot run — the shipped error stands alone, no crash, no hint."""
+    from calfkit.cli._dev_broker import MeshExtraMissingError
+    from calfkit.client.mesh import Mesh
+
+    async def other_agents(_self: Mesh) -> dict[str, Any]:
+        return {"other": _mesh_info("other")}
+
+    def no_scan(host_key: Any) -> list[Any]:
+        raise MeshExtraMissingError("needs [mesh]")
+
+    monkeypatch.setattr(Mesh, "get_agents", other_agents)
+    monkeypatch.setattr(dev_agents, "find_daemons", no_scan)
+    result = _invoke(["dev", "chat", "general"])
+    assert result.exit_code == 2
+    err = _plain(result.stderr)
+    assert "is not online" in err
+    assert "managed daemon" not in err
+
+
+def test_dev_chat_offline_name_without_a_daemon_gets_no_hint(ensure_calls: list[dict[str, Any]], monkeypatch: pytest.MonkeyPatch) -> None:
+    from calfkit.client.mesh import Mesh
+
+    async def other_agents(_self: Mesh) -> dict[str, Any]:
+        return {"other": _mesh_info("other")}
+
+    monkeypatch.setattr(Mesh, "get_agents", other_agents)
+    monkeypatch.setattr(dev_agents, "find_daemons", lambda host_key: [])
+    result = _invoke(["dev", "chat", "general"])
+    assert result.exit_code == 2
+    assert "managed daemon" not in _plain(result.stderr)
 
 
 def test_dev_chat_target_session_ensures_broker_then_preflights(detach_seams: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
@@ -769,6 +828,76 @@ def test_dev_status_borrowed_broker_renders_the_shipped_shape(status_seams: dict
     assert "reachable, not managed by calfkit" in _plain(result.stdout)
 
 
+class _RaisingMesh:
+    """A mesh handle whose reads raise a scripted MeshUnavailableError (per kind)."""
+
+    def __init__(self, reason: str) -> None:
+        from calfkit.exceptions import MeshUnavailableError
+
+        self._exc = MeshUnavailableError("unreadable", reason=reason)
+
+    async def get_agents(self) -> dict[str, Any]:
+        raise self._exc
+
+    async def get_tools(self) -> dict[str, Any]:
+        raise self._exc
+
+
+@pytest.fixture
+def real_presence_seams(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Like status_seams but with the REAL _read_presence_maps running over a fake client whose
+    mesh raises — the degrade arms themselves are under test (review round 1)."""
+    seams: dict[str, Any] = {
+        "broker": MeshStatus(target_key=_KEY, reachable=True, brokers=(_info(pid=4021),)),
+        "daemons": [_daemon_hit(4055, ("general",))],
+        "reason": "open_failed",
+    }
+    monkeypatch.setattr(dev_broker, "status", lambda target, *, timeout=5.0: seams["broker"])
+    monkeypatch.setattr(dev_agents, "find_daemons", lambda host_key: list(seams["daemons"]))
+    _FakeDetachClient.instances = []
+
+    def make_client(server_urls: object = None, **kwargs: object) -> _FakeDetachClient:
+        client = _FakeDetachClient.connect(server_urls, **kwargs)
+        client.mesh = _RaisingMesh(seams["reason"])  # type: ignore[assignment]
+        return client
+
+    monkeypatch.setattr("calfkit.client.Client", type("_C", (), {"connect": staticmethod(make_client)}))
+    return seams
+
+
+def test_dev_status_real_degrade_open_failed_is_silent_zero_rows(real_presence_seams: dict[str, Any]) -> None:
+    """E10 (review round 1): the REAL _read_presence_maps degrades a fresh-broker open_failed to
+    zero online rows — silently (it is the spec'd first-run state), exit 0, client closed."""
+    result = _invoke(["dev", "status"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    out = _plain(result.stdout)
+    assert "online" not in out
+    assert "unknown (see logs)" in out
+    assert "presence unreadable" not in _plain(result.stderr)
+    (client,) = _FakeDetachClient.instances
+    assert client.closed is True
+
+
+def test_dev_status_reader_dead_degrades_with_a_warning(real_presence_seams: dict[str, Any]) -> None:
+    """B5 (review round 1, Ryan-approved): a dead reader on a REACHABLE mesh must not render as a
+    healthy-looking empty mesh with zero trace — one stderr line names the read failure."""
+    real_presence_seams["reason"] = "reader_dead"
+    result = _invoke(["dev", "status"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    err = _plain(result.stderr)
+    assert "presence unreadable" in err
+    assert "reader_dead" in err
+    assert "unknown (see logs)" in _plain(result.stdout)
+
+
+def test_dev_stop_online_check_uses_the_real_helper_and_degrades(real_presence_seams: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    """E10: the REAL _online_name_set path — an unreadable presence view degrades to the
+    unknown-name arm (still factually scoped to the scan) instead of crashing."""
+    result = _invoke(["dev", "stop", "nope"])
+    assert result.exit_code == 2
+    assert "running at 127.0.0.1:9092: general" in _plain(result.stderr)
+
+
 # --- dev stop / dev down (agent-lifecycle spec §3.4) ----------------------------------------------------
 
 
@@ -877,6 +1006,118 @@ def test_dev_down_with_nothing_is_a_messaged_noop(stop_seams: dict[str, Any], mo
     assert "no managed broker" in out
 
 
+def test_dev_sweep_denied_daemon_warns_and_continues(stop_seams: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    """E11 (review round 1): the sweep never aborts on a denied daemon — the second daemon still
+    stops and, for down, the broker stop still runs."""
+    stop_seams["daemons"] = [
+        _daemon_hit(4055, ("general",)),
+        _daemon_hit(4102, ("finance",)),
+    ]
+    denied = {4055}
+
+    def per_pid_stop(hit: Any, *, grace: float = dev_agents.DAEMON_GRACE) -> bool:
+        stop_seams["stopped"].append((hit.pid, grace))
+        return hit.pid not in denied
+
+    monkeypatch.setattr(dev_agents, "stop_daemon", per_pid_stop)
+    broker_stops: list[str] = []
+    monkeypatch.setattr(dev_broker, "stop", lambda target, *, grace=5.0: broker_stops.append(target.key) or True)
+    result = _invoke(["dev", "down"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert "warning" in _plain(result.stderr) and "4055" in _plain(result.stderr)
+    assert "stopped daemon pid 4102" in _plain(result.stdout)
+    assert broker_stops == [_KEY]  # the broker stop still ran
+
+
+def test_dev_sweep_survives_a_raising_stop(stop_seams: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    """D7 (review round 1, Ryan-approved): stop_daemon can RAISE (survived-SIGKILL); the sweep
+    must warn and continue — the broker stop_all discipline the docstring cites — never abort
+    `down` mid-list."""
+    stop_seams["daemons"] = [
+        _daemon_hit(4055, ("general",)),
+        _daemon_hit(4102, ("finance",)),
+    ]
+
+    def raising_stop(hit: Any, *, grace: float = dev_agents.DAEMON_GRACE) -> bool:
+        if hit.pid == 4055:
+            raise DevBrokerError("the agent daemon (pid 4055) survived SIGKILL for 8.0s.")
+        stop_seams["stopped"].append((hit.pid, grace))
+        return True
+
+    monkeypatch.setattr(dev_agents, "stop_daemon", raising_stop)
+    broker_stops: list[str] = []
+    monkeypatch.setattr(dev_broker, "stop", lambda target, *, grace=5.0: broker_stops.append(target.key) or True)
+    result = _invoke(["dev", "down"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert "survived SIGKILL" in _plain(result.stderr)
+    assert "stopped daemon pid 4102" in _plain(result.stdout)
+    assert broker_stops == [_KEY]
+
+
+def test_dev_chat_targets_supervisor_scan_error_is_exit_2_not_a_traceback(detach_seams: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    """D8 (review round 1, Ryan-approved): a core-install `chat TARGET` (borrowed broker, no
+    [mesh] extra) raises MeshExtraMissingError from the lazy scan — it must surface as the
+    exit-2 install hint, never a raw traceback."""
+    from calfkit.cli._dev_broker import MeshExtraMissingError
+
+    def raising_run(coro: Any) -> None:
+        coro.close()
+        raise MeshExtraMissingError("the dev broker supervisor needs the `calfkit[mesh]` extra (psutil).")
+
+    monkeypatch.setattr("calfkit.cli.chat.run_session_command", raising_run)
+    result = _invoke(["dev", "chat", "app:agent"])
+    assert result.exit_code == 2
+    assert "[mesh]" in _plain(result.stderr)
+
+
+def test_dev_run_detach_preflight_error_exits_2_before_broker_work(ensure_calls: list[dict[str, Any]], monkeypatch: pytest.MonkeyPatch) -> None:
+    """E11: the -d preflight boundary arm — a DevAgentError at preflight exits 2 and the broker
+    is never ensured (spec §5.1 order)."""
+
+    def broken_preflight(targets: list[str], *, app_dir: str | None = None) -> list[TargetNodes]:
+        raise DevAgentError("target 'app:agent' resolves to no agents or tools")
+
+    monkeypatch.setattr(dev_agents, "preflight", broken_preflight)
+    result = _invoke(["dev", "run", "-d", "app:agent"])
+    assert result.exit_code == 2
+    assert "no agents or tools" in _plain(result.stderr)
+    assert ensure_calls == []
+
+
+def test_dev_status_without_the_mesh_extra_exits_2_with_the_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """E11: the scan is half the status join — without [mesh] the command cannot answer and says
+    how to fix it."""
+    from calfkit.cli._dev_broker import MeshExtraMissingError
+
+    monkeypatch.setattr(dev_broker, "status", lambda target, *, timeout=5.0: MeshStatus(target.key, False, ()))
+
+    def no_scan(host_key: Any) -> list[Any]:
+        raise MeshExtraMissingError("the dev broker supervisor needs the `calfkit[mesh]` extra (psutil).")
+
+    monkeypatch.setattr(dev_agents, "find_daemons", no_scan)
+    result = _invoke(["dev", "status"])
+    assert result.exit_code == 2
+    assert "[mesh]" in _plain(result.stderr)
+
+
+def test_dev_status_renders_a_managed_tool_row(status_seams: dict[str, Any]) -> None:
+    """E11: a daemon-owned name online in the TOOLS view renders KIND tool with its age."""
+    status_seams["daemons"] = [_daemon_hit(4055, ("get_weather",), targets=("tools:get_weather",))]
+    status_seams["presence"] = ({}, {"get_weather": _mesh_info("get_weather", age=4.0)})
+    result = _invoke(["dev", "status"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    row = next(line for line in _plain(result.stdout).splitlines() if "get_weather" in line)
+    assert row.startswith("tool")
+    assert "online (last seen 4s ago)" in row
+    assert "4055" in row
+
+
+def test_format_age_renders_minutes_and_hours() -> None:
+    assert dev_cli._format_age(3.2) == "3s"
+    assert dev_cli._format_age(125) == "2m05s"
+    assert dev_cli._format_age(3900) == "1h05m"
+
+
 def test_dev_run_forwards_the_hidden_internals_explicitly(ensure_calls: list[dict[str, Any]], run_calls: list[dict[str, Any]]) -> None:
     """The parity-guard contract (impl plan CG-B): `dev run` forwards the hidden internals with
     their preset values — the 5s dev heartbeat (spec §5.6 covers foreground dev runs too) and no
@@ -895,14 +1136,10 @@ def test_dev_run_help_hides_the_internal_flags() -> None:
     assert "--heartbeat-interval" not in out
 
 
-def test_dev_chat_forwards_every_parameter_of_chat(ensure_calls: list[dict[str, Any]], chat_calls: list[dict[str, Any]]) -> None:
-    import inspect
-
-    from calfkit.cli.chat import chat as chat_command
-
-    result = _invoke(["dev", "chat"])
-    assert result.exit_code == 0, result.stdout + str(result.exception)
-    assert set(chat_calls[0]) == set(inspect.signature(chat_command).parameters)
+# (The former dev_chat→chat() parameter-parity guard is gone with the delegation itself: the
+# attach path now calls run_chat_session directly — a plain function signature, so the sentinel
+# drift class the guard existed for is caught by mypy; the value-forwarding tests above pin the
+# behavior.)
 
 
 def test_dev_run_forwards_every_option_value(ensure_calls: list[dict[str, Any]], run_calls: list[dict[str, Any]]) -> None:
@@ -981,3 +1218,15 @@ def test_missing_env_file_warns_only_once_per_process(tmp_path: Path) -> None:
         _load_env(missing)
         _load_env(missing)
     assert stderr.getvalue().count("not found") == 1
+
+
+def test_dev_down_broker_stop_failure_exits_2(stop_seams: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    """A broker that survives SIGKILL surfaces as the shipped exit-2 error after the daemon sweep."""
+
+    def raising_broker_stop(target: Any, *, grace: float = 5.0) -> bool:
+        raise DevBrokerError("the dev broker at 127.0.0.1:9092 (pid 4021) survived SIGKILL for 5.0s.")
+
+    monkeypatch.setattr(dev_broker, "stop", raising_broker_stop)
+    result = _invoke(["dev", "down"])
+    assert result.exit_code == 2
+    assert "survived SIGKILL" in _plain(result.stderr)

--- a/tests/test_dev_packaging.py
+++ b/tests/test_dev_packaging.py
@@ -46,6 +46,8 @@ def test_ck_app_builds_without_mesh_deps() -> None:
         "sys.modules['calfkit_mesh'] = None\n"
         "from calfkit.cli import _build_app\n"
         "_build_app()\n"  # mounts topics/run/chat (+ dev, once it exists)
+        "import calfkit.cli._chat\n"  # the chat session path imports _dev_agents — psutil must stay scan-lazy there too
+        "import calfkit.cli._dev_agents\n"
         "print('HYGIENE_OK')\n"
     )
     result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)

--- a/tests/test_dev_packaging.py
+++ b/tests/test_dev_packaging.py
@@ -25,6 +25,15 @@ def test_mesh_extra_replaces_dead_dev_extra() -> None:
     assert 'mesh = ["calfkit-mesh>=0.1", "psutil>=5.9"]' in text
 
 
+def test_python_dash_m_calfkit_cli_runs_the_ck_app() -> None:
+    """The ``-d`` daemon spawn re-invokes the CLI as ``python -m calfkit.cli run ...``
+    (dev-agent-lifecycle plan §3.1): the module must be executable without the ``ck`` console
+    script being on PATH."""
+    result = subprocess.run([sys.executable, "-m", "calfkit.cli", "--help"], capture_output=True, text=True)
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "dev" in result.stdout
+
+
 def test_ck_app_builds_without_mesh_deps() -> None:
     """Building the ``ck`` app must not import ``psutil``/``calfkit_mesh`` (the ``[mesh]`` deps).
 

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -50,6 +50,7 @@ def test_run_no_reload_calls_serve(monkeypatch: pytest.MonkeyPatch) -> None:
         env_file: str | None,
         app_dir: str,
         enable_idempotence: bool = False,
+        heartbeat_interval: float | None = None,
     ) -> None:
         cap.update(targets=targets, host=host, provision=provision, group_id=group_id, env_file=env_file, app_dir=app_dir)
 
@@ -79,6 +80,7 @@ def test_run_forwards_flags_to_serve(monkeypatch: pytest.MonkeyPatch) -> None:
         env_file: str | None,
         app_dir: str,
         enable_idempotence: bool = False,
+        heartbeat_interval: float | None = None,
     ) -> None:
         cap.update(host=host, provision=provision, group_id=group_id)
 
@@ -174,6 +176,7 @@ def test_run_multiple_targets_forwarded_to_serve(monkeypatch: pytest.MonkeyPatch
         env_file: str | None,
         app_dir: str,
         enable_idempotence: bool = False,
+        heartbeat_interval: float | None = None,
     ) -> None:
         cap["targets"] = targets
 
@@ -199,6 +202,7 @@ def test_run_custom_app_dir_forwarded_to_serve(monkeypatch: pytest.MonkeyPatch, 
         env_file: str | None,
         app_dir: str,
         enable_idempotence: bool = False,
+        heartbeat_interval: float | None = None,
     ) -> None:
         cap["app_dir"] = app_dir
 
@@ -225,6 +229,7 @@ def test_run_enable_idempotence_flag_forwarded_to_serve(monkeypatch: pytest.Monk
         env_file: str | None,
         app_dir: str,
         enable_idempotence: bool = False,
+        heartbeat_interval: float | None = None,
     ) -> None:
         cap["enable_idempotence"] = enable_idempotence
 
@@ -237,6 +242,77 @@ def test_run_enable_idempotence_flag_forwarded_to_serve(monkeypatch: pytest.Monk
     result_off = CliRunner().invoke(_build_app(), ["run", "mymod:agent"])
     assert result_off.exit_code == 0, result_off.stdout + result_off.stderr
     assert cap["enable_idempotence"] is False
+
+
+def test_run_hidden_internal_flags_are_help_invisible() -> None:
+    """R1 guard: --dev-daemon / --heartbeat-interval are `ck dev` plumbing (internal), hidden
+    from humans — they must never surface in ck run --help."""
+    from calfkit.cli import _build_app
+
+    out = _plain(CliRunner().invoke(_build_app(), ["run", "--help"]).stdout)
+    assert "--dev-daemon" not in out
+    assert "--heartbeat-interval" not in out
+
+
+def test_run_accepts_hidden_heartbeat_interval_and_forwards_to_serve(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The hidden --heartbeat-interval is accepted and reaches serve() (the ck dev 5s preset)."""
+    import calfkit.cli.run as run_mod
+    from calfkit.cli import _build_app
+
+    cap: dict = {}
+
+    def fake_serve(*args: object, **kwargs: object) -> None:
+        cap["args"] = args
+
+    monkeypatch.setattr(run_mod, "serve", fake_serve)
+
+    result = CliRunner().invoke(_build_app(), ["run", "mymod:agent", "--heartbeat-interval", "5.0"])
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert 5.0 in cap["args"]
+
+
+def test_run_accepts_hidden_dev_daemon_marker_as_inert_bookkeeping(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--dev-daemon=<names> is the argv ownership marker (dev-agent-lifecycle spec §5.4): it is
+    accepted so it lands in the process cmdline, and ignored beyond that — serve() never sees it
+    and behavior is unchanged."""
+    import calfkit.cli.run as run_mod
+    from calfkit.cli import _build_app
+
+    cap: dict = {}
+
+    def fake_serve(*args: object, **kwargs: object) -> None:
+        cap["args"] = args
+        cap["kwargs"] = kwargs
+
+    monkeypatch.setattr(run_mod, "serve", fake_serve)
+
+    result = CliRunner().invoke(_build_app(), ["run", "mymod:agent", "--dev-daemon=general,get_weather"])
+    assert result.exit_code == 0, result.stdout + result.stderr
+    flat = list(cap["args"]) + list(cap["kwargs"].values())
+    assert "general,get_weather" not in flat  # the marker's value goes nowhere
+    assert cap["args"][0] == ["mymod:agent"]
+
+
+def test_run_reload_forwards_heartbeat_in_supervisor_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Under --reload the heartbeat preset must ride the picklable run_process args tuple, so the
+    respawned child worker keeps the dev cadence across every restart."""
+    import watchfiles
+
+    from calfkit.cli import _build_app
+
+    cap: dict = {}
+
+    def fake_run_process(*paths: str, target: object = None, args: object = None, **kwargs: object) -> None:
+        cap["args"] = args
+
+    monkeypatch.setattr(watchfiles, "run_process", fake_run_process)
+
+    result = CliRunner().invoke(
+        _build_app(),
+        ["run", "tests.provisioning_cli_nodes:single", "--reload", "--heartbeat-interval", "5.0"],
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert 5.0 in cap["args"]
 
 
 def test_run_bad_spec_exits_2() -> None:

--- a/tests/test_run_serve.py
+++ b/tests/test_run_serve.py
@@ -31,6 +31,7 @@ def captured(monkeypatch: pytest.MonkeyPatch) -> dict:
         def __init__(self, client: object, nodes: object = None, group_id: object = None, **kwargs: object) -> None:
             cap["nodes"] = nodes
             cap["group_id"] = group_id
+            cap["control_plane"] = kwargs.get("control_plane")
 
         async def run(self, **kwargs: object) -> None:
             cap["ran"] = True
@@ -117,6 +118,25 @@ def test_serve_enable_idempotence_opts_in(captured: dict) -> None:
 
     serve([f"{_FIXTURE}:single"], host=None, provision=False, group_id=None, env_file=None, app_dir=".", enable_idempotence=True)
     assert captured["enable_idempotence"] is True
+
+
+def test_serve_heartbeat_interval_threads_a_control_plane_config(captured: dict) -> None:
+    """The hidden --heartbeat-interval (the ck dev 5s preset, dev-agent-lifecycle spec §5.6)
+    reaches the Worker as ControlPlaneConfig(heartbeat_interval=...)."""
+    from calfkit.cli._run import serve
+    from calfkit.controlplane import ControlPlaneConfig
+
+    serve([f"{_FIXTURE}:single"], host=None, provision=False, group_id=None, env_file=None, app_dir=".", heartbeat_interval=5.0)
+    assert captured["control_plane"] == ControlPlaneConfig(heartbeat_interval=5.0)
+
+
+def test_serve_default_passes_no_control_plane(captured: dict) -> None:
+    """Without a heartbeat override, serve passes control_plane=None so the worker's own
+    defaults apply — production cadence is untouched by the dev plumbing."""
+    from calfkit.cli._run import serve
+
+    serve([f"{_FIXTURE}:single"], host=None, provision=False, group_id=None, env_file=None, app_dir=".")
+    assert captured["control_plane"] is None
 
 
 def test_serve_banner_shows_idempotence_state(captured: dict, capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
Implements the **dev-agent-lifecycle** feature per `docs/designs/dev-agent-lifecycle-spec.md` v2.1 + `dev-agent-lifecycle-impl-plan.md` v2.1 (both CONVERGED; §9 is the decision log). Built TDD (red→green per cluster), repo green at every commit.

## What ships

- **`ck dev run --detach/-d`** (§3.1): launch targets as a **detached daemon** (the reload supervisor tree, own session), returning only once every advertised name is **online on the presence plane** (bounded ~250 ms/15 s poll, §5.2 — child-death checked first, `open_failed` = not-ready absorbs the fresh-broker race, deadline group-kills the spawn with the log tail). Connect-or-spawn per target (§5.5): reuse-by-name with heartbeat ages, error-first over a broken marker daemon, partial-online errors. The whole check→spawn→readiness section runs under the agent-layer flock (`~/.calfkit/dev-agents.lock`).
- **`ck dev chat [NAME | TARGET...]`** (§3.2): the grammar (`:` = target, bare = name; mixing / two names / cross-target duplicate names = exit 2). Targets run as a **session worker in-process on the shared chat Client** (the `caller.py` co-located contract; 5 s heartbeat preset explicit at construction; stopped on every session end **before** the client closes) — no reload in-session (recorded exception), all-reused = no worker, ✦ exit narration, tools-only = nobody-to-chat-with error.
- **`ck dev status`** (§3.3): unfiltered host-scoped join of the argv-marker scan with one presence snapshot; never errors (broker-down degrades columns; `open_failed` = zero online rows); heartbeat ages always shown.
- **`ck dev stop NAME... | --all` / `ck dev down`** (§3.4): whole-daemon narrated stop (`stopped daemon pid N (agents: …)`), **process-group** SIGTERM → ≥8 s grace → SIGKILL (the supervisor's own teardown budget is ~6 s; broker keeps its 5 s default — R4); names resolve within the address, sweeps are global; `down` = sweep + broker stop.
- **Ownership** (§5.4): stateless argv marker `--dev-daemon=<names>` + adjacent `--host` scoping — supervisor-only matching (spawn_main descendants unmarked, empirically verified), hidden inert flags on `ck run` (R1 help-snapshot guarded), `python -m calfkit.cli` entry for the spawn.
- The 5 s **dev heartbeat preset** (§5.6) for every dev-launched worker (foreground `dev run` included) via a hidden `--heartbeat-interval` → `ControlPlaneConfig` threading; reader-side staleness untouched.
- Docs: README quickstart (`run -d … && ck dev chat`, honest one-item picker, ends `ck dev down`), `local-dev-mesh.md` team loop, `cli.md` reference (incl. the name-vs-address stop asymmetry and down-leaves-unmanaged-workers notes; `--dev-daemon` documented as internal — R3). Two ADRs (0033 launcher-owns-lifetime incl. §3.5 closure; 0034 argv-marker stateless ownership) written as `proposed` in the gitignored `docs/adr/`.

## Rulings obtained during implementation (folded into spec §9)

1. **Zero-advert launch targets** → usage error, exit 2, per target (an invisible, name-unstoppable daemon violates G4); consumer nodes co-hosted with an advertising node ride along.
2. **Offline daemon rows in `status`** → STATE **`unknown (see logs)`**, KIND **`unknown`** (crashed edit / mid-restart / booting are statelessly indistinguishable; the bare-names marker cannot recover kind). Supersedes the spec example's `offline (daemon pid alive)`/`agent` cells.

## Empirical proof gates (both PASS)

- **CG-0 argv spike** (macOS, SIP): detached session-leader child's `--dev-daemon=…` marker + `--host` fully visible via `psutil.cmdline()` from another process; committed as the C3 supervisor-only test + kafka e2e.
- **Kill-9 liveness proof** (kafka lane): a 5 s-heartbeat daemon never flaps offline across ~12 s of continuous sampling, and reads offline **within the ~15–20 s staleness window** after SIGKILL (no tombstone).

## Impl-time decisions to note (within plan-delegated latitude; called out for review)

- **Log slug** = `agents-<sanitized address key>-<sanitized targets>.log`, derived identically at spawn and scan time (the handoff rule; the spec §3.3 example showed a shorter cosmetic form).
- **Daemon argv forwards the user's `dev run` options** (`--app-dir`/`--group-id`/`--reload-dir`/`--env-file`/`--enable-idempotence`, `--no-provision`/`--no-reload` drop presets) — "everything `ck dev run` is today" (§3.1); the plan's pinned argv shape is preserved.
- **Readiness treats ANY `MeshUnavailableError` as not-ready** (spec pins `open_failed`; `establishing`/`reader_dead` are the same transient class inside a bounded gate — a persistent one still exits 2 at the deadline).
- **Ctrl-C during the `-d` wait exits 130** (spec pins the behavior — daemon left running + hint — not the code).
- Launched **tool** names print `launched tool '<name>'` (the §3.1 line says "agent"; a tools-only daemon saying "agent" would lie).
- `ck dev status` without the `[mesh]` extra exits 2 with the install hint (the scan is half the join; same posture as `broker status`).
- The kafka e2e suite **skips in CI** (no `[mesh]` extra there — the shipped `test_dev_broker_kafka` posture); it is green locally, including under `-n auto`.

## Verification

- Offline: **4065 passed** (repo-wide), `make fix` + `make check` green at every one of the 9 commits; **100 % coverage** on `calfkit/cli/_dev_agents.py` (new) and `calfkit/cli/_dev_broker.py` (extended).
- Kafka lane (local, Docker Redpanda + bundled Tansu): **93 passed, 6 skipped (pre-existing deferred stubs), 1 xpassed**, incl. the 4 new e2e slices in parallel.

