### PR TITLE
feat(cli): foreground `ck dev mesh start` and rename broker group to mesh

### DIFF
--- a/calfkit/cli/_dev_broker.py
+++ b/calfkit/cli/_dev_broker.py
@@ -477,8 +477,8 @@ def spawn_foreground(target: Target, *, resolve_bin: Callable[[], str], timeout:
     The process stays in the caller's session (no ``start_new_session``, so Ctrl-C reaches Tansu
     directly — the deliberate inverse of §5.8's detach) and inherits the terminal (no log redirect;
     its output streams live). The caller blocks on the returned process. Raises
-    :class:`DevBrokerError` when a broker is already reachable (foreground cannot attach to a
-    detached daemon — stop it, or use ``-d``), when the address is not a single loopback
+    :class:`DevBrokerError` when a broker is already reachable (foreground cannot attach to an
+    already-running broker — stop it, or use ``-d``), when the address is not a single loopback
     (connect-only), or when the spawn fails or never becomes ready.
     """
     with _spawn_lock():

--- a/calfkit/cli/_dev_broker.py
+++ b/calfkit/cli/_dev_broker.py
@@ -108,7 +108,7 @@ class BrokerInfo:
 
 @dataclass(frozen=True)
 class MeshStatus:
-    """What ``ck dev broker status`` reports: every running dev broker found by the scan, and
+    """What ``ck dev mesh status`` reports: every running dev broker found by the scan, and
     whether *anything* answers at the target address (reachable with no scan hit = a broker
     calfkit does not manage — spec §4.2)."""
 
