### PR TITLE
feat: live wait-progress feedback and live agent picker for ck dev

### DIFF
--- a/calfkit/cli/_chat.py
+++ b/calfkit/cli/_chat.py
@@ -183,7 +183,10 @@ async def _target_session(
                     to_launch,
                     client.mesh,
                     reused_names=[name for outcome in reused for name in outcome.target.names],
-                    make_reporter=make_reporter_factory(lambda n: f"Starting {n} node(s) on {host_key}"),
+                    make_reporter=make_reporter_factory(
+                        lambda n: f"Starting {n} node(s) on {host_key}",
+                        success=lambda n: f"all {n} node(s) online",
+                    ),
                     log_path=None,
                 )
         repl_entered = True

--- a/calfkit/cli/_chat.py
+++ b/calfkit/cli/_chat.py
@@ -21,6 +21,8 @@ import typer
 from calfkit.cli import _dev_agents
 from calfkit.cli._chat_io import make_reader
 from calfkit.cli._chat_render import _error_line, _render_answer, _render_fault, _render_step, format_picker
+from calfkit.cli._picker import is_interactive, live_pick
+from calfkit.cli._wait import make_reporter_factory
 from calfkit.client import Client, RunCompleted, RunFailed
 from calfkit.exceptions import NodeFaultError
 from calfkit.provisioning import ProvisioningConfig
@@ -104,7 +106,14 @@ async def _attach(
     *,
     offline_hint: Callable[[str], str | None] | None = None,
 ) -> None:
-    """Today's attach flow: discover -> pick (or resolve the name) -> REPL."""
+    """Discover -> pick (or resolve the name) -> REPL. On an interactive terminal with no named
+    agent, the live picker (which polls the mesh itself) replaces the static discover+pick; a named
+    lookup or a non-tty stream keeps the one-shot read + static numbered picker."""
+    if name is None and is_interactive():
+        picked = await live_pick(client)
+        if picked is not None:
+            await _chat_loop(client, picked, timeout, read_line)
+        return
     print("Discovering agents...")
     agents = await client.mesh.get_agents()
     if not agents:  # ready, but zero live agents
