### PR TITLE
fix: coerce a bare ContentPart to [part] instead of burying it in a DataPart

### DIFF
--- a/calfkit/models/_coerce.py
+++ b/calfkit/models/_coerce.py
@@ -15,6 +15,10 @@ def _coerce_to_parts(value: Any) -> list[ContentPart]:
 
     * ``None`` → ``[]`` (no output);
     * ``str`` → one ``TextPart``;
+    * a bare ``ContentPart`` → ``[part]`` — the vocabulary's own values are fixed
+      points of the coercion (``coerce(part) == coerce([part])``), so per-part
+      ``metadata`` (e.g. the ``calf.retry`` marker) survives instead of being buried
+      inside a ``DataPart`` (docs/issues/coerce-to-parts-drops-bare-content-part-metadata.md);
     * a ``list[ContentPart]`` passes through unchanged (the agent's preamble case —
       an empty list is vacuously such a list and yields ``[]``);
     * anything else JSON-serializable → one ``DataPart``, eagerly wire-checked via
@@ -25,6 +29,8 @@ def _coerce_to_parts(value: Any) -> list[ContentPart]:
         return []
     if isinstance(value, str):
         return [TextPart(text=value)]
+    if isinstance(value, _CONTENT_PART_TYPES):
+        return [value]
     if isinstance(value, list) and all(isinstance(p, _CONTENT_PART_TYPES) for p in value):
         return cast("list[ContentPart]", value)
     part = DataPart(data=value)

--- a/tests/test_reply_slot.py
+++ b/tests/test_reply_slot.py
@@ -29,7 +29,7 @@ from calfkit.models import (
 from calfkit.models._coerce import _coerce_to_parts
 from calfkit.models.error_report import ErrorReport
 from calfkit.models.node_result import InvocationResult
-from calfkit.models.payload import FilePart
+from calfkit.models.payload import FilePart, ToolCallPart, is_retry, retry_text_part
 from calfkit.models.reply import FaultMessage, ReturnMessage, _ReplyBase
 from calfkit.models.state import State
 
@@ -142,6 +142,31 @@ class TestCoerceToParts:
     def test_non_serializable_value_raises(self) -> None:
         with pytest.raises(pydantic_core.PydanticSerializationError):
             _coerce_to_parts(object())
+
+    def test_bare_content_part_wraps_to_singleton_list(self) -> None:
+        # A bare part is a fixed point of the coercion into its own vocabulary — never
+        # buried as opaque data inside a DataPart (docs/issues/coerce-to-parts-drops-
+        # bare-content-part-metadata.md).
+        for part in (
+            TextPart(text="hi"),
+            FilePart(media_type="image/png"),
+            DataPart(data={"k": "v"}),
+            ToolCallPart(tool_call_id="c1", kwargs={}, tool_name="t"),
+        ):
+            assert _coerce_to_parts(part) == [part]
+
+    def test_bare_retry_part_keeps_the_marker(self) -> None:
+        # The calf.retry marker must survive coercion of a BARE marked part, or a tool
+        # error renders to the model as a success (is_error fidelity lost downstream).
+        part = retry_text_part("boom: rate limited")
+        result = _coerce_to_parts(part)
+        assert result == [part]
+        assert is_retry(result)
+
+    def test_bare_part_coerces_same_as_wrapped_part(self) -> None:
+        # The faithful-embedding property: coerce(part) == coerce([part]).
+        for part in (TextPart(text="hi"), DataPart(data={"k": "v"})):
+            assert _coerce_to_parts(part) == _coerce_to_parts([part])
 
 
 class TestProtocolKind:


### PR DESCRIPTION
## The bug

`_coerce_to_parts` — the single value→parts conversion for everything a node returns (`calfkit/models/_coerce.py`) — had four arms (`None`/`str`/`list[ContentPart]`/else-`DataPart`) but **no arm for a bare single `ContentPart`**. A part returned unwrapped fell through to the generic `DataPart(data=value)` fallback, nesting the part inside another part's `data` with the outer `metadata=None`:

- A bare `retry_text_part(msg)` (a `TextPart` carrying the `calf.retry` marker) had its marker buried → `is_retry` returned `False` → the agent materialized a `ToolReturn` instead of a `RetryPromptPart` → **a tool error rendered to the model as a success** (Anthropic `is_error` fidelity lost), with the internal `calf.retry` key leaking verbatim into model-visible JSON.
- Not marker-specific: *any* bare-part return produced a mangled, double-encoded wire shape (a bare `DataPart` even double-wrapped: `DataPart(data=DataPart(...))`).

Full root-cause analysis, blast radius, and the option comparison are in the issue report: `docs/issues/coerce-to-parts-drops-bare-content-part-metadata.md` (Option A = this fix; B loud-raise and C carriage-change were rejected there).

## The fix (one line)

```python
if isinstance(value, _CONTENT_PART_TYPES):
    return [value]
```

inserted before the `DataPart` fallback. This makes the part vocabulary's own values fixed points of the coercion — `coerce(part) == coerce([part])` — so per-part metadata survives. It strictly widens accepted input; the only behavior it changes (bare part → nested `DataPart`) is the bug itself. Both in-tree marker producers already wrap in lists, so shipped behavior is unaffected.

## Blast radius

All five `_coerce_to_parts` call sites strictly improve:

| Site | Effect |
|---|---|
| `base.py` `_publish_action` (ReturnCall) | wire carries the part the author meant, not a double-encoded envelope |
| `base.py` `_output_view` | `after_node` sees the actual part |
| `base.py` `_resolve_callee` (handled-substitute materialization) | a bare `retry_text_part` substitute now keeps its marker (the silent D7 case) |
| `tool.py` / `agent.py` `project_steps` | streaming `ToolResultStep.is_error` derivation consistent with the fixed wire |

## Tests (TDD — written first, watched fail)

- `test_bare_content_part_wraps_to_singleton_list` — all four part types coerce to `[part]`
- `test_bare_retry_part_keeps_the_marker` — `is_retry(coerce(retry_text_part(...)))` is `True`
- `test_bare_part_coerces_same_as_wrapped_part` — the faithful-embedding property
- All six existing arm tests unchanged and green (the four spec'd arms still hold)

## Why now

Precursor to the agent tool-error reception feature: with this landed, that feature's spec deletes its "must return a list or the error becomes a success" patch rule (spec D7) instead of shipping and teaching a trap.

## Verification

- Full offline suite: 4104 passed, 0 failures
- `calfkit/models/_coerce.py` at 100% coverage
- `make fix` + `make check` clean (lint, format, mypy)