### PR TITLE
feat: remove `sequential_only_mode` from Agents

### DIFF
--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -114,7 +114,6 @@ class BaseAgentNodeDef(
         tools: Sequence[ToolProvider | ToolBinding | ToolSelector] | None = None,
         model_client: PydanticModelClient,
         final_output_type: OutputSpec[AgentOutputT] = str,  # type: ignore[assignment]
-        sequential_only_mode: bool = False,
         model_settings: ModelSettings | dict[str, Any] | None = None,
         peers: Sequence[Messaging | Handoff] | None = None,
     ):
@@ -127,13 +126,10 @@ class BaseAgentNodeDef(
         self._tool_selectors: list[ToolSelector] = []
         self._eager_tool_nodes: list[BaseToolNodeDef] = []
         self._add_tools(tools)  # enforce the tool-surface contract, then commit (raises before agent-loop build)
-        self.sequential_only_mode = sequential_only_mode
         # peers= (ADR-0015/0019): capability handles for agent-to-agent reach (Messaging — consult; Handoff
-        # — transfer control), validated + stored BEFORE the fan-out store @resource gate below (decision
-        # 1(b): `_needs_durable_batch` reads `self._messaging_handles`, so a `sequential_only_mode` messaging
-        # agent gets the store for its lone `message_agent`; a Handoff-only agent needs none). The own-name
-        # reject lives here — a handle can't see the enclosing agent's name (M2); `peers=` type-validates
-        # each element is a `Messaging`/`Handoff` handle (M4: no cross-absorption with `tools=`).
+        # — transfer control). The own-name reject lives here — a handle can't see the enclosing agent's
+        # name (M2); `peers=` type-validates each element is a `Messaging`/`Handoff` handle (M4: no
+        # cross-absorption with `tools=`).
         peer_handles = tuple(peers or ())
         for peer in peer_handles:
             if not isinstance(peer, (Messaging, Handoff)):
@@ -207,15 +203,15 @@ class BaseAgentNodeDef(
             model_settings=cast(ModelSettings | None, model_settings),
         )
 
-        if self._needs_durable_batch:
-            # An agent that needs the durable batch machinery owns its store as a node @resource (opened
-            # by the worker lifecycle before serving; mirrors the worker's Capability View resource).
-            # `_needs_durable_batch` (decision 1(b)) is true for a true fan-out agent OR a messaging agent
-            # (a `peers` handle) — so a `sequential_only_mode` messaging agent still gets the store for its
-            # lone `message_agent`'s degenerate batch, while its tool routing stays one-at-a-time. The
-            # @resource never runs under the synchronous TestKafkaBroker — offline, the test harness
-            # injects a fake into the bag instead (tests/providers.py::prepare_worker).
-            self.resource(name=FANOUT_STORE_KEY)(self._fanout_store_resource)
+        # Every agent owns its durable fan-out store as a node @resource (opened by the worker
+        # lifecycle before serving; mirrors the worker's Capability View resource). Registration is
+        # unconditional: no agent is statically fan-out-free — callers can inject override tools over
+        # the wire and `Tools` selectors resolve at runtime. The @resource never runs under the
+        # synchronous TestKafkaBroker — offline, the autouse `_offline_fanout_store` fixture
+        # (tests/conftest.py) swaps in `OfflineFanoutBatchStore` for the whole non-kafka lane, and
+        # tests/providers.py::prepare_worker injects a fake into the resource bag for handler-driven
+        # tests.
+        self.resource(name=FANOUT_STORE_KEY)(self._fanout_store_resource)
 
     @staticmethod
     def _compose_instructions(name: str, system_prompt: str) -> str:
@@ -277,9 +273,8 @@ class BaseAgentNodeDef(
 
     @property
     def _is_fanout_capable(self) -> bool:
-        """A non-sequential agent folds durable fan-out batches in-node; a
-        ``sequential_only_mode`` agent issues only single calls and never fans out."""
-        return not self.sequential_only_mode
+        """An agent folds durable fan-out batches in-node."""
+        return True
 
     @property
     def _seam_output_type(self) -> Any:
@@ -678,43 +673,13 @@ class BaseAgentNodeDef(
 
         if len(latest_tool_calls) > 0:
             if not ctx.state.all_call_ids_complete(*[tc.tool_call_id for tc in latest_tool_calls]):
-                if self.sequential_only_mode:
-                    target_tool_call = next(tc for tc in latest_tool_calls if tc.tool_call_id not in ctx.state.tool_results)
-                    # Defensive fork (handoff spec §3.0-gated, spec §10): a handoff call is finalized in the
-                    # delivery that produced it (winner → closing request; rejection → tool_results), so a
-                    # PENDING one arriving from outside the function means corrupt/replayed state — raise
-                    # loudly rather than skip (or mis-dispatch it to the registry lookup below).
-                    if self._handoff_handles and target_tool_call.tool_name == HANDOFF_TOOL:
-                        raise RuntimeError(
-                            f"[{ctx.correlation_id[:8]}] pending handoff call reached the sequential re-entry arm — "
-                            f"impossible by construction; state is corrupt. node={self.name} "
-                            f"tool_call_id={target_tool_call.tool_call_id}"
-                        )
-                    logger.debug(
-                        "[%s] routing pending tool call=%s tool=%s node=%s",
-                        ctx.correlation_id[:8],
-                        target_tool_call.tool_call_id,
-                        target_tool_call.tool_name,
-                        self.name,
-                    )
-                    if target_tool_call.tool_name == _MESSAGE_AGENT_TOOL:
-                        return self._message_agent_call(target_tool_call)
-                    return Call[State](
-                        tools_registry[target_tool_call.tool_name].dispatch_topic,
-                        ctx.state,
-                        body=ToolCallRef.from_tool_call_part(target_tool_call),
-                        # tag=tool_call_id so the tool's reply is self-describing (§4.2): the framework
-                        # echoes it on reply.tag and the agent materializes the result at that slot.
-                        tag=target_tool_call.tool_call_id,
-                    )
-                else:
-                    remaining = [tc for tc in latest_tool_calls if tc.tool_call_id not in ctx.state.tool_results]
-                    raise RuntimeError(
-                        f"[{ctx.correlation_id[:8]}] Parallel mode reached incomplete tool calls in run(). "
-                        f"node={self.name} frame_id={ctx.frame_id} remaining_ids={[tc.tool_call_id for tc in remaining]}. "
-                        f"The durable in-node fold should re-enter run() only on a complete batch — this indicates "
-                        f"the fan-out did not fully fold before re-entry (e.g. a lost batch from rebalance/restart)."
-                    )
+                remaining = [tc for tc in latest_tool_calls if tc.tool_call_id not in ctx.state.tool_results]
+                raise RuntimeError(
+                    f"[{ctx.correlation_id[:8]}] Reached incomplete tool calls in run(). "
+                    f"node={self.name} frame_id={ctx.frame_id} remaining_ids={[tc.tool_call_id for tc in remaining]}. "
+                    f"The durable in-node fold should re-enter run() only on a complete batch — this indicates "
+                    f"the fan-out did not fully fold before re-entry (e.g. a lost batch from rebalance/restart)."
+                )
 
             tool_results = DeferredToolResults(calls={tc.tool_call_id: ctx.state.get_tool_result(tc.tool_call_id) for tc in latest_tool_calls})
 
@@ -905,7 +870,7 @@ class BaseAgentNodeDef(
 
             pending_tool_calls = [tc for tc in latest_tool_calls if tc.tool_call_id not in ctx.state.tool_results]
 
-            if self.sequential_only_mode or len(pending_tool_calls) == 1:
+            if len(pending_tool_calls) == 1:
                 target_tool_call = pending_tool_calls[0]
                 logger.debug(
                     "[%s] routing new tool call=%s tool=%s node=%s",

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -206,11 +206,11 @@ class BaseAgentNodeDef(
         # Every agent owns its durable fan-out store as a node @resource (opened by the worker
         # lifecycle before serving; mirrors the worker's Capability View resource). Registration is
         # unconditional: no agent is statically fan-out-free — callers can inject override tools over
-        # the wire and `Tools` selectors resolve at runtime. The @resource never runs under the
-        # synchronous TestKafkaBroker — offline, the autouse `_offline_fanout_store` fixture
-        # (tests/conftest.py) swaps in `OfflineFanoutBatchStore` for the whole non-kafka lane, and
-        # tests/providers.py::prepare_worker injects a fake into the resource bag for handler-driven
-        # tests.
+        # the wire and `Tools` selectors resolve at runtime. Offline the @resource must not dial a
+        # real cluster: the autouse `_offline_fanout_store` fixture (tests/conftest.py) swaps
+        # `KtablesFanoutBatchStore` → `OfflineFanoutBatchStore` for every non-kafka `worker.start()`;
+        # handler-driven tests never start the worker (the @resource never runs), so
+        # tests/providers.py::prepare_worker injects a fake into the resource bag instead.
         self.resource(name=FANOUT_STORE_KEY)(self._fanout_store_resource)
 
     @staticmethod
@@ -676,9 +676,11 @@ class BaseAgentNodeDef(
                 remaining = [tc for tc in latest_tool_calls if tc.tool_call_id not in ctx.state.tool_results]
                 raise RuntimeError(
                     f"[{ctx.correlation_id[:8]}] Reached incomplete tool calls in run(). "
-                    f"node={self.name} frame_id={ctx.frame_id} remaining_ids={[tc.tool_call_id for tc in remaining]}. "
-                    f"The durable in-node fold should re-enter run() only on a complete batch — this indicates "
-                    f"the fan-out did not fully fold before re-entry (e.g. a lost batch from rebalance/restart)."
+                    f"node={self.name} frame_id={ctx.frame_id} "
+                    f"remaining={[(tc.tool_call_id, tc.tool_name) for tc in remaining]}. "
+                    f"run() must only re-enter with every latest tool call resolved — this indicates "
+                    f"corrupt or half-folded state (e.g. a lost fan-out batch from rebalance/restart, "
+                    f"or a replayed/hand-built State carrying an unresolved call)."
                 )
 
             tool_results = DeferredToolResults(calls={tc.tool_call_id: ctx.state.get_tool_result(tc.tool_call_id) for tc in latest_tool_calls})
@@ -728,7 +730,7 @@ class BaseAgentNodeDef(
             # + a ToolCallStep per requested call (raw model emission; covers message_agent + valid +
             # invalid) + an is_error ToolResultStep for each call this hop rejects (the arms below, via
             # _reject_invalid_call). Read at the chokepoint via project_steps; committed to ctx._step_draft
-            # after the loop. A pre-model re-dispatch hop never reaches here, so its draft stays None ⇒ no step.
+            # after the loop. A hop that never reaches this dispatch loop (e.g. a final-output turn) leaves its draft None ⇒ no step.
             #
             # Authoring runs OUTSIDE the chokepoint's best-effort wrap (spec §2.9), so a raise here would
             # FAULT the run — the one thing a step must never do. It is total by construction: step_preamble
@@ -941,7 +943,7 @@ class BaseAgentNodeDef(
         ``ToolResultStep`` keyed by the frame ``tag`` (``name`` = this peer's ``node_id``; it pairs by
         ``tool_call_id``, not name). ``is_error`` is derived once here, coerce-first. Otherwise
         (``Call`` / ``list[Call]`` / ``TailCall``) the agent's authored ``_step_draft`` is the
-        projection — ``None`` on a pre-model re-dispatch hop ⇒ ``[]`` (the double-emit guard)."""
+        projection — ``None`` on a hop that authored no draft (e.g. a final-output turn) ⇒ ``[]``."""
         if isinstance(output, ReturnCall) and frame is not None and frame.tag is not None:
             parts = _coerce_to_parts(output.value)
             return [ToolResultStep(tool_call_id=frame.tag, name=self.node_id, parts=parts, is_error=is_retry(parts))]

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -901,8 +901,9 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin, AdvertRegis
     @property
     def _is_fanout_capable(self) -> bool:
         """Whether this node folds durable fan-out batches in-node. ``False`` for every
-        node kind except an agent (which overrides this) — it gates the staged handler's
-        fan-out recognition and the OPEN dispatch path."""
+        node kind except an agent (which overrides this) — the fan-out disjunct of
+        :attr:`_needs_durable_batch`, which gates the staged handler's fan-out recognition
+        and the OPEN dispatch path."""
         return False
 
     @property
@@ -911,7 +912,8 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin, AdvertRegis
 
         True iff the node can parallel fan out (:attr:`_is_fanout_capable`) **or** it can dispatch an
         ``isolate_state`` call — i.e. it carries a ``Messaging`` handle (set by ``Agent(peers=[Messaging…])``).
-        For every agent both disjuncts collapse to ``True`` (an agent is always fan-out capable); the
+        For every agent the disjunction collapses to ``True`` via the first disjunct (an agent is always
+        fan-out capable); the
         decoupling from :attr:`_is_fanout_capable` is retained deliberately as future-proofing for a
         non-agent node kind that carries Messaging handles and would need the snapshot machinery for its
         ``isolate_state`` dispatches without folding parallel batches. Gates ``_classify_fanout`` and the

--- a/calfkit/nodes/base.py
+++ b/calfkit/nodes/base.py
@@ -901,8 +901,8 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin, AdvertRegis
     @property
     def _is_fanout_capable(self) -> bool:
         """Whether this node folds durable fan-out batches in-node. ``False`` for every
-        node type except a non-sequential agent (which overrides this) — it gates the
-        staged handler's fan-out recognition and the OPEN dispatch path."""
+        node kind except an agent (which overrides this) — it gates the staged handler's
+        fan-out recognition and the OPEN dispatch path."""
         return False
 
     @property
@@ -911,13 +911,11 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin, AdvertRegis
 
         True iff the node can parallel fan out (:attr:`_is_fanout_capable`) **or** it can dispatch an
         ``isolate_state`` call — i.e. it carries a ``Messaging`` handle (set by ``Agent(peers=[Messaging…])``).
-        This decouples "needs the snapshot machinery" from "does parallel fan-out", so a
-        ``sequential_only_mode`` messaging agent still snapshots/restores the caller's state for a lone
-        ``message_agent`` (a degenerate one-element batch) while keeping its tool routing one-at-a-time. A
-        ``Handoff``-only agent needs NO durable batch — a winning handoff is a ``TailCall`` disposition, never a
-        ``Call``, so it never opens one (keyed on ``_messaging_handles``, not any ``peers`` handle). For
-        non-agent nodes (no ``_messaging_handles``) it equals :attr:`_is_fanout_capable`. Gates the store
-        ``@resource``, ``_classify_fanout``, and the OPEN trigger."""
+        For every agent both disjuncts collapse to ``True`` (an agent is always fan-out capable); the
+        decoupling from :attr:`_is_fanout_capable` is retained deliberately as future-proofing for a
+        non-agent node kind that carries Messaging handles and would need the snapshot machinery for its
+        ``isolate_state`` dispatches without folding parallel batches. Gates ``_classify_fanout`` and the
+        OPEN trigger."""
         return self._is_fanout_capable or bool(getattr(self, "_messaging_handles", None))
 
     def _resolve_fanout_store(self, ctx: SessionRunContext) -> FanoutBatchStore:
@@ -1200,8 +1198,8 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin, AdvertRegis
         marker rides the node's OWN frame (``fanout_id`` set), so it is the top frame when
         a fan-out continuation re-enters; the reply slot's ``in_reply_to`` then tells a
         sibling callee (≠ the frame id) from the re-entry (== it). Gated on
-        ``_needs_durable_batch`` (decision 1(b)) so a sequential messaging agent's
-        degenerate-batch continuations classify + fold, not just a parallel-fan-out agent's."""
+        ``_needs_durable_batch`` (decision 1(b)) so any degenerate one-element batch's
+        continuations classify + fold, not just a true parallel fan-out's."""
         if not self._needs_durable_batch:
             return None
         frame = envelope.internal_workflow_state.current_frame_or_none
@@ -1852,8 +1850,8 @@ class BaseNodeDef(BaseNodeSchema, LifecycleHookMixin, RegistryMixin, AdvertRegis
         # history). A bare Call is normalized to a one-element list first so a flagged bare Call cannot
         # slip through to _publish_action's bare-Call fast path (which would skip the snapshot, C1). An
         # *unflagged* single Call / 1-element list stays a stateless continuation and reroutes to the
-        # plain publish in _publish_action below. Gated on `_needs_durable_batch` (not `_is_fanout_capable`),
-        # so a `sequential_only_mode` messaging agent also opens the degenerate batch for its lone peer message.
+        # plain publish in _publish_action below. Gated on `_needs_durable_batch` (the retained 1(b)
+        # decoupling — see its docstring), so a lone `message_agent` opens its degenerate batch here.
         fanout_calls = [output] if isinstance(output, Call) else output
         if (
             self._needs_durable_batch

--- a/docs/api.md
+++ b/docs/api.md
@@ -218,7 +218,6 @@ Agent(
     tools: Sequence[...] | None = None,
     model_client: PydanticModelClient,
     final_output_type: type = str,
-    sequential_only_mode: bool = False,
     model_settings: ModelSettings | dict | None = None,
     peers: Sequence[Messaging | Handoff] | None = None,
 )

--- a/docs/topic-provisioning.md
+++ b/docs/topic-provisioning.md
@@ -102,6 +102,14 @@ references. For each node:
 missing. Agent nodes are detected *structurally* (they expose a `tools`
 collection) so `calfkit.provisioning` stays decoupled from `calfkit.nodes`.
 
+**Not included: the per-agent durable fan-out topics.** Every agent owns two
+compacted topics — `calf.fanout.<name>.state` and `calf.fanout.<name>.basestate` —
+provisioned by the agent's own fan-out store at worker startup (the store's
+ktables readers create them with `ensure_topic=True`). They are part of every
+agent's operational footprint (unconditional — no agent opts out) but are
+self-provisioned by the store rather than computed here; on clusters where the
+worker principal lacks topic-creation rights, create them ahead of deployment.
+
 ### 3.3 `ProvisionReport`
 
 Returned by a successful provisioning pass; the basis for logging / the CLI

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,12 +67,6 @@ def container():
     c.close()
 
 
-@pytest.fixture(params=["parallel", "sequential"])
-def agent_constructor_args_sequential_modes(request) -> dict[str, bool]:
-    mode: str = request.param
-    return {"sequential_only_mode": mode == "sequential"}
-
-
 @pytest.fixture(params=["openai_responses", "openai_chat"])
 def agent_constructor_args_model_client(request) -> dict[str, Any]:
     model_type: str = request.param
@@ -101,7 +95,7 @@ def deploy_agent(agent_constructor_args_model_client, container) -> SimpleAgent:
 
 
 @pytest.fixture
-def deploy_function_agent(agent_constructor_args_sequential_modes, container) -> Agent:
+def deploy_function_agent(container) -> Agent:
     worker = container.get(Worker)
     model = container.get(FunctionModel)
     agent = Agent(
@@ -110,9 +104,7 @@ def deploy_function_agent(agent_constructor_args_sequential_modes, container) ->
         subscribe_topics="test_function_agent.input",
         publish_topic="test_function_agent.output",
         model_client=model,
-        **agent_constructor_args_sequential_modes,
     )
-    print(f"\nDeployed agent with sequential_only_mode={agent_constructor_args_sequential_modes}")
     worker.add_nodes(agent)
     return agent
 

--- a/tests/integration/test_decode_floor_kafka.py
+++ b/tests/integration/test_decode_floor_kafka.py
@@ -48,7 +48,6 @@ async def test_undecodable_body_floored_and_worker_survives(kafka_bootstrap: str
         subscribe_topics=agent_in,
         model_client=scripted_model([ToolCallPart("ok_a", {}, tool_call_id="c1")]),
         tools=[ok_a],
-        sequential_only_mode=True,
     )
     await ensure_topic(kafka_bootstrap, agent_in)
     driver = Client.connect(kafka_bootstrap)

--- a/tests/integration/test_durable_fanout_agent_kafka.py
+++ b/tests/integration/test_durable_fanout_agent_kafka.py
@@ -15,7 +15,7 @@ that only exists under a real lifecycle against a live broker:
 * the durable fold + the self-published re-entry close the batch over the wire,
   so the agent resumes to a final result.
 
-Crucially this test injects **no** store: the agent is a plain non-sequential
+Crucially this test injects **no** store: the agent is a plain
 :class:`~calfkit.nodes.Agent`, which auto-registers its ``@resource`` in
 ``__init__``; the worker's resource phase opens the real ktables-backed store
 before serving. An offline ``FunctionModel`` removes any LLM dependency — only
@@ -120,7 +120,7 @@ async def test_fanout_agent_opens_real_store_and_resumes_over_the_wire(kafka_boo
         tools=[fanout_tool_a, fanout_tool_b],
     )
 
-    # A non-sequential agent auto-registers its durable-store @resource in
+    # An agent auto-registers its durable-store @resource in
     # __init__; the worker lifecycle opens the REAL KtablesFanoutBatchStore.
     # Guard the premise of this test: nothing pre-seeds the bag (the offline
     # fake-injection pattern must NOT be in play here).

--- a/tests/integration/test_exception_harvest_kafka.py
+++ b/tests/integration/test_exception_harvest_kafka.py
@@ -38,7 +38,6 @@ def _agent(node_id: str, *, agent_in: str, agent_pub: str, call: ToolCallPart) -
         publish_topic=agent_pub,
         model_client=scripted_model([call]),
         tools=[ctx_overflow],
-        sequential_only_mode=True,
     )
 
 

--- a/tests/integration/test_fanout_faults_kafka.py
+++ b/tests/integration/test_fanout_faults_kafka.py
@@ -1,6 +1,6 @@
 """Suite X — fan-out fault paths over the real durable store.
 
-A fan-out-capable agent (no ``sequential_only_mode``) opens a real
+A fan-out agent opens a real
 ``KtablesFanoutBatchStore`` and folds N sibling replies; these tests drive faulting
 siblings through that durable fold over the wire (offline-only today):
 

--- a/tests/integration/test_fanout_faults_kafka.py
+++ b/tests/integration/test_fanout_faults_kafka.py
@@ -1,7 +1,7 @@
 """Suite X — fan-out fault paths over the real durable store.
 
-A fan-out agent opens a real
-``KtablesFanoutBatchStore`` and folds N sibling replies; these tests drive faulting
+A fan-out agent opens a real ``KtablesFanoutBatchStore`` and folds N sibling
+replies; these tests drive faulting
 siblings through that durable fold over the wire (offline-only today):
 
 * **X-1** — one unhandled sibling fault → at closure the batch fails with a *flattened*

--- a/tests/integration/test_fault_escalation_kafka.py
+++ b/tests/integration/test_fault_escalation_kafka.py
@@ -13,9 +13,10 @@ channels:
 * **Channel C** — the client edge: a routed fault is received as a typed ``NodeFaultError``
   (#250 reception), so ``await handle.result()`` raises it carrying the verbatim ``ErrorReport``.
 
-Every case dispatches a single tool call,
-so the fault path is identical to a fan-out-capable agent's, and the durable fan-out
-store (a separate ktables dependency, covered by Suite X) stays out of the way.
+Every case dispatches a single tool call, so no durable fan-out batch is ever opened
+(the single-call plain-``Call`` path). The store @resource still opens at worker startup —
+unconditional for every agent — but the fault path never touches it; batch-fold fault
+coverage lives in Suite X.
 
 Opt-in (``-m kafka`` / ``make test-kafka``); skips cleanly without Docker.
 """

--- a/tests/integration/test_fault_escalation_kafka.py
+++ b/tests/integration/test_fault_escalation_kafka.py
@@ -13,7 +13,7 @@ channels:
 * **Channel C** — the client edge: a routed fault is received as a typed ``NodeFaultError``
   (#250 reception), so ``await handle.result()`` raises it carrying the verbatim ``ErrorReport``.
 
-The agents run ``sequential_only_mode=True``: every case dispatches a single tool call,
+Every case dispatches a single tool call,
 so the fault path is identical to a fan-out-capable agent's, and the durable fan-out
 store (a separate ktables dependency, covered by Suite X) stays out of the way.
 
@@ -54,7 +54,6 @@ def _agent(node_id: str, *, agent_in: str, agent_pub: str, tool, call: ToolCallP
         publish_topic=agent_pub,
         model_client=scripted_model([call]),
         tools=[tool],
-        sequential_only_mode=True,
         **seams,
     )
 

--- a/tests/integration/test_mcp_roundtrip_kafka.py
+++ b/tests/integration/test_mcp_roundtrip_kafka.py
@@ -14,7 +14,6 @@ distributed loop over a live broker —
 Coverage (happy + contract/edge paths — fault paths live with the fault-rail work):
   * single dispatch and concurrent fan-out (baseline);
   * fan-out slot routing keyed by tool_call_id (same tool twice);
-  * sequential mode (one call per turn, no durable store);
   * routing across two MCP servers; reply routing for two agents on one toolbox;
   * the ``include`` trust boundary; and dynamic ``tools/list_changed`` re-discovery.
 
@@ -350,54 +349,6 @@ async def test_duplicate_tool_concurrent_slots_route_by_call_id(kafka_bootstrap:
     # Same tool name, two ids, two distinct results in their own slots.
     assert "5" in _serialized(by_id["call-a"])
     assert "30" in _serialized(by_id["call-b"])
-
-    await driver.aclose()
-    await toolbox_worker._client.aclose()
-    await agent_worker._client.aclose()
-
-
-async def test_sequential_mode_dispatches_without_fanout(kafka_bootstrap: str, topic_namespace: str) -> None:
-    """A sequential-only agent emitting two calls dispatches them one per turn
-    and never opens the durable fan-out store (no calf.fanout topics), yet both
-    results still round-trip."""
-    agent_id = f"{topic_namespace}-seq-agent"
-    agent_in = f"{topic_namespace}.seq-agent.input"
-    control_plane = fast_control_plane(kafka_bootstrap)
-    server_name = _server_name(topic_namespace)
-
-    toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
-    agent = Agent(
-        agent_id,
-        system_prompt="call both tools sequentially",
-        subscribe_topics=agent_in,
-        model_client=scripted_model(
-            [
-                ToolCallPart(_ns(server_name, "add"), {"a": 2, "b": 3}, tool_call_id="call-add"),
-                ToolCallPart(_ns(server_name, "echo"), {"text": "hi"}, tool_call_id="call-echo"),
-            ]
-        ),
-        tools=[toolbox.select(include=_TOOLS)],
-        sequential_only_mode=True,
-    )
-    assert not agent._is_fanout_capable
-
-    driver = Client.connect(kafka_bootstrap)
-    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], control_plane=control_plane)
-    agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
-
-    async with toolbox_worker:
-        await _await_capability(kafka_bootstrap, server_name, timeout=60)
-        async with agent_worker:
-            result = await driver.agent(topic=agent_in).execute("add then echo", timeout=120)
-            topics = await _topics(kafka_bootstrap)
-
-    assert result.output is not None and FINAL_OUTPUT in result.output
-    returns = tool_returns(result.message_history)
-    assert "5" in _serialized(returns[_ns(server_name, "add")])
-    assert "hi" in _serialized(returns[_ns(server_name, "echo")])
-    # No durable store was opened — the sequential path never fans out.
-    assert f"calf.fanout.{agent_id}.state" not in topics
-    assert f"calf.fanout.{agent_id}.basestate" not in topics
 
     await driver.aclose()
     await toolbox_worker._client.aclose()

--- a/tests/integration/test_oversized_fault_kafka.py
+++ b/tests/integration/test_oversized_fault_kafka.py
@@ -61,7 +61,6 @@ async def test_oversized_fault_strips_to_minimal_and_still_arrives(kafka_bootstr
         subscribe_topics=agent_in,
         model_client=scripted_model([ToolCallPart("oversized_fault", {"x": 1}, tool_call_id="c1")]),
         tools=[oversized_fault],
-        sequential_only_mode=True,
     )
     driver = Client.connect(kafka_bootstrap, inbox_topic=reply_topic)
     worker = fault_worker(kafka_bootstrap, nodes=[agent, oversized_fault])

--- a/tests/integration/test_retry_marker_kafka.py
+++ b/tests/integration/test_retry_marker_kafka.py
@@ -39,7 +39,6 @@ async def test_model_retry_round_trips_as_calf_retry_not_a_fault(kafka_bootstrap
         publish_topic=agent_pub,
         model_client=scripted_model([ToolCallPart("needs_retry", {"x": -1}, tool_call_id="c1")]),
         tools=[needs_retry],
-        sequential_only_mode=True,
     )
     await ensure_topic(kafka_bootstrap, agent_pub)
     driver = Client.connect(kafka_bootstrap)

--- a/tests/integration/test_seam_pipeline_kafka.py
+++ b/tests/integration/test_seam_pipeline_kafka.py
@@ -93,7 +93,6 @@ def _agent(node_id: str, *, agent_in: str, publish_topic: str | None = None, **s
         subscribe_topics=agent_in,
         publish_topic=publish_topic,
         model_client=final_model(),
-        sequential_only_mode=True,
         **seams,
     )
 

--- a/tests/integration/test_step_streaming_kafka.py
+++ b/tests/integration/test_step_streaming_kafka.py
@@ -115,7 +115,6 @@ async def test_single_agent_stream_yields_steps_then_terminal(kafka_bootstrap: s
         subscribe_topics=a_in,
         model_client=scripted_model([ToolCallPart(tool_name, {}, tool_call_id="t1")]),
         tools=[tool],
-        sequential_only_mode=True,
     )
     driver = Client.connect(kafka_bootstrap)
     worker = _worker(kafka_bootstrap, nodes=[agent, tool], control_plane=fast_control_plane(kafka_bootstrap))

--- a/tests/integration/test_tool_discovery_kafka.py
+++ b/tests/integration/test_tool_discovery_kafka.py
@@ -222,7 +222,6 @@ async def test_discovered_bad_args_escalate_unhandled_fault(kafka_bootstrap: str
         publish_topic=agent_pub,
         model_client=scripted_model([ToolCallPart(tool_name, {"a": "not-an-int", "b": 3}, tool_call_id="c1")]),
         tools=[Tools(tool_name)],
-        sequential_only_mode=True,  # single dispatch; keep the durable fan-out store out of the fault path
     )
     await ensure_topic(kafka_bootstrap, agent_pub)
 

--- a/tests/integration/test_tool_error_reception_gate0_kafka.py
+++ b/tests/integration/test_tool_error_reception_gate0_kafka.py
@@ -106,7 +106,6 @@ async def test_gate_a_single_tool_fault_resolves_via_state_over_the_wire(kafka_b
         subscribe_topics=agent_in,
         model_client=scripted_model([ToolCallPart("boom", {"x": 7}, tool_call_id="c1")]),
         tools=[boom],
-        sequential_only_mode=True,
         on_callee_error=recorder,
     )
     driver = Client.connect(kafka_bootstrap)

--- a/tests/integration/test_tool_node_roundtrip_kafka.py
+++ b/tests/integration/test_tool_node_roundtrip_kafka.py
@@ -373,7 +373,7 @@ async def test_two_agents_share_one_tool_node_replies_route_per_caller(kafka_boo
     await agent_worker._client.aclose()
 
 
-# ── Group C: modes / multi-turn ──────────────────────────────────────────────
+# ── Group C: multi-turn ──────────────────────────────────────────────────────
 
 
 async def test_multi_turn_tool_use_feeds_result_into_next_call(kafka_bootstrap: str, topic_namespace: str) -> None:

--- a/tests/integration/test_tool_node_roundtrip_kafka.py
+++ b/tests/integration/test_tool_node_roundtrip_kafka.py
@@ -20,7 +20,7 @@ exact equality (not substring on a CallToolResult like MCP).
 Existing real-broker tool-node coverage was only the durable fan-out test
 (`test_durable_fanout_agent_kafka.py`) — concurrent, no-arg, constant-returning
 tools, as a vehicle for the fan-out store. This module covers the gaps: single
-dispatch, argument and structured-return wire fidelity, sequential mode,
+dispatch, argument and structured-return wire fidelity,
 multi-turn data-flow, cross-worker and multi-agent routing, and the agent's
 pre-dispatch arg validation.
 
@@ -374,45 +374,6 @@ async def test_two_agents_share_one_tool_node_replies_route_per_caller(kafka_boo
 
 
 # ── Group C: modes / multi-turn ──────────────────────────────────────────────
-
-
-async def test_sequential_mode_dispatches_tool_nodes_without_fanout(kafka_bootstrap: str, topic_namespace: str) -> None:
-    """A sequential-only agent emitting two calls dispatches them one per turn
-    and never opens the durable fan-out store, yet both results round-trip."""
-    agent_id = f"{topic_namespace}-tn-seq"
-    agent_in = f"{topic_namespace}.tn-seq.input"
-    agent = Agent(
-        agent_id,
-        system_prompt="add then shout",
-        subscribe_topics=agent_in,
-        model_client=scripted_model(
-            [
-                ToolCallPart("add", {"a": 2, "b": 3}, tool_call_id="c-add"),
-                ToolCallPart("shout", {"text": "hi"}, tool_call_id="c-shout"),
-            ]
-        ),
-        tools=[add, shout],
-        sequential_only_mode=True,
-    )
-    assert not agent._is_fanout_capable
-
-    driver = Client.connect(kafka_bootstrap)
-    worker = _worker(kafka_bootstrap, nodes=[agent, add, shout])
-
-    async with worker:
-        result = await driver.agent(topic=agent_in).execute("add then shout", timeout=120)
-        topics = await _topics(kafka_bootstrap)
-
-    assert result.output is not None and FINAL_OUTPUT in result.output
-    returns = tool_returns(result.message_history)
-    assert returns["add"] == 5
-    assert returns["shout"] == "HI"
-    # No durable store was opened — the sequential path never fans out.
-    assert f"calf.fanout.{agent_id}.state" not in topics
-    assert f"calf.fanout.{agent_id}.basestate" not in topics
-
-    await driver.aclose()
-    await worker._client.aclose()
 
 
 async def test_multi_turn_tool_use_feeds_result_into_next_call(kafka_bootstrap: str, topic_namespace: str) -> None:

--- a/tests/providers.py
+++ b/tests/providers.py
@@ -172,8 +172,8 @@ class WorkerProvider(Provider):
 def prepare_worker(container):
     worker: Worker = container.get(Worker)
     worker.register_handlers()
-    # Offline analog of the production node-owned fan-out @resource (which never runs under the
-    # synchronous TestKafkaBroker): give each fan-out-capable node a fake durable store, unless a
+    # Offline analog of the production node-owned fan-out @resource (which never runs for
+    # handler-driven tests — no worker.start()): give each fan-out-capable node a fake durable store, unless a
     # test already injected its own (e.g. the spy store in tests/test_durable_fanout_e2e.py).
     for node in worker._nodes:
         if node._is_fanout_capable and FANOUT_STORE_KEY not in node.resources:

--- a/tests/test_agent_loop_integration.py
+++ b/tests/test_agent_loop_integration.py
@@ -279,7 +279,6 @@ async def test_deferred_tool_reentry_keeps_self_tool_call_ids_no_user_error():
         subscribe_topics="viewer.input",
         model_client=model,  # pyright: ignore[reportArgumentType]
         tools=[tool_node],
-        sequential_only_mode=True,
     )
 
     # Multi-participant canonical history with the viewer's own in-flight tool call last.

--- a/tests/test_carriage_switch_e2e.py
+++ b/tests/test_carriage_switch_e2e.py
@@ -5,7 +5,7 @@ The carriage switch (fault-rail §4.5/§6.9): a tool returns its result on the r
 (``_resolve_slot``) keyed by the echoed ``tag`` — no more ``state.tool_results`` blob-write. These
 drive a REAL single tool call through ``TestKafkaBroker`` to prove the full round trip:
 
-- a single (sequential) tool call's result materializes and the agent resumes to a final answer
+- a single tool call's result materializes and the agent resumes to a final answer
   incorporating it — THE regression guard for the single-call ``tag`` (decision 9): without the tag
   on the ``Call``, the reply's ``tag`` is ``None`` and ``_resolve_slot`` no-ops, so the agent never
   sees the result and loops;
@@ -51,10 +51,10 @@ def _call_then_echo_the_tool_result(messages: list[ModelMessage], info: AgentInf
 
 
 async def test_single_tool_call_result_materializes_and_agent_resumes(container) -> None:
-    # THE single-call tag regression guard (decision 9): a sequential agent calls one tool; the tool's
+    # THE single-call tag regression guard (decision 9): the agent calls one tool; the tool's
     # result rides the reply slot and must materialize at the callee slot (keyed by the echoed tag) so
     # the agent's next turn sees it. Without the tag on the Call, the reply tag is None, _resolve_slot
-    # no-ops, the tool result never materializes, and the sequential agent loops until the TTL.
+    # no-ops, the tool result never materializes, and the agent loops until the TTL.
     worker = container.get(Worker)
     agent = Agent(
         "year_agent",
@@ -62,7 +62,6 @@ async def test_single_tool_call_result_materializes_and_agent_resumes(container)
         subscribe_topics="year_agent.input",
         model_client=FunctionModel(_call_then_echo_the_tool_result),
         tools=[lookup_year],
-        sequential_only_mode=True,
     )
     worker.add_nodes(agent, lookup_year)
     prepare_worker(container)
@@ -103,7 +102,6 @@ async def test_tool_model_retry_round_trips_as_retry_prompt(container) -> None:
         subscribe_topics="retry_agent.input",
         model_client=FunctionModel(_call_then_react_to_the_retry),
         tools=[flaky_tool],
-        sequential_only_mode=True,
     )
     worker.add_nodes(agent, flaky_tool)
     prepare_worker(container)

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -265,7 +265,6 @@ async def test_chat_loop_renders_transcript_and_threads_history(container: objec
         subscribe_topics="agent.helpbot.private.input",  # == derive_input_topic("helpbot")
         model_client=FunctionModel(_preamble_call_then_final),
         tools=[_lookup_year],
-        sequential_only_mode=True,
     )
     worker.add_nodes(agent, _lookup_year)
     prepare_worker(container)

--- a/tests/test_fanout_handler.py
+++ b/tests/test_fanout_handler.py
@@ -1,8 +1,8 @@
 """PR-4 step 6b: the in-node fan-out machinery on BaseNodeDef.
 
-Tested in isolation against the injected fake store + constructed envelopes (the
-@resource never runs offline, so a fan-out agent just gets `agent.resources[KEY] =
-fake`). These pin the pieces the staged handler wires together in 6b-B:
+Tested in isolation against the injected fake store + constructed envelopes (these
+tests are handler-driven — no worker lifecycle, so the @resource never runs and a
+fan-out agent just gets `agent.resources[KEY] = fake`). These pin the pieces the staged handler wires together in 6b-B:
 
 - _is_fanout_capable: agents fan out durably; every other node kind does not
 - _resolve_fanout_store: the store comes from ctx.resources, required for fan-out
@@ -340,7 +340,7 @@ async def test_lone_isolate_state_call_opens_degenerate_batch() -> None:
 async def test_messaging_only_node_opens_degenerate_batch() -> None:
     # decision 1(b): a NON-fan-out-capable node carrying a Messaging handle is
     # `_needs_durable_batch`, so it still opens the degenerate batch for a lone isolate_state call.
-    node = _MessagingOnlyNode(node_id="seq", subscribe_topics=["seq.in"])
+    node = _MessagingOnlyNode(node_id="msg", subscribe_topics=["msg.in"])
     assert node._is_fanout_capable is False and node._needs_durable_batch is True
     fake, _ = await _drive_open(node)
     assert await fake.read_state("A") is not None
@@ -403,8 +403,8 @@ def test_classify_fanout_uses_needs_durable_batch() -> None:
     # decision 1(b): the fold/close continuation gate keys on `_needs_durable_batch`, not
     # `_is_fanout_capable` — so a messaging-only node (Messaging handle, not fan-out-capable)
     # classifies + folds its marked sibling/re-entry continuations.
-    node = _MessagingOnlyNode(node_id="seq", subscribe_topics=["seq.in"])
-    marked = CallFrame(target_topic="seq.in", callback_topic="caller", frame_id="A", fanout_id="A")
+    node = _MessagingOnlyNode(node_id="msg", subscribe_topics=["msg.in"])
+    marked = CallFrame(target_topic="msg.in", callback_topic="caller", frame_id="A", fanout_id="A")
     env = Envelope(
         context=SessionRunContext(state=State(), deps={}),
         internal_workflow_state=WorkflowState(call_stack=Stack([marked])),

--- a/tests/test_fanout_handler.py
+++ b/tests/test_fanout_handler.py
@@ -4,7 +4,7 @@ Tested in isolation against the injected fake store + constructed envelopes (the
 @resource never runs offline, so a fan-out agent just gets `agent.resources[KEY] =
 fake`). These pin the pieces the staged handler wires together in 6b-B:
 
-- _is_fanout_capable: only non-sequential agents fan out durably
+- _is_fanout_capable: agents fan out durably; every other node kind does not
 - _resolve_fanout_store: the store comes from ctx.resources, required for fan-out
 - _classify_fanout: marker + reply slot => SIBLING fold / RE-ENTRY close / NORMAL
 """
@@ -48,12 +48,11 @@ def _model(_messages: object, _info: AgentInfo) -> ModelResponse:
     return ModelResponse(parts=[TextPart("ok")])
 
 
-def _agent(*, sequential: bool = False) -> Agent[str]:
+def _agent() -> Agent[str]:
     return Agent(
         name="a",
         subscribe_topics=["a.in"],
         model_client=FunctionModel(_model),
-        sequential_only_mode=sequential,
     )
 
 
@@ -79,10 +78,6 @@ def test_agent_is_fanout_capable() -> None:
     assert _agent()._is_fanout_capable is True
 
 
-def test_sequential_agent_is_not_fanout_capable() -> None:
-    assert _agent(sequential=True)._is_fanout_capable is False
-
-
 # ── store resolution ─────────────────────────────────────────────────────────
 
 
@@ -106,16 +101,11 @@ def test_resolve_fanout_store_raises_when_absent() -> None:
 
 
 def test_fanout_agent_registers_durable_store_resource() -> None:
-    # A non-sequential agent registers the node-owned fan-out store @resource (opened by the
+    # Every agent registers the node-owned fan-out store @resource unconditionally (opened by the
     # worker lifecycle in production; injected by prepare_worker offline). The @resource itself
     # is not run here — only its registration is asserted.
     names = {name for name, _ in _agent()._resource_registry()}
     assert FANOUT_STORE_KEY in names
-
-
-def test_sequential_agent_registers_no_store_resource() -> None:
-    names = {name for name, _ in _agent(sequential=True)._resource_registry()}
-    assert FANOUT_STORE_KEY not in names
 
 
 # ── classification ───────────────────────────────────────────────────────────
@@ -221,16 +211,16 @@ def test_call_isolate_state_field() -> None:
 
 
 def test_needs_durable_batch_decouples_from_fanout_capability() -> None:
-    # decision 1(b), NARROWED in PR-C: the durable-batch machinery is needed iff the node can parallel-
-    # fan-out (`_is_fanout_capable`) OR can dispatch an `isolate_state` call (it carries a `Messaging`
-    # handle, signalled by `_messaging_handles`). Decoupled so a `sequential_only_mode` messaging agent
-    # still gets the machinery for a lone `message_agent`; for non-messaging nodes — incl. a Handoff-only
-    # agent (a winning handoff is a TailCall disposition, never a dispatched Call) — it equals `_is_fanout_capable`.
+    # decision 1(b), retained as future-proofing: the durable-batch machinery is needed iff the node can
+    # parallel-fan-out (`_is_fanout_capable`) OR can dispatch an `isolate_state` call (it carries a
+    # `Messaging` handle, signalled by `_messaging_handles`). Every agent satisfies the first disjunct;
+    # the decoupling is only observable on a non-agent node carrying Messaging handles, pinned here
+    # synthetically.
     plain = NodeDef(node_id="n", subscribe_topics=["n.in"])  # not fan-out-capable, no messaging
     assert plain._needs_durable_batch is False
     fanout = _SingleCallFanoutNode(node_id="f", subscribe_topics=["f.in"])  # fan-out-capable
     assert fanout._needs_durable_batch is True
-    plain._messaging_handles = ("messaging-handle",)  # type: ignore[attr-defined]  # a sequential messaging agent
+    plain._messaging_handles = ("messaging-handle",)  # type: ignore[attr-defined]  # a messaging-only node
     assert plain._needs_durable_batch is True
     plain._messaging_handles = ()  # type: ignore[attr-defined]  # no messaging handle => no machinery
     assert plain._needs_durable_batch is False
@@ -313,10 +303,10 @@ class _IsolateStateBareCallNode(NodeDef[Any]):
         return Call("agent.peer.private.input", State(), tag="tc1", isolate_state=True)
 
 
-class _SequentialMessagingNode(NodeDef[Any]):
-    """A NON-fan-out-capable node (a ``sequential_only_mode`` analog) carrying a ``Messaging`` handle, whose
-    body returns a BARE ``Call(isolate_state=True)``: ``_needs_durable_batch`` is True via
-    ``_messaging_handles`` (1(b), narrowed to messaging in PR-C — a Handoff-only agent needs no batch)."""
+class _MessagingOnlyNode(NodeDef[Any]):
+    """A NON-fan-out-capable node carrying a ``Messaging`` handle, whose body returns a BARE
+    ``Call(isolate_state=True)``: ``_needs_durable_batch`` is True via ``_messaging_handles``
+    (decision 1(b) — the decoupling retained for exactly this non-agent shape)."""
 
     _messaging_handles = ("messaging-handle",)
 
@@ -347,10 +337,10 @@ async def test_lone_isolate_state_call_opens_degenerate_batch() -> None:
     assert await fake.read_basestate("A") is not None  # caller state snapshotted at OPEN
 
 
-async def test_sequential_messaging_node_opens_degenerate_batch() -> None:
-    # decision 1(b): a NON-fan-out-capable node (sequential_only_mode analog) carrying a Messaging handle
-    # is `_needs_durable_batch`, so it still opens the degenerate batch for a lone isolate_state call.
-    node = _SequentialMessagingNode(node_id="seq", subscribe_topics=["seq.in"])
+async def test_messaging_only_node_opens_degenerate_batch() -> None:
+    # decision 1(b): a NON-fan-out-capable node carrying a Messaging handle is
+    # `_needs_durable_batch`, so it still opens the degenerate batch for a lone isolate_state call.
+    node = _MessagingOnlyNode(node_id="seq", subscribe_topics=["seq.in"])
     assert node._is_fanout_capable is False and node._needs_durable_batch is True
     fake, _ = await _drive_open(node)
     assert await fake.read_state("A") is not None
@@ -411,9 +401,9 @@ async def test_unflagged_bare_call_stays_fast_path() -> None:
 
 def test_classify_fanout_uses_needs_durable_batch() -> None:
     # decision 1(b): the fold/close continuation gate keys on `_needs_durable_batch`, not
-    # `_is_fanout_capable` — so a sequential messaging agent (Messaging handle, not fan-out-capable)
+    # `_is_fanout_capable` — so a messaging-only node (Messaging handle, not fan-out-capable)
     # classifies + folds its marked sibling/re-entry continuations.
-    node = _SequentialMessagingNode(node_id="seq", subscribe_topics=["seq.in"])
+    node = _MessagingOnlyNode(node_id="seq", subscribe_topics=["seq.in"])
     marked = CallFrame(target_topic="seq.in", callback_topic="caller", frame_id="A", fanout_id="A")
     env = Envelope(
         context=SessionRunContext(state=State(), deps={}),
@@ -629,14 +619,14 @@ async def test_fanout_store_resource_raises_without_bootstrap() -> None:
         await gen.__anext__()
 
 
-# ── parallel-mode incomplete-batch guard in run() (coverage d) ────────────────
+# ── incomplete-batch guard in run() (coverage d) ─────────────────────────────
 
 
-async def test_parallel_run_on_incomplete_batch_raises_runtime_error() -> None:
+async def test_run_on_incomplete_batch_raises_runtime_error() -> None:
     # (coverage d) run() must only be re-entered on a COMPLETE batch (the durable close materializes
-    # every outcome first). A parallel-mode ctx whose latest tool-call set is incomplete (one call
-    # has no result) is the lost-batch/rebalance signal — run() raises a diagnostic RuntimeError
-    # rather than silently proceeding.
+    # every outcome first). A ctx whose latest tool-call set is incomplete (one call has no result)
+    # is the lost-batch/rebalance signal — run() raises a diagnostic RuntimeError rather than
+    # silently proceeding.
     agent = Agent(
         "agent_incomplete_batch",
         system_prompt="x",

--- a/tests/test_handoff_dispatch.py
+++ b/tests/test_handoff_dispatch.py
@@ -350,6 +350,21 @@ async def test_peer_re_enters_cleanly_on_the_inherited_state() -> None:
     assert "on it" in "".join(getattr(p, "text", "") for p in b_result.value)
 
 
+async def test_pending_handoff_at_reentry_raises_incomplete_reentry() -> None:
+    """Corrupt-state tripwire (successor to the deleted sequential-arm fork test): a PENDING
+    handoff call surviving to re-entry is impossible by construction — a handoff is finalized
+    in the delivery that produced it — so it must trip the unconditional incomplete-re-entry
+    RuntimeError, never skip or mis-dispatch to the registry lookup. Guards against a future
+    pre-model handoff routing landing ahead of the gate."""
+    agent = _agent(TestModel(), peers=[Handoff("billing")])
+    ctx = _ctx_with_view(_view({"billing": None}))
+    part = _handoff_part("billing", "x")
+    ctx.state.extend_with_responses([ModelResponse(parts=[part])], agent.name)
+    ctx.state.add_tool_call(part)  # registered but unresolved — the impossible state
+    with pytest.raises(RuntimeError, match="incomplete tool calls in run"):
+        await agent.run(ctx)
+
+
 async def test_returning_handoff_a_to_b_to_a_re_enters_cleanly() -> None:
     """The A-return direction of spec §4's re-entry pin (review round 1): after A→B→A, A
     re-enters over its OWN persisted handoff turn (real call + self-owned closing request)

--- a/tests/test_handoff_dispatch.py
+++ b/tests/test_handoff_dispatch.py
@@ -350,19 +350,6 @@ async def test_peer_re_enters_cleanly_on_the_inherited_state() -> None:
     assert "on it" in "".join(getattr(p, "text", "") for p in b_result.value)
 
 
-async def test_pending_handoff_in_reentry_arm_raises_loudly() -> None:
-    """The defensive fork (plan S2b): a PENDING handoff call surviving to the sequential
-    re-entry arm is impossible by construction — a silent skip would hide a bug, so it
-    raises. Contrived state: registered handoff call, no result, sequential mode."""
-    agent = _agent(TestModel(), sequential_only_mode=True, peers=[Handoff("billing")])
-    ctx = _ctx_with_view(_view({"billing": None}))
-    part = _handoff_part("billing", "x")
-    ctx.state.extend_with_responses([ModelResponse(parts=[part])], agent.name)
-    ctx.state.add_tool_call(part)  # registered but unresolved — the impossible state
-    with pytest.raises(RuntimeError, match="handoff"):
-        await agent.run(ctx)
-
-
 async def test_returning_handoff_a_to_b_to_a_re_enters_cleanly() -> None:
     """The A-return direction of spec §4's re-entry pin (review round 1): after A→B→A, A
     re-enters over its OWN persisted handoff turn (real call + self-owned closing request)

--- a/tests/test_message_agent.py
+++ b/tests/test_message_agent.py
@@ -15,7 +15,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from calfkit._vendor.pydantic_ai.messages import ModelRequest, ModelResponse, RetryPromptPart, ToolCallPart, ToolReturn
+from calfkit._vendor.pydantic_ai.messages import ModelResponse, RetryPromptPart, ToolCallPart
 from calfkit._vendor.pydantic_ai.messages import TextPart as ModelTextPart
 from calfkit._vendor.pydantic_ai.models.function import AgentInfo, FunctionModel
 from calfkit._vendor.pydantic_ai.models.test import TestModel
@@ -149,29 +149,6 @@ async def test_message_agent_parallel_mixed_batch_dispatches_per_kind() -> None:
     assert tool_call.target_topic == "adder.in"
     assert tool_call.isolate_state is False
     assert tool_call.body is not None  # ToolCallRef
-
-
-async def test_message_agent_dispatched_via_reentry_arm() -> None:
-    # A sequential agent that emitted a tool + a message_agent in one turn dispatches them one at a time:
-    # the tool first, then — on RE-ENTRY after the tool returns — the still-pending message_agent. The
-    # re-entry arm must fork on the well-known name BEFORE indexing tools_registry (message_agent is never
-    # a registry binding). Per Ryan: the re-entry arm does NOT re-validate (accepts the §9 staleness window).
-    msg = _msg_call("billing", "balance?", tool_call_id="m1")
-    add = ToolCallPart(tool_name="add", args={}, tool_call_id="a1")
-    state = State()
-    state.add_tool_call(add)
-    state.add_tool_call(msg)
-    state.add_tool_result("a1", ToolReturn(return_value="3", metadata={"tool_call_id": "a1"}))  # the tool already returned
-    state.message_history.append(ModelRequest.user_text_prompt("add then ask billing"))
-    state.message_history.append(ModelResponse(parts=[add, msg]))  # one turn emitted both calls
-    agent = Agent("triage", subscribe_topics="triage.in", model_client=TestModel(), peers=[Messaging("billing")], sequential_only_mode=True)
-    ctx = _ctx_with_view(_view({"billing": "Billing."}))
-    ctx.state = state  # the re-entry state; the model is never called (the pending call dispatches first)
-    result = await agent.run(ctx)
-    assert isinstance(result, Call)
-    assert result.target_topic == "agent.billing.private.input"
-    assert result.isolate_state is True
-    assert result.tag == "m1"
 
 
 async def test_message_agent_is_never_looked_up_in_tools_registry() -> None:

--- a/tests/test_messaging_carry_forwards.py
+++ b/tests/test_messaging_carry_forwards.py
@@ -37,9 +37,10 @@ def _final_model() -> FunctionModel:
 async def test_stray_non_toolcallref_call_to_agent_inbox_is_disposed_not_swallowed() -> None:
     # PR-A `_private_input_topic` contract: a stray `call` (NO x-calf-kind header => classified "call"; no
     # reply slot; a non-ToolCallRef body) delivered to an agent's derived input topic is disposed by the
-    # EXISTING pipeline — it does NOT raise/escape into FastStream. (A sequential agent with no peers is
-    # not `_needs_durable_batch`, so no fan-out store is needed to drive the handler offline.)
-    agent = Agent("a", subscribe_topics="a.in", model_client=_final_model(), sequential_only_mode=True)
+    # EXISTING pipeline — it does NOT raise/escape into FastStream. (No fan-out store is needed to
+    # drive the handler offline: a stray-call disposal never resolves the store, and the @resource
+    # never runs when the handler is driven directly.)
+    agent = Agent("a", subscribe_topics="a.in", model_client=_final_model())
     frame = CallFrame(target_topic=derive_input_topic("a"), callback_topic=None, payload={"not": "a ToolCallRef"})
     env = Envelope(context=SessionRunContext(state=State(), deps={}), internal_workflow_state=WorkflowState(call_stack=Stack([frame])))
     broker = _CaptureBroker()

--- a/tests/test_peers_surface.py
+++ b/tests/test_peers_surface.py
@@ -101,16 +101,19 @@ def test_messaging_in_tools_raises() -> None:
         _agent(tools=[Messaging("billing")])
 
 
-def test_sequential_messaging_agent_registers_fanout_store() -> None:
-    # decision 1(b): a `sequential_only_mode` messaging agent still needs the durable-batch store for its
-    # lone message_agent (it is `_needs_durable_batch` via `_peers`), even though it routes tools
-    # one-at-a-time. A sequential agent WITHOUT peers registers no store.
+def test_every_agent_registers_fanout_store() -> None:
+    # Uniform store rule: every agent registers the durable-batch store @resource unconditionally —
+    # plain, Messaging, and Handoff-only alike. No agent is statically fan-out-free (override tools
+    # arrive over the wire; Tools selectors resolve at runtime). The messaging-vs-handoff
+    # `_needs_durable_batch` distinction is no longer observable on agents; its non-agent form is
+    # pinned by test_fanout_handler.py::test_needs_durable_batch_decouples_from_fanout_capability.
     from calfkit.nodes._fanout_store import FANOUT_STORE_KEY
 
-    messaging_seq = Agent(name="t", subscribe_topics="t.in", model_client=TestModel(), sequential_only_mode=True, peers=[Messaging("p")])
-    assert FANOUT_STORE_KEY in [n for n, _ in messaging_seq._resource_cms()]
-    plain_seq = Agent(name="t2", subscribe_topics="t2.in", model_client=TestModel(), sequential_only_mode=True)
-    assert FANOUT_STORE_KEY not in [n for n, _ in plain_seq._resource_cms()]
+    plain = Agent(name="t", subscribe_topics="t.in", model_client=TestModel())
+    messaging = Agent(name="t2", subscribe_topics="t2.in", model_client=TestModel(), peers=[Messaging("p")])
+    handoff_only = Agent(name="t3", subscribe_topics="t3.in", model_client=TestModel(), peers=[Handoff("p")])
+    for agent in (plain, messaging, handoff_only):
+        assert FANOUT_STORE_KEY in [n for n, _ in agent._resource_cms()]
 
 
 def test_agent_messaging_discover_exclusivity() -> None:
@@ -250,14 +253,3 @@ def test_same_name_in_messaging_and_handoff_is_allowed_and_partitioned() -> None
     a = _agent(peers=[Messaging("billing"), Handoff("billing")])
     assert a._messaging_handles == [Messaging("billing")]
     assert a._handoff_handles == [Handoff("billing")]
-
-
-def test_sequential_handoff_only_agent_registers_no_fanout_store() -> None:
-    # decision 1(b), NARROWED for PR-C: `_needs_durable_batch` keys on MESSAGING handles, not any peer. A
-    # Handoff-only agent never dispatches an isolate_state Call (a winning handoff is a TailCall, not
-    # a Call), so a SEQUENTIAL Handoff-only agent (not fanout-capable) provisions NO durable store — unlike
-    # a sequential MESSAGING agent (test_sequential_messaging_agent_registers_fanout_store).
-    from calfkit.nodes._fanout_store import FANOUT_STORE_KEY
-
-    handoff_seq = Agent(name="t", subscribe_topics="t.in", model_client=TestModel(), sequential_only_mode=True, peers=[Handoff("p")])
-    assert FANOUT_STORE_KEY not in [n for n, _ in handoff_seq._resource_cms()]

--- a/tests/test_project_steps.py
+++ b/tests/test_project_steps.py
@@ -300,7 +300,7 @@ class TestProjectStepsAgentNode:
         assert agent.project_steps(out, ctx, CallFrame(target_topic="t", callback_topic="cb")) == ctx._step_draft
 
     def test_no_draft_emits_nothing(self) -> None:
-        # the pre-model re-dispatch double-emit guard: _step_draft None -> [].
+        # the no-draft guard: a hop that authored no draft (_step_draft None) -> [].
         agent = _agent_node()
         ctx = SessionRunContext(state=State(), deps={})
         assert ctx._step_draft is None

--- a/tests/test_step_emission_integration.py
+++ b/tests/test_step_emission_integration.py
@@ -52,7 +52,6 @@ async def test_step_emission_failure_does_not_break_the_run(container, monkeypat
         subscribe_topics="guard_agent.input",
         model_client=FunctionModel(_call_then_final),
         tools=[echo_for_guard],
-        sequential_only_mode=True,
     )
     worker.add_nodes(agent, echo_for_guard)
     prepare_worker(container)
@@ -75,7 +74,6 @@ async def test_stream_yields_intermediate_steps_then_terminal(container) -> None
         subscribe_topics="stream_agent.input",
         model_client=FunctionModel(_call_then_final),
         tools=[echo_for_guard],
-        sequential_only_mode=True,
     )
     worker.add_nodes(agent, echo_for_guard)
     prepare_worker(container)

--- a/tests/test_tool_error_reception_e2e.py
+++ b/tests/test_tool_error_reception_e2e.py
@@ -68,8 +68,8 @@ async def _run(container: Any, agent: Agent[str], *tools: Any, message: str = "g
         return await client.agent(topic=agent.subscribe_topics[0]).execute(message, timeout=10)
 
 
-def _agent(name: str, model: FunctionModel, *, tools: list[Any], sequential: bool = True, **seams: Any) -> Agent[str]:
-    return Agent(name, subscribe_topics=f"{name}.in", model_client=model, tools=tools, sequential_only_mode=sequential, **seams)
+def _agent(name: str, model: FunctionModel, *, tools: list[Any], **seams: Any) -> Agent[str]:
+    return Agent(name, subscribe_topics=f"{name}.in", model_client=model, tools=tools, **seams)
 
 
 # ── conversion: the model sees the level-A is_error result ─────────────────────
@@ -142,7 +142,7 @@ async def test_same_tool_twice_distinct_tags_both_convert(container) -> None:
     # A parallel batch of the SAME tool (distinct tags) → surface_to_model converts each independently.
     capture: dict[str, list[str]] = {}
     calls = [ToolCallPart("kaboom", {"x": 1}, tool_call_id="t1"), ToolCallPart("kaboom", {"x": 2}, tool_call_id="t2")]
-    agent = _agent("s6", _react_model(calls, capture), tools=[kaboom], sequential=False, on_tool_error=[surface_to_model()])
+    agent = _agent("s6", _react_model(calls, capture), tools=[kaboom], on_tool_error=[surface_to_model()])
     await _run(container, agent, kaboom)
     assert sorted(capture["retries"]) == ["ValueError: kaboom(1)", "ValueError: kaboom(2)"]
 
@@ -152,7 +152,7 @@ async def test_fanout_sibling_fault_converts(container) -> None:
     # successful sibling folds normally. Both results reach the model, the run finalizes.
     capture: dict[str, list[str]] = {}
     calls = [ToolCallPart("kaboom", {"x": 9}, tool_call_id="t1"), ToolCallPart("ok_tool", {"x": 5}, tool_call_id="t2")]
-    agent = _agent("s7", _react_model(calls, capture), tools=[kaboom, ok_tool], sequential=False, on_tool_error=[surface_to_model()])
+    agent = _agent("s7", _react_model(calls, capture), tools=[kaboom, ok_tool], on_tool_error=[surface_to_model()])
     await _run(container, agent, kaboom, ok_tool)
     assert capture["retries"] == ["ValueError: kaboom(9)"]  # the faulting sibling converted
     assert capture["returns"] == ["ok(5)"]  # the successful sibling folded normally
@@ -221,7 +221,7 @@ async def test_d12_one_unhandled_sibling_escalates_the_whole_batch(container) ->
             return retry_text_part("converted-1")  # convert the x=1 sibling
         return None  # decline the x=2 sibling → unhandled → the batch escalates
 
-    agent = _agent("e6", _react_model(calls, capture), tools=[kaboom], sequential=False, on_tool_error=selective)
+    agent = _agent("e6", _react_model(calls, capture), tools=[kaboom], on_tool_error=selective)
     with pytest.raises(NodeFaultError):
         await _run(container, agent, kaboom)
     assert capture == {}  # the converted sibling was discarded — the batch escalated as a fault group
@@ -270,7 +270,7 @@ async def test_m2_fanout_sibling_state_mutation_is_discarded(container) -> None:
     # fold-time state mutation surviving a fan-out.
     capture: dict[str, bool] = {}
     calls = [ToolCallPart("kaboom", {"x": 1}, tool_call_id="t1"), ToolCallPart("kaboom", {"x": 2}, tool_call_id="t2")]
-    agent = _agent("m2f", _marker_scan_model(calls, capture), tools=[kaboom], sequential=False, on_tool_error=_mutate_and_convert)
+    agent = _agent("m2f", _marker_scan_model(calls, capture), tools=[kaboom], on_tool_error=_mutate_and_convert)
     await _run(container, agent, kaboom)
     assert capture["saw_marker"] is False  # discarded at close
 

--- a/tests/test_tool_error_reception_gate0.py
+++ b/tests/test_tool_error_reception_gate0.py
@@ -4,7 +4,7 @@ These are **characterization probes** of *existing* framework behaviour, run bef
 feature code is written, to prove the provenance assumptions the design (spec D3,
 state-first resolution) depends on:
 
-* **Gate A** — a single (sequential) tool fault folds back to the agent's ``on_callee_error``
+* **Gate A** — a single tool fault folds back to the agent's ``on_callee_error``
   seam with ``ctx.state.tool_calls[tag]`` populated as the *full* ``ToolCallPart`` (with ``.args``).
 * **Gate B1** — a normal fan-out sibling fault likewise resolves via ``state.tool_calls[tag]``
   **with ``.args`` intact** (the deep-copied sibling state is mirrored back unchanged).
@@ -84,7 +84,7 @@ class _ToolCallProbe:
 
 
 async def test_gate_a_single_tool_fault_resolves_via_state_with_args(container) -> None:
-    # Gate A: a sequential single tool fault folds to on_callee_error with the caller's State
+    # Gate A: a single tool fault folds to on_callee_error with the caller's State
     # carried back on the reply, so state.tool_calls[tag] resolves the FULL ToolCallPart (with
     # .args). This is the state-first happy path the resolver will reuse (spec D3).
     recorder = _ToolCallProbe()
@@ -95,7 +95,6 @@ async def test_gate_a_single_tool_fault_resolves_via_state_with_args(container) 
         subscribe_topics="gatea_agent.input",
         model_client=_scripted([ToolCallPart("boom_tool", {"x": 7}, tool_call_id="c1")]),
         tools=[boom_tool],
-        sequential_only_mode=True,
         on_callee_error=recorder,
     )
     worker.add_nodes(agent, boom_tool)

--- a/tests/test_tool_errors.py
+++ b/tests/test_tool_errors.py
@@ -348,7 +348,7 @@ async def test_agent_dispatches_valid_args_unchanged():
     ctx = _make_ctx(State())
     result = await agent.run(ctx)
 
-    # Single valid call → sequential dispatch via Call (no parallel batch).
+    # Single valid call → single-call dispatch via a plain Call (no durable batch).
     assert isinstance(result, Call), f"expected Call, got {type(result).__name__}"
     assert tool_call_id not in ctx.state.tool_results
 
@@ -405,7 +405,7 @@ async def test_agent_partial_validation_failure_dispatches_valid_calls():
     # the worker reply.
     assert valid_id not in ctx.state.tool_results
 
-    # Only one valid pending call remains, so the agent takes the sequential
+    # Only one valid pending call remains, so the agent takes the single-call
     # dispatch branch (len(pending_tool_calls) == 1 → single Call, not list).
     if isinstance(result, list):
         target_ids = [call.body.tool_call_id for call in result if isinstance(call, Call)]
@@ -721,7 +721,7 @@ async def test_agent_validator_failure_branch_continues_loop():
     result = await agent.run(ctx)
 
     # Bad call lands as a RetryPromptPart; good call is dispatched (only one
-    # valid pending call remains, so the agent takes the sequential Call branch).
+    # valid pending call remains, so the agent takes the single-call plain-Call branch).
     bad_stored = ctx.state.tool_results.get("tc-bad-002")
     assert isinstance(bad_stored, RetryPromptPart)
     assert "tc-good-002" not in ctx.state.tool_results, "good call should still be pending dispatch"


### PR DESCRIPTION
## Summary

Removes the `sequential_only_mode` ctor knob from `Agent` (`BaseAgentNodeDef`). Parallel tool dispatch becomes the only behavior:

- A model turn emitting N tool calls always dispatches as N concurrent siblings under a durable fan-out batch (N ≥ 2), or as the unchanged plain single `Call` (N = 1).
- **Gate 1** (pre-model re-entry with incomplete tool calls): the sequential re-dispatch arm is deleted — incomplete re-entry is now an unconditional diagnostic `RuntimeError`. This also removes #340's defensive handoff name-fork, whose corrupt-state class the unconditional error now covers.
- **Gate 2** (post-model dispatch): the cadence condition drops to `len(pending) == 1`.
- **Uniform store**: every agent registers the durable fan-out store `@resource` unconditionally — no agent is statically fan-out-free (override tools arrive over the wire; `Tools` selectors resolve at runtime). Sequential Handoff-only agents, previously store-less, now provision it.
- `_is_fanout_capable` / `_needs_durable_batch` are deliberately retained as trait properties (the agent override becomes a constant `True`); the decoupling's non-agent form stays pinned by synthetic tests.

## Breaking change

`Agent(sequential_only_mode=...)` now raises `TypeError`. Serialized execution of an emitted multi-call batch is gone with no dispatch-layer replacement — to constrain a model to one tool call per turn, set `parallel_tool_calls=False` on the model client.

## Verification

- Inventory-validated RED: source edits with tests untouched failed on exactly the plan's predicted set (43 failures + 8 errors, all mapped; zero unexpected).
- GREEN: offline suite 4281 passed / 0 failed; kafka lane (real Redpanda broker) 95 passed, 11 skipped, 1 xpassed.
- `make fix` + `make check` clean; repo-wide grep gates confirm the identifier is extinct outside historical notes.

Plan of record: `docs/plans/remove-sequential-only-mode.md` (local design corpus; review-converged rev 4, 3 adversarial rounds — gate-1 collapse verified safe against every `run()` re-entry path).