@@ -347,11 +347,7 @@ def ensure_broker(
             # that is the canonical key, not any single listener.
             return BrokerInfo(listener=target.key, pid=None, managed=False)
         if not (target.is_single and target.is_loopback):
-            raise DevBrokerError(
-                f"no broker is reachable at {target.bootstrap!r} and it is not a single loopback "
-                "address, so `ck dev` will not spawn one there (connect-only; spec §5.2). Start the "
-                "broker at that address, or point --host at a loopback address to get a managed one."
-            )
+            raise _connect_only_error(target)
         binary = _resolve_binary(resolve_bin)
         return _spawn_and_wait(target, binary, timeout)
 
@@ -387,16 +383,70 @@ def _log_tail(log_path: Path) -> str:
         return f"(could not read the log: {exc})"
 
 
-def _spawn_and_wait(target: Target, binary: str, timeout: float) -> BrokerInfo:
-    listener = target.listener
-    log_path = _calfkit_dir() / "logs" / f"tansu-{target.key}.log"
-    cmd = [
+def _broker_cmd(binary: str, listener: str) -> list[str]:
+    """The dev broker argv — the single source of truth for both the detached and the foreground
+    spawn, so the §5.4 ownership scan recognizes either by the same memory-engine + listener
+    anchors."""
+    return [
         binary,
         "broker",
         "--storage-engine=memory://tansu/",
         f"--kafka-listener-url=tcp://{listener}",
         f"--kafka-advertised-listener-url=tcp://{listener}",
     ]
+
+
+def _connect_only_error(target: Target) -> DevBrokerError:
+    """Spec §5.2's refusal to bind anywhere but a single loopback address — shared by the detached
+    :func:`ensure_broker` and the foreground :func:`spawn_foreground`."""
+    return DevBrokerError(
+        f"no broker is reachable at {target.bootstrap!r} and it is not a single loopback "
+        "address, so `ck dev` will not spawn one there (connect-only; spec §5.2). Start the "
+        "broker at that address, or point --host at a loopback address to get a managed one."
+    )
+
+
+def _startup_detail(log_path: Path | None) -> str:
+    """The tail appended to a startup-failure message: the spawn log's last bytes for a detached
+    broker (its output went to a file), or a pointer to the terminal for a foreground broker (its
+    output already streamed there)."""
+    if log_path is None:
+        return "; see its output above."
+    return f"; log tail from {log_path}:\n{_log_tail(log_path)}"
+
+
+def _await_ready(proc: Any, listener: str, timeout: float, *, log_path: Path | None) -> None:
+    """Block until *proc* answers on *listener*, or raise (spec §5.2): a startup exit fails fast, a
+    readiness timeout kills the spawn first. Shared by the detached and foreground spawns; *log_path*
+    selects where a failure points the reader — a log file, or the terminal (``None``)."""
+    deadline = time.monotonic() + timeout
+    while True:
+        if proc.poll() is not None:
+            code = proc.returncode
+            if code is not None and code < 0:
+                cause = f"killed by a signal ({code}) — a concurrent `ck dev mesh stop/restart`?"
+            else:
+                cause = f"exit code {code}"
+            raise DevBrokerError(f"the dev broker exited during startup ({cause})" + _startup_detail(log_path))
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            proc.kill()
+            try:
+                proc.wait(timeout=DEFAULT_GRACE)  # reap our own child — no zombie for long-lived callers
+            except subprocess.TimeoutExpired:
+                pass  # kill was delivered; the CLI exits next and init reaps
+            raise DevBrokerError(f"the dev broker did not become ready within {timeout:.1f}s" + _startup_detail(log_path))
+        # Per-attempt probe budget: capped at 1s so proc.poll() keeps getting re-checked, and
+        # bounded by the remaining deadline so the total wait never overshoots `timeout`.
+        if is_reachable(listener, timeout=min(1.0, max(0.1, remaining))):
+            break
+        time.sleep(_READINESS_POLL_INTERVAL)
+
+
+def _spawn_and_wait(target: Target, binary: str, timeout: float) -> BrokerInfo:
+    listener = target.listener
+    log_path = _calfkit_dir() / "logs" / f"tansu-{target.key}.log"
+    cmd = _broker_cmd(binary, listener)
     # Overwritten each spawn — bounded logs, one daemon per address (spec §5.2). A real file fd,
     # never PIPE: an unread pipe would deadlock Tansu once its buffer fills.
     try:
@@ -410,28 +460,7 @@ def _spawn_and_wait(target: Target, binary: str, timeout: float) -> BrokerInfo:
         except OSError as exc:
             # Wrong-arch / corrupt binary fails at exec time (spec §7.3) — distinct from a timeout.
             raise DevBrokerError(f"failed to launch the dev broker binary {binary!r}: {exc}") from exc
-    deadline = time.monotonic() + timeout
-    while True:
-        if proc.poll() is not None:
-            code = proc.returncode
-            if code is not None and code < 0:
-                cause = f"killed by a signal ({code}) — a concurrent `ck dev broker stop/restart`?"
-            else:
-                cause = f"exit code {code}"
-            raise DevBrokerError(f"the dev broker exited during startup ({cause}); log tail from {log_path}:\n{_log_tail(log_path)}")
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            proc.kill()
-            try:
-                proc.wait(timeout=DEFAULT_GRACE)  # reap our own child — no zombie for long-lived callers
-            except subprocess.TimeoutExpired:
-                pass  # kill was delivered; the CLI exits next and init reaps
-            raise DevBrokerError(f"the dev broker did not become ready within {timeout:.1f}s; log tail from {log_path}:\n{_log_tail(log_path)}")
-        # Per-attempt probe budget: capped at 1s so proc.poll() keeps getting re-checked, and
-        # bounded by the remaining deadline so the total wait never overshoots `timeout`.
-        if is_reachable(listener, timeout=min(1.0, max(0.1, remaining))):
-            break
-        time.sleep(_READINESS_POLL_INTERVAL)
+    _await_ready(proc, listener, timeout, log_path=log_path)
     return BrokerInfo(
         listener=listener,
         pid=proc.pid,
@@ -439,6 +468,38 @@ def _spawn_and_wait(target: Target, binary: str, timeout: float) -> BrokerInfo:
         started_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
         log_path=str(log_path),
     )
+
+
+def spawn_foreground(target: Target, *, resolve_bin: Callable[[], str], timeout: float = DEFAULT_TIMEOUT) -> Popen[bytes]:
+    """Spawn an **attached** dev broker and return the live process once it is ready — the foreground
+    counterpart of :func:`ensure_broker`'s detached spawn (spec §5.2).
+
+    The process stays in the caller's session (no ``start_new_session``, so Ctrl-C reaches Tansu
+    directly — the deliberate inverse of §5.8's detach) and inherits the terminal (no log redirect;
+    its output streams live). The caller blocks on the returned process. Raises
+    :class:`DevBrokerError` when a broker is already reachable (foreground cannot attach to a
+    detached daemon — stop it, or use ``-d``), when the address is not a single loopback
+    (connect-only), or when the spawn fails or never becomes ready.
+    """
+    with _spawn_lock():
+        if is_reachable(list(target.servers), timeout=timeout):
+            raise DevBrokerError(
+                f"a broker is already running at {target.key} — stop it with `ck dev mesh stop`, "
+                "or start a detached daemon with `ck dev mesh start -d`."
+            )
+        if not (target.is_single and target.is_loopback):
+            raise _connect_only_error(target)
+        binary = _resolve_binary(resolve_bin)
+        listener = target.listener
+        try:
+            # Attached: inherit stdout/stderr (the terminal) and stay in our session so Ctrl-C
+            # reaches Tansu directly. stdin is DEVNULL — Tansu never reads it.
+            proc: Popen[bytes] = Popen(_broker_cmd(binary, listener), stdin=subprocess.DEVNULL)
+        except OSError as exc:
+            # Wrong-arch / corrupt binary fails at exec time (spec §7.3) — distinct from a timeout.
+            raise DevBrokerError(f"failed to launch the dev broker binary {binary!r}: {exc}") from exc
+        _await_ready(proc, listener, timeout, log_path=None)
+        return proc
 
 
 # --- stop / status / restart (spec §4.2, §5.6) ------------------------------------------------------

--- a/calfkit/cli/dev.py
+++ b/calfkit/cli/dev.py
@@ -11,7 +11,7 @@ Four surfaces (agent-lifecycle spec §3): foreground ``dev run`` delegates to th
 ``run()`` command function forwarding every argument explicitly; ``dev run -d`` connect-or-spawns
 a detached agent daemon via :mod:`calfkit.cli._dev_agents`; ``dev chat`` attaches (or, given
 targets, runs an in-process session worker) through ``run_chat_session`` directly; and
-``status``/``stop``/``down`` manage the daemons the argv-marker scan owns. ``ck dev broker``
+``status``/``stop``/``down`` manage the daemons the argv-marker scan owns. ``ck dev mesh``
 controls the broker daemon directly.
 
 Import hygiene (load-bearing): ``_build_app()`` imports this module on **every** ``ck``
@@ -23,6 +23,7 @@ the supervisor's spawn branch.
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 import typer
@@ -41,12 +42,12 @@ dev_app = typer.Typer(
     help="Run against a zero-setup local mesh: connect to (or spawn) a managed dev broker.",
     no_args_is_help=True,
 )
-broker_app = typer.Typer(
-    name="broker",
-    help="Control the managed dev broker daemon directly.",
+mesh_app = typer.Typer(
+    name="mesh",
+    help="Control the local dev mesh — the broker your agents run on.",
     no_args_is_help=True,
 )
-dev_app.add_typer(broker_app, name="broker")
+dev_app.add_typer(mesh_app, name="mesh")
 
 _HOST_HELP = "Kafka bootstrap server(s), comma-separated. Precedence: this flag > $CALFKIT_MESH_URL > localhost."
 
@@ -612,17 +613,53 @@ def _target_or_exit(host: str | None, env_file: str | None = None) -> Target:
     return _normalize_or_exit(resolve_mesh_url(_parse_host(host)))
 
 
-@broker_app.command(name="start")
-def broker_start(
+def _run_broker_foreground(target: Target) -> None:
+    """Spawn an attached broker and block on it until it exits or Ctrl-C stops it (spec §5.2)."""
+    try:
+        proc = _dev_broker.spawn_foreground(target, resolve_bin=_resolve_bin, timeout=_dev_broker.DEFAULT_TIMEOUT)
+    except DevBrokerError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(2) from exc
+    typer.echo(f"ck dev: broker listening at {target.listener} (pid {proc.pid}) — Ctrl-C to stop")
+    try:
+        returncode = proc.wait()
+    except KeyboardInterrupt:
+        # Ctrl-C reached Tansu too (shared session); reap its clean shutdown and exit success.
+        with suppress(KeyboardInterrupt):
+            proc.wait()
+        typer.echo("ck dev: broker stopped")
+        return
+    if returncode:
+        typer.echo(f"ck dev: broker exited with code {returncode}", err=True)
+        raise typer.Exit(returncode if returncode > 0 else 1)
+
+
+@mesh_app.command(name="start")
+def mesh_start(
     host: str | None = typer.Option(None, "--host", "-H", help=_HOST_HELP),
+    detach: bool = typer.Option(
+        False,
+        "--detach",
+        "-d",
+        help="Run the broker as a detached background daemon and return, instead of in the foreground.",
+    ),
     env_file: str | None = typer.Option(None, "--env-file", help=_ENV_FILE_HELP),
 ) -> None:
-    """Connect-or-spawn the dev broker and return (the daemon keeps running). Idempotent."""
-    _ensure_or_exit(_target_or_exit(host, env_file))
+    """Run the dev broker in the foreground (Ctrl-C stops it); -d runs it as a detached daemon.
+
+    Foreground is the default: the broker's output streams to your terminal and it stops when you
+    press Ctrl-C. With -d it connect-or-spawns a detached daemon and returns (idempotent) — the
+    shape 'ck dev run' and 'ck dev chat' share when they ensure a broker.
+    """
+    target = _target_or_exit(host, env_file)
+    if detach:
+        _ensure_or_exit(target)
+        return
+    _run_broker_foreground(target)
 
 
-@broker_app.command(name="stop")
-def broker_stop(
+@mesh_app.command(name="stop")
+def mesh_stop(
     host: str | None = typer.Option(None, "--host", "-H", help=_HOST_HELP),
     stop_all: bool = typer.Option(
         False,
@@ -654,8 +691,8 @@ def broker_stop(
         raise typer.Exit(2) from exc
 
 
-@broker_app.command(name="status")
-def broker_status(
+@mesh_app.command(name="status")
+def mesh_status(
     host: str | None = typer.Option(None, "--host", "-H", help=_HOST_HELP),
     env_file: str | None = typer.Option(None, "--env-file", help=_ENV_FILE_HELP),
 ) -> None:
@@ -678,8 +715,8 @@ def broker_status(
             typer.echo(f"{report.target_key}: no broker reachable")
 
 
-@broker_app.command(name="restart")
-def broker_restart(
+@mesh_app.command(name="restart")
+def mesh_restart(
     host: str | None = typer.Option(None, "--host", "-H", help=_HOST_HELP),
     env_file: str | None = typer.Option(None, "--env-file", help=_ENV_FILE_HELP),
 ) -> None:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -274,8 +274,10 @@ but everything that manages agent daemons needs the extra's process scan.
 multi-address is never a spawn target, so there is nothing to scan);
 `ck dev run -d` and `ck dev chat TARGET…` need it to launch (they still
 succeed on a core install when every target is already online — pure reuse
-never scans); `ck dev mesh start`/`restart` degrade gracefully (reuse/borrow
-still works; only the managed-vs-reused classification is lost). See
+never scans); `ck dev mesh start -d`/`restart` degrade gracefully (reuse/borrow
+still works; only the managed-vs-reused classification is lost). Bare foreground
+`ck dev mesh start` never reuses — it errors if a broker is already reachable —
+so it only needs the binary, not the scan. See
 [How to run a local mesh with `ck dev`](local-dev-mesh.md).
 
 ### Spawn rules

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -249,7 +249,7 @@ delegating to the equivalent top-level command, every `ck dev` command
 **ensures a broker** at the target address: if one is reachable it is reused;
 otherwise a bundled [Tansu](https://tansu.io) broker (in-memory, Kafka-compatible)
 is spawned as a detached background daemon that persists until an explicit
-`ck dev broker stop`/`restart` or a reboot.
+`ck dev mesh stop`/`restart` or a reboot.
 
 ```text
 ck dev run  TARGET [TARGET ...] [--detach/-d] [OPTIONS]
@@ -257,7 +257,7 @@ ck dev chat [NAME | TARGET ...] [OPTIONS]
 ck dev status [OPTIONS]
 ck dev stop (NAME [NAME ...] | --all) [OPTIONS]
 ck dev down [OPTIONS]
-ck dev broker (start | stop | status | restart) [OPTIONS]
+ck dev mesh (start [--detach/-d] | stop | status | restart) [OPTIONS]
 ```
 
 The bundled broker requires the **`[mesh]` extra** (`pip install 'calfkit[mesh]'`),
@@ -268,13 +268,13 @@ extra installed (resolution order: `CALF_TANSU_BIN` → bundled → `tansu` on
 `PATH`). Without the extra, foreground `ck dev run` and the `ck dev chat`
 attach forms still work as pure clients against an already-reachable broker —
 but everything that manages agent daemons needs the extra's process scan.
-`ck dev status`, `ck dev stop`, `ck dev down`, `ck dev broker stop`, and
-`ck dev broker status` exit `2` with the install hint without it (one edge:
-`ck dev broker stop` against a *multi-address* target is a messaged no-op —
+`ck dev status`, `ck dev stop`, `ck dev down`, `ck dev mesh stop`, and
+`ck dev mesh status` exit `2` with the install hint without it (one edge:
+`ck dev mesh stop` against a *multi-address* target is a messaged no-op —
 multi-address is never a spawn target, so there is nothing to scan);
 `ck dev run -d` and `ck dev chat TARGET…` need it to launch (they still
 succeed on a core install when every target is already online — pure reuse
-never scans); `ck dev broker start`/`restart` degrade gracefully (reuse/borrow
+never scans); `ck dev mesh start`/`restart` degrade gracefully (reuse/borrow
 still works; only the managed-vs-reused classification is lost). See
 [How to run a local mesh with `ck dev`](local-dev-mesh.md).
 
@@ -394,7 +394,7 @@ shown all the same.
 | --- | --- |
 | `stop NAME…` | Stop the daemon(s) owning those names — **whole-daemon**: co-hosted names go down together and every one is narrated (`stopped daemon pid 51288 (agents: general, finance)`). SIGTERM → 8 s grace → SIGKILL, delivered to the daemon's whole **process group**. |
 | `stop --all` | Every `ck dev` agent daemon on **every** address (ignores `--host`). |
-| `down` | `stop --all`, then `broker stop` at the resolved address. |
+| `down` | `stop --all`, then `mesh stop` at the resolved address. |
 
 Names resolve **within the target address** while `--all`/`down` sweep
 globally — that is the one name-vs-address asymmetry in the family. An unknown
@@ -406,9 +406,10 @@ Foreground runs and chat-session workers **survive `down`** by design (they
 carry no marker) and will error against the stopped broker — stop them where
 they run. Finding nothing to stop is a messaged no-op, exit `0`.
 
-### `ck dev broker`
+### `ck dev mesh`
 
-Direct control of the dev broker daemon, decoupled from any app run. Every
+Direct control of the local dev mesh — the broker your agents run on —
+decoupled from any app run. Every
 subcommand takes `--host`/`-H` (same precedence as above; default
 `127.0.0.1:9092`) and loads `./.env` first, like `ck dev run`/`ck dev chat` —
 so a `.env`-set `CALFKIT_MESH_URL` targets the same address across every
@@ -416,10 +417,11 @@ so a `.env`-set `CALFKIT_MESH_URL` targets the same address across every
 
 | Command | Behavior |
 | --- | --- |
-| `start` | Connect-or-spawn and return (the daemon keeps running). Idempotent. |
+| `start` | Run the broker in the **foreground** (its output streams to your terminal; Ctrl-C stops it). Errors if a broker is already running — foreground can't attach, so stop it or use `-d`. |
+| `start -d`/`--detach` | Connect-or-spawn a **detached** daemon and return (it keeps running). Idempotent — the shape `ck dev run`/`ck dev chat` share when they ensure a broker. |
 | `stop` | Stop the dev broker at the target address. `--all` stops every running dev broker (ignores `--host`). A no-op with a message when none matches. |
 | `status` | List the running dev broker(s) (address, pid, start time) and probe the target address — a reachable broker that isn't a dev broker reports as *reachable, not managed by calfkit*. |
-| `restart` | `stop` then `start` — the clean slate (all in-memory data is lost). |
+| `restart` | `stop` then re-spawn a detached daemon — the clean slate (all in-memory data is lost). |
 
 `ck dev` manages **dev brokers only**: a process is recognized by its command
 line (an in-memory-engine `tansu` bound to the target address), whoever started

--- a/docs/local-dev-mesh.md
+++ b/docs/local-dev-mesh.md
@@ -141,19 +141,21 @@ Daemon logs live at `~/.calfkit/logs/agents-<address>-<targets>.log`,
 overwritten on each launch — consult them *before* relaunching over a broken
 daemon.
 
-## Control the broker directly
+## Control the mesh directly
 
 ```console
-$ ck dev broker status
+$ ck dev mesh status
 127.0.0.1:9092: pid 51234, running, started 2026-07-01T22:38:13+00:00
 ```
 
-- `ck dev broker start` — connect-or-spawn and return. Idempotent.
-- `ck dev broker stop` — stop the dev broker at the target address
+- `ck dev mesh start` — run the broker in the **foreground** (its output streams
+  to your terminal; Ctrl-C stops it). Add `-d`/`--detach` to run it as a
+  detached daemon and return instead — idempotent connect-or-spawn.
+- `ck dev mesh stop` — stop the dev broker at the target address
   (`--all` stops every running one).
-- `ck dev broker restart` — stop then start. **The data is in-memory**, so this
-  is the clean slate: all topics and messages are gone. (A reboot resets it the
-  same way.)
+- `ck dev mesh restart` — stop then re-spawn a detached daemon. **The data is
+  in-memory**, so this is the clean slate: all topics and messages are gone.
+  (A reboot resets it the same way.)
 
 Target a non-default address with `--host/-H` on any of these; each address is
 its own independent single-node mesh.

--- a/tests/integration/test_dev_agents_kafka.py
+++ b/tests/integration/test_dev_agents_kafka.py
@@ -267,11 +267,11 @@ def test_fresh_broker_first_run_end_to_end(isolated_home: Path, tmp_path: Path) 
         assert stop.exit_code == 0, stop.stdout + str(stop.exception)
         assert f"stopped daemon pid {pid}" in stop.stdout
 
-        broker_stop = _invoke(["dev", "broker", "stop", "--host", host])
+        broker_stop = _invoke(["dev", "mesh", "stop", "--host", host])
         assert broker_stop.exit_code == 0, broker_stop.stdout + str(broker_stop.exception)
         assert f"stopped {host}" in broker_stop.stdout
         assert is_reachable(host, timeout=2.0) is False
     finally:
         if pid is not None:
             _reap_tree(pid)
-        _invoke(["dev", "broker", "stop", "--host", host])  # belt-and-braces if the assert path bailed early
+        _invoke(["dev", "mesh", "stop", "--host", host])  # belt-and-braces if the assert path bailed early

--- a/tests/test_dev_broker.py
+++ b/tests/test_dev_broker.py
@@ -371,7 +371,7 @@ def test_spawn_that_exits_during_startup_fails_fast_with_the_log_tail(monkeypatc
 
 
 def test_spawn_killed_by_a_signal_hints_at_a_concurrent_stop(monkeypatch: pytest.MonkeyPatch) -> None:
-    # A lock-free `ck dev broker stop/restart` can race an in-flight readiness wait (spec §5.3);
+    # A lock-free `ck dev mesh stop/restart` can race an in-flight readiness wait (spec §5.3);
     # the negative returncode gets a hint instead of a bare "exit code -15".
     def factory(cmd: list[str], **kwargs: object) -> FakePopen:
         proc = FakePopen(cmd, **kwargs)
@@ -571,6 +571,17 @@ def test_foreground_spawn_that_exits_during_startup_fails_fast(monkeypatch: pyte
     monkeypatch.setattr(dev_broker, "Popen", factory)
     monkeypatch.setattr(dev_broker, "is_reachable", scripted_probe(False))
     with pytest.raises(DevBrokerError, match="exited during startup"):
+        dev_broker.spawn_foreground(normalize(["localhost"]), resolve_bin=CountingResolveBin(_BIN))
+
+
+def test_foreground_wrong_arch_binary_surfaces_a_distinct_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The exec-time failure twin of test_wrong_arch_binary_surfaces_a_distinct_error (detached path).
+    def factory(cmd: list[str], **kwargs: object) -> FakePopen:
+        raise OSError(8, "Exec format error")
+
+    monkeypatch.setattr(dev_broker, "Popen", factory)
+    monkeypatch.setattr(dev_broker, "is_reachable", scripted_probe(False))
+    with pytest.raises(DevBrokerError, match="failed to launch"):
         dev_broker.spawn_foreground(normalize(["localhost"]), resolve_bin=CountingResolveBin(_BIN))
 
 

--- a/tests/test_dev_broker.py
+++ b/tests/test_dev_broker.py
@@ -516,6 +516,97 @@ def test_detach_kwargs_per_platform(monkeypatch: pytest.MonkeyPatch) -> None:
     assert dev_broker._detach_kwargs() == {"creationflags": expected}
 
 
+# --- spawn_foreground: the attached spawn (the `ck dev mesh start` foreground path) ----------------
+
+
+def test_foreground_spawns_attached_when_loopback_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    import subprocess
+
+    spawned = _capture_popen(monkeypatch)
+    resolve_bin = CountingResolveBin(_BIN)
+    monkeypatch.setattr(dev_broker, "is_reachable", scripted_probe(False, True))  # absent, then ready
+
+    proc = dev_broker.spawn_foreground(normalize(["localhost"]), resolve_bin=resolve_bin)
+
+    assert resolve_bin.calls == 1
+    (spawned_proc,) = spawned
+    assert spawned_proc is proc, "the live attached process is returned for the caller to wait on"
+    # Byte-identical argv to the detached spawn, so the §5.4 ownership scan recognizes it too.
+    assert proc.cmd == _broker_argv()
+    # Attached: shares our session (Ctrl-C reaches it) and inherits the terminal (no log redirect).
+    assert "start_new_session" not in proc.kwargs
+    assert proc.kwargs["stdin"] is subprocess.DEVNULL
+    assert "stdout" not in proc.kwargs and "stderr" not in proc.kwargs
+
+
+def test_foreground_errors_when_a_broker_is_already_running(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Foreground cannot attach to an already-detached daemon — refuse (no spawn, no binary resolve).
+    monkeypatch.setattr(dev_broker, "is_reachable", scripted_probe(True))
+    with pytest.raises(DevBrokerError, match="already running"):
+        dev_broker.spawn_foreground(normalize(["localhost"]), resolve_bin=MustNotCall())
+
+
+def test_foreground_refuses_a_non_loopback_address(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Same connect-only rule as ensure_broker (spec §5.2): never spawn at a non-loopback address.
+    monkeypatch.setattr(dev_broker, "is_reachable", scripted_probe(False))
+    with pytest.raises(DevBrokerError, match="connect-only"):
+        dev_broker.spawn_foreground(normalize(["203.0.113.7:9092"]), resolve_bin=MustNotCall())
+
+
+def test_foreground_readiness_timeout_kills_the_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    spawned = _capture_popen(monkeypatch)
+    monkeypatch.setattr(dev_broker, "is_reachable", scripted_probe(False))  # absent, then never ready
+    with pytest.raises(DevBrokerError, match="did not become ready"):
+        dev_broker.spawn_foreground(normalize(["localhost"]), resolve_bin=CountingResolveBin(_BIN), timeout=0.05)
+    (proc,) = spawned
+    assert proc.killed is True
+
+
+def test_foreground_spawn_that_exits_during_startup_fails_fast(monkeypatch: pytest.MonkeyPatch) -> None:
+    def factory(cmd: list[str], **kwargs: object) -> FakePopen:
+        proc = FakePopen(cmd, **kwargs)
+        proc.returncode = 1  # bind failure — died immediately
+        return proc
+
+    monkeypatch.setattr(dev_broker, "Popen", factory)
+    monkeypatch.setattr(dev_broker, "is_reachable", scripted_probe(False))
+    with pytest.raises(DevBrokerError, match="exited during startup"):
+        dev_broker.spawn_foreground(normalize(["localhost"]), resolve_bin=CountingResolveBin(_BIN))
+
+
+def test_foreground_holds_the_lock_across_probe_and_readiness(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The attached spawn takes the same §5.3 lock and releases it once ready, before the caller
+    blocks on the process — a concurrent invocation must never see the not-yet-ready broker."""
+    from contextlib import contextmanager
+
+    events: list[str] = []
+
+    @contextmanager
+    def spy_lock():  # type: ignore[no-untyped-def]
+        events.append("lock")
+        yield
+        events.append("unlock")
+
+    def factory(cmd: list[str], **kwargs: object) -> FakePopen:
+        events.append("popen")
+        return FakePopen(cmd, **kwargs)
+
+    probe = scripted_probe(False, True)
+
+    def probing(bootstrap: object, *, timeout: float) -> bool:
+        events.append("probe")
+        result: bool = probe(bootstrap, timeout=timeout)
+        return result
+
+    monkeypatch.setattr(dev_broker, "_spawn_lock", spy_lock)
+    monkeypatch.setattr(dev_broker, "Popen", factory)
+    monkeypatch.setattr(dev_broker, "is_reachable", probing)
+    dev_broker.spawn_foreground(normalize(["localhost"]), resolve_bin=CountingResolveBin(_BIN))
+    assert events[0] == "lock"
+    assert events[-1] == "unlock"
+    assert events[1:-1] == ["probe", "popen", "probe"], "probe→spawn→readiness must all run under the lock"
+
+
 # --- the spawn lock (spec §5.3) ---------------------------------------------------------------------
 
 

--- a/tests/test_dev_cli.py
+++ b/tests/test_dev_cli.py
@@ -101,12 +101,12 @@ def test_dev_help_lists_the_subcommands() -> None:
     result = _invoke(["dev", "--help"])
     assert result.exit_code == 0, result.stdout
     out = _plain(result.stdout)
-    for sub in ("run", "chat", "broker"):
+    for sub in ("run", "chat", "mesh"):
         assert sub in out
 
 
 def test_dev_broker_help_lists_lifecycle_commands() -> None:
-    result = _invoke(["dev", "broker", "--help"])
+    result = _invoke(["dev", "mesh", "--help"])
     assert result.exit_code == 0, result.stdout
     out = _plain(result.stdout)
     for sub in ("start", "stop", "status", "restart"):
@@ -260,22 +260,77 @@ def test_dev_chat_broker_ensure_failure_exits_2(monkeypatch: pytest.MonkeyPatch,
     assert attach_calls == []
 
 
-# --- dev broker start/stop/status/restart (spec §4.2) ---------------------------------------------------
+# --- dev mesh start (foreground by default; -d detaches) ------------------------------------------------
 
 
-def test_broker_start_ensures_and_reports(ensure_calls: list[dict[str, Any]]) -> None:
-    result = _invoke(["dev", "broker", "start"])
+class _RecordingPopen:
+    """A stand-in for the attached broker the foreground ``mesh start`` blocks on: records each
+    ``wait`` and can interrupt the first to model a Ctrl-C."""
+
+    def __init__(self, returncode: int = 0, wait_raises: BaseException | None = None) -> None:
+        self.pid = 5555
+        self.returncode = returncode
+        self._wait_raises = wait_raises
+        self.waits = 0
+
+    def wait(self, timeout: float | None = None) -> int:
+        self.waits += 1
+        if self._wait_raises is not None and self.waits == 1:
+            raise self._wait_raises
+        return self.returncode
+
+
+def test_mesh_start_runs_in_the_foreground_and_waits(monkeypatch: pytest.MonkeyPatch, ensure_calls: list[dict[str, Any]]) -> None:
+    proc = _RecordingPopen(returncode=0)
+    seen: dict[str, Any] = {}
+
+    def fake_foreground(target: Any, *, resolve_bin: Any, timeout: float) -> _RecordingPopen:
+        seen["target"] = target
+        return proc
+
+    monkeypatch.setattr(dev_broker, "spawn_foreground", fake_foreground)
+    result = _invoke(["dev", "mesh", "start"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert proc.waits == 1, "the command blocks on the attached broker"
+    assert ensure_calls == [], "the foreground path never goes through the detached ensure"
+    assert seen["target"].key == _KEY
+    assert "listening" in _plain(result.stdout).lower()
+
+
+def test_mesh_start_foreground_already_running_exits_2(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(target: Any, *, resolve_bin: Any, timeout: float) -> Any:
+        raise DevBrokerError(
+            "a broker is already running at 127.0.0.1:9092 — stop it with `ck dev mesh stop`, or start a detached daemon with `ck dev mesh start -d`."
+        )
+
+    monkeypatch.setattr(dev_broker, "spawn_foreground", boom)
+    result = _invoke(["dev", "mesh", "start"])
+    assert result.exit_code == 2
+    assert "already running" in _plain(result.stderr)
+
+
+def test_mesh_start_foreground_ctrl_c_stops_cleanly(monkeypatch: pytest.MonkeyPatch) -> None:
+    proc = _RecordingPopen(returncode=0, wait_raises=KeyboardInterrupt())
+    monkeypatch.setattr(dev_broker, "spawn_foreground", lambda *a, **k: proc)
+    result = _invoke(["dev", "mesh", "start"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert proc.waits == 2, "Ctrl-C interrupts the first wait; the second reaps the clean shutdown"
+    assert "stopped" in _plain(result.stdout).lower()
+
+
+def test_mesh_start_detach_ensures_and_reports(ensure_calls: list[dict[str, Any]]) -> None:
+    result = _invoke(["dev", "mesh", "start", "-d"])
     assert result.exit_code == 0, result.stdout + str(result.exception)
     assert len(ensure_calls) == 1
     assert "managed broker" in _plain(result.stdout)
 
 
-def test_broker_start_failure_exits_2(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_mesh_start_detach_failure_exits_2(monkeypatch: pytest.MonkeyPatch) -> None:
     def boom(target: Any, *, resolve_bin: Any, timeout: float) -> BrokerInfo:
         raise DevBrokerError("no binary")
 
     monkeypatch.setattr(dev_broker, "ensure_broker", boom)
-    assert _invoke(["dev", "broker", "start"]).exit_code == 2
+    assert _invoke(["dev", "mesh", "start", "-d"]).exit_code == 2
 
 
 def test_broker_stop_reports_a_stop(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -286,7 +341,7 @@ def test_broker_stop_reports_a_stop(monkeypatch: pytest.MonkeyPatch) -> None:
         return True
 
     monkeypatch.setattr(dev_broker, "stop", fake_stop)
-    result = _invoke(["dev", "broker", "stop", "--host", "127.0.0.1:19092"])
+    result = _invoke(["dev", "mesh", "stop", "--host", "127.0.0.1:19092"])
     assert result.exit_code == 0, result.stdout + str(result.exception)
     assert stopped == ["127.0.0.1:19092"]
     assert "stopped" in _plain(result.stdout).lower()
@@ -294,7 +349,7 @@ def test_broker_stop_reports_a_stop(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_broker_stop_noop_reports_nothing_managed(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(dev_broker, "stop", lambda target, *, grace=5.0: False)
-    result = _invoke(["dev", "broker", "stop"])
+    result = _invoke(["dev", "mesh", "stop"])
     assert result.exit_code == 0, result.stdout + str(result.exception)
     assert "no managed broker" in _plain(result.stdout).lower()
 
@@ -303,7 +358,7 @@ def test_broker_stop_all_stops_everything(monkeypatch: pytest.MonkeyPatch) -> No
     calls: list[str] = []
     monkeypatch.setattr(dev_broker, "stop_all", lambda *, grace=5.0: calls.append("all") or ["a:1", "b:2"])
     monkeypatch.setattr(dev_broker, "stop", lambda *a, **kw: pytest.fail("stop --all must call stop_all, not stop"))
-    result = _invoke(["dev", "broker", "stop", "--all"])
+    result = _invoke(["dev", "mesh", "stop", "--all"])
     assert result.exit_code == 0, result.stdout + str(result.exception)
     assert calls == ["all"]
     out = _plain(result.stdout)
@@ -313,7 +368,7 @@ def test_broker_stop_all_stops_everything(monkeypatch: pytest.MonkeyPatch) -> No
 
 def test_broker_stop_all_with_nothing_to_stop(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(dev_broker, "stop_all", lambda *, grace=5.0: [])
-    result = _invoke(["dev", "broker", "stop", "--all"])
+    result = _invoke(["dev", "mesh", "stop", "--all"])
     assert result.exit_code == 0, result.stdout + str(result.exception)
     assert "no managed brokers" in _plain(result.stdout).lower()
 
@@ -324,7 +379,7 @@ def test_broker_stop_without_mesh_extra_exits_2(monkeypatch: pytest.MonkeyPatch)
         raise DevBrokerError("needs the `calfkit[mesh]` extra")
 
     monkeypatch.setattr(dev_broker, "stop", boom)
-    result = _invoke(["dev", "broker", "stop"])
+    result = _invoke(["dev", "mesh", "stop"])
     assert result.exit_code == 2
     assert "calfkit[mesh]" in _plain(result.stdout) + _plain(result.output)
 
@@ -334,7 +389,7 @@ def test_broker_status_without_mesh_extra_exits_2(monkeypatch: pytest.MonkeyPatc
         raise DevBrokerError("needs the `calfkit[mesh]` extra")
 
     monkeypatch.setattr(dev_broker, "status", boom)
-    assert _invoke(["dev", "broker", "status"]).exit_code == 2
+    assert _invoke(["dev", "mesh", "status"]).exit_code == 2
 
 
 def test_broker_status_reports_managed_and_reachable(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -344,7 +399,7 @@ def test_broker_status_reports_managed_and_reachable(monkeypatch: pytest.MonkeyP
         brokers=(_info(),),
     )
     monkeypatch.setattr(dev_broker, "status", lambda target, *, timeout=5.0: report)
-    out = _plain(_invoke(["dev", "broker", "status"]).stdout)
+    out = _plain(_invoke(["dev", "mesh", "status"]).stdout)
     assert _KEY in out
     assert "4242" in out
     assert "running" in out.lower()
@@ -353,7 +408,7 @@ def test_broker_status_reports_managed_and_reachable(monkeypatch: pytest.MonkeyP
 def test_broker_status_reports_reachable_not_managed(monkeypatch: pytest.MonkeyPatch) -> None:
     report = MeshStatus(target_key=_KEY, reachable=True, brokers=())
     monkeypatch.setattr(dev_broker, "status", lambda target, *, timeout=5.0: report)
-    out = _plain(_invoke(["dev", "broker", "status"]).stdout)
+    out = _plain(_invoke(["dev", "mesh", "status"]).stdout)
     assert "reachable" in out.lower()
     assert "not managed by calfkit" in out.lower()
 
@@ -361,7 +416,7 @@ def test_broker_status_reports_reachable_not_managed(monkeypatch: pytest.MonkeyP
 def test_broker_status_reports_nothing_reachable(monkeypatch: pytest.MonkeyPatch) -> None:
     report = MeshStatus(target_key=_KEY, reachable=False, brokers=())
     monkeypatch.setattr(dev_broker, "status", lambda target, *, timeout=5.0: report)
-    out = _plain(_invoke(["dev", "broker", "status"]).stdout)
+    out = _plain(_invoke(["dev", "mesh", "status"]).stdout)
     assert "no broker" in out.lower()
 
 
@@ -373,7 +428,7 @@ def test_broker_restart_reports_the_new_broker(monkeypatch: pytest.MonkeyPatch) 
         return _info()
 
     monkeypatch.setattr(dev_broker, "restart", fake_restart)
-    result = _invoke(["dev", "broker", "restart"])
+    result = _invoke(["dev", "mesh", "restart"])
     assert result.exit_code == 0, result.stdout + str(result.exception)
     assert calls == [_KEY]
     assert "managed broker" in _plain(result.stdout)
@@ -384,7 +439,7 @@ def test_broker_restart_failure_exits_2(monkeypatch: pytest.MonkeyPatch) -> None
         raise DevBrokerError("no binary")
 
     monkeypatch.setattr(dev_broker, "restart", boom)
-    assert _invoke(["dev", "broker", "restart"]).exit_code == 2
+    assert _invoke(["dev", "mesh", "restart"]).exit_code == 2
 
 
 # --- the resolve_bin thunk ------------------------------------------------------------------------------
@@ -1256,8 +1311,8 @@ def test_broker_commands_load_dotenv_before_resolving(monkeypatch: pytest.Monkey
     monkeypatch.setattr(dev_cli, "_load_env", lambda env_file: loaded.append(env_file))
     monkeypatch.setattr(dev_broker, "status", lambda target, *, timeout=5.0: MeshStatus(target.key, False, ()))
     monkeypatch.setattr(dev_broker, "stop", lambda target, *, grace=5.0: False)
-    _invoke(["dev", "broker", "status"])
-    _invoke(["dev", "broker", "stop"])
+    _invoke(["dev", "mesh", "status"])
+    _invoke(["dev", "mesh", "stop"])
     assert loaded == [None, None]
 
 
@@ -1265,7 +1320,7 @@ def test_broker_commands_forward_an_explicit_env_file(monkeypatch: pytest.Monkey
     loaded: list[str | None] = []
     monkeypatch.setattr(dev_cli, "_load_env", lambda env_file: loaded.append(env_file))
     monkeypatch.setattr(dev_broker, "status", lambda target, *, timeout=5.0: MeshStatus(target.key, False, ()))
-    result = _invoke(["dev", "broker", "status", "--env-file", "custom.env"])
+    result = _invoke(["dev", "mesh", "status", "--env-file", "custom.env"])
     assert result.exit_code == 0, result.stdout + str(result.exception)
     assert loaded == ["custom.env"]
 
@@ -1279,7 +1334,7 @@ def test_broker_status_multi_target_with_all_elements_managed(monkeypatch: pytes
         brokers=(_info(), _info(listener="127.0.0.1:19092", pid=4343)),
     )
     monkeypatch.setattr(dev_broker, "status", lambda target, *, timeout=5.0: report)
-    out = _plain(_invoke(["dev", "broker", "status", "--host", "127.0.0.1:9092,127.0.0.1:19092"]).stdout)
+    out = _plain(_invoke(["dev", "mesh", "status", "--host", "127.0.0.1:9092,127.0.0.1:19092"]).stdout)
     assert "not managed" not in out
     assert "pid 4242" in out
     assert "pid 4343" in out

--- a/tests/test_dev_cli.py
+++ b/tests/test_dev_cli.py
@@ -318,7 +318,39 @@ def test_mesh_start_foreground_ctrl_c_stops_cleanly(monkeypatch: pytest.MonkeyPa
     assert "stopped" in _plain(result.stdout).lower()
 
 
-def test_mesh_start_detach_ensures_and_reports(ensure_calls: list[dict[str, Any]]) -> None:
+def test_mesh_start_foreground_reports_a_nonzero_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    proc = _RecordingPopen(returncode=1)
+    monkeypatch.setattr(dev_broker, "spawn_foreground", lambda *a, **k: proc)
+    result = _invoke(["dev", "mesh", "start"])
+    assert result.exit_code == 1
+    assert "exited with code 1" in _plain(result.stderr)
+
+
+def test_mesh_start_foreground_signal_death_maps_to_exit_1(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A broker killed by a signal reports returncode -N; typer.Exit needs a valid 0-255 code, so the
+    # negative is mapped to 1 while the signal number stays visible in the message.
+    proc = _RecordingPopen(returncode=-9)
+    monkeypatch.setattr(dev_broker, "spawn_foreground", lambda *a, **k: proc)
+    result = _invoke(["dev", "mesh", "start"])
+    assert result.exit_code == 1
+    assert "exited with code -9" in _plain(result.stderr)
+
+
+def test_mesh_start_foreground_forwards_the_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, Any] = {}
+
+    def fake_foreground(target: Any, *, resolve_bin: Any, timeout: float) -> _RecordingPopen:
+        seen["target"] = target
+        return _RecordingPopen(returncode=0)
+
+    monkeypatch.setattr(dev_broker, "spawn_foreground", fake_foreground)
+    result = _invoke(["dev", "mesh", "start", "--host", "127.0.0.1:19092"])
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert seen["target"].key == "127.0.0.1:19092"
+
+
+def test_mesh_start_detach_ensures_and_reports(ensure_calls: list[dict[str, Any]], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dev_broker, "spawn_foreground", lambda *a, **k: pytest.fail("-d must not take the foreground path"))
     result = _invoke(["dev", "mesh", "start", "-d"])
     assert result.exit_code == 0, result.stdout + str(result.exception)
     assert len(ensure_calls) == 1


### PR DESCRIPTION
## What & why

Two related changes to the local dev-mesh CLI:

1. **`ck dev broker` → `ck dev mesh`.** The command group is renamed to calfkit's own abstraction. The commands manage an ephemeral, loopback-only, in-memory (`memory://`) broker recognized purely by its process signature — they're intrinsically "dev mesh" operations, so the noun rises to `mesh`. Internals stay named `broker` (the concrete tansu daemon).
2. **`ck dev mesh start` runs in the foreground by default.** Previously `start` connect-or-spawned a **detached** daemon and returned. Now it runs the broker **attached** to your terminal (output streams live, Ctrl-C stops it). `-d`/`--detach` preserves the prior detached-and-return behavior.

## Surface

```
ck dev mesh start          # foreground (default): blocks, Ctrl-C stops it
ck dev mesh start -d        # detached daemon, returns immediately (old default)
ck dev mesh stop|status|restart
```

- Foreground errors `exit 2` if a broker is already running there (it can't attach to a detached daemon — stop it or use `-d`), and refuses non-loopback addresses (connect-only, unchanged).
- `-d` is the exact prior `ensure_broker` path — idempotent connect-or-spawn. `ck dev run`/`ck dev chat`'s auto-spawn is untouched.

## Implementation notes

- New `spawn_foreground()` in `_dev_broker.py`: attached `Popen` (no `start_new_session`, inherits the terminal), holding the same §5.3 spawn-lock through probe→spawn→readiness and releasing it before the CLI blocks on `proc.wait()`.
- Extracted the tansu argv (`_broker_cmd`) and readiness wait (`_await_ready`) so the foreground and detached spawns are byte-identical — the §5.4 ownership scan recognizes a foreground broker too, so `status`/`stop` from another terminal still work.
- Runtime diagnostic prose stays "broker" (e.g. "managed broker at X (pid N)") to match the internals and avoid rippling shared output into `dev run`/`dev chat`.

## Tests (TDD)

- 6 new `spawn_foreground` unit tests (attached spawn / already-running / non-loopback / readiness-timeout-kills / startup-exit / lock discipline).
- 5 new CLI tests (foreground blocks+reports, already-running→exit 2, Ctrl-C→clean exit 0, `-d` detaches, `-d` failure→exit 2).
- Full offline suite: **4174 passed**. `make fix` + `make check` clean. Docs updated (`docs/cli.md`, `docs/local-dev-mesh.md`).

## BREAKING CHANGE

`ck dev broker …` is now `ck dev mesh …`, and `ck dev mesh start` blocks in the foreground instead of returning. Use `ck dev mesh start -d` for the old detached behavior.