@@ -169,11 +178,12 @@ async def _target_session(
                     traceback.print_exc()  # §7: surface directly — it IS this process
                     raise _dev_agents.DevAgentError(f"the session worker failed to start: {exc}") from exc
                 launched = list(to_launch)
-                await _dev_agents.wait_agents_ready(
+                await _dev_agents.gate_launched_ready(
                     None,  # the chat variant: no process arm — a failed start already raised above
-                    [n for t in to_launch for n in t.agent_names],
-                    [n for t in to_launch for n in t.tool_names],
+                    to_launch,
                     client.mesh,
+                    reused_names=[name for outcome in reused for name in outcome.target.names],
+                    make_reporter=make_reporter_factory(lambda n: f"Starting {n} node(s) on {host_key}"),
                     log_path=None,
                 )
         repl_entered = True

--- a/calfkit/cli/_chat_io.py
+++ b/calfkit/cli/_chat_io.py
@@ -108,19 +108,29 @@ Key = Literal["up", "down", "enter", "quit", "other"]
 
 def _decode_keys(chunk: bytes) -> list[Key]:
     """Split one raw read into picker key tokens. A single ``os.read`` is not a single key: an arrow
-    is a 3-byte escape sequence, and fast typing / a paste can deliver several keys at once."""
+    is a multi-byte escape sequence, fast typing / a paste can deliver several keys at once, and an
+    unhandled escape sequence must be consumed WHOLE so no interior byte leaks out as a stray key."""
     keys: list[Key] = []
     i, n = 0, len(chunk)
     while i < n:
-        if chunk[i] == 0x1B and chunk[i + 1 : i + 3] == b"[A":
+        if chunk[i : i + 3] == b"\x1b[A":
             keys.append("up")
             i += 3
-        elif chunk[i] == 0x1B and chunk[i + 1 : i + 3] == b"[B":
+        elif chunk[i : i + 3] == b"\x1b[B":
             keys.append("down")
             i += 3
-        elif chunk[i] == 0x1B and chunk[i + 1 : i + 2] in (b"[", b"O"):
-            keys.append("other")  # an unhandled CSI/SS3 (←/→, Home, F-keys, …): consumed and ignored
-            i += 3
+        elif chunk[i] == 0x1B and chunk[i + 1 : i + 2] == b"[":
+            # An unhandled CSI (modified arrows, Home/End, F-keys, …). Consume THROUGH its final byte
+            # (0x40-0x7E) — parameter/intermediate bytes are 0x20-0x3F — so a trailing byte such as the
+            # 'Q' of a modified F2 (ESC[1;2Q) is never re-scanned as a standalone quit that cancels.
+            j = i + 2
+            while j < n and 0x20 <= chunk[j] <= 0x3F:
+                j += 1
+            i = j + 1 if j < n else n  # include the final byte, or clamp if truncated across a read
+            keys.append("other")
+        elif chunk[i] == 0x1B and chunk[i + 1 : i + 2] == b"O":
+            keys.append("other")  # an SS3 sequence (introducer + one final byte): app-mode arrows / F1-F4
+            i = min(i + 3, n)
         elif chunk[i] == 0x1B and i + 1 < n:
             keys.append("other")  # ESC + a byte = a Meta/Alt combo (or other esc): ignored, never a cancel
             i += 2

--- a/calfkit/cli/_chat_io.py
+++ b/calfkit/cli/_chat_io.py
@@ -27,6 +27,7 @@ import io
 import os
 import sys
 from collections.abc import Awaitable, Callable
+from typing import Literal
 
 _READ_SIZE = 4096
 
@@ -102,29 +103,49 @@ def make_reader(loop: asyncio.AbstractEventLoop, fd: int | None = None) -> Calla
     return read_line
 
 
-def _decode_key(chunk: bytes) -> str:
-    """Map one raw keypress to a picker token."""
-    if chunk == b"\x1b[A":
-        return "up"
-    if chunk == b"\x1b[B":
-        return "down"
-    if chunk in (b"\r", b"\n"):
-        return "enter"
-    if chunk in (b"\x03", b"\x04", b"\x1b", b"q", b"Q"):  # Ctrl-C / Ctrl-D / Esc / q
-        return "quit"
-    return "other"
+Key = Literal["up", "down", "enter", "quit", "other"]
 
 
-def make_key_reader(loop: asyncio.AbstractEventLoop, fd: int | None = None) -> Callable[[], Awaitable[str]]:
-    """Build a single-keypress reader for the live picker. The terminal is expected to already be in
-    raw mode (the caller sets and restores it), so each keypress arrives as one ``os.read`` and
-    decodes to a token (``up`` / ``down`` / ``enter`` / ``quit`` / ``other``). Same ``add_reader``
+def _decode_keys(chunk: bytes) -> list[Key]:
+    """Split one raw read into picker key tokens. A single ``os.read`` is not a single key: an arrow
+    is a 3-byte escape sequence, and fast typing / a paste can deliver several keys at once."""
+    keys: list[Key] = []
+    i, n = 0, len(chunk)
+    while i < n:
+        if chunk[i] == 0x1B and chunk[i + 1 : i + 3] == b"[A":
+            keys.append("up")
+            i += 3
+        elif chunk[i] == 0x1B and chunk[i + 1 : i + 3] == b"[B":
+            keys.append("down")
+            i += 3
+        elif chunk[i] == 0x1B and chunk[i + 1 : i + 2] == b"[":
+            keys.append("other")  # an unhandled CSI (←/→, Home, …): consumed and ignored
+            i += 3
+        elif chunk[i] in (0x1B, 0x03, 0x04) or chunk[i : i + 1] in (b"q", b"Q"):
+            keys.append("quit")  # Esc / Ctrl-C(byte) / Ctrl-D(byte) / q
+            i += 1
+        elif chunk[i : i + 1] in (b"\r", b"\n"):
+            keys.append("enter")
+            i += 1
+        else:
+            keys.append("other")  # any unmapped key: ignored by the picker, not an error
+            i += 1
+    return keys
+
+
+def make_key_reader(loop: asyncio.AbstractEventLoop, fd: int | None = None) -> Callable[[], Awaitable[Key]]:
+    """Build a single-key reader for the live picker. The terminal is expected to be in **cbreak**
+    mode (the caller sets and restores it — not raw, which would fight ``rich.Live``). One ``os.read``
+    may carry several keys, so decoded keys are buffered and returned one per call. Same ``add_reader``
     mechanics as :func:`make_reader` — cancellable, no executor thread; tests inject an ``os.pipe()``
-    read-end."""
+    read-end. An empty read (EOF) yields ``quit``."""
     resolved_fd = fd
+    pending: list[Key] = []
 
-    async def read_key() -> str:
+    async def read_key() -> Key:
         nonlocal resolved_fd
+        if pending:
+            return pending.pop(0)
         if resolved_fd is None:
             resolved_fd = _resolve_stdin_fd()
         read_fd = resolved_fd
@@ -134,7 +155,7 @@ def make_key_reader(loop: asyncio.AbstractEventLoop, fd: int | None = None) -> C
             if future.done():  # pragma: no cover - cancel/resolve race
                 return
             try:
-                chunk = os.read(read_fd, 8)
+                chunk = os.read(read_fd, 16)
             except OSError as exc:
                 future.set_exception(exc)
                 return
@@ -145,6 +166,10 @@ def make_key_reader(loop: asyncio.AbstractEventLoop, fd: int | None = None) -> C
             chunk = await future
         finally:
             loop.remove_reader(read_fd)
-        return _decode_key(chunk)
+        keys = _decode_keys(chunk)
+        if not keys:  # empty read == EOF; treat as cancel
+            return "quit"
+        pending.extend(keys[1:])
+        return keys[0]
 
     return read_key

--- a/calfkit/cli/_chat_io.py
+++ b/calfkit/cli/_chat_io.py
@@ -118,11 +118,16 @@ def _decode_keys(chunk: bytes) -> list[Key]:
         elif chunk[i] == 0x1B and chunk[i + 1 : i + 3] == b"[B":
             keys.append("down")
             i += 3
-        elif chunk[i] == 0x1B and chunk[i + 1 : i + 2] == b"[":
-            keys.append("other")  # an unhandled CSI (←/→, Home, …): consumed and ignored
+        elif chunk[i] == 0x1B and chunk[i + 1 : i + 2] in (b"[", b"O"):
+            keys.append("other")  # an unhandled CSI/SS3 (←/→, Home, F-keys, …): consumed and ignored
             i += 3
+        elif chunk[i] == 0x1B and i + 1 < n:
+            keys.append("other")  # ESC + a byte = a Meta/Alt combo (or other esc): ignored, never a cancel
+            i += 2
         elif chunk[i] in (0x1B, 0x03, 0x04) or chunk[i : i + 1] in (b"q", b"Q"):
-            keys.append("quit")  # Esc / Ctrl-C(byte) / Ctrl-D(byte) / q
+            # A lone/terminal ESC is the Escape key; q/Q is quit; a raw Ctrl-D byte arrives here (ICANON
+            # off). Ctrl-C is normally a SIGINT under cbreak (ISIG on) — the 0x03 arm is only defensive.
+            keys.append("quit")
             i += 1
         elif chunk[i : i + 1] in (b"\r", b"\n"):
             keys.append("enter")

--- a/calfkit/cli/_chat_io.py
+++ b/calfkit/cli/_chat_io.py
@@ -100,3 +100,51 @@ def make_reader(loop: asyncio.AbstractEventLoop, fd: int | None = None) -> Calla
         return line
 
     return read_line
+
+
+def _decode_key(chunk: bytes) -> str:
+    """Map one raw keypress to a picker token."""
+    if chunk == b"\x1b[A":
+        return "up"
+    if chunk == b"\x1b[B":
+        return "down"
+    if chunk in (b"\r", b"\n"):
+        return "enter"
+    if chunk in (b"\x03", b"\x04", b"\x1b", b"q", b"Q"):  # Ctrl-C / Ctrl-D / Esc / q
+        return "quit"
+    return "other"
+
+
+def make_key_reader(loop: asyncio.AbstractEventLoop, fd: int | None = None) -> Callable[[], Awaitable[str]]:
+    """Build a single-keypress reader for the live picker. The terminal is expected to already be in
+    raw mode (the caller sets and restores it), so each keypress arrives as one ``os.read`` and
+    decodes to a token (``up`` / ``down`` / ``enter`` / ``quit`` / ``other``). Same ``add_reader``
+    mechanics as :func:`make_reader` — cancellable, no executor thread; tests inject an ``os.pipe()``
+    read-end."""
+    resolved_fd = fd
+
+    async def read_key() -> str:
+        nonlocal resolved_fd
+        if resolved_fd is None:
+            resolved_fd = _resolve_stdin_fd()
+        read_fd = resolved_fd
+        future: asyncio.Future[bytes] = loop.create_future()
+
+        def _on_readable() -> None:
+            if future.done():  # pragma: no cover - cancel/resolve race
+                return
+            try:
+                chunk = os.read(read_fd, 8)
+            except OSError as exc:
+                future.set_exception(exc)
+                return
+            future.set_result(chunk)
+
+        loop.add_reader(read_fd, _on_readable)
+        try:
+            chunk = await future
+        finally:
+            loop.remove_reader(read_fd)
+        return _decode_key(chunk)
+
+    return read_key

--- a/calfkit/cli/_chat_io.py
+++ b/calfkit/cli/_chat_io.py
@@ -126,7 +126,12 @@ def _decode_keys(chunk: bytes) -> list[Key]:
             j = i + 2
             while j < n and 0x20 <= chunk[j] <= 0x3F:
                 j += 1
-            i = j + 1 if j < n else n  # include the final byte, or clamp if truncated across a read
+            if j < n and 0x40 <= chunk[j] <= 0x7E:
+                i = j + 1  # consumed a valid final byte
+            else:
+                # Truncated across a read, OR an ESC/control byte aborted the CSI: stop AT that byte so
+                # the next iteration re-parses it as a fresh key (e.g. an ESC[ that precedes a real arrow).
+                i = max(j, i + 1)
             keys.append("other")
         elif chunk[i] == 0x1B and chunk[i + 1 : i + 2] == b"O":
             keys.append("other")  # an SS3 sequence (introducer + one final byte): app-mode arrows / F1-F4

--- a/calfkit/cli/_dev_agents.py
+++ b/calfkit/cli/_dev_agents.py
@@ -18,7 +18,7 @@ import signal
 import subprocess
 import sys
 import time
-from collections.abc import Callable, Collection, Iterator, Mapping, Sequence
+from collections.abc import Collection, Iterator, Mapping, Sequence
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -42,7 +42,7 @@ from calfkit.cli._dev_broker import (
     normalize,
 )
 from calfkit.cli._loader import load_nodes
-from calfkit.cli._wait import NULL_REPORTER, WaitReporter
+from calfkit.cli._wait import NULL_REPORTER, ReporterFactory, WaitReporter
 from calfkit.exceptions import MeshUnavailableError
 from calfkit.models.agents import AGENTS_TOPIC
 from calfkit.models.capability import CAPABILITY_TOPIC
@@ -408,7 +408,7 @@ async def gate_launched_ready(
     mesh: PresenceReader,
     *,
     reused_names: Sequence[str],
-    make_reporter: Callable[[list[str], list[str]], WaitReporter] = _null_reporter_factory,
+    make_reporter: ReporterFactory = _null_reporter_factory,
     log_path: str | None,
     timeout: float = READY_TIMEOUT,
     poll_interval: float = _POLL_INTERVAL,
@@ -420,7 +420,7 @@ async def gate_launched_ready(
     ``None`` for the chat variant's in-process worker."""
     launched_agents = [name for target in to_launch for name in target.agent_names]
     launched_tools = [name for target in to_launch for name in target.tool_names]
-    reporter = make_reporter(launched_agents + launched_tools, list(reused_names))
+    reporter = make_reporter(waiting=launched_agents + launched_tools, pre_done=list(reused_names))
     with reporter:
         await wait_agents_ready(
             proc,
@@ -615,7 +615,7 @@ async def ensure_agents(
     mesh: PresenceReader,
     *,
     run_args: RunOptions,
-    make_reporter: Callable[[list[str], list[str]], WaitReporter] = _null_reporter_factory,
+    make_reporter: ReporterFactory = _null_reporter_factory,
     timeout: float = READY_TIMEOUT,
     poll_interval: float = _POLL_INTERVAL,
 ) -> EnsureReport:

--- a/calfkit/cli/_dev_agents.py
+++ b/calfkit/cli/_dev_agents.py
@@ -18,7 +18,7 @@ import signal
 import subprocess
 import sys
 import time
-from collections.abc import Collection, Iterator, Mapping, Sequence
+from collections.abc import Callable, Collection, Iterator, Mapping, Sequence
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -42,6 +42,7 @@ from calfkit.cli._dev_broker import (
     normalize,
 )
 from calfkit.cli._loader import load_nodes
+from calfkit.cli._wait import NULL_REPORTER, WaitReporter
 from calfkit.exceptions import MeshUnavailableError
 from calfkit.models.agents import AGENTS_TOPIC
 from calfkit.models.capability import CAPABILITY_TOPIC
@@ -340,6 +341,7 @@ async def wait_agents_ready(
     log_path: str | None,
     timeout: float = READY_TIMEOUT,
     poll_interval: float = _POLL_INTERVAL,
+    reporter: WaitReporter = NULL_REPORTER,
 ) -> None:
     """Wait until every name is online, bounded (spec §5.2) — the broker readiness loop's shape.
 
@@ -355,6 +357,7 @@ async def wait_agents_ready(
     """
     deadline = time.monotonic() + timeout
     last_read_failure: MeshUnavailableError | None = None
+    last_missing: list[str] = [*agent_names, *tool_names]
     while True:
         if proc is not None and proc.poll() is not None:
             code = proc.returncode
@@ -374,7 +377,9 @@ async def wait_agents_ready(
             last_read_failure = result  # open_failed / establishing: not ready yet, keep polling
         else:
             last_read_failure = None
-            if not _missing_names(agent_names, tool_names, result):
+            last_missing = _missing_names(agent_names, tool_names, result)
+            reporter.update(done=[name for name in (*agent_names, *tool_names) if name not in last_missing])
+            if not last_missing:
                 return
         if time.monotonic() >= deadline:
             if proc is not None:
@@ -387,8 +392,46 @@ async def wait_agents_ready(
                     f"presence read failed ({last_read_failure.reason}: {last_read_failure})"
                     f"{_tail_suffix(log_path)}"
                 ) from last_read_failure
-            raise DevAgentError(f"the launched agents did not come online within {timeout:.1f}s{_tail_suffix(log_path)}")
+            raise DevAgentError(
+                f"the launched agents did not come online within {timeout:.1f}s (still waiting on: {', '.join(last_missing)}){_tail_suffix(log_path)}"
+            )
         await asyncio.sleep(poll_interval)
+
+
+def _null_reporter_factory(waiting: list[str], pre_done: list[str]) -> WaitReporter:
+    return NULL_REPORTER
+
+
+async def gate_launched_ready(
+    proc: Any | None,
+    to_launch: Sequence[TargetNodes],
+    mesh: PresenceReader,
+    *,
+    reused_names: Sequence[str],
+    make_reporter: Callable[[list[str], list[str]], WaitReporter] = _null_reporter_factory,
+    log_path: str | None,
+    timeout: float = READY_TIMEOUT,
+    poll_interval: float = _POLL_INTERVAL,
+) -> None:
+    """The single readiness-gate seam shared by ``ck dev run -d`` and ``ck dev chat TARGET``
+    (spec §4.5): build the launched name lists, construct the reporter from the factory (given the
+    launched-vs-reused split), and wait for the launched names to come online with the reporter
+    wrapped around the gate. *proc* is the ``-d`` daemon handle (its death aborts the wait) or
+    ``None`` for the chat variant's in-process worker."""
+    launched_agents = [name for target in to_launch for name in target.agent_names]
+    launched_tools = [name for target in to_launch for name in target.tool_names]
+    reporter = make_reporter(launched_agents + launched_tools, list(reused_names))
+    with reporter:
+        await wait_agents_ready(
+            proc,
+            launched_agents,
+            launched_tools,
+            mesh,
+            log_path=log_path,
+            reporter=reporter,
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
 
 
 def _tail_suffix(log_path: str | None) -> str:
@@ -572,6 +615,7 @@ async def ensure_agents(
     mesh: PresenceReader,
     *,
     run_args: RunOptions,
+    make_reporter: Callable[[list[str], list[str]], WaitReporter] = _null_reporter_factory,
     timeout: float = READY_TIMEOUT,
     poll_interval: float = _POLL_INTERVAL,
 ) -> EnsureReport:
@@ -584,11 +628,12 @@ async def ensure_agents(
             return EnsureReport(outcomes=tuple(reused), pid=None, log_path=None)
         log_path = daemon_log_path(target.key, tuple(t.spec for t in to_launch))
         proc = _spawn_daemon(to_launch, target, log_path, run_args)
-        await wait_agents_ready(
+        await gate_launched_ready(
             proc,
-            [n for t in to_launch for n in t.agent_names],
-            [n for t in to_launch for n in t.tool_names],
+            to_launch,
             mesh,
+            reused_names=[name for outcome in reused for name in outcome.target.names],
+            make_reporter=make_reporter,
             log_path=str(log_path),
             timeout=timeout,
             poll_interval=poll_interval,

--- a/calfkit/cli/_dev_agents.py
+++ b/calfkit/cli/_dev_agents.py
@@ -398,7 +398,7 @@ async def wait_agents_ready(
         await asyncio.sleep(poll_interval)
 
 
-def _null_reporter_factory(waiting: list[str], pre_done: list[str]) -> WaitReporter:
+def _null_reporter_factory(*, waiting: list[str], pre_done: list[str]) -> WaitReporter:
     return NULL_REPORTER
 
 

--- a/calfkit/cli/_dev_broker.py
+++ b/calfkit/cli/_dev_broker.py
@@ -37,6 +37,7 @@ from subprocess import Popen
 from typing import Any
 
 from calfkit.cli._dev_probe import is_reachable
+from calfkit.cli._wait import NULL_REPORTER, WaitReporter
 
 DEFAULT_PORT = 9092
 DEFAULT_TIMEOUT = 5.0
@@ -320,6 +321,7 @@ def ensure_broker(
     *,
     resolve_bin: Callable[[], str],
     timeout: float = DEFAULT_TIMEOUT,
+    reporter: WaitReporter = NULL_REPORTER,
 ) -> BrokerInfo:
     """Connect-or-spawn: return the broker serving *target*, spawning one only when the address is
     a single loopback address with nothing reachable there (spec §5.2).
@@ -353,7 +355,7 @@ def ensure_broker(
                 "broker at that address, or point --host at a loopback address to get a managed one."
             )
         binary = _resolve_binary(resolve_bin)
-        return _spawn_and_wait(target, binary, timeout)
+        return _spawn_and_wait(target, binary, timeout, reporter=reporter)
 
 
 def _resolve_binary(resolve_bin: Callable[[], str]) -> str:
@@ -387,7 +389,7 @@ def _log_tail(log_path: Path) -> str:
         return f"(could not read the log: {exc})"
 
 
-def _spawn_and_wait(target: Target, binary: str, timeout: float) -> BrokerInfo:
+def _spawn_and_wait(target: Target, binary: str, timeout: float, *, reporter: WaitReporter = NULL_REPORTER) -> BrokerInfo:
     listener = target.listener
     log_path = _calfkit_dir() / "logs" / f"tansu-{target.key}.log"
     cmd = [
@@ -411,27 +413,28 @@ def _spawn_and_wait(target: Target, binary: str, timeout: float) -> BrokerInfo:
             # Wrong-arch / corrupt binary fails at exec time (spec §7.3) — distinct from a timeout.
             raise DevBrokerError(f"failed to launch the dev broker binary {binary!r}: {exc}") from exc
     deadline = time.monotonic() + timeout
-    while True:
-        if proc.poll() is not None:
-            code = proc.returncode
-            if code is not None and code < 0:
-                cause = f"killed by a signal ({code}) — a concurrent `ck dev broker stop/restart`?"
-            else:
-                cause = f"exit code {code}"
-            raise DevBrokerError(f"the dev broker exited during startup ({cause}); log tail from {log_path}:\n{_log_tail(log_path)}")
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            proc.kill()
-            try:
-                proc.wait(timeout=DEFAULT_GRACE)  # reap our own child — no zombie for long-lived callers
-            except subprocess.TimeoutExpired:
-                pass  # kill was delivered; the CLI exits next and init reaps
-            raise DevBrokerError(f"the dev broker did not become ready within {timeout:.1f}s; log tail from {log_path}:\n{_log_tail(log_path)}")
-        # Per-attempt probe budget: capped at 1s so proc.poll() keeps getting re-checked, and
-        # bounded by the remaining deadline so the total wait never overshoots `timeout`.
-        if is_reachable(listener, timeout=min(1.0, max(0.1, remaining))):
-            break
-        time.sleep(_READINESS_POLL_INTERVAL)
+    with reporter:
+        while True:
+            if proc.poll() is not None:
+                code = proc.returncode
+                if code is not None and code < 0:
+                    cause = f"killed by a signal ({code}) — a concurrent `ck dev broker stop/restart`?"
+                else:
+                    cause = f"exit code {code}"
+                raise DevBrokerError(f"the dev broker exited during startup ({cause}); log tail from {log_path}:\n{_log_tail(log_path)}")
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                proc.kill()
+                try:
+                    proc.wait(timeout=DEFAULT_GRACE)  # reap our own child — no zombie for long-lived callers
+                except subprocess.TimeoutExpired:
+                    pass  # kill was delivered; the CLI exits next and init reaps
+                raise DevBrokerError(f"the dev broker did not become ready within {timeout:.1f}s; log tail from {log_path}:\n{_log_tail(log_path)}")
+            # Per-attempt probe budget: capped at 1s so proc.poll() keeps getting re-checked, and
+            # bounded by the remaining deadline so the total wait never overshoots `timeout`.
+            if is_reachable(listener, timeout=min(1.0, max(0.1, remaining))):
+                break
+            time.sleep(_READINESS_POLL_INTERVAL)
     return BrokerInfo(
         listener=listener,
         pid=proc.pid,

--- a/calfkit/cli/_dev_probe.py
+++ b/calfkit/cli/_dev_probe.py
@@ -14,6 +14,7 @@ cheap and pulls no aiokafka at load time.
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Sequence
 
 
@@ -28,12 +29,18 @@ async def broker_reachable(bootstrap: str | Sequence[str], *, timeout: float) ->
 
     servers = bootstrap if isinstance(bootstrap, str) else list(bootstrap)
     client = AIOKafkaClient(bootstrap_servers=servers)
+    # aiokafka logs 'Unable connect …' at ERROR on every failed bootstrap attempt; while a broker is
+    # still coming up those are expected noise, so raise its threshold for the probe and restore it.
+    aiokafka_log = logging.getLogger("aiokafka.client")
+    previous_level = aiokafka_log.level
+    aiokafka_log.setLevel(logging.CRITICAL)
     try:
         await asyncio.wait_for(client.bootstrap(), timeout)
         return True
     except (KafkaError, asyncio.TimeoutError, OSError):
         return False
     finally:
+        aiokafka_log.setLevel(previous_level)
         await client.close()
 
 

--- a/calfkit/cli/_dev_probe.py
+++ b/calfkit/cli/_dev_probe.py
@@ -20,12 +20,17 @@ from collections.abc import Sequence
 
 
 class _DropConnectRetryNoise(logging.Filter):
-    """Drops aiokafka's expected per-attempt ``Unable connect …`` retry logs while a broker is still
-    coming up; every other aiokafka record passes through, so a genuinely different error
-    (auth/TLS/protocol) stays visible."""
+    """Drops aiokafka's expected per-attempt bootstrap retry log while a broker is still coming up.
+
+    aiokafka has TWO ``Unable connect …`` ERROR sites on the ``aiokafka`` logger: the bootstrap-attempt
+    retry ``Unable connect to "<host>:<port>": …`` (client.py, the noise we want gone) and a genuine
+    ``Unable connect to node with id <n>: …`` diagnostic for a discovered node dropping. We anchor on
+    the ``to "`` quote so ONLY the bootstrap noise is dropped and the node-failure diagnostic — like
+    every other aiokafka error (auth/TLS/protocol) — stays visible. (String-coupled to a pinned
+    aiokafka message; it fails *open* — noise reappears — if that wording ever changes.)"""
 
     def filter(self, record: logging.LogRecord) -> bool:
-        return not record.getMessage().startswith("Unable connect")
+        return not record.getMessage().startswith('Unable connect to "')
 
 
 async def broker_reachable(bootstrap: str | Sequence[str], *, timeout: float) -> bool:

--- a/calfkit/cli/_dev_probe.py
+++ b/calfkit/cli/_dev_probe.py
@@ -14,8 +14,18 @@ cheap and pulls no aiokafka at load time.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from collections.abc import Sequence
+
+
+class _DropConnectRetryNoise(logging.Filter):
+    """Drops aiokafka's expected per-attempt ``Unable connect …`` retry logs while a broker is still
+    coming up; every other aiokafka record passes through, so a genuinely different error
+    (auth/TLS/protocol) stays visible."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return not record.getMessage().startswith("Unable connect")
 
 
 async def broker_reachable(bootstrap: str | Sequence[str], *, timeout: float) -> bool:
@@ -29,19 +39,24 @@ async def broker_reachable(bootstrap: str | Sequence[str], *, timeout: float) ->
 
     servers = bootstrap if isinstance(bootstrap, str) else list(bootstrap)
     client = AIOKafkaClient(bootstrap_servers=servers)
-    # aiokafka logs 'Unable connect …' at ERROR on every failed bootstrap attempt; while a broker is
-    # still coming up those are expected noise, so raise its threshold for the probe and restore it.
-    aiokafka_log = logging.getLogger("aiokafka.client")
-    previous_level = aiokafka_log.level
-    aiokafka_log.setLevel(logging.CRITICAL)
+    # aiokafka logs 'Unable connect …' at ERROR on the "aiokafka" logger (client.py binds
+    # logging.getLogger("aiokafka")) on every failed bootstrap attempt; while a broker is still
+    # coming up those are expected retry noise. Drop ONLY those records for the probe with a
+    # message-scoped filter, removed afterward — so a genuinely different aiokafka error still
+    # surfaces (visibility into a real failure) and logging during real operation is untouched.
+    aiokafka_log = logging.getLogger("aiokafka")
+    noise_filter = _DropConnectRetryNoise()
+    aiokafka_log.addFilter(noise_filter)
     try:
         await asyncio.wait_for(client.bootstrap(), timeout)
         return True
     except (KafkaError, asyncio.TimeoutError, OSError):
         return False
     finally:
-        aiokafka_log.setLevel(previous_level)
-        await client.close()
+        aiokafka_log.removeFilter(noise_filter)
+        # Best-effort cleanup — the probe result is the signal, a close failure must not surface as a throw.
+        with contextlib.suppress(Exception):
+            await client.close()
 
 
 def is_reachable(bootstrap: str | Sequence[str], *, timeout: float) -> bool:

--- a/calfkit/cli/_picker.py
+++ b/calfkit/cli/_picker.py
@@ -1,0 +1,153 @@
+"""The ``ck dev chat`` live agent picker (spec ``docs/designs/cli-live-feedback-spec.md`` §5).
+
+A cbreak-mode ``rich.Live`` selector whose online-agent menu refreshes as agents come and go.
+The selection logic is a pure state-machine (:class:`PickerModel`) kept apart from the terminal
+I/O so it is testable without a tty.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import sys
+from collections.abc import Awaitable, Callable, Collection
+from typing import TYPE_CHECKING
+
+from rich.console import Console, Group, RenderableType
+from rich.live import Live
+from rich.text import Text
+
+from calfkit.cli._chat_io import make_key_reader
+
+if TYPE_CHECKING:
+    from calfkit.client import Client
+
+
+class PickerModel:
+    """The picker's pure selection state: the display *order* (arrival order — existing rows stay
+    put, new agents append) and the *highlighted* agent tracked by name, not index. Reconciled
+    against the live online set by :meth:`sync`."""
+
+    def __init__(self) -> None:
+        self._order: list[str] = []
+        self._highlight: str | None = None
+
+    def sync(self, online: Collection[str]) -> None:
+        """Reconcile with the current online set: drop agents that went offline (keeping the rest
+        in place), append new arrivals (sorted within the batch), and keep the highlight on its
+        agent — moving it to the nearest surviving row if that agent went offline."""
+        online_set = set(online)
+        old_index = self._order.index(self._highlight) if self._highlight in self._order else 0
+        self._order = [name for name in self._order if name in online_set]
+        for name in sorted(online_set):
+            if name not in self._order:
+                self._order.append(name)
+        if self._highlight not in self._order:
+            self._highlight = self._order[min(old_index, len(self._order) - 1)] if self._order else None
+
+    def move(self, delta: int) -> None:
+        """Shift the highlight by *delta* rows, clamped to the list ends."""
+        if not self._order or self._highlight is None:
+            return
+        index = self._order.index(self._highlight)
+        clamped = max(0, min(len(self._order) - 1, index + delta))
+        self._highlight = self._order[clamped]
+
+    @property
+    def names(self) -> list[str]:
+        return list(self._order)
+
+    @property
+    def highlighted(self) -> str | None:
+        return self._highlight
+
+
+def render_menu(model: PickerModel) -> RenderableType:
+    """Render the picker: a header, then one row per online agent with the highlighted row marked
+    (``❯``). An empty roster shows a waiting hint (agents may still be coming online)."""
+    header = Text("Select an agent  (↑/↓ move · Enter pick · q quit)")
+    if not model.names:
+        return Group(header, Text("  (no agents online yet — waiting… press q to quit)"))
+    rows = [Text(f"{'❯ ' if name == model.highlighted else '  '}{name}") for name in model.names]
+    return Group(header, *rows)
+
+
+async def _run_picker(
+    read_key: Callable[[], Awaitable[str]],
+    poll_agents: Callable[[], Awaitable[Collection[str]]],
+    render: Callable[[PickerModel], None],
+    *,
+    cadence: float,
+) -> str | None:
+    """The picker's control loop, decoupled from the terminal (spec §5.1): race a keypress against a
+    re-poll tick. On a tick, re-sync the model from *poll_agents* and re-render; on a key, move /
+    select (Enter) / cancel (quit). The keypress task persists across ticks so a press is never lost
+    to a poll boundary. Returns the selected agent name, or ``None`` if cancelled."""
+    model = PickerModel()
+    model.sync(await poll_agents())
+    render(model)
+    key_task = asyncio.ensure_future(read_key())
+    try:
+        while True:
+            tick_task = asyncio.ensure_future(asyncio.sleep(cadence))
+            done, _ = await asyncio.wait({key_task, tick_task}, return_when=asyncio.FIRST_COMPLETED)
+            if key_task in done:
+                tick_task.cancel()
+                key = key_task.result()
+                if key == "quit":
+                    return None
+                if key == "enter":
+                    return model.highlighted
+                if key == "up":
+                    model.move(-1)
+                elif key == "down":
+                    model.move(1)
+                render(model)
+                key_task = asyncio.ensure_future(read_key())
+            else:  # poll tick — the keypress task stays armed
+                model.sync(await poll_agents())
+                render(model)
+    finally:
+        key_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await key_task
+
+
+def is_interactive() -> bool:
+    """True when both stdin and stdout are real terminals — the precondition for the live picker
+    (POSIX cbreak input). Otherwise the caller falls back to the static numbered picker."""
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+async def live_pick(client: Client, *, cadence: float = 1.0) -> str | None:
+    """The interactive live agent picker (spec §5.1): render the online-agent menu with ``rich.Live``
+    and read single keys in **cbreak** mode (line-editing + echo off, output translation kept so Live
+    renders cleanly — not raw mode, which would fight Live). Re-polls ``get_agents()`` every *cadence*
+    seconds so agents appear/disappear live. The terminal mode is restored on every exit path; Ctrl-C
+    (a SIGINT under cbreak) is treated as cancel, alongside ``q``/``Esc``. POSIX-only, like the ``ck
+    chat`` line reader."""
+    import termios
+    import tty
+
+    loop = asyncio.get_running_loop()
+    fd = sys.stdin.fileno()
+    console = Console()
+    read_key = make_key_reader(loop, fd)
+
+    async def poll_agents() -> list[str]:
+        return list(await client.mesh.get_agents())
+
+    old_attrs = termios.tcgetattr(fd)
+    tty.setcbreak(fd)
+    try:
+        with Live("", console=console, auto_refresh=False, transient=True) as live:
+
+            def render(model: PickerModel) -> None:
+                live.update(render_menu(model), refresh=True)
+
+            try:
+                return await _run_picker(read_key, poll_agents, render, cadence=cadence)
+            except KeyboardInterrupt:
+                return None
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old_attrs)

--- a/calfkit/cli/_picker.py
+++ b/calfkit/cli/_picker.py
@@ -17,10 +17,17 @@ from rich.console import Console, Group, RenderableType
 from rich.live import Live
 from rich.text import Text
 
-from calfkit.cli._chat_io import make_key_reader
+from calfkit.cli._chat_io import Key, make_key_reader
 
 if TYPE_CHECKING:
     from calfkit.client import Client
+    from calfkit.client.mesh import AgentInfo
+
+
+def _roster_descriptions(agents: Mapping[str, AgentInfo]) -> dict[str, str | None]:
+    """Project the mesh's agent directory down to the picker's ``name → description`` roster — the
+    only fields the live menu needs, keeping :class:`PickerModel` decoupled from the mesh DTO."""
+    return {name: info.description for name, info in agents.items()}
 
 
 class PickerModel:
@@ -86,7 +93,7 @@ def render_menu(model: PickerModel) -> RenderableType:
 
 
 async def _run_picker(
-    read_key: Callable[[], Awaitable[str]],
+    read_key: Callable[[], Awaitable[Key]],
     poll_agents: Callable[[], Awaitable[Mapping[str, str | None]]],
     render: Callable[[PickerModel], None],
     *,
@@ -150,8 +157,7 @@ async def live_pick(client: Client, *, cadence: float = 1.0) -> str | None:
     read_key = make_key_reader(loop, fd)
 
     async def poll_agents() -> dict[str, str | None]:
-        agents = await client.mesh.get_agents()
-        return {name: info.description for name, info in agents.items()}
+        return _roster_descriptions(await client.mesh.get_agents())
 
     old_attrs = termios.tcgetattr(fd)
     tty.setcbreak(fd)

--- a/calfkit/cli/_picker.py
+++ b/calfkit/cli/_picker.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import sys
-from collections.abc import Awaitable, Callable, Collection
+from collections.abc import Awaitable, Callable, Mapping
 from typing import TYPE_CHECKING
 
 from rich.console import Console, Group, RenderableType
@@ -25,25 +25,28 @@ if TYPE_CHECKING:
 
 class PickerModel:
     """The picker's pure selection state: the display *order* (arrival order — existing rows stay
-    put, new agents append) and the *highlighted* agent tracked by name, not index. Reconciled
-    against the live online set by :meth:`sync`."""
+    put, new agents append), the *highlighted* agent tracked by name (not index), and each agent's
+    advertised *description*. Reconciled against the live online roster by :meth:`sync`."""
 
     def __init__(self) -> None:
         self._order: list[str] = []
         self._highlight: str | None = None
+        self._descriptions: dict[str, str | None] = {}
 
-    def sync(self, online: Collection[str]) -> None:
-        """Reconcile with the current online set: drop agents that went offline (keeping the rest
-        in place), append new arrivals (sorted within the batch), and keep the highlight on its
-        agent — moving it to the nearest surviving row if that agent went offline."""
-        online_set = set(online)
+    def sync(self, agents: Mapping[str, str | None]) -> None:
+        """Reconcile with the current online roster (name → description): drop agents that went
+        offline (keeping the rest in place), append new arrivals (sorted within the batch), refresh
+        descriptions, and keep the highlight on its agent — moving it to the nearest surviving row
+        if that agent went offline."""
+        online = set(agents)
         old_index = self._order.index(self._highlight) if self._highlight in self._order else 0
-        self._order = [name for name in self._order if name in online_set]
-        for name in sorted(online_set):
+        self._order = [name for name in self._order if name in online]
+        for name in sorted(online):
             if name not in self._order:
                 self._order.append(name)
         if self._highlight not in self._order:
             self._highlight = self._order[min(old_index, len(self._order) - 1)] if self._order else None
+        self._descriptions = dict(agents)
 
     def move(self, delta: int) -> None:
         """Shift the highlight by *delta* rows, clamped to the list ends."""
@@ -61,20 +64,30 @@ class PickerModel:
     def highlighted(self) -> str | None:
         return self._highlight
 
+    def description(self, name: str) -> str | None:
+        return self._descriptions.get(name)
+
 
 def render_menu(model: PickerModel) -> RenderableType:
-    """Render the picker: a header, then one row per online agent with the highlighted row marked
-    (``❯``). An empty roster shows a waiting hint (agents may still be coming online)."""
+    """Render the picker: a header, then one row per online agent — ``❯`` marks the highlighted row,
+    and each agent's description follows its (padded) name. An empty roster shows a waiting hint
+    (agents may still be coming online)."""
     header = Text("Select an agent  (↑/↓ move · Enter pick · q quit)")
     if not model.names:
         return Group(header, Text("  (no agents online yet — waiting… press q to quit)"))
-    rows = [Text(f"{'❯ ' if name == model.highlighted else '  '}{name}") for name in model.names]
+    name_width = max(len(name) for name in model.names)
+    rows: list[RenderableType] = []
+    for name in model.names:
+        marker = "❯ " if name == model.highlighted else "  "
+        description = model.description(name)
+        row = f"{marker}{name.ljust(name_width)}" + (f"  {description}" if description else "")
+        rows.append(Text(row))
     return Group(header, *rows)
 
 
 async def _run_picker(
     read_key: Callable[[], Awaitable[str]],
-    poll_agents: Callable[[], Awaitable[Collection[str]]],
+    poll_agents: Callable[[], Awaitable[Mapping[str, str | None]]],
     render: Callable[[PickerModel], None],
     *,
     cadence: float,
@@ -96,8 +109,10 @@ async def _run_picker(
                 key = key_task.result()
                 if key == "quit":
                     return None
-                if key == "enter":
+                if key == "enter" and model.highlighted is not None:
                     return model.highlighted
+                # Enter on an empty roster is ignored (falls through) — not a selection, and never a
+                # silent cancel — so the picker stays open until an agent arrives or the user quits.
                 if key == "up":
                     model.move(-1)
                 elif key == "down":
@@ -134,8 +149,9 @@ async def live_pick(client: Client, *, cadence: float = 1.0) -> str | None:
     console = Console()
     read_key = make_key_reader(loop, fd)
 
-    async def poll_agents() -> list[str]:
-        return list(await client.mesh.get_agents())
+    async def poll_agents() -> dict[str, str | None]:
+        agents = await client.mesh.get_agents()
+        return {name: info.description for name, info in agents.items()}
 
     old_attrs = termios.tcgetattr(fd)
     tty.setcbreak(fd)

--- a/calfkit/cli/_wait.py
+++ b/calfkit/cli/_wait.py
@@ -1,0 +1,150 @@
+"""The CLI wait reporter seam (spec ``docs/designs/cli-live-feedback-spec.md`` §4).
+
+A :class:`WaitReporter` is a passive, push-driven sink a foreground CLI wait uses to
+visualize progress toward a *known* set of named targets and, on failure, attribute the
+wait to the exact item that never resolved. The wait owns the data and completion clock;
+the reporter only renders. :data:`NULL_REPORTER` is the silent default so callers that do
+not opt in (unit tests, the detached daemon child) are unaffected.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Collection, Sequence
+from types import TracebackType
+from typing import Protocol
+
+from rich.console import Console, Group, RenderableType
+from rich.live import Live
+from rich.spinner import Spinner
+from rich.text import Text
+
+
+class WaitReporter(Protocol):
+    """The sink a wait pushes progress snapshots to. Used as a context manager so
+    teardown and success/failure rendering are exception-driven; the wait's only
+    obligation inside its loop is a single :meth:`update` call."""
+
+    def __enter__(self) -> WaitReporter: ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None: ...
+
+    def update(self, done: Collection[str]) -> None: ...
+
+
+class ConsoleWaitReporter:
+    """Renders a wait's progress toward a known set of named targets via Rich.
+
+    ``waiting`` are the targets being waited on (``pending -> done`` as :meth:`update`
+    is called); ``pre_done`` are already-satisfied targets, shown done from the start and
+    never updated (e.g. reused agents). Self-branches on ``console.is_terminal``: an
+    interactive terminal gets a live in-place view, any other stream gets append-only
+    milestone lines.
+    """
+
+    def __init__(
+        self,
+        title: str,
+        waiting: Sequence[str],
+        *,
+        pre_done: Sequence[str] = (),
+        console: Console | None = None,
+    ) -> None:
+        self._title = title
+        self._waiting = list(waiting)
+        self._pre_done = list(pre_done)
+        self._console = console if console is not None else Console()
+        self._done: set[str] = set(self._pre_done)
+        self._total = len(self._waiting) + len(self._pre_done)
+        self._live: Live | None = None
+
+    def __enter__(self) -> ConsoleWaitReporter:
+        if self._console.is_terminal:
+            self._live = Live(self._render(), console=self._console, transient=True)
+            self._live.start()
+        else:
+            self._console.print(self._title, markup=False, highlight=False)
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        pending = [name for name in self._waiting if name not in self._done]
+        if self._console.is_terminal:
+            if self._live is not None:
+                self._live.stop()
+                self._live = None
+            if exc_type is not None:
+                self._console.print(f"✘ still pending: {', '.join(pending)}", markup=False, highlight=False)
+            else:
+                self._console.print(f"✔ all {self._total} done", markup=False, highlight=False)
+        elif exc_type is not None and pending:
+            self._console.print(f"still pending: {', '.join(pending)}", markup=False, highlight=False)
+        return None
+
+    def update(self, done: Collection[str]) -> None:
+        newly = [name for name in self._waiting if name in done and name not in self._done]
+        for name in newly:
+            self._done.add(name)
+            if not self._console.is_terminal:
+                self._console.print(f"{name} ({len(self._done)}/{self._total})", markup=False, highlight=False)
+        if self._console.is_terminal and self._live is not None:
+            self._live.update(self._render())
+
+    def _display_order(self) -> list[str]:
+        # pre_done (reused context) first, then the targets being waited on.
+        return [*self._pre_done, *self._waiting]
+
+    def _render(self) -> RenderableType:
+        rows: list[RenderableType] = []
+        for name in self._display_order():
+            if name in self._done:
+                rows.append(Text(f"✔ {name}"))
+            else:
+                rows.append(Spinner("dots", text=Text(f" {name}")))
+        header = Text(f"{self._title}  {len(self._done)}/{self._total}")
+        return Group(header, *rows)
+
+
+class _NullWaitReporter:
+    """The silent default: every method is a no-op."""
+
+    def __enter__(self) -> _NullWaitReporter:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        return None
+
+    def update(self, done: Collection[str]) -> None:
+        return None
+
+
+NULL_REPORTER: WaitReporter = _NullWaitReporter()
+
+
+def make_reporter_factory(
+    title: Callable[[int], str],
+    *,
+    console: Console | None = None,
+) -> Callable[[list[str], list[str]], WaitReporter]:
+    """Build a ``gate_launched_ready`` reporter factory: given the launched (``waiting``) and reused
+    (``pre_done``) name lists, construct a :class:`ConsoleWaitReporter` whose title is
+    ``title(len(waiting))``. The command layer supplies the title wording, so this module stays
+    domain-neutral."""
+
+    def _factory(waiting: list[str], pre_done: list[str]) -> WaitReporter:
+        return ConsoleWaitReporter(title(len(waiting)), waiting, pre_done=pre_done, console=console)
+
+    return _factory

--- a/calfkit/cli/_wait.py
+++ b/calfkit/cli/_wait.py
@@ -9,6 +9,7 @@ not opt in (unit tests, the detached daemon child) are unaffected.
 
 from __future__ import annotations
 
+import contextlib
 from collections.abc import Callable, Collection, Sequence
 from types import TracebackType
 from typing import Protocol
@@ -36,6 +37,15 @@ class WaitReporter(Protocol):
     def update(self, done: Collection[str]) -> None: ...
 
 
+class ReporterFactory(Protocol):
+    """Builds a reporter once the launched (``waiting``) / reused (``pre_done``) split is known —
+    deferred because that partition is computed inside ``gate_launched_ready``, not at the call site.
+    Named (rather than a bare ``Callable[[list[str], list[str]], WaitReporter]``) so call sites pass
+    by keyword and cannot transpose the two same-typed lists."""
+
+    def __call__(self, waiting: list[str], pre_done: list[str]) -> WaitReporter: ...
+
+
 class ConsoleWaitReporter:
     """Renders a wait's progress toward a known set of named targets via Rich.
 
@@ -52,11 +62,13 @@ class ConsoleWaitReporter:
         waiting: Sequence[str],
         *,
         pre_done: Sequence[str] = (),
+        success_label: str | None = None,
         console: Console | None = None,
     ) -> None:
         self._title = title
         self._waiting = list(waiting)
         self._pre_done = list(pre_done)
+        self._success_label = success_label
         self._console = console if console is not None else Console()
         self._done: set[str] = set(self._pre_done)
         self._total = len(self._waiting) + len(self._pre_done)
@@ -79,15 +91,20 @@ class ConsoleWaitReporter:
         pending = [name for name in self._waiting if name not in self._done]
         if self._console.is_terminal:
             if self._live is not None:
-                self._live.stop()
+                # A teardown-render glitch must never mask the wait's own in-flight exception.
+                with contextlib.suppress(Exception):
+                    self._live.stop()
                 self._live = None
             if exc_type is not None:
                 self._console.print(f"✘ still pending: {', '.join(pending)}", markup=False, highlight=False)
             else:
-                self._console.print(f"✔ all {self._total} done", markup=False, highlight=False)
+                self._console.print(f"✔ {self._success_line()}", markup=False, highlight=False)
         elif exc_type is not None and pending:
             self._console.print(f"still pending: {', '.join(pending)}", markup=False, highlight=False)
         return None
+
+    def _success_line(self) -> str:
+        return self._success_label if self._success_label is not None else f"all {self._total} done"
 
     def update(self, done: Collection[str]) -> None:
         newly = [name for name in self._waiting if name in done and name not in self._done]
@@ -96,7 +113,10 @@ class ConsoleWaitReporter:
             if not self._console.is_terminal:
                 self._console.print(f"{name} ({len(self._done)}/{self._total})", markup=False, highlight=False)
         if self._console.is_terminal and self._live is not None:
-            self._live.update(self._render())
+            # A cosmetic side-channel must not fail the operation it decorates: a render glitch
+            # degrades to silent rather than aborting the wait.
+            with contextlib.suppress(Exception):
+                self._live.update(self._render())
 
     def _display_order(self) -> list[str]:
         # pre_done (reused context) first, then the targets being waited on.
@@ -137,14 +157,22 @@ NULL_REPORTER: WaitReporter = _NullWaitReporter()
 def make_reporter_factory(
     title: Callable[[int], str],
     *,
+    success: Callable[[int], str] | None = None,
     console: Console | None = None,
-) -> Callable[[list[str], list[str]], WaitReporter]:
+) -> ReporterFactory:
     """Build a ``gate_launched_ready`` reporter factory: given the launched (``waiting``) and reused
-    (``pre_done``) name lists, construct a :class:`ConsoleWaitReporter` whose title is
-    ``title(len(waiting))``. The command layer supplies the title wording, so this module stays
-    domain-neutral."""
+    (``pre_done``) name lists, construct a :class:`ConsoleWaitReporter` titled ``title(len(waiting))``
+    with a success finalize of ``success(len(waiting))`` (generic ``all N done`` when *success* is
+    absent). The command layer supplies the wording, so this module stays domain-neutral."""
 
     def _factory(waiting: list[str], pre_done: list[str]) -> WaitReporter:
-        return ConsoleWaitReporter(title(len(waiting)), waiting, pre_done=pre_done, console=console)
+        n = len(waiting)
+        return ConsoleWaitReporter(
+            title(n),
+            waiting,
+            pre_done=pre_done,
+            success_label=success(n) if success is not None else None,
+            console=console,
+        )
 
     return _factory

--- a/calfkit/cli/_wait.py
+++ b/calfkit/cli/_wait.py
@@ -43,7 +43,7 @@ class ReporterFactory(Protocol):
     Named (rather than a bare ``Callable[[list[str], list[str]], WaitReporter]``) so call sites pass
     by keyword and cannot transpose the two same-typed lists."""
 
-    def __call__(self, waiting: list[str], pre_done: list[str]) -> WaitReporter: ...
+    def __call__(self, *, waiting: list[str], pre_done: list[str]) -> WaitReporter: ...
 
 
 class ConsoleWaitReporter:
@@ -165,7 +165,7 @@ def make_reporter_factory(
     with a success finalize of ``success(len(waiting))`` (generic ``all N done`` when *success* is
     absent). The command layer supplies the wording, so this module stays domain-neutral."""
 
-    def _factory(waiting: list[str], pre_done: list[str]) -> WaitReporter:
+    def _factory(*, waiting: list[str], pre_done: list[str]) -> WaitReporter:
         n = len(waiting)
         return ConsoleWaitReporter(
             title(n),

--- a/calfkit/cli/dev.py
+++ b/calfkit/cli/dev.py
@@ -30,6 +30,7 @@ import typer
 from calfkit.cli import _dev_agents, _dev_broker
 from calfkit.cli._common import _load_env, _parse_host
 from calfkit.cli._dev_broker import BrokerInfo, DevBrokerError, Target, normalize
+from calfkit.cli._wait import ConsoleWaitReporter, make_reporter_factory
 from calfkit.cli.run import run as _run_command
 from calfkit.client._mesh_url import resolve_mesh_url
 
@@ -88,7 +89,12 @@ def _echo_broker_line(broker: BrokerInfo) -> None:
 
 def _ensure_or_exit(target: Target) -> BrokerInfo:
     try:
-        broker = _dev_broker.ensure_broker(target, resolve_bin=_resolve_bin, timeout=_dev_broker.DEFAULT_TIMEOUT)
+        broker = _dev_broker.ensure_broker(
+            target,
+            resolve_bin=_resolve_bin,
+            timeout=_dev_broker.DEFAULT_TIMEOUT,
+            reporter=ConsoleWaitReporter(f"Starting dev broker at {target.bootstrap}", ["dev broker"]),
+        )
     except DevBrokerError as exc:
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(2) from exc
@@ -257,7 +263,13 @@ async def _ensure_agents_with_client(
 
     client = Client.connect(_session_servers(target))
     try:
-        return await _dev_agents.ensure_agents(plan, target, client.mesh, run_args=run_args)
+        return await _dev_agents.ensure_agents(
+            plan,
+            target,
+            client.mesh,
+            run_args=run_args,
+            make_reporter=make_reporter_factory(lambda n: f"Starting {n} node(s) on {target.bootstrap}"),
+        )
     finally:
         await client.aclose()
 

--- a/calfkit/cli/dev.py
+++ b/calfkit/cli/dev.py
@@ -93,7 +93,7 @@ def _ensure_or_exit(target: Target) -> BrokerInfo:
             target,
             resolve_bin=_resolve_bin,
             timeout=_dev_broker.DEFAULT_TIMEOUT,
-            reporter=ConsoleWaitReporter(f"Starting dev broker at {target.bootstrap}", ["dev broker"]),
+            reporter=ConsoleWaitReporter(f"Starting dev broker at {target.bootstrap}", ["dev broker"], success_label="dev broker ready"),
         )
     except DevBrokerError as exc:
         typer.echo(f"Error: {exc}", err=True)
@@ -268,7 +268,10 @@ async def _ensure_agents_with_client(
             target,
             client.mesh,
             run_args=run_args,
-            make_reporter=make_reporter_factory(lambda n: f"Starting {n} node(s) on {target.bootstrap}"),
+            make_reporter=make_reporter_factory(
+                lambda n: f"Starting {n} node(s) on {target.bootstrap}",
+                success=lambda n: f"all {n} node(s) online",
+            ),
         )
     finally:
         await client.aclose()

--- a/docs/chat-with-agents.md
+++ b/docs/chat-with-agents.md
@@ -27,12 +27,12 @@ the highlight with ↑/↓, press Enter to pick, and `q` / `Esc` / Ctrl-C to qui
 ```console
 $ ck chat
 Select an agent  (↑/↓ move · Enter pick · q quit)
-  ❯ researcher
-    support-bot
+  researcher   Deep web research with citations
+❯ support-bot  Handles customer support tickets and refunds
 ```
 
 When the output isn't a terminal (piped or redirected), `ck chat` falls back to a
-static numbered menu — which also shows each agent's description:
+static numbered menu:
 
 ```console
 Discovering agents...

--- a/docs/chat-with-agents.md
+++ b/docs/chat-with-agents.md
@@ -19,10 +19,22 @@ a different broker with `--host`.
 
 ## Pick an agent and start chatting
 
-Run `ck chat` with no arguments to see who's online and choose one:
+Run `ck chat` with no arguments to pick from the agents online. On an interactive
+terminal the menu is **live** — it refreshes as agents come online or go offline,
+so one you start in another terminal appears here without re-running anything. Move
+the highlight with ↑/↓, press Enter to pick, and `q` / `Esc` / Ctrl-C to quit:
 
 ```console
 $ ck chat
+Select an agent  (↑/↓ move · Enter pick · q quit)
+  ❯ researcher
+    support-bot
+```
+
+When the output isn't a terminal (piped or redirected), `ck chat` falls back to a
+static numbered menu — which also shows each agent's description:
+
+```console
 Discovering agents...
 Online agents
 
@@ -30,7 +42,11 @@ Online agents
   2  support-bot  Handles customer support tickets and refunds
 
 Select an agent [1-2, q to quit]: 2
+```
 
+Either way, once you choose, the session opens:
+
+```text
 Chatting with support-bot. Type /exit or press Ctrl-D to leave.
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -166,10 +166,12 @@ calls and results, and any handoffs — live, followed by its answer.
 ck chat [NAME] [OPTIONS]
 ```
 
-With no `NAME`, `ck chat` lists the agents online and prompts you to choose;
-`ck chat researcher` skips the picker and connects to that agent directly (and
-exits `2` if it isn't online). There is no "back" — leave and rerun to switch
-agents.
+With no `NAME`, `ck chat` lists the agents online and prompts you to choose — on an
+interactive terminal a **live menu** (↑/↓ to move, Enter to pick, `q`/`Esc`/Ctrl-C
+to quit) that refreshes as agents come and go; when the output isn't a terminal, a
+static numbered menu with descriptions. `ck chat researcher` skips the picker and
+connects to that agent directly (and exits `2` if it isn't online). There is no
+"back" — leave and rerun to switch agents.
 
 ### A session
 
@@ -306,15 +308,18 @@ preset**:
 The broker is ensured once, in the parent — under `--reload` the restarted
 workers only reconnect — and each command first prints whether the broker is
 **managed** (`ck dev: managed broker at 127.0.0.1:9092 (pid 51234)`) or
-**reused** (`… — not managed by calfkit`).
+**reused** (`… — not managed by calfkit`). When a broker has to be spawned, a
+short `Starting dev broker …` progress line shows while it comes up.
 
 ### `ck dev run --detach/-d`
 
 Everything `ck dev run` is, with the attachment cut (the `docker compose up
 -d` gesture): the worker tree — the reload supervisor plus the worker it
 restarts on edits — is spawned as a **detached daemon** and the command
-returns only when its agents/tools are **online on the mesh** (bounded at
-15 s; a failure reports the daemon's log tail). Lifetime: until
+returns only when its agents/tools are **online on the mesh** — a live
+**readiness roster** shows each name as it comes up (plain milestone lines when
+the output isn't a terminal), bounded at 15 s; a failure names which agents never
+came online and reports the daemon's log tail. Lifetime: until
 `ck dev stop <name>`, `ck dev down`, or a reboot.
 
 - Per launched name it prints the **supervisor pid** (the process `stop`
@@ -352,7 +357,8 @@ An argument containing `:` is a `module:attr` **target**; a bare word is an
 agent **name** (mixing them, passing two names, or duplicate node names across
 targets: exit `2`). With targets, the chat runs them **inside its own
 process** — a *session worker* on the chat's own client — waits for them to be
-online, then opens the normal picker:
+online (the same **readiness roster** as `-d`, with any already-online targets
+shown as reused), then opens the normal picker:
 
 - The session worker dies **with the chat process**, on any exit — there is no
   child process to orphan. Its logs share the chat terminal.

--- a/docs/local-dev-mesh.md
+++ b/docs/local-dev-mesh.md
@@ -42,8 +42,9 @@ share the same mesh.
 
 ```console
 $ ck dev run -d general:general
+✔ dev broker ready
 ck dev: managed broker at 127.0.0.1:9092 (pid 51234)
-✔ all 1 done
+✔ all 1 node(s) online
 ck dev: launched agent 'general' (pid 51288) — runs until 'ck dev stop general' — logs: /Users/you/.calfkit/logs/agents-127.0.0.1_9092-general_general.log
 ```
 

--- a/docs/local-dev-mesh.md
+++ b/docs/local-dev-mesh.md
@@ -43,13 +43,17 @@ share the same mesh.
 ```console
 $ ck dev run -d general:general
 ck dev: managed broker at 127.0.0.1:9092 (pid 51234)
+✔ all 1 done
 ck dev: launched agent 'general' (pid 51288) — runs until 'ck dev stop general' — logs: /Users/you/.calfkit/logs/agents-127.0.0.1_9092-general_general.log
 ```
 
 `--detach/-d` (the `docker compose up -d` gesture) runs the same reload
 supervisor as a **managed background daemon** and returns only once the agent
 is **online on the mesh** — so `ck dev run -d … && ck dev chat` always lands
-on a mesh where the agent already exists. The daemon keeps reloading on your
+on a mesh where the agent already exists. While it waits, a live **readiness
+roster** shows each launched agent and tool as it comes online (a plain list of
+milestone lines when the output is piped); if one never comes up, the error names
+exactly which. The daemon keeps reloading on your
 edits until an explicit `ck dev stop <name>` (or `ck dev down`, or a reboot).
 
 Launching the same target again while it is online **reuses** it instead
@@ -73,7 +77,8 @@ session itself.
 
 `ck dev chat` can also **launch agents for the session**: give it
 `module:attr` target(s) instead of a name and it runs them *inside the chat
-process itself*, then opens the picker:
+process itself* — showing the same **readiness roster** while they come online
+(any already-online target appears as reused) — then opens the picker:
 
 ```console
 $ ck dev chat general:general

--- a/tests/test_chat_io.py
+++ b/tests/test_chat_io.py
@@ -276,6 +276,39 @@ def test_decode_keys_consumes_a_whole_csi_without_leaking_a_quit() -> None:
     assert _decode_keys(b"\x1b[") == ["other"]  # a truncated CSI (ESC+bracket, nothing after) never quits
 
 
+def test_decode_keys_when_an_esc_aborts_a_partial_csi_the_next_key_survives() -> None:
+    """A partial CSI (no final byte yet) immediately followed by another sequence/key in the SAME read
+    must not swallow that following key: the aborting byte is not a valid CSI final (0x40-0x7E), so the
+    partial CSI ends and the next key is re-parsed. Guards a dropped-arrow / swallowed-Enter edge."""
+    from calfkit.cli._chat_io import _decode_keys
+
+    assert _decode_keys(b"\x1b[1\x1b[A") == ["other", "up"]  # partial CSI then a real Up arrow — arrow survives
+    assert _decode_keys(b"\x1b[1\x1b[B") == ["other", "down"]  # partial CSI then Down
+    assert _decode_keys(b"\x1b[\r") == ["other", "enter"]  # ESC[ then Enter — Enter survives
+    assert _decode_keys(b"\x1b[1;2\r") == ["other", "enter"]  # longer partial CSI then Enter
+    # a q/Q that is a genuine CSI FINAL byte (e.g. DECSCUSR ESC[0q) is part of the sequence, not a quit
+    assert _decode_keys(b"\x1b[0q") == ["other"]
+
+
+def test_decode_keys_never_leaks_quit_from_any_escape_sequence() -> None:
+    """Property guard against the recurring bug class: NO escape-introduced sequence (CSI / SS3 / Meta),
+    over every final byte, may emit ``quit`` — only a lone/terminal Esc or a raw q/Q/Ctrl-C/Ctrl-D byte
+    is a quit. Enumerated rather than hand-picked so it keeps pace with future decoder edits."""
+    from calfkit.cli._chat_io import _decode_keys
+
+    param_sets = [b"", b"1", b"1;2", b"1;5", b"1;3", b"24", b"24;5", b"?25", b";", b"0", b">", b"="]
+    for final in range(0x40, 0x7F):  # every valid CSI/SS3 final byte
+        for params in param_sets:
+            csi = b"\x1b[" + params + bytes([final])
+            assert "quit" not in _decode_keys(csi), f"CSI {csi!r} leaked quit"
+        ss3 = b"\x1bO" + bytes([final])
+        assert "quit" not in _decode_keys(ss3), f"SS3 {ss3!r} leaked quit"
+    for byte in range(0x20, 0x7F):  # Meta/Alt: ESC + a byte (excludes the lone-ESC quit case)
+        assert "quit" not in _decode_keys(b"\x1b" + bytes([byte])), f"Meta ESC+{byte:#x} leaked quit"
+    for truncated in (b"\x1b[", b"\x1bO", b"\x1b[1", b"\x1b[1;5", b"\x1b[?", b"\x1b[1;"):
+        assert "quit" not in _decode_keys(truncated), f"truncated {truncated!r} leaked quit"
+
+
 async def test_key_reader_ignores_unrecognized_escape_sequences_instead_of_quitting() -> None:
     """An ESC that begins an escape sequence we don't map (SS3 arrows in application-cursor mode,
     Meta/Alt combos, function keys) must decode to a harmless ``other`` — NOT ``quit``, which would

--- a/tests/test_chat_io.py
+++ b/tests/test_chat_io.py
@@ -250,6 +250,32 @@ async def test_key_reader_decodes_ctrl_d_uppercase_q_and_unmapped_keys() -> None
         os.close(w)
 
 
+def test_decode_keys_consumes_a_whole_csi_without_leaking_a_quit() -> None:
+    """A CSI sequence longer than 3 bytes must decode to a SINGLE ``other`` — no interior/final byte
+    may leak out as a standalone key. In particular a modified F-key like ``ESC[1;2Q`` (Shift+F2) ends
+    in ``Q``; the trailing ``Q`` must NOT be re-scanned as ``quit`` and cancel the picker."""
+    from calfkit.cli._chat_io import _decode_keys
+
+    ignored_sequences = (
+        b"\x1b[1;2Q",  # Shift+F2  (ends in Q — the regression trigger)
+        b"\x1b[1;5Q",  # Ctrl+F2
+        b"\x1b[1;3Q",  # Alt+F2
+        b"\x1b[24;5~",  # Ctrl+F12
+        b"\x1b[1;5A",  # Ctrl+Up (modified arrow — not the bare arrow we bind)
+        b"\x1b[3~",  # Delete
+        b"\x1b[H",  # Home
+    )
+    for seq in ignored_sequences:
+        assert _decode_keys(seq) == ["other"], f"{seq!r} must be one ignored token, got {_decode_keys(seq)}"
+    # the bare arrows and a lone Esc must still decode as before
+    assert _decode_keys(b"\x1b[A") == ["up"]
+    assert _decode_keys(b"\x1b[B") == ["down"]
+    assert _decode_keys(b"\x1b") == ["quit"]  # a lone Esc IS the Escape key → quit
+    assert _decode_keys(b"\x1b[B\r") == ["down", "enter"]  # merged read still splits correctly
+    assert _decode_keys(b"\x1bOA\r") == ["other", "enter"]  # an unhandled ESC-lead seq + a key: both survive
+    assert _decode_keys(b"\x1b[") == ["other"]  # a truncated CSI (ESC+bracket, nothing after) never quits
+
+
 async def test_key_reader_ignores_unrecognized_escape_sequences_instead_of_quitting() -> None:
     """An ESC that begins an escape sequence we don't map (SS3 arrows in application-cursor mode,
     Meta/Alt combos, function keys) must decode to a harmless ``other`` — NOT ``quit``, which would

--- a/tests/test_chat_io.py
+++ b/tests/test_chat_io.py
@@ -220,3 +220,31 @@ async def test_key_reader_decodes_arrows_enter_and_quit() -> None:
     finally:
         os.close(r)
         os.close(w)
+
+
+async def test_key_reader_splits_a_merged_read_into_separate_keys() -> None:
+    """A fast/pasted arrow-then-Enter arriving in one os.read is split into both keys, not dropped."""
+    r, w = os.pipe()
+    try:
+        read_key = make_key_reader(asyncio.get_running_loop(), fd=r)
+        os.write(w, b"\x1b[B\r")  # down + enter in one write
+        assert await _drain(read_key()) == "down"
+        assert await _drain(read_key()) == "enter"  # from the buffer, no further write
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+async def test_key_reader_decodes_ctrl_d_uppercase_q_and_unmapped_keys() -> None:
+    r, w = os.pipe()
+    try:
+        read_key = make_key_reader(asyncio.get_running_loop(), fd=r)
+        os.write(w, b"\x04")
+        assert await _drain(read_key()) == "quit"  # Ctrl-D byte
+        os.write(w, b"Q")
+        assert await _drain(read_key()) == "quit"
+        os.write(w, b"x")
+        assert await _drain(read_key()) == "other"  # unmapped: ignored, not an error
+    finally:
+        os.close(r)
+        os.close(w)

--- a/tests/test_chat_io.py
+++ b/tests/test_chat_io.py
@@ -200,8 +200,8 @@ async def test_cancel_in_flight_read_line_removes_reader_no_leak() -> None:
 
 
 async def test_key_reader_decodes_arrows_enter_and_quit() -> None:
-    """The raw-mode single-key reader (picker input): arrow escape sequences, Enter, and the
-    quit keys (q / Ctrl-C / Ctrl-D / Esc) each decode to a token."""
+    """The cbreak-mode single-key reader (picker input): arrow escape sequences, Enter, and the
+    quit keys (q / Esc / a raw Ctrl-C/Ctrl-D byte) each decode to a token."""
     r, w = os.pipe()
     try:
         read_key = make_key_reader(asyncio.get_running_loop(), fd=r)
@@ -245,6 +245,26 @@ async def test_key_reader_decodes_ctrl_d_uppercase_q_and_unmapped_keys() -> None
         assert await _drain(read_key()) == "quit"
         os.write(w, b"x")
         assert await _drain(read_key()) == "other"  # unmapped: ignored, not an error
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+async def test_key_reader_ignores_unrecognized_escape_sequences_instead_of_quitting() -> None:
+    """An ESC that begins an escape sequence we don't map (SS3 arrows in application-cursor mode,
+    Meta/Alt combos, function keys) must decode to a harmless ``other`` — NOT ``quit``, which would
+    cancel the picker out from under the user. Only a lone/terminal ESC (the Escape key) is quit."""
+    r, w = os.pipe()
+    try:
+        read_key = make_key_reader(asyncio.get_running_loop(), fd=r)
+        os.write(w, b"\x1bOA")  # SS3 up-arrow (application-cursor mode) — must be ignored, not quit
+        assert await _drain(read_key()) == "other"
+        os.write(w, b"\x1bOP")  # SS3 F1
+        assert await _drain(read_key()) == "other"
+        os.write(w, b"\x1ba")  # Meta/Alt-a
+        assert await _drain(read_key()) == "other"
+        os.write(w, b"\x1b")  # a lone Esc IS the Escape key → quit
+        assert await _drain(read_key()) == "quit"
     finally:
         os.close(r)
         os.close(w)

--- a/tests/test_chat_io.py
+++ b/tests/test_chat_io.py
@@ -15,7 +15,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from calfkit.cli._chat_io import _resolve_stdin_fd, make_reader
+from calfkit.cli._chat_io import _resolve_stdin_fd, make_key_reader, make_reader
 
 
 async def _drain(coro: Awaitable[str], timeout: float = 1.0) -> str:
@@ -194,6 +194,29 @@ async def test_cancel_in_flight_read_line_removes_reader_no_leak() -> None:
         with pytest.raises(asyncio.CancelledError):
             await task
         assert loop.remove_reader(r) is False  # the read's finally already removed it — no leak
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+async def test_key_reader_decodes_arrows_enter_and_quit() -> None:
+    """The raw-mode single-key reader (picker input): arrow escape sequences, Enter, and the
+    quit keys (q / Ctrl-C / Ctrl-D / Esc) each decode to a token."""
+    r, w = os.pipe()
+    try:
+        read_key = make_key_reader(asyncio.get_running_loop(), fd=r)
+        os.write(w, b"\x1b[A")
+        assert await _drain(read_key()) == "up"
+        os.write(w, b"\x1b[B")
+        assert await _drain(read_key()) == "down"
+        os.write(w, b"\r")
+        assert await _drain(read_key()) == "enter"
+        os.write(w, b"q")
+        assert await _drain(read_key()) == "quit"
+        os.write(w, b"\x03")  # Ctrl-C
+        assert await _drain(read_key()) == "quit"
+        os.write(w, b"\x1b")  # lone Esc
+        assert await _drain(read_key()) == "quit"
     finally:
         os.close(r)
         os.close(w)

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -732,3 +732,20 @@ async def test_attach_uses_the_live_picker_on_an_interactive_terminal(monkeypatc
     await run_chat_session(None, "localhost:9092", None)
     assert "client" in called  # the live picker was used
     assert "Discovering agents" not in capsys.readouterr().out  # the static path was skipped
+
+
+async def test_attach_falls_back_to_the_static_picker_when_not_interactive(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Off a TTY (piped/redirected/CI), the live picker is bypassed for the static discover+numbered
+    menu — so the raw-mode selector never runs where it cannot render."""
+
+    async def boom_live_pick(client: object, **_: object) -> None:
+        raise AssertionError("live_pick must not run when the terminal is not interactive")
+
+    monkeypatch.setattr("calfkit.cli._chat.is_interactive", lambda: False)
+    monkeypatch.setattr("calfkit.cli._chat.live_pick", boom_live_pick)
+    monkeypatch.setattr("calfkit.cli._chat.make_reader", lambda _loop: _scripted(["q"]))
+    _patch_get_agents(monkeypatch, result={"alpha": _agent("alpha", "x")})
+    await run_chat_session(None, "localhost:9092", None)
+    assert "Discovering agents" in capsys.readouterr().out  # the static path was taken

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -707,3 +707,28 @@ async def test_session_failed_launch_prints_no_narration(
 async def test_session_plan_without_host_key_is_a_programming_error(monkeypatch: pytest.MonkeyPatch) -> None:
     with pytest.raises(ValueError, match="session_host_key"):
         await run_chat_session(None, "localhost:9092", None, session_plan=[])
+
+
+async def test_session_shows_the_readiness_roster(session_seams: dict, capsys: pytest.CaptureFixture[str]) -> None:
+    """PR2 adoption: the chat-TARGET launch shows a readiness roster titled by launched count + host."""
+    plan = [_target_nodes()]
+    session_seams["evaluate"] = ([], plan)
+    await run_chat_session(None, "localhost:9092", None, session_plan=plan, session_host_key="127.0.0.1:9092")
+    assert "Starting 1 node(s) on 127.0.0.1:9092" in capsys.readouterr().out
+
+
+async def test_attach_uses_the_live_picker_on_an_interactive_terminal(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """On a TTY with no named agent, the live picker (which polls the mesh itself) replaces the
+    static discover+pick; a quit returns without entering the REPL."""
+    called: dict[str, object] = {}
+
+    async def fake_live_pick(client: object, **_: object) -> None:
+        called["client"] = client
+        return None
+
+    monkeypatch.setattr("calfkit.cli._chat.is_interactive", lambda: True)
+    monkeypatch.setattr("calfkit.cli._chat.live_pick", fake_live_pick)
+    _patch_get_agents(monkeypatch, result={"a": _agent("a", None)})
+    await run_chat_session(None, "localhost:9092", None)
+    assert "client" in called  # the live picker was used
+    assert "Discovering agents" not in capsys.readouterr().out  # the static path was skipped

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -738,7 +738,7 @@ async def test_attach_falls_back_to_the_static_picker_when_not_interactive(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """Off a TTY (piped/redirected/CI), the live picker is bypassed for the static discover+numbered
-    menu — so the raw-mode selector never runs where it cannot render."""
+    menu — so the cbreak-mode live picker never runs where it cannot render."""
 
     async def boom_live_pick(client: object, **_: object) -> None:
         raise AssertionError("live_pick must not run when the terminal is not interactive")

--- a/tests/test_dev_agents.py
+++ b/tests/test_dev_agents.py
@@ -918,3 +918,67 @@ async def test_ensure_holds_the_agents_flock_across_its_critical_section(monkeyp
     with (tmp_path / ".calfkit" / "dev-agents.lock").open("rb") as fd:
         fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+async def test_wait_ready_pushes_resolved_targets_to_the_reporter() -> None:
+    """PR2 adoption (spec §4.5): the wait pushes each poll's resolved set to the reporter."""
+    updates: list[set[str]] = []
+
+    class _Recorder:
+        def __enter__(self) -> _Recorder:
+            return self
+
+        def __exit__(self, *a: object) -> None:
+            return None
+
+        def update(self, done: Any) -> None:
+            updates.append(set(done))
+
+    mesh = FakeMesh(agents_frames=[{}, {"general": _agent_info("general")}])
+    await _dev_agents.wait_agents_ready(None, ("general",), (), mesh, log_path=None, reporter=_Recorder(), **_fast_wait())
+    assert {"general"} in updates
+
+
+async def test_wait_ready_deadline_error_names_the_pending_targets(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Attribution (spec §4.4): the deadline error names the targets that never came online."""
+    _record_killpg(monkeypatch)
+    mesh = FakeMesh(agents_frames=[{"a": _agent_info("a")}])  # 'a' online, 'b' never
+    with pytest.raises(DevAgentError, match=r"(?s)did not come online.*still waiting on: b") as exc:
+        await _dev_agents.wait_agents_ready(None, ("a", "b"), (), mesh, log_path=None, **_fast_wait())
+    assert "still waiting on: b" in str(exc.value)
+
+
+async def test_gate_launched_ready_gates_on_the_launched_names() -> None:
+    """The shared gate extracts the launched name lists and blocks until they are online."""
+    mesh = FakeMesh(agents_frames=[{}, {"general": _agent_info("general")}])
+    plan = _dev_agents.preflight([f"{_NODES}:general"])
+    await _dev_agents.gate_launched_ready(None, plan, mesh, reused_names=(), log_path=None, **_fast_wait())
+
+
+async def test_gate_launched_ready_builds_and_wraps_a_reporter_from_the_factory() -> None:
+    """The single reporter-injection point: the factory is called with (launched, reused) and the
+    reporter is used as a context manager around the gate."""
+    events: list[str] = []
+
+    class _Rec:
+        def __enter__(self) -> _Rec:
+            events.append("enter")
+            return self
+
+        def __exit__(self, *a: object) -> None:
+            events.append("exit")
+            return None
+
+        def update(self, done: Any) -> None:
+            events.append("update")
+
+    def _make(waiting: list[str], pre_done: list[str]) -> _Rec:
+        events.append(f"make {waiting} {pre_done}")
+        return _Rec()
+
+    mesh = FakeMesh(agents_frames=[{"general": _agent_info("general")}])
+    plan = _dev_agents.preflight([f"{_NODES}:general"])
+    await _dev_agents.gate_launched_ready(None, plan, mesh, reused_names=("old",), make_reporter=_make, log_path=None, **_fast_wait())
+    assert events[0] == "make ['general'] ['old']"
+    assert events[1] == "enter"
+    assert events[-1] == "exit"

--- a/tests/test_dev_agents.py
+++ b/tests/test_dev_agents.py
@@ -972,7 +972,7 @@ async def test_gate_launched_ready_builds_and_wraps_a_reporter_from_the_factory(
         def update(self, done: Any) -> None:
             events.append("update")
 
-    def _make(waiting: list[str], pre_done: list[str]) -> _Rec:
+    def _make(*, waiting: list[str], pre_done: list[str]) -> _Rec:  # keyword-only, per ReporterFactory
         events.append(f"make {waiting} {pre_done}")
         return _Rec()
 

--- a/tests/test_dev_broker.py
+++ b/tests/test_dev_broker.py
@@ -805,3 +805,26 @@ def test_restart_of_a_borrowed_broker_just_reuses_it(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(dev_broker, "is_reachable", scripted_probe(True))
     out = dev_broker.restart(normalize(["localhost"]), resolve_bin=MustNotCall())
     assert out.managed is False
+
+
+def test_ensure_broker_spawn_wraps_the_readiness_wait_in_the_reporter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BR2 adoption (spec §4.5): a broker spawn runs its readiness wait inside the reporter."""
+    _capture_popen(monkeypatch)
+    monkeypatch.setattr(dev_broker, "is_reachable", scripted_probe(False, True))
+    events: list[str] = []
+
+    class _Rec:
+        def __enter__(self) -> _Rec:
+            events.append("enter")
+            return self
+
+        def __exit__(self, *a: object) -> None:
+            events.append("exit")
+            return None
+
+        def update(self, done: object) -> None:
+            events.append("update")
+
+    ensure_broker(normalize(["localhost"]), resolve_bin=CountingResolveBin(_BIN), reporter=_Rec())
+    assert events[0] == "enter"
+    assert events[-1] == "exit"

--- a/tests/test_dev_cli.py
+++ b/tests/test_dev_cli.py
@@ -23,6 +23,7 @@ import calfkit.cli._dev_broker as dev_broker
 import calfkit.cli.dev as dev_cli
 from calfkit.cli._dev_agents import DevAgentError, EnsureReport, TargetNodes, TargetOutcome
 from calfkit.cli._dev_broker import BrokerInfo, DevBrokerError, MeshStatus
+from calfkit.cli._wait import ConsoleWaitReporter
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 _KEY = "127.0.0.1:9092"
@@ -61,8 +62,8 @@ def ensure_calls(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
     """Monkeypatch ``ensure_broker`` at the supervisor seam, recording each call."""
     calls: list[dict[str, Any]] = []
 
-    def fake_ensure(target: Any, *, resolve_bin: Any, timeout: float) -> BrokerInfo:
-        calls.append({"target": target, "resolve_bin": resolve_bin, "timeout": timeout})
+    def fake_ensure(target: Any, *, resolve_bin: Any, timeout: float, reporter: Any = None) -> BrokerInfo:
+        calls.append({"target": target, "resolve_bin": resolve_bin, "timeout": timeout, "reporter": reporter})
         return _info(listener=target.key)
 
     monkeypatch.setattr(dev_broker, "ensure_broker", fake_ensure)
@@ -210,7 +211,7 @@ def test_dev_run_unreachable_remote_exits_2_without_spawning(monkeypatch: pytest
 
 
 def test_dev_run_broker_ensure_failure_exits_2(monkeypatch: pytest.MonkeyPatch, run_calls: list[dict[str, Any]]) -> None:
-    def boom(target: Any, *, resolve_bin: Any, timeout: float) -> BrokerInfo:
+    def boom(target: Any, *, resolve_bin: Any, timeout: float, reporter: Any = None) -> BrokerInfo:
         raise DevBrokerError("did not become ready")
 
     monkeypatch.setattr(dev_broker, "ensure_broker", boom)
@@ -251,7 +252,7 @@ def test_dev_chat_forwards_name_timeout_and_no_provision(ensure_calls: list[dict
 
 
 def test_dev_chat_broker_ensure_failure_exits_2(monkeypatch: pytest.MonkeyPatch, attach_calls: list[dict[str, Any]]) -> None:
-    def boom(target: Any, *, resolve_bin: Any, timeout: float) -> BrokerInfo:
+    def boom(target: Any, *, resolve_bin: Any, timeout: float, reporter: Any = None) -> BrokerInfo:
         raise DevBrokerError("nope")
 
     monkeypatch.setattr(dev_broker, "ensure_broker", boom)
@@ -271,7 +272,7 @@ def test_broker_start_ensures_and_reports(ensure_calls: list[dict[str, Any]]) ->
 
 
 def test_broker_start_failure_exits_2(monkeypatch: pytest.MonkeyPatch) -> None:
-    def boom(target: Any, *, resolve_bin: Any, timeout: float) -> BrokerInfo:
+    def boom(target: Any, *, resolve_bin: Any, timeout: float, reporter: Any = None) -> BrokerInfo:
         raise DevBrokerError("no binary")
 
     monkeypatch.setattr(dev_broker, "ensure_broker", boom)
@@ -481,7 +482,7 @@ def detach_seams(monkeypatch: pytest.MonkeyPatch, ensure_calls: list[dict[str, A
 
     async def fake_ensure(plan: list[TargetNodes], target: Any, mesh: Any, *, run_args: Any, **kwargs: Any) -> EnsureReport:
         seams["order"].append("ensure_agents")
-        seams["ensure"] = {"plan": plan, "target": target, "mesh": mesh, "run_args": run_args}
+        seams["ensure"] = {"plan": plan, "target": target, "mesh": mesh, "run_args": run_args, **kwargs}
         report: EnsureReport = seams.get("report") or EnsureReport(
             outcomes=tuple(TargetOutcome(target=t, reused=False) for t in plan),
             pid=4055,
@@ -1311,3 +1312,25 @@ def test_dev_down_broker_stop_failure_exits_2(stop_seams: dict[str, Any], monkey
     result = _invoke(["dev", "down"])
     assert result.exit_code == 2
     assert "survived SIGKILL" in _plain(result.stderr)
+
+
+def test_dev_run_detach_wires_a_console_reporter(detach_seams: dict[str, Any]) -> None:
+    """PR2 adoption: the -d path hands ensure_agents a factory that builds a ConsoleWaitReporter."""
+    result = _invoke(["dev", "run", "-d", "app:agent"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    make_reporter = detach_seams["ensure"]["make_reporter"]
+    assert isinstance(make_reporter(["general"], []), ConsoleWaitReporter)
+
+
+def test_ensure_or_exit_gives_ensure_broker_a_console_reporter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BR2 adoption: the broker-ensure command layer hands ensure_broker a ConsoleWaitReporter."""
+    captured: dict[str, Any] = {}
+
+    def fake_ensure_broker(target: Any, *, resolve_bin: Any, timeout: Any, reporter: Any = None) -> BrokerInfo:
+        captured["reporter"] = reporter
+        return BrokerInfo(listener="127.0.0.1:9092", pid=1, managed=True)
+
+    monkeypatch.setattr(dev_broker, "ensure_broker", fake_ensure_broker)
+    result = _invoke(["dev", "broker", "start"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert isinstance(captured["reporter"], ConsoleWaitReporter)

--- a/tests/test_dev_cli.py
+++ b/tests/test_dev_cli.py
@@ -1319,7 +1319,7 @@ def test_dev_run_detach_wires_a_console_reporter(detach_seams: dict[str, Any]) -
     result = _invoke(["dev", "run", "-d", "app:agent"])
     assert result.exit_code == 0, result.stdout + str(result.exception)
     make_reporter = detach_seams["ensure"]["make_reporter"]
-    assert isinstance(make_reporter(["general"], []), ConsoleWaitReporter)
+    assert isinstance(make_reporter(waiting=["general"], pre_done=[]), ConsoleWaitReporter)
 
 
 def test_ensure_or_exit_gives_ensure_broker_a_console_reporter(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_dev_probe.py
+++ b/tests/test_dev_probe.py
@@ -34,7 +34,12 @@ class _FakeAIOKafkaClient:
         if _BEHAVIOR == "log_and_refuse":
             import logging
 
-            logging.getLogger("aiokafka.client").error('Unable connect to "%s:%s": refused', "127.0.0.1", 9092)
+            logging.getLogger("aiokafka").error('Unable connect to "%s:%s": refused', "127.0.0.1", 9092)
+            raise OSError("connection refused")
+        if _BEHAVIOR == "log_other_and_refuse":
+            import logging
+
+            logging.getLogger("aiokafka").error("SASL authentication failed")  # a real, non-noise diagnostic
             raise OSError("connection refused")
         if _BEHAVIOR == "hang":
             await asyncio.sleep(10)
@@ -89,26 +94,34 @@ def test_is_reachable_sync_wrapper() -> None:
 
 
 async def test_broker_reachable_suppresses_the_aiokafka_unable_connect_error(caplog: pytest.LogCaptureFixture) -> None:
-    """The probe raises the aiokafka.client log threshold so the expected per-attempt 'Unable
-    connect' ERROR does not leak while a broker is coming up (spec §4.5)."""
+    """The probe installs a filter that drops aiokafka's expected per-attempt 'Unable connect' ERROR
+    so it does not leak while a broker is coming up (spec §4.5)."""
     import logging
 
     _set("log_and_refuse")
-    caplog.set_level(logging.DEBUG, logger="aiokafka.client")
+    caplog.set_level(logging.DEBUG, logger="aiokafka")
     assert await probe.broker_reachable("127.0.0.1:9092", timeout=0.5) is False
     assert not any("Unable connect" in r.getMessage() for r in caplog.records)
 
 
-async def test_broker_reachable_restores_the_aiokafka_log_level() -> None:
-    """The quieting is scoped: the aiokafka.client level is restored after the probe, never left
-    permanently suppressed."""
+async def test_broker_reachable_lets_other_aiokafka_errors_through(caplog: pytest.LogCaptureFixture) -> None:
+    """Visibility on failure: the filter drops ONLY the 'Unable connect' noise — a genuinely
+    different aiokafka error during the probe (auth/TLS/protocol) still surfaces."""
     import logging
 
-    logger = logging.getLogger("aiokafka.client")
-    logger.setLevel(logging.INFO)
-    try:
-        _set("refused")
-        await probe.broker_reachable("127.0.0.1:9092", timeout=0.5)
-        assert logger.level == logging.INFO
-    finally:
-        logger.setLevel(logging.NOTSET)
+    _set("log_other_and_refuse")
+    caplog.set_level(logging.DEBUG, logger="aiokafka")
+    assert await probe.broker_reachable("127.0.0.1:9092", timeout=0.5) is False
+    assert any("SASL authentication failed" in r.getMessage() for r in caplog.records)
+
+
+async def test_broker_reachable_removes_its_noise_filter_after_the_probe() -> None:
+    """The suppression is scoped: the noise filter is removed after the probe, so aiokafka logging
+    (including a real 'Unable connect' during actual operation) is untouched afterward."""
+    import logging
+
+    logger = logging.getLogger("aiokafka")
+    before = list(logger.filters)
+    _set("refused")
+    await probe.broker_reachable("127.0.0.1:9092", timeout=0.5)
+    assert list(logger.filters) == before  # no filter leaked

--- a/tests/test_dev_probe.py
+++ b/tests/test_dev_probe.py
@@ -41,6 +41,13 @@ class _FakeAIOKafkaClient:
 
             logging.getLogger("aiokafka").error("SASL authentication failed")  # a real, non-noise diagnostic
             raise OSError("connection refused")
+        if _BEHAVIOR == "log_node_unreachable_and_refuse":
+            import logging
+
+            # aiokafka's SECOND "Unable connect" site (client.py:435): a discovered node dropping — a
+            # genuine diagnostic, NOT the bootstrap retry noise. Its message lacks the `to "` quote.
+            logging.getLogger("aiokafka").error("Unable connect to node with id %s: %s", 3, "refused")
+            raise OSError("connection refused")
         if _BEHAVIOR == "hang":
             await asyncio.sleep(10)
         # "ok": return immediately
@@ -113,6 +120,18 @@ async def test_broker_reachable_lets_other_aiokafka_errors_through(caplog: pytes
     caplog.set_level(logging.DEBUG, logger="aiokafka")
     assert await probe.broker_reachable("127.0.0.1:9092", timeout=0.5) is False
     assert any("SASL authentication failed" in r.getMessage() for r in caplog.records)
+
+
+async def test_broker_reachable_keeps_the_node_unreachable_diagnostic_visible(caplog: pytest.LogCaptureFixture) -> None:
+    """aiokafka has TWO 'Unable connect' log sites: the bootstrap retry noise (`...to "host:port"...`)
+    and a genuine node-dropped diagnostic (`...to node with id N...`). The filter must drop ONLY the
+    former — anchored on the `to "` quote — so the real node-failure error stays visible."""
+    import logging
+
+    _set("log_node_unreachable_and_refuse")
+    caplog.set_level(logging.DEBUG, logger="aiokafka")
+    assert await probe.broker_reachable("127.0.0.1:9092", timeout=0.5) is False
+    assert any("Unable connect to node with id" in r.getMessage() for r in caplog.records)
 
 
 async def test_broker_reachable_removes_its_noise_filter_after_the_probe() -> None:

--- a/tests/test_dev_probe.py
+++ b/tests/test_dev_probe.py
@@ -31,6 +31,11 @@ class _FakeAIOKafkaClient:
             raise KafkaConnectionError("no broker there")
         if _BEHAVIOR == "oserror":
             raise OSError("socket-level failure surfaced unwrapped (e.g. DNS)")
+        if _BEHAVIOR == "log_and_refuse":
+            import logging
+
+            logging.getLogger("aiokafka.client").error('Unable connect to "%s:%s": refused', "127.0.0.1", 9092)
+            raise OSError("connection refused")
         if _BEHAVIOR == "hang":
             await asyncio.sleep(10)
         # "ok": return immediately
@@ -81,3 +86,29 @@ async def test_reachable_false_on_timeout() -> None:
 def test_is_reachable_sync_wrapper() -> None:
     _set("ok")
     assert probe.is_reachable("127.0.0.1:9092", timeout=1.0) is True
+
+
+async def test_broker_reachable_suppresses_the_aiokafka_unable_connect_error(caplog: pytest.LogCaptureFixture) -> None:
+    """The probe raises the aiokafka.client log threshold so the expected per-attempt 'Unable
+    connect' ERROR does not leak while a broker is coming up (spec §4.5)."""
+    import logging
+
+    _set("log_and_refuse")
+    caplog.set_level(logging.DEBUG, logger="aiokafka.client")
+    assert await probe.broker_reachable("127.0.0.1:9092", timeout=0.5) is False
+    assert not any("Unable connect" in r.getMessage() for r in caplog.records)
+
+
+async def test_broker_reachable_restores_the_aiokafka_log_level() -> None:
+    """The quieting is scoped: the aiokafka.client level is restored after the probe, never left
+    permanently suppressed."""
+    import logging
+
+    logger = logging.getLogger("aiokafka.client")
+    logger.setLevel(logging.INFO)
+    try:
+        _set("refused")
+        await probe.broker_reachable("127.0.0.1:9092", timeout=0.5)
+        assert logger.level == logging.INFO
+    finally:
+        logger.setLevel(logging.NOTSET)

--- a/tests/test_picker.py
+++ b/tests/test_picker.py
@@ -1,0 +1,145 @@
+"""Unit tests for the live agent picker (``calfkit.cli._picker``).
+
+The picker splits into a pure selection state-machine (``PickerModel`` — tested here with
+no terminal), a pure renderer, and the raw-mode interactive loop (spec
+``docs/designs/cli-live-feedback-spec.md`` §5).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from io import StringIO
+
+from rich.console import Console
+
+from calfkit.cli._picker import PickerModel, _run_picker, render_menu
+
+_ANSI = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+
+def _menu_text(renderable: object) -> str:
+    buf = StringIO()
+    Console(file=buf, width=80, color_system=None).print(renderable)
+    return _ANSI.sub("", buf.getvalue())
+
+
+def test_sync_populates_order_and_highlights_the_first() -> None:
+    model = PickerModel()
+    model.sync(["triage", "backend"])
+    assert model.names == ["backend", "triage"]  # deterministic (sorted) initial order
+    assert model.highlighted == "backend"
+
+
+def test_move_shifts_highlight_and_clamps_at_the_ends() -> None:
+    model = PickerModel()
+    model.sync(["a", "b", "c"])  # highlight 'a'
+    model.move(1)
+    assert model.highlighted == "b"
+    model.move(1)
+    assert model.highlighted == "c"
+    model.move(1)  # clamp at the bottom
+    assert model.highlighted == "c"
+    model.move(-5)  # clamp at the top
+    assert model.highlighted == "a"
+
+
+def test_new_arrivals_append_at_the_bottom_preserving_existing_order() -> None:
+    model = PickerModel()
+    model.sync(["m"])
+    model.sync(["a", "m"])  # 'a' arrives; it appends, it does NOT re-sort above 'm'
+    assert model.names == ["m", "a"]
+
+
+def test_offline_highlighted_agent_moves_highlight_to_the_nearest_survivor() -> None:
+    model = PickerModel()
+    model.sync(["a", "b", "c"])
+    model.move(1)  # highlight 'b'
+    model.sync(["a", "c"])  # 'b' goes offline
+    assert model.names == ["a", "c"]
+    assert model.highlighted == "c"
+
+
+def test_all_offline_empties_the_list_and_clears_the_highlight() -> None:
+    model = PickerModel()
+    model.sync(["a"])
+    model.sync([])
+    assert model.names == []
+    assert model.highlighted is None
+
+
+def test_render_menu_marks_the_highlighted_row() -> None:
+    model = PickerModel()
+    model.sync(["backend", "triage"])
+    model.move(1)  # highlight 'triage'
+    text = _menu_text(render_menu(model))
+    assert "❯ triage" in text  # highlighted row carries the caret marker
+    assert "  backend" in text  # non-highlighted row is indented, no marker
+
+
+def test_render_menu_shows_an_empty_hint_when_no_agents() -> None:
+    model = PickerModel()
+    model.sync([])
+    text = _menu_text(render_menu(model))
+    assert "no agents online" in text.lower()
+
+
+async def test_run_picker_moves_and_selects() -> None:
+    keys = iter(["down", "enter"])
+
+    async def read_key() -> str:
+        return next(keys)
+
+    async def poll() -> list[str]:
+        return ["a", "b", "c"]
+
+    result = await _run_picker(read_key, poll, lambda _m: None, cadence=100.0)
+    assert result == "b"  # 'down' moves a->b, 'enter' selects it
+
+
+async def test_run_picker_resyncs_the_roster_on_a_poll_tick() -> None:
+    rosters = iter([["a"], ["a", "z"]])
+
+    async def poll() -> list[str]:
+        return next(rosters, ["a", "z"])
+
+    keys: asyncio.Queue[str] = asyncio.Queue()
+
+    async def read_key() -> str:
+        return await keys.get()
+
+    seen: list[list[str]] = []
+    task = asyncio.create_task(_run_picker(read_key, poll, lambda m: seen.append(m.names), cadence=0.01))
+    await asyncio.sleep(0.08)  # let a poll tick fire → 'z' appears
+    await keys.put("quit")
+    assert await asyncio.wait_for(task, 1.0) is None
+    assert any("z" in names for names in seen)  # the tick picked up the newly-online agent
+
+
+async def test_live_pick_end_to_end_over_a_pty(monkeypatch: object) -> None:
+    """Smoke-test the real glue (cbreak + key reader + loop) over a pseudo-terminal: navigate down
+    one and select. Exercises termios set/restore and make_key_reader against a real tty."""
+    import os
+    import pty
+    from types import SimpleNamespace
+
+    master, slave = pty.openpty()
+    monkeypatch.setattr("sys.stdin", SimpleNamespace(fileno=lambda: slave, isatty=lambda: True))  # type: ignore[attr-defined]
+
+    class _Mesh:
+        async def get_agents(self) -> dict[str, None]:
+            return {"a": None, "b": None}
+
+    client = SimpleNamespace(mesh=_Mesh())
+    from calfkit.cli._picker import live_pick
+
+    task = asyncio.create_task(live_pick(client, cadence=100.0))  # type: ignore[arg-type]
+    try:
+        await asyncio.sleep(0.05)
+        os.write(master, b"\x1b[B")  # down -> highlight 'b'
+        await asyncio.sleep(0.05)
+        os.write(master, b"\r")  # enter -> select
+        assert await asyncio.wait_for(task, 2.0) == "b"
+    finally:
+        os.close(master)
+        os.close(slave)

--- a/tests/test_picker.py
+++ b/tests/test_picker.py
@@ -1,7 +1,7 @@
 """Unit tests for the live agent picker (``calfkit.cli._picker``).
 
 The picker splits into a pure selection state-machine (``PickerModel`` — tested here with
-no terminal), a pure renderer, and the raw-mode interactive loop (spec
+no terminal), a pure renderer, and the cbreak interactive loop (spec
 ``docs/designs/cli-live-feedback-spec.md`` §5).
 """
 
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import re
 from io import StringIO
+from typing import Any
 
 from rich.console import Console
 
@@ -24,16 +25,21 @@ def _menu_text(renderable: object) -> str:
     return _ANSI.sub("", buf.getvalue())
 
 
+def _roster(*names: str) -> dict[str, str | None]:
+    """A roster with no descriptions — for the ordering/selection tests."""
+    return {name: None for name in names}
+
+
 def test_sync_populates_order_and_highlights_the_first() -> None:
     model = PickerModel()
-    model.sync(["triage", "backend"])
+    model.sync(_roster("triage", "backend"))
     assert model.names == ["backend", "triage"]  # deterministic (sorted) initial order
     assert model.highlighted == "backend"
 
 
 def test_move_shifts_highlight_and_clamps_at_the_ends() -> None:
     model = PickerModel()
-    model.sync(["a", "b", "c"])  # highlight 'a'
+    model.sync(_roster("a", "b", "c"))  # highlight 'a'
     model.move(1)
     assert model.highlighted == "b"
     model.move(1)
@@ -46,40 +52,55 @@ def test_move_shifts_highlight_and_clamps_at_the_ends() -> None:
 
 def test_new_arrivals_append_at_the_bottom_preserving_existing_order() -> None:
     model = PickerModel()
-    model.sync(["m"])
-    model.sync(["a", "m"])  # 'a' arrives; it appends, it does NOT re-sort above 'm'
+    model.sync(_roster("m"))
+    model.sync(_roster("a", "m"))  # 'a' arrives; it appends, it does NOT re-sort above 'm'
     assert model.names == ["m", "a"]
 
 
 def test_offline_highlighted_agent_moves_highlight_to_the_nearest_survivor() -> None:
     model = PickerModel()
-    model.sync(["a", "b", "c"])
+    model.sync(_roster("a", "b", "c"))
     model.move(1)  # highlight 'b'
-    model.sync(["a", "c"])  # 'b' goes offline
+    model.sync(_roster("a", "c"))  # 'b' goes offline
     assert model.names == ["a", "c"]
     assert model.highlighted == "c"
 
 
 def test_all_offline_empties_the_list_and_clears_the_highlight() -> None:
     model = PickerModel()
-    model.sync(["a"])
-    model.sync([])
+    model.sync(_roster("a"))
+    model.sync(_roster())
     assert model.names == []
     assert model.highlighted is None
 
 
 def test_render_menu_marks_the_highlighted_row() -> None:
     model = PickerModel()
-    model.sync(["backend", "triage"])
+    model.sync(_roster("backend", "triage"))
     model.move(1)  # highlight 'triage'
     text = _menu_text(render_menu(model))
     assert "❯ triage" in text  # highlighted row carries the caret marker
     assert "  backend" in text  # non-highlighted row is indented, no marker
 
 
+def test_render_menu_shows_each_agent_description() -> None:
+    model = PickerModel()
+    model.sync({"researcher": "Deep web research", "support-bot": "Handles support tickets"})
+    text = _menu_text(render_menu(model))
+    assert "Deep web research" in text  # descriptions render alongside names (D9 parity with the static picker)
+    assert "Handles support tickets" in text
+
+
+def test_render_menu_tolerates_a_missing_description() -> None:
+    model = PickerModel()
+    model.sync({"researcher": None})  # no advertised description
+    text = _menu_text(render_menu(model))
+    assert "researcher" in text  # renders the name without a description, no crash
+
+
 def test_render_menu_shows_an_empty_hint_when_no_agents() -> None:
     model = PickerModel()
-    model.sync([])
+    model.sync(_roster())
     text = _menu_text(render_menu(model))
     assert "no agents online" in text.lower()
 
@@ -90,18 +111,60 @@ async def test_run_picker_moves_and_selects() -> None:
     async def read_key() -> str:
         return next(keys)
 
-    async def poll() -> list[str]:
-        return ["a", "b", "c"]
+    async def poll() -> dict[str, str | None]:
+        return _roster("a", "b", "c")
 
     result = await _run_picker(read_key, poll, lambda _m: None, cadence=100.0)
     assert result == "b"  # 'down' moves a->b, 'enter' selects it
 
 
-async def test_run_picker_resyncs_the_roster_on_a_poll_tick() -> None:
-    rosters = iter([["a"], ["a", "z"]])
+async def test_run_picker_up_moves_the_highlight() -> None:
+    keys = iter(["down", "down", "up", "enter"])
 
-    async def poll() -> list[str]:
-        return next(rosters, ["a", "z"])
+    async def read_key() -> str:
+        return next(keys)
+
+    async def poll() -> dict[str, str | None]:
+        return _roster("a", "b", "c")
+
+    result = await _run_picker(read_key, poll, lambda _m: None, cadence=100.0)
+    assert result == "b"  # down->b, down->c, up->b, enter selects b
+
+
+async def test_run_picker_quit_returns_none() -> None:
+    async def read_key() -> str:
+        return "quit"
+
+    async def poll() -> dict[str, str | None]:
+        return _roster("a", "b")
+
+    assert await _run_picker(read_key, poll, lambda _m: None, cadence=100.0) is None
+
+
+async def test_run_picker_enter_on_empty_roster_does_not_select() -> None:
+    # An empty roster + Enter must NOT return (returning None would read as a cancel and drop the
+    # user out of the picker); it stays open until an agent arrives or the user quits.
+    consumed: list[str] = []
+    keys = iter(["enter", "quit"])
+
+    async def read_key() -> str:
+        key = next(keys)
+        consumed.append(key)
+        return key
+
+    async def poll() -> dict[str, str | None]:
+        return {}  # no agents online yet
+
+    result = await _run_picker(read_key, poll, lambda _m: None, cadence=100.0)
+    assert result is None
+    assert consumed == ["enter", "quit"]  # the Enter was ignored; only the later quit ended the loop
+
+
+async def test_run_picker_resyncs_the_roster_on_a_poll_tick() -> None:
+    rosters = iter([_roster("a"), _roster("a", "z")])
+
+    async def poll() -> dict[str, str | None]:
+        return next(rosters, _roster("a", "z"))
 
     keys: asyncio.Queue[str] = asyncio.Queue()
 
@@ -127,8 +190,8 @@ async def test_live_pick_end_to_end_over_a_pty(monkeypatch: object) -> None:
     monkeypatch.setattr("sys.stdin", SimpleNamespace(fileno=lambda: slave, isatty=lambda: True))  # type: ignore[attr-defined]
 
     class _Mesh:
-        async def get_agents(self) -> dict[str, None]:
-            return {"a": None, "b": None}
+        async def get_agents(self) -> dict[str, object]:
+            return {"a": SimpleNamespace(description="alpha"), "b": SimpleNamespace(description="beta")}
 
     client = SimpleNamespace(mesh=_Mesh())
     from calfkit.cli._picker import live_pick
@@ -140,6 +203,53 @@ async def test_live_pick_end_to_end_over_a_pty(monkeypatch: object) -> None:
         await asyncio.sleep(0.05)
         os.write(master, b"\r")  # enter -> select
         assert await asyncio.wait_for(task, 2.0) == "b"
+    finally:
+        os.close(master)
+        os.close(slave)
+
+
+async def test_live_pick_restores_the_terminal_on_keyboard_interrupt(monkeypatch: object) -> None:
+    """A SIGINT surfaced as KeyboardInterrupt cancels cleanly (returns None) and always restores the
+    terminal attributes captured on entry — the picker must never leave the tty in cbreak mode.
+
+    (We assert the restore *reinstates the entry attributes* rather than comparing ``tcgetattr``
+    round-trips: a macOS pty slave does not report the pre-``setcbreak`` lflag back verbatim.)"""
+    import os
+    import pty
+    import termios
+    from types import SimpleNamespace
+
+    master, slave = pty.openpty()
+    monkeypatch.setattr("sys.stdin", SimpleNamespace(fileno=lambda: slave, isatty=lambda: True))  # type: ignore[attr-defined]
+
+    entry_attrs: list[Any] = []
+    restored_attrs: list[Any] = []
+    real_get, real_set = termios.tcgetattr, termios.tcsetattr
+
+    def spy_get(fd: int) -> Any:
+        attrs = real_get(fd)
+        if fd == slave:
+            entry_attrs.append(attrs)
+        return attrs
+
+    def spy_set(fd: int, when: int, attrs: Any) -> None:
+        if fd == slave:
+            restored_attrs.append(attrs)
+        real_set(fd, when, attrs)
+
+    monkeypatch.setattr(termios, "tcgetattr", spy_get)  # type: ignore[attr-defined]
+    monkeypatch.setattr(termios, "tcsetattr", spy_set)  # type: ignore[attr-defined]
+
+    class _Mesh:
+        async def get_agents(self) -> dict[str, object]:
+            raise KeyboardInterrupt  # the first poll is interrupted
+
+    client = SimpleNamespace(mesh=_Mesh())
+    from calfkit.cli._picker import live_pick
+
+    try:
+        assert await live_pick(client, cadence=100.0) is None  # type: ignore[arg-type]
+        assert restored_attrs and restored_attrs[-1] == entry_attrs[0]  # restored to the entry snapshot
     finally:
         os.close(master)
         os.close(slave)

--- a/tests/test_picker.py
+++ b/tests/test_picker.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 
 import asyncio
 import re
+from collections.abc import Iterator
 from io import StringIO
 from typing import Any
 
 from rich.console import Console
 
+from calfkit.cli._chat_io import Key
 from calfkit.cli._picker import PickerModel, _run_picker, render_menu
 
 _ANSI = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
@@ -83,6 +85,22 @@ def test_render_menu_marks_the_highlighted_row() -> None:
     assert "  backend" in text  # non-highlighted row is indented, no marker
 
 
+def test_roster_descriptions_projects_name_and_description() -> None:
+    # The adapter live_pick uses to feed the model: mesh AgentInfo -> {name: description}, the seam
+    # that surfaces descriptions in the live menu.
+    from datetime import datetime, timezone
+
+    from calfkit.cli._picker import _roster_descriptions
+    from calfkit.client.mesh import AgentInfo
+
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    agents = {
+        "researcher": AgentInfo(name="researcher", description="Deep research", last_seen=now),
+        "bot": AgentInfo(name="bot", description=None, last_seen=now),  # no advertised description
+    }
+    assert _roster_descriptions(agents) == {"researcher": "Deep research", "bot": None}
+
+
 def test_render_menu_shows_each_agent_description() -> None:
     model = PickerModel()
     model.sync({"researcher": "Deep web research", "support-bot": "Handles support tickets"})
@@ -106,9 +124,9 @@ def test_render_menu_shows_an_empty_hint_when_no_agents() -> None:
 
 
 async def test_run_picker_moves_and_selects() -> None:
-    keys = iter(["down", "enter"])
+    keys: Iterator[Key] = iter(["down", "enter"])
 
-    async def read_key() -> str:
+    async def read_key() -> Key:
         return next(keys)
 
     async def poll() -> dict[str, str | None]:
@@ -119,9 +137,9 @@ async def test_run_picker_moves_and_selects() -> None:
 
 
 async def test_run_picker_up_moves_the_highlight() -> None:
-    keys = iter(["down", "down", "up", "enter"])
+    keys: Iterator[Key] = iter(["down", "down", "up", "enter"])
 
-    async def read_key() -> str:
+    async def read_key() -> Key:
         return next(keys)
 
     async def poll() -> dict[str, str | None]:
@@ -132,7 +150,7 @@ async def test_run_picker_up_moves_the_highlight() -> None:
 
 
 async def test_run_picker_quit_returns_none() -> None:
-    async def read_key() -> str:
+    async def read_key() -> Key:
         return "quit"
 
     async def poll() -> dict[str, str | None]:
@@ -145,9 +163,9 @@ async def test_run_picker_enter_on_empty_roster_does_not_select() -> None:
     # An empty roster + Enter must NOT return (returning None would read as a cancel and drop the
     # user out of the picker); it stays open until an agent arrives or the user quits.
     consumed: list[str] = []
-    keys = iter(["enter", "quit"])
+    keys: Iterator[Key] = iter(["enter", "quit"])
 
-    async def read_key() -> str:
+    async def read_key() -> Key:
         key = next(keys)
         consumed.append(key)
         return key
@@ -166,9 +184,9 @@ async def test_run_picker_resyncs_the_roster_on_a_poll_tick() -> None:
     async def poll() -> dict[str, str | None]:
         return next(rosters, _roster("a", "z"))
 
-    keys: asyncio.Queue[str] = asyncio.Queue()
+    keys: asyncio.Queue[Key] = asyncio.Queue()
 
-    async def read_key() -> str:
+    async def read_key() -> Key:
         return await keys.get()
 
     seen: list[list[str]] = []

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -145,7 +145,7 @@ def test_make_reporter_factory_builds_a_console_reporter_titled_by_launched_coun
     # launched count and carries the reused set as pre_done.
     console, buf = _non_tty_console()
     factory = make_reporter_factory(lambda n: f"Starting {n} node(s)", console=console)
-    with factory(["a", "b"], ["old"]):
+    with factory(waiting=["a", "b"], pre_done=["old"]):
         pass
     assert "Starting 2 node(s)" in buf.getvalue()
 
@@ -174,3 +174,33 @@ def test_reporter_isolates_live_faults_from_the_wait() -> None:
         reporter._live = _BoomLive()  # type: ignore[assignment]
         reporter.update({"a"})  # guarded: must not raise
     # leaving the `with` (which calls _live.stop) must not raise either
+
+
+def test_reporter_live_teardown_glitch_does_not_mask_the_waits_exception() -> None:
+    # The load-bearing property (_wait.py __exit__): when the wait itself raises AND the live teardown
+    # also glitches, the wait's OWN exception must propagate — the cosmetic stop() fault must not mask it.
+    console, _ = _tty_console()
+
+    class _BoomStopLive:
+        def update(self, *a: object, **k: object) -> None: ...
+
+        def stop(self) -> None:
+            raise RuntimeError("stop boom")
+
+    class DomainError(Exception):
+        pass
+
+    with pytest.raises(DomainError):  # the wait's DomainError, not the teardown's RuntimeError
+        with ConsoleWaitReporter("t", ["a"], console=console) as reporter:
+            reporter._live = _BoomStopLive()  # type: ignore[assignment]
+            raise DomainError("the real failure")
+
+
+def test_make_reporter_factory_threads_the_success_label_into_the_finalize() -> None:
+    # The `success=` callable must reach the reporter's success finalize, titled by the launched count
+    # (n = len(waiting)) — the wiring both production call sites depend on (dev.py / _chat.py).
+    console, buf = _tty_console()
+    factory = make_reporter_factory(lambda n: f"Starting {n}", success=lambda n: f"all {n} node(s) online", console=console)
+    with factory(waiting=["a", "b"], pre_done=[]):
+        pass  # clean exit -> success finalize
+    assert "✔ all 2 node(s) online" in _ANSI.sub("", buf.getvalue())

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -150,6 +150,14 @@ def test_make_reporter_factory_builds_a_console_reporter_titled_by_launched_coun
     assert "Starting 2 node(s)" in buf.getvalue()
 
 
+def test_reporter_factory_rejects_positional_args_to_prevent_transposition() -> None:
+    # The factory is keyword-only (ReporterFactory Protocol) so the two same-typed lists — waiting vs
+    # pre_done — can never be silently transposed: a positional call is a TypeError, not a mislabel.
+    factory = make_reporter_factory(lambda n: f"Starting {n}")
+    with pytest.raises(TypeError):
+        factory(["a"], [])  # type: ignore[call-arg]
+
+
 def test_tty_success_finalize_uses_the_success_label() -> None:
     # The finalize is titled (context), not a bare "all N done" (review round 1).
     console, buf = _tty_console()

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -1,0 +1,139 @@
+"""Unit tests for the CLI wait reporter seam (``calfkit.cli._wait``).
+
+The reporter is a passive push-sink (spec ``docs/designs/cli-live-feedback-spec.md`` §4):
+tests feed it snapshots and assert the rendered output via a ``rich.Console`` over a
+``StringIO``. ``NULL_REPORTER`` is the silent default that keeps non-opted-in callers
+(tests, the detached daemon child) unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+from io import StringIO
+
+import pytest
+from rich.console import Console
+
+from calfkit.cli._wait import NULL_REPORTER, ConsoleWaitReporter, make_reporter_factory
+
+_ANSI = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+
+def _non_tty_console() -> tuple[Console, StringIO]:
+    buf = StringIO()
+    return Console(file=buf, force_terminal=False, width=100), buf
+
+
+def _tty_console() -> tuple[Console, StringIO]:
+    buf = StringIO()
+    return Console(file=buf, force_terminal=True, color_system=None, width=100), buf
+
+
+def _render_text(reporter: ConsoleWaitReporter, width: int = 100) -> str:
+    """Render the reporter's current renderable to plain text (ANSI stripped)."""
+    buf = StringIO()
+    Console(file=buf, width=width, color_system=None).print(reporter._render())
+    return _ANSI.sub("", buf.getvalue())
+
+
+def test_null_reporter_is_a_usable_silent_no_op() -> None:
+    # The default parameter value: usable as a context manager, update() does nothing,
+    # __exit__ suppresses no exception.
+    with NULL_REPORTER as reporter:
+        assert reporter is NULL_REPORTER
+        reporter.update({"a", "b"})
+    assert NULL_REPORTER.__exit__(None, None, None) in (None, False)
+
+
+def test_non_tty_prints_milestone_line_naming_the_resolved_item() -> None:
+    # A non-terminal stream gets append-only milestone lines: one per newly-resolved
+    # item, naming it and the running progress (spec §4.3, Option A).
+    console, buf = _non_tty_console()
+    with ConsoleWaitReporter("Starting 2 nodes", ["a", "b"], console=console) as reporter:
+        reporter.update({"a"})
+    out = buf.getvalue()
+    assert "a (1/2)" in out
+
+
+def test_non_tty_failure_names_the_still_pending_items() -> None:
+    # On an exception exit, the reporter attributes the failure by naming the targets that
+    # never resolved (spec §4.4) — b and c here appear only in that failure summary.
+    console, buf = _non_tty_console()
+
+    class BoomError(Exception):
+        pass
+
+    with pytest.raises(BoomError):
+        with ConsoleWaitReporter("Starting 3 nodes", ["a", "b", "c"], console=console) as reporter:
+            reporter.update({"a"})
+            raise BoomError()
+    out = buf.getvalue()
+    assert "b" in out
+    assert "c" in out
+
+
+def test_tty_render_marks_resolved_and_shows_pending_targets() -> None:
+    # On a terminal the reporter renders a live roster: resolved targets carry a done
+    # mark, pending targets are still shown (spec §4.3 checklist mode).
+    console, _ = _tty_console()
+    reporter = ConsoleWaitReporter("Starting", ["backend", "triage"], console=console)
+    reporter.update({"backend"})
+    text = _render_text(reporter)
+    assert "backend" in text
+    assert "triage" in text
+    assert "✔" in text  # backend resolved
+
+
+def test_tty_success_finalizes_with_a_done_summary() -> None:
+    # A clean exit collapses the live roster to a single done summary (spec §4.3).
+    console, buf = _tty_console()
+    with ConsoleWaitReporter("Starting", ["a", "b"], console=console) as reporter:
+        reporter.update({"a", "b"})
+    out = _ANSI.sub("", buf.getvalue())
+    assert "✔" in out
+    assert "all 2 done" in out
+
+
+def test_tty_failure_finalizes_by_naming_pending_targets() -> None:
+    console, buf = _tty_console()
+
+    class BoomError(Exception):
+        pass
+
+    with pytest.raises(BoomError):
+        with ConsoleWaitReporter("Starting", ["a", "b", "c"], console=console) as reporter:
+            reporter.update({"a"})
+            raise BoomError()
+    out = _ANSI.sub("", buf.getvalue())
+    assert "still pending" in out
+    assert "b" in out and "c" in out
+
+
+def test_tty_starts_and_stops_the_live_view() -> None:
+    # The live view is active for the duration of the wait and torn down on exit.
+    console, _ = _tty_console()
+    reporter = ConsoleWaitReporter("Starting", ["a"], console=console)
+    assert reporter._live is None
+    with reporter:
+        assert reporter._live is not None
+    assert reporter._live is None
+
+
+def test_single_item_spinner_mode_resolves_and_finalizes() -> None:
+    # A 1-item wait (e.g. the broker spawn) is a degenerate checklist: it resolves and
+    # finalizes like any other (spec §4.1 spinner mode).
+    console, buf = _non_tty_console()
+    with ConsoleWaitReporter("Starting dev broker", ["dev broker"], console=console) as reporter:
+        reporter.update({"dev broker"})
+    out = buf.getvalue()
+    assert "dev broker (1/1)" in out
+
+
+def test_make_reporter_factory_builds_a_console_reporter_titled_by_launched_count() -> None:
+    # The command-layer helper: a gate_launched_ready factory that titles the reporter by the
+    # launched count and carries the reused set as pre_done.
+    console, buf = _non_tty_console()
+    factory = make_reporter_factory(lambda n: f"Starting {n} node(s)", console=console)
+    with factory(["a", "b"], ["old"]):
+        pass
+    assert "Starting 2 node(s)" in buf.getvalue()

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -129,6 +129,17 @@ def test_single_item_spinner_mode_resolves_and_finalizes() -> None:
     assert "dev broker (1/1)" in out
 
 
+def test_pre_done_targets_render_as_already_done_and_count_toward_total() -> None:
+    # Reused agents (pre_done) show done from the start and are counted in the total, while only the
+    # waited set drives completion (spec §4.5) — so a mixed launch reads e.g. "1/2" immediately.
+    console, _ = _tty_console()
+    reporter = ConsoleWaitReporter("Starting", ["triage"], pre_done=["backend"], console=console)
+    text = _render_text(reporter)
+    assert "✔ backend" in text  # reused agent shown done immediately
+    assert "triage" in text  # still-waiting agent shown
+    assert "1/2" in text  # pre_done counts toward the total from the start
+
+
 def test_make_reporter_factory_builds_a_console_reporter_titled_by_launched_count() -> None:
     # The command-layer helper: a gate_launched_ready factory that titles the reporter by the
     # launched count and carries the reused set as pre_done.
@@ -137,3 +148,29 @@ def test_make_reporter_factory_builds_a_console_reporter_titled_by_launched_coun
     with factory(["a", "b"], ["old"]):
         pass
     assert "Starting 2 node(s)" in buf.getvalue()
+
+
+def test_tty_success_finalize_uses_the_success_label() -> None:
+    # The finalize is titled (context), not a bare "all N done" (review round 1).
+    console, buf = _tty_console()
+    with ConsoleWaitReporter("Starting dev broker", ["dev broker"], success_label="dev broker ready", console=console):
+        pass
+    assert "✔ dev broker ready" in _ANSI.sub("", buf.getvalue())
+
+
+def test_reporter_isolates_live_faults_from_the_wait() -> None:
+    # A rich render/teardown glitch in the live view must never abort or mask the wait it decorates.
+    console, _ = _tty_console()
+
+    class _BoomLive:
+        def update(self, *a: object, **k: object) -> None:
+            raise RuntimeError("render boom")
+
+        def stop(self) -> None:
+            raise RuntimeError("stop boom")
+
+    reporter = ConsoleWaitReporter("t", ["a"], console=console)
+    with reporter:
+        reporter._live = _BoomLive()  # type: ignore[assignment]
+        reporter.update({"a"})  # guarded: must not raise
+    # leaving the `with` (which calls _live.stop) must not raise either


### PR DESCRIPTION
## Summary

Automatic, terminal-aware live feedback for the `ck dev` commands — **no new flags**, graceful non-TTY fallback:

1. **Readiness roster** — while `ck dev run -d` and `ck dev chat TARGET` wait for launched agents/tools to come online, a live per-item roster shows each coming up (`rich.Live` checklist on a TTY; plain `name (n/total)` milestone lines when piped/CI). On timeout the roster and the **enriched `DevAgentError`** name exactly which agents never came online (previously the error named nobody).
2. **Broker-spawn spinner** — a `Starting dev broker …` progress line while `ck dev` spawns its managed broker.
3. **Quieted broker-startup noise** — the `Unable connect to "127.0.0.1:9092"` aiokafka ERROR lines during broker warm-up are suppressed.
4. **Live agent picker** — `ck chat` / `ck dev chat` with no agent name on an interactive terminal shows an arrow-key menu that **live-refreshes** as agents come online/offline (↑/↓ + Enter; `q`/`Esc`/Ctrl-C to quit). Piped/non-TTY falls back to the existing static numbered picker.

## Design

- **`WaitReporter` seam** (`_wait.py`): a passive, push-driven sink — the wait pushes resolved-name snapshots, `rich.Live` renders. One `ConsoleWaitReporter` self-branches on `console.is_terminal` (live view vs milestone lines); a `NULL_REPORTER` no-op default keeps non-opted-in callers silent. ADR-0036.
- **`gate_launched_ready`**: the `-d` and `chat TARGET` paths shared an "evaluate → gate on readiness" preamble; extracted into one seam so the reporter injects once. Behaviour-preserving — existing `ensure_agents` / `_target_session` tests are the safety net.
- **Picker**: `rich.Live` for render + a **cbreak** single-key reader. Rich's `Live` is output-only by design; keyboard input is a separate concern, and cbreak (not raw) keeps `Live`'s output from stair-stepping. The pure `PickerModel` + `_run_picker` loop are unit-tested; a pty smoke test covers the termios glue.

## Testing

Built strictly test-first (TDD). Full offline suite green (**4131 passed, 7 skipped**); `make check` clean (lint + format + mypy across 89 files). Kafka/live lanes untouched (CI, main-only).

## Notes for review

- **Live picker shows agent names only** — the live menu lists names; the static numbered fallback shows names **+ descriptions**. v1 per spec §5, but flagging the asymmetry: should the live menu carry descriptions too?
- **Roster finalize wording** — the success line is a generic `✔ all N done` (no elapsed time); the spec examples envisioned `✔ all N online (11s)`. Generic wording was a deliberate call (the reporter is domain-agnostic) — flagging in case "online"/elapsed is wanted for the roster.
- **Out of scope (tracked)** — the non-scaling 15s readiness timeout (`docs/issues/readiness-timeout-does-not-scale-with-node-count.md`). The reporter makes the failure legible but does not change the bound.
