### PR TITLE
feat: caller-side arg validation for discovered tools

### DIFF
--- a/calfkit/models/args_schema.py
+++ b/calfkit/models/args_schema.py
@@ -1,0 +1,146 @@
+"""Caller-side JSON-schema arg-validator factory (issue: discovered tools get no caller-side arg
+validation).
+
+A discovered tool (capability-plane ``Tools``/``MCPToolbox`` discovery, wire-deserialized per-run
+overrides, hand-rolled bindings) carries no process-local validator — only its advertised
+``parameters_json_schema``. :func:`schema_args_validator` compiles that schema into an
+:data:`~calfkit.models.tool_dispatch.ArgsValidator` the agent consults at the dispatch chokepoint,
+so the LLM's args are checked against the advertised contract before crossing the wire.
+
+Three laws (spec D2/D3/D4):
+
+- **Contract by translation (D2).** The returned validator raises the same
+  ``pydantic.ValidationError`` every ``ArgsValidator`` promises — synthesized from jsonschema's
+  violations via ``pydantic_core.ValidationError.from_exception_data`` — so the agent's existing
+  ``except ValidationError`` arm needs no new species.
+- **Non-coercing subset check (D3).** ``jsonschema`` checks conformance to the advertised schema
+  *as written* (no coercion, no ``format`` enforcement); the callee's own validation stays
+  authoritative. The dialect follows a declared ``$schema`` (default Draft 2020-12).
+- **Totality (D4).** The only exception this module ever raises is that contract error, for a real
+  instance violation. Every other failure degrades OPEN — dispatch unvalidated, today's behavior —
+  with a warning:
+    * a schema that cannot compile (malformed ``$schema`` non-string, bad keyword, non-dict) or
+      cannot be serialized into a cache key (unserializable value, or a pathologically deep schema
+      that blows ``json.dumps``'s recursion limit) yields a pass-through validator (warn-once per
+      schema; the uncached key-construction failures warn per call);
+    * a schema that compiles but fails *while validating an instance* (unresolvable ``$ref``,
+      ``RecursionError`` from a cyclic schema or deep args) swallows THAT call (warn-once per
+      schema) and keeps enforcing every other args shape — per-call, never a permanent disable,
+      because such failures can be instance-driven (spec §8.3 [R2-M1]).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Mapping
+from functools import lru_cache
+from typing import Any
+
+from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
+from jsonschema.validators import validator_for
+from pydantic_core import InitErrorDetails, PydanticCustomError
+from pydantic_core import ValidationError as CoreValidationError
+
+from calfkit.models.tool_dispatch import ArgsValidator
+
+logger = logging.getLogger(__name__)
+
+# Bounded: per-run override schemas vary over process lifetime, so an unbounded cache would leak;
+# the bound is a runaway backstop, not a working set (cluster tool count is small and repeats).
+_CACHE_SIZE = 1024
+# Truncate the schema echoed in a degrade warning — an advertised schema is unbounded wire data.
+_MAX_LOGGED_SCHEMA = 500
+
+
+def _passthrough(args: dict[str, Any]) -> None:  # noqa: ARG001
+    """The degrade-open validator: accepts any args (dispatch unvalidated)."""
+
+
+def _truncate(text: str) -> str:
+    return text if len(text) <= _MAX_LOGGED_SCHEMA else text[:_MAX_LOGGED_SCHEMA] + "…"
+
+
+def _sort_key(error: JsonSchemaValidationError) -> tuple[list[str], str, str]:
+    """Deterministic ordering for a violation set. Path elements are stringified so a mixed
+    ``str`` (object key) / ``int`` (array index) path never raises on comparison; the failing
+    keyword and message break ties for full stability."""
+    return ([str(part) for part in error.absolute_path], str(error.validator), str(error.message))
+
+
+@lru_cache(maxsize=_CACHE_SIZE)
+def _compiled(schema_key: str) -> ArgsValidator:
+    """Compile a canonical schema key into the validator closure — cached so the per-turn rebuilt
+    bindings for one tool share a single compiled validator. Keyed by canonical JSON content
+    (``lru_cache`` can only key the string), loaded back to the schema dict here.
+
+    Warn-once-per-schema falls out of the cache: the compile-time warning fires exactly once (the
+    cached entry is reused thereafter), and the validate-time warning is deduped by the closure's
+    ``warned`` cell.
+    """
+    try:
+        schema = json.loads(schema_key)
+        validator_cls = validator_for(schema)
+        validator_cls.check_schema(schema)
+        validator = validator_cls(schema)
+    except Exception:
+        # Compile-time failure (bad $schema, bad keyword, non-dict, …): degrade open. exc_info is
+        # kept — a compile exception is shallow and identifies the malformed keyword.
+        logger.warning("tool arg schema does not compile; dispatching unvalidated: %s", _truncate(schema_key), exc_info=True)
+        return _passthrough
+
+    warned = False  # validate-time per-call swallow, deduped to warn-once per schema
+
+    def _validate(args: dict[str, Any]) -> None:
+        nonlocal warned
+        try:
+            # Eager drain (via sorted): a generator that yields real violations and THEN raises
+            # (e.g. required-then-unresolvable-$ref) must discard the partials — enforcement is
+            # all-or-none per call, not a nondeterministic partial report.
+            errors = sorted(validator.iter_errors(args), key=_sort_key)
+        except Exception:
+            # An instance-driven failure (unresolvable $ref reached by this instance, RecursionError
+            # from a cyclic schema or deep args): swallow THIS call, keep enforcing others. exc_info
+            # is suppressed — a RecursionError traceback is ~2000 frames.
+            if not warned:
+                logger.warning("tool arg schema failed to validate an instance; dispatching this call unvalidated: %s", _truncate(schema_key))
+                warned = True
+            return
+        if not errors:
+            return
+        # The contract raise sits OUTSIDE the swallow catch: it is built from already-materialized
+        # violation data and must never be mistaken for an "unenforceable" degrade.
+        line_errors: list[InitErrorDetails] = [
+            {
+                "type": PydanticCustomError("json_schema_violation", "{reason}", {"reason": error.message}),
+                "loc": tuple(error.absolute_path),
+                "input": error.instance,
+            }
+            for error in errors
+        ]
+        raise CoreValidationError.from_exception_data("tool-args", line_errors)
+
+    return _validate
+
+
+def schema_args_validator(schema: Mapping[str, Any]) -> ArgsValidator:
+    """Compile ``schema`` into an :data:`ArgsValidator` that raises ``pydantic.ValidationError`` on
+    a real instance violation and is otherwise total (spec D4). Content-keyed and cached:
+    equal-content schemas share one validator."""
+    try:
+        schema_key = json.dumps(schema, sort_keys=True, separators=(",", ":"))
+    except Exception:
+        # The cache key could not be built. Two known causes, both degrade OPEN (dispatch
+        # unvalidated), uncached — so this warns on every dispatch of that tool: a schema value that
+        # is not JSON-serializable (hand-rolled edge; wire schemas are JSON-native by provenance),
+        # or a pathologically deep schema whose serialization blows the recursion limit. The message
+        # carries only the top-level keys — ``repr`` of a deep schema would itself recurse and raise.
+        hint = list(schema)[:10] if isinstance(schema, Mapping) else type(schema).__name__
+        logger.warning("tool arg schema cannot be serialized as a cache key; dispatching unvalidated (top-level keys=%r)", hint)
+        return _passthrough
+    return _compiled(schema_key)
+
+
+def cache_clear() -> None:
+    """Reset the compile cache (test isolation)."""
+    _compiled.cache_clear()

--- a/calfkit/models/capability.py
+++ b/calfkit/models/capability.py
@@ -93,9 +93,10 @@ def _namespace_prefix(node_kind: str, name: str) -> str:
 def record_to_bindings(record: CapabilityRecord, *, name: str) -> list[ToolBinding]:
     """Expand a record into validator-less :class:`ToolBinding`s.
 
-    Wire-crossing tools dispatch unvalidated (the schema-only carve-out): the advertiser
-    validates arguments on receipt — the toolbox's MCP server, or the tool node's own
-    function schema.
+    Validator-less by construction (no local function to build a signature validator from — only
+    the advertised schema): the agent validates args at dispatch against
+    ``parameters_json_schema`` (a non-coercing subset check), and the advertiser stays
+    authoritative on receipt — the toolbox's MCP server, or the tool node's own function schema.
 
     ``name`` is the advertiser's identity (its ``node_id`` / capability key — the
     control-plane wire key, never a field in the record value), supplied by the caller.

--- a/calfkit/models/tool_dispatch.py
+++ b/calfkit/models/tool_dispatch.py
@@ -15,7 +15,12 @@ if TYPE_CHECKING:
     from calfkit.models.capability import EnumerableCapabilityView
 
 ArgsValidator = Callable[[dict[str, Any]], Any]
-"""Validates LLM-emitted tool args pre-dispatch; raises ``pydantic.ValidationError`` on mismatch."""
+"""Validates LLM-emitted tool args pre-dispatch; raises ``pydantic.ValidationError`` on mismatch.
+
+Two implementations satisfy this contract: a local tool node's signature-built validator, and the
+advertised-schema validator :func:`~calfkit.models.args_schema.schema_args_validator` builds for a
+wire-crossing binding. The latter translates jsonschema's violations into the *same*
+``pydantic.ValidationError``, so the agent's dispatch loop stays blind to which one ran."""
 
 
 class ToolBinding(BaseModel):
@@ -32,8 +37,10 @@ class ToolBinding(BaseModel):
     Doubles as the wire model for per-run tool overrides
     (``OverridesState.override_agent_tools``): ``validator`` is process-local
     and excluded from serialization, so a deserialized binding always carries
-    ``validator=None`` and dispatches unvalidated — the schema-only carve-out,
-    enforced by the type instead of by convention.
+    ``validator=None``. Such a binding is not unvalidated — at dispatch the agent
+    validates its args against the advertised ``tool_def.parameters_json_schema``
+    (:func:`~calfkit.models.args_schema.schema_args_validator`); the ``validator``
+    field only distinguishes a local *signature* validator from that schema fallback.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -46,9 +53,10 @@ class ToolBinding(BaseModel):
     dispatch_topic: str = Field(min_length=1)
     """Target topic for the ``Call`` carrying the :class:`ToolCallRef`."""
     validator: SkipJsonSchema[ArgsValidator | None] = Field(default=None, exclude=True)
-    """Validates args before dispatch; ``None`` dispatches unvalidated (e.g. a
-    schema-only override binding, or an MCP tool where the server validates).
-    Excluded from serialization and JSON schema: callables never ride the wire."""
+    """A local tool node's signature-built validator, or ``None`` for a wire-crossing binding
+    (override, discovered, MCP) — in which case the agent falls back to a validator built from
+    ``tool_def.parameters_json_schema`` at dispatch. Excluded from serialization and JSON schema:
+    callables never ride the wire."""
 
     @property
     def name(self) -> str:

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -25,6 +25,7 @@ from calfkit.controlplane import ControlPlaneStamp, advertises
 from calfkit.exceptions import DeserializationError, safe_exc_message
 from calfkit.models import Call, DataPart, NodeResult, ReturnCall, State, TailCall, TextPart
 from calfkit.models.agents import AGENTS_TOPIC, AGENTS_VIEW_RESOURCE_KEY, AgentCard, derive_input_topic
+from calfkit.models.args_schema import schema_args_validator
 from calfkit.models.capability import CAPABILITY_VIEW_RESOURCE_KEY, SelectorResult
 from calfkit.models.envelope import Envelope
 from calfkit.models.marker import ToolCallMarker
@@ -627,9 +628,9 @@ class BaseAgentNodeDef(
     async def run(self, ctx: SessionRunContext) -> NodeResult[State] | Observed[State]:
         tools_registry = dict[str, ToolBinding]()
         if ctx.state.overrides is not None and ctx.state.overrides.override_agent_tools is not None:
-            # Override tools arrive over the wire as ToolBindings whose
-            # validator was stripped at serialization, so they dispatch
-            # unvalidated (the documented schema-only carve-out).
+            # Override tools arrive over the wire as ToolBindings whose validator was stripped at
+            # serialization (validator=None); the dispatch loop validates their args against the
+            # advertised schema instead (the schema fallback), so they are not unvalidated.
             tools_registry = {binding.name: binding for binding in ctx.state.overrides.override_agent_tools}
         elif self.tools:
             tools_registry = {binding.name: binding for binding in self.tools}
@@ -789,9 +790,10 @@ class BaseAgentNodeDef(
                     continue
 
                 # Parse args from the LLM's emission. Applies to ALL dispatch
-                # paths so that malformed-JSON args from override (schema-only)
-                # tools are also surfaced as an LLM-visible RetryPromptPart at the
-                # agent, instead of dispatching unparseable args across the wire.
+                # paths so that malformed-JSON args from a validator-less binding
+                # (override, discovered) are also surfaced as an LLM-visible
+                # RetryPromptPart at the agent, instead of dispatching unparseable
+                # args across the wire.
                 #
                 # ``args_as_dict()`` can raise more than just ValueError /
                 # AssertionError: ``pydantic_core.from_json`` raises TypeError
@@ -813,42 +815,46 @@ class BaseAgentNodeDef(
                     self._reject_invalid_call(tool_call, ctx, facts, content)
                     continue
 
-                # Validate against the schema if we have a runtime validator.
-                # Validator-less bindings (e.g. wire-deserialized overrides)
-                # skip this step and dispatch unvalidated; this is the
-                # documented carve-out.
-                if binding.validator is not None:
-                    try:
-                        binding.validator(args)
-                    except ValidationError as e:
-                        validation_errors = e.errors(include_url=False, include_context=False)
-                        logger.warning(
-                            "[%s] tool=%s arg validation failed at dispatch: %s",
-                            ctx.correlation_id[:8],
-                            tool_call.tool_name,
-                            validation_errors,
-                        )
-                        # validation_errors is a list[dict] (e.errors()): the RetryPromptPart carries it
-                        # verbatim; _reject_invalid_call renders it to JSON text for the step.
-                        self._reject_invalid_call(tool_call, ctx, facts, validation_errors)
-                        continue
-                    except Exception as e:
-                        # A user-authored Pydantic ``field_validator`` raised
-                        # something other than ``ValidationError`` (e.g.
-                        # ``RuntimeError``, ``TypeError``, a custom exception).
-                        # Surface as ``RetryPromptPart`` so the LLM can retry
-                        # rather than letting the exception escape ``run()`` and
-                        # silently hang the caller.
-                        validator_content = f"Tool argument validator raised {type(e).__name__}: {safe_exc_message(e)}"
-                        logger.warning(
-                            "[%s] tool=%s arg validator raised %s; surfacing as RetryPromptPart",
-                            ctx.correlation_id[:8],
-                            tool_call.tool_name,
-                            type(e).__name__,
-                            exc_info=True,
-                        )
-                        self._reject_invalid_call(tool_call, ctx, facts, validator_content)
-                        continue
+                # Validate args before dispatch. A local tool carries a signature-built validator
+                # (rich: field_validators, coercion); a wire-crossing binding (discovered /
+                # override / hand-rolled) carries none, so we fall back to a validator compiled
+                # from its advertised ``parameters_json_schema`` — a non-coercing subset check
+                # against the contract shown to the model. The callee stays authoritative. The
+                # factory is TOTAL (it raises nothing except the ``ValidationError`` contract error),
+                # so the build sits OUTSIDE the try: a raise here would be a logic bug, not a retry.
+                validator = binding.validator or schema_args_validator(binding.tool_def.parameters_json_schema)
+                try:
+                    validator(args)
+                except ValidationError as e:
+                    validation_errors = e.errors(include_url=False, include_context=False)
+                    logger.warning(
+                        "[%s] tool=%s arg validation failed at dispatch: %s",
+                        ctx.correlation_id[:8],
+                        tool_call.tool_name,
+                        validation_errors,
+                    )
+                    # validation_errors is a list[dict] (e.errors()): the RetryPromptPart carries it
+                    # verbatim; _reject_invalid_call renders it to JSON text for the step.
+                    self._reject_invalid_call(tool_call, ctx, facts, validation_errors)
+                    continue
+                except Exception as e:
+                    # A user-authored Pydantic ``field_validator`` raised
+                    # something other than ``ValidationError`` (e.g.
+                    # ``RuntimeError``, ``TypeError``, a custom exception).
+                    # Surface as ``RetryPromptPart`` so the LLM can retry
+                    # rather than letting the exception escape ``run()`` and
+                    # silently hang the caller. (The schema fallback validator is
+                    # total, so only a local signature validator reaches here.)
+                    validator_content = f"Tool argument validator raised {type(e).__name__}: {safe_exc_message(e)}"
+                    logger.warning(
+                        "[%s] tool=%s arg validator raised %s; surfacing as RetryPromptPart",
+                        ctx.correlation_id[:8],
+                        tool_call.tool_name,
+                        type(e).__name__,
+                        exc_info=True,
+                    )
+                    self._reject_invalid_call(tool_call, ctx, facts, validator_content)
+                    continue
 
             # Every dispatch-loop exit below returns Observed(action, tuple(facts)) UNCONDITIONALLY
             # (an empty facts tuple is permitted) — the kernel absorbs the facts at the unwrap.

--- a/docs/tool-discovery.md
+++ b/docs/tool-discovery.md
@@ -53,10 +53,11 @@ process — is picked up on the next turn. No restarts, no bring-up order.
 
 **Which handle?** Reach for `Tools(...)` when you want the agent's deployment
 decoupled from the tool's code — the schema travels over the plane. Pass the live
-node (`tools=[add]`) when you'd rather bake the schema in and validate arguments
-locally *before* dispatch, at the cost of importing the tool. Same node, either
-handle. (A discovered binding defers argument validation to the tool node; see the
-[design spec](designs/runtime-tool-discoverability-spec.md) for the full trade-off.)
+node (`tools=[add]`) when you'd rather import the tool and bake its schema in. Either
+way the agent validates the model's arguments *before* dispatch: a live node uses the
+tool's own signature validator (with coercion and any custom field validators), while a
+discovered binding checks them against the advertised JSON schema — a non-coercing
+subset check, with the tool node staying authoritative on receipt.
 
 ## Discover every tool node
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,11 @@ dependencies = [
     # CLI (`ck`): typer powers the console script, watchfiles powers `ck run --reload`.
     "typer>=0.12",
     "watchfiles>=0.21",
+    # Caller-side tool-arg validation: the Draft 2020-12 reference implementation, used to
+    # compile a runtime validator from a discovered tool's advertised `parameters_json_schema`.
+    # Floor >=4.18 is the first `referencing`-based release (stable `$ref` resolution); already
+    # in the locked closure as a hard dep of `mcp`, so this direct declaration is install-free.
+    "jsonschema>=4.18",
 ]
 
 [project.urls]
@@ -96,6 +101,13 @@ exclude = ["calfkit/_vendor"]
 # two under warn_unused_ignores, so the suppression lives here, env-independent.
 [[tool.mypy.overrides]]
 module = "calfkit_mesh"
+ignore_missing_imports = true
+
+# jsonschema ships no py.typed; its published stubs (types-jsonschema) are a separate package the
+# project does not vendor. Suppress here rather than inline, matching the calfkit_mesh precedent
+# (env-independent under warn_unused_ignores).
+[[tool.mypy.overrides]]
+module = "jsonschema.*"
 ignore_missing_imports = true
 
 [tool.coverage.run]

--- a/tests/integration/_roundtrip_helpers.py
+++ b/tests/integration/_roundtrip_helpers.py
@@ -99,6 +99,31 @@ def final_model(text: str = FINAL_OUTPUT) -> FunctionModel:
     return FunctionModel(_fn)
 
 
+def correcting_model(bad_calls: list[ToolCallPart], good_calls: list[ToolCallPart]) -> FunctionModel:
+    """A model for the validate → reject → correct loop.
+
+    Emits ``bad_calls`` on its first turn, ``good_calls`` on its second (after the agent rejected
+    the bad args), then finalizes with :data:`FINAL_OUTPUT`. The phase is keyed on how many tool
+    calls THIS MODEL has already emitted (its own ``ToolCallPart``s in prior ``ModelResponse``s) —
+    NOT on the kind of answer it got back. That distinction matters: a caller-side arg rejection
+    reaches the model as a ``ToolReturnPart`` whose content is the schema-violation error (not a
+    ``RetryPromptPart``), indistinguishable by type from a genuine tool result — so keying on
+    "did a tool return?" would finalize on the rejection and never send the correction. Counting
+    own emissions is rendering-agnostic and idempotent (a redelivered turn re-derives the same
+    count from history).
+    """
+
+    def _fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        emitted = sum(1 for msg in messages if isinstance(msg, ModelResponse) for part in msg.parts if isinstance(part, ToolCallPart))
+        if emitted == 0:
+            return ModelResponse(parts=list(bad_calls))
+        if emitted == 1:
+            return ModelResponse(parts=list(good_calls))
+        return ModelResponse(parts=[TextPart(FINAL_OUTPUT)])
+
+    return FunctionModel(_fn)
+
+
 def reactive_model(decide: Callable[[dict[str, object]], list[ToolCallPart] | None]) -> FunctionModel:
     """A multi-turn model driven by the tool returns seen so far.
 

--- a/tests/integration/test_mcp_roundtrip_kafka.py
+++ b/tests/integration/test_mcp_roundtrip_kafka.py
@@ -55,6 +55,7 @@ from tests.integration._kafka_helpers import fast_control_plane
 from tests.integration._roundtrip_helpers import (
     FINAL_OUTPUT,
     capturing_model,
+    correcting_model,
     retry_prompt_texts,
     returns_by_call_id,
     scripted_model,
@@ -647,6 +648,75 @@ async def test_agent_pov_is_namespaced_and_strips_to_bare_on_dispatch(
     assert result.output is not None and FINAL_OUTPUT in result.output
     assert "5" in _serialized(returns[_ns(server_name, "add")])
     assert "hi" in _serialized(returns[_ns(server_name, "echo")])
+
+    await driver.aclose()
+    await toolbox_worker._client.aclose()
+    await agent_worker._client.aclose()
+
+
+async def test_mcp_bad_args_rejected_before_dispatch_then_corrected(
+    kafka_bootstrap: str, topic_namespace: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Caller-side arg validation applies to a DISCOVERED MCP tool too: the agent builds a validator
+    from the server's advertised ``inputSchema`` and rejects schema-invalid args BEFORE dispatch.
+    The bad call never reaches the MCP server; the model corrects itself and the corrected call
+    round-trips to ``5``.
+
+    "The server never saw the bad call" is proved at the ``mcp.ClientSession.call_tool`` boundary
+    (the same spy the POV test uses): it records exactly one invocation — the corrected ``add(2, 3)``
+    — and never the bad args.
+    """
+    import mcp
+
+    agent_id = f"{topic_namespace}-mcp-reject"
+    agent_in = f"{topic_namespace}.mcp-reject.input"
+    control_plane = fast_control_plane(kafka_bootstrap)
+    server_name = _server_name(topic_namespace)
+
+    # Spy the node->server boundary: record (bare tool name, arguments) for every real call_tool.
+    # calfkit calls ``session.call_tool(name=..., arguments=...)`` (both keyword), so the arguments
+    # ride in kwargs. monkeypatch auto-reverts.
+    seen: list[tuple[str, object]] = []
+    _orig_call_tool = mcp.ClientSession.call_tool
+
+    async def _spy_call_tool(self: Any, name: str, *args: Any, **kwargs: Any) -> Any:
+        seen.append((name, kwargs.get("arguments", args[0] if args else None)))
+        return await _orig_call_tool(self, name, *args, **kwargs)
+
+    monkeypatch.setattr(mcp.ClientSession, "call_tool", _spy_call_tool)
+
+    toolbox = MCPToolboxNode(server_name, connection_params=_server_params(_SERVER_SCRIPT))
+    tool = _ns(server_name, "add")  # `add(a: int, b: int)` — the server advertises typed integer args
+    agent = Agent(
+        agent_id,
+        system_prompt="add two numbers",
+        subscribe_topics=agent_in,
+        model_client=correcting_model(
+            [ToolCallPart(tool, {"a": "not-an-int", "b": 3}, tool_call_id="bad")],
+            [ToolCallPart(tool, {"a": 2, "b": 3}, tool_call_id="good")],
+        ),
+        tools=[toolbox.select(include=["add"])],  # include = BARE (C5)
+    )
+
+    driver = Client.connect(kafka_bootstrap)
+    toolbox_worker = _worker(kafka_bootstrap, nodes=[toolbox], control_plane=control_plane)
+    agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
+
+    async with toolbox_worker:
+        await _await_capability(kafka_bootstrap, server_name, timeout=60)
+        async with agent_worker:
+            result = await driver.agent(topic=agent_in).execute("add 2 and 3", timeout=120)
+
+    by_id = returns_by_call_id(result.message_history)
+    # The bad call was rejected caller-side (calfkit's json_schema_violation — NOT a server-side
+    # FastMCP validation error, which would prove the server was contacted).
+    surfaced_bad = f"{by_id.get('bad', '')} {' '.join(retry_prompt_texts(result.message_history))}"
+    assert "json_schema_violation" in surfaced_bad, f"expected a caller-side schema violation, got: {surfaced_bad!r}"
+    # The corrected call round-tripped through the real server.
+    assert result.output is not None and FINAL_OUTPUT in result.output
+    assert "5" in _serialized(by_id.get("good"))
+    # The server saw ONLY the corrected call — the bad args never crossed the node->server boundary.
+    assert seen == [("add", {"a": 2, "b": 3})], f"the server must see only the corrected call, but saw: {seen}"
 
     await driver.aclose()
     await toolbox_worker._client.aclose()

--- a/tests/integration/test_tool_discovery_kafka.py
+++ b/tests/integration/test_tool_discovery_kafka.py
@@ -8,18 +8,18 @@ its schema at runtime from the capability view, then dispatching the call over K
 
     the tool node advertises -> the agent's view catch-up includes it
       -> the model emits a tool call
-      -> the agent resolves ``Tools(name)`` from the view (validator=None: schema-only)
-      -> dispatches a ToolCallRef over Kafka to the tool node's topic
+      -> the agent resolves ``Tools(name)`` from the view (validator=None: no local validator)
+      -> validates the args against the advertised schema, then dispatches a ToolCallRef over Kafka
       -> the tool node runs the Python function
       -> the return value comes back over Kafka
       -> the agent re-enters the model loop and finalizes.
 
-The bad-args case is the discovered-binding contrast with the eager path
-(``test_invalid_tool_node_args_rejected_before_dispatch``): a discovered binding has NO
-validator, so the agent does NOT reject schema-invalid args locally — it dispatches them,
-the tool node raises on receipt, and the chokepoint escalates a typed ``calf.exception``
-``FaultMessage`` on the agent's ``publish_topic`` mirror (observed via the fault tap; typed
-client reception is deferred to #250).
+The bad-args case now matches the eager path
+(``test_invalid_tool_node_args_rejected_before_dispatch``): a discovered binding has no local
+validator, so the agent builds one from the advertised schema and rejects schema-invalid args
+BEFORE dispatch — a model-visible ``RetryPromptPart``, not a fault. The tool node never runs the
+bad call, and the model self-corrects on the next turn (the full advertise → discover → reject →
+correct → dispatch → result loop).
 
 Opt-in (``-m kafka`` / ``make test-kafka``); skips cleanly without Docker. Run with
 ``uv run --group integration pytest tests/integration/test_tool_discovery_kafka.py -m kafka``.
@@ -33,19 +33,23 @@ from typing import Any
 
 import pytest
 
-from calfkit._protocol import HDR_ERROR_TYPE, HDR_KIND
 from calfkit._vendor.pydantic_ai import models
 from calfkit._vendor.pydantic_ai.messages import ToolCallPart
 from calfkit.client import Client
 from calfkit.controlplane import ControlPlaneConfig, ControlPlaneView
 from calfkit.models.capability import CAPABILITY_TOPIC, CapabilityRecord
-from calfkit.models.error_report import FaultTypes
 from calfkit.nodes import Agent, ToolNodeDef, Tools, agent_tool
 from calfkit.worker import Worker
-from tests.integration._fault_kafka import ensure_topic
-from tests.integration._fault_tap import fault_tap
 from tests.integration._kafka_helpers import fast_control_plane
-from tests.integration._roundtrip_helpers import FINAL_OUTPUT, capturing_model, scripted_model, tool_returns
+from tests.integration._roundtrip_helpers import (
+    FINAL_OUTPUT,
+    capturing_model,
+    correcting_model,
+    retry_prompt_texts,
+    returns_by_call_id,
+    scripted_model,
+    tool_returns,
+)
 
 # Every test here needs a real broker. FunctionModel is offline, but pydantic-ai still
 # gates "model requests" behind this flag (matches the other kafka-lane agent suites).
@@ -72,6 +76,19 @@ def _add_tool(name: str) -> ToolNodeDef:
         return a + b
 
     return agent_tool(add, name=name)
+
+
+def _counting_add_tool(name: str) -> tuple[ToolNodeDef, list[dict]]:
+    """Like :func:`_add_tool` but records every invocation into a returned list. Workers run
+    in-process on the kafka lane, so the closure list is mutated live — a direct "did the tool
+    body run, and with what args?" observable (no fault-tap timeout race)."""
+    calls: list[dict] = []
+
+    def add(a: int, b: int) -> int:
+        calls.append({"a": a, "b": b})
+        return a + b
+
+    return agent_tool(add, name=name), calls
 
 
 async def _wait(predicate: Callable[[], bool], *, timeout: float, what: str) -> None:
@@ -203,27 +220,25 @@ async def test_model_pov_matches_the_advertised_tool(kafka_bootstrap: str, topic
     await agent_worker._client.aclose()
 
 
-async def test_discovered_bad_args_escalate_unhandled_fault(kafka_bootstrap: str, topic_namespace: str) -> None:
-    """A discovered binding carries NO validator (schema-only), so the agent dispatches
-    schema-invalid args instead of rejecting them locally (the eager path's contrast): the
-    tool node raises on receipt and the chokepoint escalates a typed ``calf.exception``
-    ``FaultMessage`` on the agent's ``publish_topic`` mirror."""
+async def test_discovered_bad_args_rejected_before_dispatch(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """A discovered binding has no local validator, so the agent builds one from the advertised
+    schema and rejects schema-invalid args BEFORE dispatch — matching the eager path. The tool
+    node never runs the bad call (no Kafka dispatch, no fault); the model sees a json-schema
+    violation and finalizes."""
     tool_name = f"{topic_namespace}-add"
-    agent_id = f"{topic_namespace}-disc-fault"
-    agent_in = f"{topic_namespace}.disc-fault.input"
-    agent_pub = f"{topic_namespace}.disc-fault.mirror"
+    agent_id = f"{topic_namespace}-disc-reject"
+    agent_in = f"{topic_namespace}.disc-reject.input"
     control_plane = fast_control_plane(kafka_bootstrap)
 
-    tool = _add_tool(tool_name)
+    tool, calls = _counting_add_tool(tool_name)
     agent = Agent(
         agent_id,
         system_prompt="add with bad args",
         subscribe_topics=agent_in,
-        publish_topic=agent_pub,
+        # `a` is typed int in the advertised schema; the model emits a string -> schema violation.
         model_client=scripted_model([ToolCallPart(tool_name, {"a": "not-an-int", "b": 3}, tool_call_id="c1")]),
         tools=[Tools(tool_name)],
     )
-    await ensure_topic(kafka_bootstrap, agent_pub)
 
     driver = Client.connect(kafka_bootstrap)
     tool_worker = _worker(kafka_bootstrap, nodes=[tool], control_plane=control_plane)
@@ -231,16 +246,63 @@ async def test_discovered_bad_args_escalate_unhandled_fault(kafka_bootstrap: str
 
     async with tool_worker:
         await _await_capability(kafka_bootstrap, tool_name, timeout=60)
-        async with agent_worker, fault_tap(kafka_bootstrap, agent_pub) as tap:
-            await driver.agent(topic=agent_in).start("add with bad args")  # reply owed; the discovered binding dispatches the bad args
+        async with agent_worker:
+            result = await driver.agent(topic=agent_in).execute("add with bad args", timeout=120)
 
-            fault, headers = await tap.next_fault(timeout=60)
-            # The bad args reached the tool node (the discovered binding did NOT validate
-            # locally), and its raise escalated as a typed unhandled fault.
-            assert headers[HDR_KIND] == "fault"
-            assert headers[HDR_ERROR_TYPE] == FaultTypes.EXCEPTION
-            assert fault.error.error_type == FaultTypes.EXCEPTION
-            assert fault.error.exception is not None  # the tool's exception class
+    # Finalized (scripted_model treats the retry as "acted" -> FINAL_OUTPUT), the tool body NEVER
+    # ran (rejected pre-dispatch), and the model saw the typed json-schema violation. The rejection
+    # surfaces in the persisted transcript as the answer to call "c1" (a tool-return-style entry on
+    # some paths, a retry prompt on others — check both, mirroring the eager template).
+    assert result.output is not None and FINAL_OUTPUT in result.output
+    assert calls == [], f"the tool must not run on schema-invalid args, but it saw: {calls}"
+    surfaced = f"{returns_by_call_id(result.message_history).get('c1', '')} {' '.join(retry_prompt_texts(result.message_history))}"
+    assert "json_schema_violation" in surfaced, f"expected the schema violation surfaced to the model, got: {surfaced!r}"
+
+    await driver.aclose()
+    await tool_worker._client.aclose()
+    await agent_worker._client.aclose()
+
+
+async def test_discovered_bad_args_retry_loop_self_corrects(kafka_bootstrap: str, topic_namespace: str) -> None:
+    """The full advertise -> discover -> reject -> correct -> dispatch -> result loop over a real
+    broker: the model emits schema-invalid args, sees the caller-side rejection, re-emits
+    conforming args on the next turn, and the corrected call round-trips to ``5``."""
+    tool_name = f"{topic_namespace}-add"
+    agent_id = f"{topic_namespace}-disc-correct"
+    agent_in = f"{topic_namespace}.disc-correct.input"
+    control_plane = fast_control_plane(kafka_bootstrap)
+
+    tool, calls = _counting_add_tool(tool_name)
+    agent = Agent(
+        agent_id,
+        system_prompt="add two numbers",
+        subscribe_topics=agent_in,
+        model_client=correcting_model(
+            [ToolCallPart(tool_name, {"a": "not-an-int", "b": 3}, tool_call_id="bad")],
+            [ToolCallPart(tool_name, {"a": 2, "b": 3}, tool_call_id="good")],
+        ),
+        tools=[Tools(tool_name)],
+    )
+
+    driver = Client.connect(kafka_bootstrap)
+    tool_worker = _worker(kafka_bootstrap, nodes=[tool], control_plane=control_plane)
+    agent_worker = _worker(kafka_bootstrap, nodes=[agent], control_plane=control_plane)
+
+    async with tool_worker:
+        await _await_capability(kafka_bootstrap, tool_name, timeout=60)
+        async with agent_worker:
+            result = await driver.agent(topic=agent_in).execute("add 2 and 3", timeout=120)
+
+    # The rejection was model-visible (a json-schema violation on the "bad" call) AND recoverable:
+    # the corrected "good" call dispatched over the wire and 5 came back. The tool ran exactly once
+    # — with the GOOD args only. Probe by call id so the bad rejection and good result don't collide.
+    assert result.output is not None and FINAL_OUTPUT in result.output
+    by_id = returns_by_call_id(result.message_history)
+    surfaced_bad = f"{by_id.get('bad', '')} {' '.join(retry_prompt_texts(result.message_history))}"
+    assert "json_schema_violation" in surfaced_bad, f"expected the bad call's schema violation surfaced, got: {surfaced_bad!r}"
+    assert by_id.get("good") == 5
+    assert tool_returns(result.message_history)[tool_name] == 5
+    assert calls == [{"a": 2, "b": 3}], f"the tool must run once with corrected args only, but saw: {calls}"
 
     await driver.aclose()
     await tool_worker._client.aclose()

--- a/tests/test_args_schema.py
+++ b/tests/test_args_schema.py
@@ -1,0 +1,278 @@
+"""Unit tests for the caller-side JSON-schema arg-validator factory
+(``calfkit/models/args_schema.py``).
+
+The factory compiles a discovered tool's advertised ``parameters_json_schema`` into an
+``ArgsValidator`` that raises ``pydantic.ValidationError`` on a real instance violation and is
+otherwise TOTAL — every compile/validate-time failure degrades OPEN (dispatch unvalidated) with a
+warning, never propagating past the contract error (spec D4).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from pydantic import ValidationError
+
+from calfkit.models import args_schema
+from calfkit.models.args_schema import schema_args_validator
+
+
+@pytest.fixture(autouse=True)
+def _clear_validator_cache():
+    """The factory's compile cache is module-global and outlives each test, so warn-once and
+    cache-identity assertions are order-dependent without a reset. Clear before AND after."""
+    args_schema.cache_clear()
+    yield
+    args_schema.cache_clear()
+
+
+# --------------------------------------------------------------------------- #
+# Cycle 1 — translation shape, valid args, determinism                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_multiple_violations_raise_one_validation_error_with_all_entries():
+    schema = {
+        "type": "object",
+        "properties": {
+            "city": {"type": "string"},
+            "days": {"type": "integer"},
+            "units": {"enum": ["metric", "imperial"]},
+        },
+        "required": ["city"],
+        "additionalProperties": False,
+    }
+    validator = schema_args_validator(schema)
+
+    with pytest.raises(ValidationError) as exc_info:
+        validator({"days": "twenty", "units": "kelvin", "bogus": 1})
+
+    errors = exc_info.value.errors(include_url=False, include_context=False)
+    # Every violation surfaces at once (not first-only), each in the pydantic error shape.
+    assert len(errors) == 4
+    assert all(e["type"] == "json_schema_violation" for e in errors)
+    assert all({"type", "loc", "msg", "input"} <= set(e) for e in errors)
+    # The jsonschema message text rides through verbatim (brace-safe: the reason is a ctx value,
+    # never a format template).
+    assert any("'city' is a required property" in e["msg"] for e in errors)
+    # For a whole-object keyword (additionalProperties), `input` is the FULL args subtree, not the
+    # offending scalar — pin it, since that payload is what the retry prompt / step text echoes (D2).
+    extra_key = next(e for e in errors if "Additional properties" in e["msg"])
+    assert extra_key["loc"] == ()
+    assert extra_key["input"] == {"days": "twenty", "units": "kelvin", "bogus": 1}
+
+
+def test_bool_is_rejected_for_an_integer_field():
+    # Python's ``bool`` is an ``int`` subclass, but jsonschema (correctly) rejects ``True``/``False``
+    # for ``integer``. The strictness delta (spec D6.2) names both ``"3"`` and ``True``; this pins
+    # the subtler bool case so a future engine/dialect change can't silently start accepting it.
+    validator = schema_args_validator({"type": "object", "properties": {"n": {"type": "integer"}}})
+    with pytest.raises(ValidationError):
+        validator({"n": True})
+    validator({"n": 3})  # a real integer still passes
+
+
+def test_valid_args_do_not_raise():
+    schema = {
+        "type": "object",
+        "properties": {"city": {"type": "string"}, "days": {"type": "integer", "default": 3}},
+        "required": ["city"],
+    }
+    validator = schema_args_validator(schema)
+    # Conforming args, including an omitted optional with a default, return without raising.
+    validator({"city": "SF"})
+
+
+def test_violation_order_is_deterministic_and_carries_int_array_indices():
+    schema = {
+        "type": "object",
+        "properties": {"tags": {"type": "array", "items": {"type": "string"}}},
+    }
+    validator = schema_args_validator(schema)
+
+    with pytest.raises(ValidationError) as first:
+        validator({"tags": [1, 2, 3]})
+    with pytest.raises(ValidationError) as second:
+        validator({"tags": [1, 2, 3]})
+
+    locs_first = [e["loc"] for e in first.value.errors(include_url=False)]
+    locs_second = [e["loc"] for e in second.value.errors(include_url=False)]
+    assert locs_first == locs_second  # stable across runs
+    # Array-item paths put an int index in loc — the sort key must not choke on mixed str/int.
+    assert ("tags", 0) in locs_first and ("tags", 1) in locs_first and ("tags", 2) in locs_first
+
+
+# --------------------------------------------------------------------------- #
+# Cycle 2 — content-keyed cache identity                                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_equal_content_schemas_share_one_compiled_validator():
+    # Distinct dict objects, shuffled key order — same content once canonicalized.
+    schema_a = {"type": "object", "properties": {"x": {"type": "integer"}, "y": {"type": "string"}}}
+    schema_b = {"properties": {"y": {"type": "string"}, "x": {"type": "integer"}}, "type": "object"}
+    assert schema_args_validator(schema_a) is schema_args_validator(schema_b)
+
+
+def test_different_content_schemas_get_distinct_validators():
+    v1 = schema_args_validator({"type": "object", "properties": {"x": {"type": "integer"}}})
+    v2 = schema_args_validator({"type": "object", "properties": {"x": {"type": "string"}}})
+    assert v1 is not v2
+
+
+# --------------------------------------------------------------------------- #
+# Cycle 3 — totality (spec D4): the factory never raises but the contract error #
+# --------------------------------------------------------------------------- #
+
+
+def _warnings(caplog) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if r.levelno == logging.WARNING]
+
+
+@pytest.mark.parametrize(
+    "bad_schema",
+    [
+        {"type": "not-a-type"},  # check_schema rejects
+        {"$schema": 3},  # crashes validator_for BEFORE check_schema
+        None,  # json-serializable ("null") but validator_for(None) raises
+        [1, 2, 3],  # non-dict schema
+    ],
+    ids=["bad-type", "bad-$schema", "none", "non-dict"],
+)
+def test_compile_time_failure_degrades_open_and_warns_once(bad_schema, caplog):
+    with caplog.at_level(logging.WARNING, logger="calfkit.models.args_schema"):
+        validator = schema_args_validator(bad_schema)
+        # Degrades OPEN: the returned validator accepts anything (dispatch unvalidated).
+        validator({"anything": [1, {"nested": True}]})
+        validator({})
+        # A second construction of the same schema hits the cache — no second warning.
+        schema_args_validator(bad_schema)
+    assert len(_warnings(caplog)) == 1
+
+
+def test_validate_time_unresolvable_external_ref_swallows_per_call_and_warns_once(caplog):
+    schema = {"type": "object", "properties": {"b": {"$ref": "https://example.invalid/s.json"}}}
+    validator = schema_args_validator(schema)
+    with caplog.at_level(logging.WARNING, logger="calfkit.models.args_schema"):
+        validator({"b": "touches the unresolvable branch"})  # no raise — swallowed
+        validator({"b": "again"})  # still no raise; no second warning
+    assert len(_warnings(caplog)) == 1
+
+
+def test_validate_time_internal_dangling_ref_is_lazy_and_keeps_enforcing_untouched_shapes(caplog):
+    # `b`'s $ref dangles; `a` is a real constraint. A call that never touches `b` must still be
+    # validated (and rejected) — the per-call-swallow (b) property, not permanent degrade.
+    schema = {
+        "type": "object",
+        "properties": {"a": {"type": "string"}, "b": {"$ref": "#/$defs/nope"}},
+    }
+    validator = schema_args_validator(schema)
+    with caplog.at_level(logging.WARNING, logger="calfkit.models.args_schema"):
+        # Touches `b` → resolves the dangling ref → swallowed, no raise.
+        validator({"b": "x"})
+        # Does NOT touch `b` → the real `a` violation is still enforced.
+        with pytest.raises(ValidationError):
+            validator({"a": 123})
+    assert len(_warnings(caplog)) == 1
+
+
+def test_validate_time_cyclic_ref_recursionerror_is_swallowed(caplog):
+    schema = {
+        "type": "object",
+        "properties": {"x": {"$ref": "#/$defs/a"}},
+        "$defs": {"a": {"$ref": "#/$defs/b"}, "b": {"$ref": "#/$defs/a"}},
+    }
+    validator = schema_args_validator(schema)
+    with caplog.at_level(logging.WARNING, logger="calfkit.models.args_schema"):
+        validator({"x": 1})  # RecursionError from iter_errors → swallowed, no raise
+    assert len(_warnings(caplog)) == 1
+
+
+def test_validate_time_deep_args_on_valid_recursive_schema_swallow_then_shallow_still_validated(caplog):
+    # A LEGITIMATELY recursive schema (a tree). Deep args blow Python's recursion limit at
+    # validate time (instance-driven, not schema-driven), but a following shallow call must still
+    # be enforced — this is exactly why per-call swallow beats permanent degrade [R2-M1].
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}, "children": {"type": "array", "items": {"$ref": "#"}}},
+        "required": ["name"],
+    }
+    validator = schema_args_validator(schema)
+    node: dict = {"name": "leaf", "children": []}
+    for _ in range(2000):  # 2000 levels × several frames each ≫ the default 1000 recursion limit
+        node = {"name": "n", "children": [node]}
+    with caplog.at_level(logging.WARNING, logger="calfkit.models.args_schema"):
+        validator(node)  # RecursionError → swallowed, no raise
+    assert len(_warnings(caplog)) == 1
+    # The working tool is NOT permanently disabled: a shallow call is still validated + rejected.
+    with pytest.raises(ValidationError):
+        validator({"children": []})  # missing required "name"
+
+
+def test_within_call_all_or_none_no_partial_report(caplog):
+    # One call that both violates `required` AND touches an unresolvable branch → NO partial
+    # report; the whole call is swallowed (the eager sorted() drain discards yielded partials).
+    schema = {"type": "object", "properties": {"b": {"$ref": "#/$defs/nope"}}, "required": ["a"]}
+    validator = schema_args_validator(schema)
+    with caplog.at_level(logging.WARNING, logger="calfkit.models.args_schema"):
+        validator({"b": "x"})  # touches ref AND misses required "a" → swallowed, no raise
+        # Contrast: not touching the ref → the required violation IS reported.
+        with pytest.raises(ValidationError):
+            validator({})
+    assert len(_warnings(caplog)) == 1
+
+
+def test_unserializable_schema_degrades_open_and_warns_every_call(caplog):
+    schema = {"type": "object", "x": {1, 2}}  # a set is not JSON-serializable → cannot be cached
+    with caplog.at_level(logging.WARNING, logger="calfkit.models.args_schema"):
+        v1 = schema_args_validator(schema)
+        v1({"anything": True})  # degrades open
+        schema_args_validator(schema)  # uncached → warns AGAIN
+    assert len(_warnings(caplog)) == 2
+
+
+def test_pathologically_deep_schema_degrades_open_not_raises(caplog):
+    # A deeply-nested (acyclic, valid) advertised schema makes the cache-key `json.dumps` blow the
+    # recursion limit — a RecursionError, which is NOT a TypeError/ValueError. Totality (D4) means
+    # this degrades OPEN (dispatch unvalidated + warn), never escaping the factory to crash the run.
+    schema: dict = {"type": "integer"}
+    for _ in range(6000):
+        schema = {"type": "object", "properties": {"x": schema}}
+    with caplog.at_level(logging.WARNING, logger="calfkit.models.args_schema"):
+        validator = schema_args_validator(schema)  # must NOT raise
+        validator({"x": {"x": 1}})  # pass-through accepts anything
+    assert len(_warnings(caplog)) >= 1
+
+
+def test_dialect_defaults_to_2020_12_when_no_schema_declared():
+    # `prefixItems` (tuple validation) is a 2020-12 keyword. With no `$schema`, the factory must
+    # default to Draft 2020-12 and ENFORCE it.
+    schema = {"type": "object", "properties": {"pair": {"type": "array", "prefixItems": [{"type": "integer"}]}}}
+    validator = schema_args_validator(schema)
+    with pytest.raises(ValidationError):
+        validator({"pair": ["should-be-int"]})
+
+
+def test_dialect_honors_a_declared_draft07_schema():
+    # The SAME body under a declared draft-07 `$schema`: draft-07 has no `prefixItems`, so it is an
+    # unknown (ignored) keyword — the args that failed under 2020-12 now pass. Proves `$schema` is honored.
+    schema = {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {"pair": {"type": "array", "prefixItems": [{"type": "integer"}]}},
+    }
+    validator = schema_args_validator(schema)
+    validator({"pair": ["should-be-int"]})  # no raise — draft-07 ignores prefixItems
+
+
+def test_permissive_floors_accept_anything():
+    for schema in ({"type": "object", "properties": {}}, {}):
+        validator = schema_args_validator(schema)
+        validator({"whatever": [1, 2, 3], "nested": {"a": True}})
+
+
+def test_format_is_annotation_only_not_enforced():
+    schema = {"type": "object", "properties": {"when": {"type": "string", "format": "date-time"}}}
+    validator = schema_args_validator(schema)
+    validator({"when": "definitely not a date"})  # format is advisory — no raise

--- a/tests/test_capability_models.py
+++ b/tests/test_capability_models.py
@@ -108,7 +108,8 @@ class TestRecordToBindings:
         assert [b.name for b in bindings] == ["docs_server__search", "docs_server__fetch"]
         assert all(isinstance(b, ToolBinding) for b in bindings)
         assert all(b.dispatch_topic == "mcp_server.docs_server" for b in bindings)
-        # Wire-crossing tools dispatch unvalidated (schema-only carve-out).
+        # Validator-less by construction (no local function); the agent validates against the
+        # advertised schema at dispatch.
         assert all(b.validator is None for b in bindings)
 
     def test_tool_def_fields_survive(self) -> None:

--- a/tests/test_discover_kernel.py
+++ b/tests/test_discover_kernel.py
@@ -48,7 +48,7 @@ class TestResolveAllCapabilities:
     def test_discovered_bindings_are_validatorless(self) -> None:
         result = resolve_all_capabilities(_FakeView({"add": _record("add")}), node_kind="tool")
         assert [b.name for b in result.bindings] == ["add"]
-        assert result.bindings[0].validator is None  # discovered = schema-only (node validates on receipt)
+        assert result.bindings[0].validator is None  # discovered = no local validator (agent validates against the advertised schema at dispatch)
 
     def test_poisoned_record_of_the_right_kind_degrades_to_invalid_targets(self) -> None:
         # An empty dispatch_topic survives the tolerant reader but fails ToolBinding's

--- a/tests/test_schema_only_dispatch.py
+++ b/tests/test_schema_only_dispatch.py
@@ -1,24 +1,30 @@
 """Schema-only tool dispatch via the ``Agent(tools=[...])`` kwarg path.
 
-Pins two load-bearing properties of the agent loop for tools registered as
+Pins the load-bearing properties of the agent loop for tools registered as
 validator-less ``ToolBinding`` instances passed through the
 ``Agent(tools=[...])`` kwarg:
 
-  1. The agent dispatches the tool call without attempting client-side
-     argument validation. The ``binding.validator is not None`` gate in
-     ``calfkit/nodes/agent.py`` is False for a validator-less binding, so the
-     validation block is skipped entirely.
+  1. A call whose args CONFORM to the binding's advertised
+     ``parameters_json_schema`` dispatches. The binding carries no process-local
+     validator, so the agent builds a schema fallback validator from the advertised
+     schema and checks the args against it before dispatch.
 
-  2. Malformed JSON args from the LLM still become a ``RetryPromptPart`` (an
-     LLM-visible recoverable, not an escalating fault), via the ``args_as_dict()``
-     try/except which runs on *all* dispatch paths regardless of the validation gate.
+  2. A call whose args VIOLATE the advertised schema is rejected pre-dispatch as a
+     ``RetryPromptPart`` — the same in-band recoverable a local tool produces (no
+     more crossing the wire to fault at the callee).
 
-The override-mode tests in ``test_tool_errors.py`` cover the same two
-properties via the ``state.overrides.override_agent_tools`` path; this test
-exercises the ``Agent(tools=[...])`` kwarg branch instead.
+  3. Malformed JSON args from the LLM still become a ``RetryPromptPart`` via the
+     ``args_as_dict()`` try/except which runs on *all* dispatch paths before the
+     validation step.
+
+The override-mode tests in ``test_tool_errors.py`` cover the same properties via the
+``state.overrides.override_agent_tools`` path; this test exercises the
+``Agent(tools=[...])`` kwarg branch instead.
 """
 
 from __future__ import annotations
+
+from typing import Any
 
 import pytest
 
@@ -34,38 +40,43 @@ from calfkit.nodes import Agent
 # fail-fast signal to update both tests together.
 from tests.test_tool_errors import _make_ctx, _model_emits_tool_calls, _unwrap
 
+# The default schema-only tool: one required string arg, no extra keys.
+_DEFAULT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"q": {"type": "string"}},
+    "required": ["q"],
+    "additionalProperties": False,
+}
+
 
 def _make_schema_only_tool(
     *,
     tool_name: str = "search",
     topic_base: str = "tools.search",
+    parameters_json_schema: dict[str, Any] | None = None,
 ) -> ToolBinding:
     """Construct a validator-less ``ToolBinding`` (a schema-only tool).
 
     Carries a real ``ToolDefinition`` (so the LLM sees a valid schema) but
-    ``validator=None`` — which is what makes it "schema-only": the agent's
-    ``binding.validator is not None`` gate is False, skipping validation.
+    ``validator=None`` — the wire form. At dispatch the agent builds a schema fallback
+    validator from ``parameters_json_schema`` (overridable, e.g. to add a typed field
+    for the strictness pin).
     """
     return ToolBinding(
         dispatch_topic=f"{topic_base}.input",
         tool_def=ToolDefinition(
             name=tool_name,
-            description="Synthetic tool with one required string arg.",
-            parameters_json_schema={
-                "type": "object",
-                "properties": {"q": {"type": "string"}},
-                "required": ["q"],
-                "additionalProperties": False,
-            },
+            description="Synthetic tool.",
+            parameters_json_schema=parameters_json_schema or _DEFAULT_SCHEMA,
         ),
     )
 
 
-async def test_schema_only_tool_via_tools_kwarg_dispatches_without_validation() -> None:
-    """Property 1: ``Agent(tools=[ToolBinding(...)])`` dispatches the call.
+async def test_schema_only_tool_via_tools_kwarg_dispatches_conforming_args() -> None:
+    """Property 1: ``Agent(tools=[ToolBinding(...)])`` dispatches a schema-CONFORMING call.
 
-    No validator runs (the binding carries none), and the result is a ``Call``
-    to the binding's dispatch topic.
+    The schema fallback validator passes, and the result is a ``Call`` to the binding's
+    dispatch topic.
     """
     schema_only = _make_schema_only_tool()
 
@@ -90,6 +101,77 @@ async def test_schema_only_tool_via_tools_kwarg_dispatches_without_validation() 
     assert isinstance(result, Call), f"expected Call, got {type(result).__name__}"
     assert isinstance(result.body, ToolCallRef) and result.body.tool_call_id == tool_call_id
     assert result.target_topic == "tools.search.input"
+
+
+@pytest.mark.parametrize(
+    ("args", "why"),
+    [
+        ({}, "missing required 'q'"),
+        ({"q": "hi", "extra": 1}, "additionalProperties:false forbids 'extra'"),
+        ({"q": 123}, "'q' must be a string"),
+    ],
+    ids=["missing-required", "extra-key", "wrong-type"],
+)
+async def test_schema_only_tool_schema_violating_args_become_retry_prompt(args, why) -> None:
+    """Property 2: args that VIOLATE the advertised schema are rejected pre-dispatch.
+
+    Each shape trips the schema fallback validator and lands a ``RetryPromptPart`` instead of
+    dispatching — the fix's whole point (no fault-at-the-callee for a model mistake).
+    """
+    schema_only = _make_schema_only_tool()
+
+    tcid = "tc-schema-violation"
+    bad_call = ToolCallPart(tool_name="search", args=args, tool_call_id=tcid)
+
+    agent = Agent(
+        "agent_schema_only_violation",
+        system_prompt="x",
+        subscribe_topics="agent_schema_only_violation.input",
+        publish_topic="agent_schema_only_violation.output",
+        model_client=_model_emits_tool_calls([bad_call]),
+        tools=[schema_only],
+    )
+
+    ctx = _make_ctx(State())
+    result = _unwrap(await agent.run(ctx))
+
+    assert isinstance(result, TailCall), f"{why}: expected TailCall, got {type(result).__name__}"
+    stored = ctx.state.tool_results.get(tcid)
+    assert isinstance(stored, RetryPromptPart), f"{why}: expected RetryPromptPart, got {type(stored).__name__}"
+    assert stored.content, f"{why}: expected non-empty violation content"
+
+
+async def test_schema_only_tool_rejects_coercible_but_off_spec_args() -> None:
+    """The strictness delta (spec D6.2): a discovered tool's schema is enforced AS WRITTEN. An
+    integer field emitted as the string ``"3"`` — which a lax callee would coerce — is rejected at
+    the caller and the model retries. This is the deliberate, chosen behavior, not an accident.
+    """
+    schema = {
+        "type": "object",
+        "properties": {"n": {"type": "integer"}},
+        "required": ["n"],
+        "additionalProperties": False,
+    }
+    schema_only = _make_schema_only_tool(tool_name="counter", topic_base="tools.counter", parameters_json_schema=schema)
+
+    tcid = "tc-coercible-off-spec"
+    call = ToolCallPart(tool_name="counter", args={"n": "3"}, tool_call_id=tcid)
+
+    agent = Agent(
+        "agent_schema_only_strict",
+        system_prompt="x",
+        subscribe_topics="agent_schema_only_strict.input",
+        publish_topic="agent_schema_only_strict.output",
+        model_client=_model_emits_tool_calls([call]),
+        tools=[schema_only],
+    )
+
+    ctx = _make_ctx(State())
+    result = _unwrap(await agent.run(ctx))
+
+    assert isinstance(result, TailCall), f"expected TailCall (non-coercing reject), got {type(result).__name__}"
+    stored = ctx.state.tool_results.get(tcid)
+    assert isinstance(stored, RetryPromptPart), f"expected RetryPromptPart, got {type(stored).__name__}"
 
 
 async def test_schema_only_tool_malformed_args_become_retry_prompt() -> None:

--- a/tests/test_schema_roundtrip_validation.py
+++ b/tests/test_schema_roundtrip_validation.py
@@ -1,0 +1,108 @@
+"""Roundtrip contract: a tool's ADVERTISED schema (as the vendored generator emits it) must be
+consumable by the caller-side validator factory.
+
+The factory unit tests (``test_args_schema.py``) use hand-written schemas; this suite closes the
+loop against the *real* ``Tool(func).tool_def.parameters_json_schema`` the framework advertises for
+a discovered tool — nested models (``$defs``/``$ref``), defaults, ``Optional`` (``anyOf`` + null),
+``**kwargs`` (``additionalProperties: true``), and no-arg tools — plus a loose MCP-style
+``inputSchema``. It fails loudly if the generator ever emits a shape the factory cannot validate.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from calfkit.models import ToolContext
+from calfkit.models.args_schema import schema_args_validator
+from calfkit.nodes import ToolNodeDef
+
+
+class Point(BaseModel):
+    lat: float
+    lon: float
+
+
+def _schema_for(func) -> dict:
+    """The advertised ``parameters_json_schema`` for ``func`` — the exact dict a discovered
+    binding carries and the agent hands the factory."""
+    node = ToolNodeDef.create_tool_node(func=func, subscribe_topics=f"tool.{func.__name__}.input", publish_topic=f"tool.{func.__name__}.output")
+    return node.tool_schema.parameters_json_schema
+
+
+def _locs(exc: pytest.ExceptionInfo[ValidationError]) -> list[tuple]:
+    return [e["loc"] for e in exc.value.errors(include_url=False)]
+
+
+def test_simple_with_defaults_roundtrips():
+    def tool(ctx: ToolContext, a: int, b: str = "hi") -> str:
+        return "x"
+
+    validate = schema_args_validator(_schema_for(tool))
+    validate({"a": 1})  # b defaulted — valid
+    validate({"a": 1, "b": "x"})
+    with pytest.raises(ValidationError):
+        validate({})  # missing required `a`
+    with pytest.raises(ValidationError) as exc:
+        validate({"a": "not-an-int"})
+    assert ("a",) in _locs(exc)
+    with pytest.raises(ValidationError):
+        validate({"a": 1, "surprise": True})  # additionalProperties: false
+
+
+def test_nested_model_roundtrips_through_ref():
+    def tool(ctx: ToolContext, p: Point, tag: str) -> str:
+        return "x"
+
+    validate = schema_args_validator(_schema_for(tool))
+    validate({"p": {"lat": 1.0, "lon": 2.0}, "tag": "t"})
+    with pytest.raises(ValidationError) as exc:
+        validate({"p": {"lat": "nope", "lon": 2.0}, "tag": "t"})
+    # The violation is located THROUGH the $ref, at the nested field.
+    assert ("p", "lat") in _locs(exc)
+    with pytest.raises(ValidationError):
+        validate({"tag": "t"})  # missing required `p`
+
+
+def test_optional_model_roundtrips_through_anyof_null():
+    def tool(ctx: ToolContext, loc: Point | None = None) -> str:
+        return "x"
+
+    validate = schema_args_validator(_schema_for(tool))
+    validate({})  # loc optional, defaults null
+    validate({"loc": None})  # anyOf null branch
+    validate({"loc": {"lat": 1.0, "lon": 2.0}})  # anyOf Point branch
+    with pytest.raises(ValidationError):
+        validate({"loc": {"lat": "nope", "lon": 2.0}})  # neither branch matches
+
+
+def test_var_kwargs_allows_additional_properties():
+    def tool(ctx: ToolContext, a: int, **rest: object) -> str:
+        return "x"
+
+    validate = schema_args_validator(_schema_for(tool))
+    validate({"a": 1, "anything": "goes", "more": [1, 2, 3]})  # additionalProperties: true
+    with pytest.raises(ValidationError):
+        validate({"a": "not-an-int"})  # the declared field is still enforced
+
+
+def test_no_arg_tool_roundtrips():
+    def tool(ctx: ToolContext) -> str:
+        return "x"
+
+    validate = schema_args_validator(_schema_for(tool))
+    validate({})
+    with pytest.raises(ValidationError):
+        validate({"unexpected": 1})  # additionalProperties: false on the empty object
+
+
+def test_loose_mcp_style_input_schema_is_permissive_but_typed():
+    # An MCP server's inputSchema rides verbatim: no `required`, no `additionalProperties`. The
+    # subset check enforces declared types where present and admits everything else — this
+    # permissiveness is correct, not a gap (the server stays authoritative on receipt).
+    loose = {"type": "object", "properties": {"q": {"type": "string"}}}
+    validate = schema_args_validator(loose)
+    validate({})  # nothing required
+    validate({"q": "hi", "extra": 1})  # additionalProperties defaults open
+    with pytest.raises(ValidationError):
+        validate({"q": 123})  # the declared type IS enforced

--- a/tests/test_tool_binding.py
+++ b/tests/test_tool_binding.py
@@ -57,8 +57,8 @@ class TestToolBinding:
 class TestToolBindingWireForm:
     """ToolBinding doubles as the wire model for per-run tool overrides: the
     ``validator`` callable is process-local and must never serialize, so a
-    deserialized binding always dispatches unvalidated (the schema-only
-    carve-out, enforced by the type instead of by convention)."""
+    deserialized binding always carries ``validator=None`` (the agent then
+    validates its args against the advertised schema at dispatch, not here)."""
 
     def make_binding_with_validator(self) -> ToolBinding:
         return ToolBinding(

--- a/tests/test_tool_errors.py
+++ b/tests/test_tool_errors.py
@@ -32,8 +32,8 @@ from calfkit.models.actions import Call, ReturnCall, TailCall
 from calfkit.models.payload import TextPart, is_retry
 from calfkit.models.state import OverridesState, State
 from calfkit.models.tool_dispatch import ToolBinding
-from calfkit.nodes import Agent, ToolNodeDef
-from calfkit.nodes._steps import Observed
+from calfkit.nodes import Agent, ToolNodeDef, Tools
+from calfkit.nodes._steps import DeniedCall, Observed
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -426,13 +426,10 @@ async def test_agent_partial_validation_failure_dispatches_valid_calls():
         )
 
 
-async def test_agent_skips_validation_for_schema_only_override_tools():
-    # Override carve-out: a validator-less ToolBinding (the wire form — the
-    # validator never serializes) skips the validation branch entirely.
-    # Without this carve-out, an override toolset would crash on every
-    # dispatch because there is no validator to call. Pins the documented
-    # limitation so a future refactor that adds validation for overrides
-    # updates this test deliberately.
+async def test_agent_validates_schema_only_override_tools():
+    # A validator-less ToolBinding (the wire form — the validator never serializes) is validated
+    # at dispatch against its ADVERTISED parameters_json_schema: the agent builds a schema
+    # fallback validator, so bad args are rejected pre-dispatch exactly like a local tool's.
     def typed_tool(ctx: ToolContext, x: int) -> str:
         return f"got {x}"
 
@@ -442,22 +439,21 @@ async def test_agent_skips_validation_for_schema_only_override_tools():
         publish_topic="tool.typed_tool.output",
     )
 
-    # Construct a wire-form binding mirroring the real tool but lacking the
-    # validator. It must take the override path in agent.run.
+    # A wire-form binding mirroring the real tool but lacking the validator. It takes the override
+    # path in agent.run; its tool_def carries the pydantic-generated schema (x: integer, required).
     schema_only = ToolBinding(
         tool_def=full_tool_node.tool_schema,
         dispatch_topic=full_tool_node.subscribe_topics[0],
     )
 
     tool_call_id = "tc-override"
-    # Args that would fail validation if the validator ran.
     bad_call = ToolCallPart(tool_name="typed_tool", args={"x": "not-a-number"}, tool_call_id=tool_call_id)
 
     agent = Agent(
-        "agent_override_skip",
+        "agent_override_validate",
         system_prompt="x",
-        subscribe_topics="agent_override_skip.input",
-        publish_topic="agent_override_skip.output",
+        subscribe_topics="agent_override_validate.input",
+        publish_topic="agent_override_validate.output",
         model_client=_model_emits_tool_calls([bad_call]),
         tools=[full_tool_node],
     )
@@ -465,12 +461,135 @@ async def test_agent_skips_validation_for_schema_only_override_tools():
     state = State()
     state.overrides = OverridesState(override_agent_tools=[schema_only])
     ctx = _make_ctx(state)
+    raw = await agent.run(ctx)
+    result = _unwrap(raw)
+
+    # The schema-rejected call does NOT dispatch: a RetryPromptPart lands and the single all-invalid
+    # turn tail-calls itself so the LLM sees the typed feedback.
+    assert isinstance(result, TailCall), f"expected TailCall, got {type(result).__name__}"
+    stored = ctx.state.tool_results.get(tool_call_id)
+    assert isinstance(stored, RetryPromptPart), f"expected RetryPromptPart, got {type(stored).__name__}: {stored!r}"
+    assert stored.content, "expected non-empty json-schema violation content"
+    # The step side: the rejection is declared as a DeniedCall fact (the ledger expands it into the
+    # denied ToolCall+ToolResult pair — we assert what our change produces, not the ledger).
+    assert isinstance(raw, Observed)
+    assert any(isinstance(f, DeniedCall) and f.tool_call_id == tool_call_id for f in raw.facts), "expected a DeniedCall fact for the rejected call"
+
+
+async def test_agent_local_tool_keeps_its_signature_validator_not_the_schema_fallback():
+    # Freeze pin (anti-double-validation): a LOCAL tool carries a signature validator, so the
+    # schema fallback must NOT also run. The signature validator lax-coerces "3" -> 3 and
+    # dispatches; the non-coercing schema validator would REJECT "3" for an integer. If the flip
+    # ran BOTH, this call would wrongly retry — so a dispatched Call proves the fallback is a
+    # fallback, not an addition.
+    def typed_tool(ctx: ToolContext, x: int) -> str:
+        return f"got {x}"
+
+    tool_node = ToolNodeDef.create_tool_node(
+        func=typed_tool,
+        subscribe_topics="tool.typed_tool.input",
+        publish_topic="tool.typed_tool.output",
+    )
+
+    tool_call_id = "tc-coerce"
+    coercible_call = ToolCallPart(tool_name="typed_tool", args={"x": "3"}, tool_call_id=tool_call_id)
+
+    agent = Agent(
+        "agent_local_coerce",
+        system_prompt="x",
+        subscribe_topics="agent_local_coerce.input",
+        publish_topic="agent_local_coerce.output",
+        model_client=_model_emits_tool_calls([coercible_call]),
+        tools=[tool_node],
+    )
+
+    ctx = _make_ctx(State())
     result = _unwrap(await agent.run(ctx))
 
-    # No RetryPromptPart — validation was skipped, so the call dispatches.
+    assert isinstance(result, Call), f"expected Call (local validator lax-coerces), got {type(result).__name__}"
     assert tool_call_id not in ctx.state.tool_results
-    assert isinstance(result, Call), f"expected Call, got {type(result).__name__}"
-    assert isinstance(result.body, ToolCallRef) and result.body.tool_call_id == tool_call_id
+
+
+async def test_agent_validates_discovered_tool_args():
+    # A discovered tool (resolved from the capability view via a `Tools` selector) is validator-less
+    # but carries an advertised schema; the agent validates against it at dispatch. Drives the full
+    # run() so the selector resolves from ctx.resources into the dispatch registry.
+    from calfkit.models.capability import CAPABILITY_VIEW_RESOURCE_KEY, CapabilityToolDef
+    from tests.test_tools_selector import make_tool_record
+
+    typed_schema = {
+        "type": "object",
+        "properties": {"x": {"type": "integer"}},
+        "required": ["x"],
+        "additionalProperties": False,
+    }
+    # The default record schema is the permissive floor (accepts anything) — the typed override is
+    # load-bearing, else bad args validate fine and the test could never go red.
+    record = make_tool_record("add", tools=[CapabilityToolDef(name="add", parameters_json_schema=typed_schema)])
+
+    tool_call_id = "tc-discovered"
+    bad_call = ToolCallPart(tool_name="add", args={"x": "not-a-number"}, tool_call_id=tool_call_id)
+
+    agent = Agent(
+        "agent_discovered_validate",
+        system_prompt="x",
+        subscribe_topics="agent_discovered_validate.input",
+        publish_topic="agent_discovered_validate.output",
+        model_client=_model_emits_tool_calls([bad_call]),
+        tools=[Tools("add")],
+    )
+
+    ctx = _make_ctx(State())
+    ctx._resources = {CAPABILITY_VIEW_RESOURCE_KEY: {"add": record}}
+    raw = await agent.run(ctx)
+    result = _unwrap(raw)
+
+    assert isinstance(result, TailCall), f"expected TailCall, got {type(result).__name__}"
+    stored = ctx.state.tool_results.get(tool_call_id)
+    assert isinstance(stored, RetryPromptPart), f"expected RetryPromptPart, got {type(stored).__name__}"
+    assert isinstance(raw, Observed)
+    assert any(isinstance(f, DeniedCall) and f.tool_call_id == tool_call_id for f in raw.facts)
+
+
+async def test_agent_mixed_batch_validator_less_dispatches_valid_rejects_invalid():
+    # Mixed batch on validator-less (override) bindings: the invalid call lands a RetryPromptPart
+    # and the valid call still dispatches — mirrors the local-tool partial-failure contract.
+    def tool_a(ctx: ToolContext, x: int) -> str:
+        return f"a={x}"
+
+    def tool_b(ctx: ToolContext, y: str) -> str:
+        return f"b={y}"
+
+    node_a = ToolNodeDef.create_tool_node(func=tool_a, subscribe_topics="tool.tool_a.input", publish_topic="tool.tool_a.output")
+    node_b = ToolNodeDef.create_tool_node(func=tool_b, subscribe_topics="tool.tool_b.input", publish_topic="tool.tool_b.output")
+    override_a = ToolBinding(tool_def=node_a.tool_schema, dispatch_topic=node_a.subscribe_topics[0])
+    override_b = ToolBinding(tool_def=node_b.tool_schema, dispatch_topic=node_b.subscribe_topics[0])
+
+    valid_id, invalid_id = "tc-valid", "tc-invalid"
+    valid_call = ToolCallPart(tool_name="tool_a", args={"x": 5}, tool_call_id=valid_id)
+    invalid_call = ToolCallPart(tool_name="tool_b", args={"y": 123}, tool_call_id=invalid_id)  # int for a string schema
+
+    agent = Agent(
+        "agent_mixed_validator_less",
+        system_prompt="x",
+        subscribe_topics="agent_mixed_validator_less.input",
+        publish_topic="agent_mixed_validator_less.output",
+        model_client=_model_emits_tool_calls([valid_call, invalid_call]),
+        tools=[node_a, node_b],
+    )
+
+    state = State()
+    state.overrides = OverridesState(override_agent_tools=[override_a, override_b])
+    ctx = _make_ctx(state, frame_id="frame-mixed")
+    result = _unwrap(await agent.run(ctx))
+
+    # The invalid call is rejected in-band; the valid one is left pending and dispatches (a single
+    # remaining pending call → a plain Call).
+    invalid_stored = ctx.state.tool_results.get(invalid_id)
+    assert isinstance(invalid_stored, RetryPromptPart), f"expected RetryPromptPart for the invalid call, got {type(invalid_stored).__name__}"
+    assert valid_id not in ctx.state.tool_results
+    assert isinstance(result, Call), f"expected the valid call to dispatch as a Call, got {type(result).__name__}"
+    assert isinstance(result.body, ToolCallRef) and result.body.tool_call_id == valid_id
 
 
 async def test_agent_handles_malformed_json_args_as_retry_prompt():

--- a/tests/test_tool_node_advert.py
+++ b/tests/test_tool_node_advert.py
@@ -99,7 +99,8 @@ class TestEagerDiscoveredParity:
         discovered = record_to_bindings(node._capability_advert(make_stamp()), name="add")[0]  # discovered; node_kind="tool" stays BARE (C2)
         # Same ToolDefinition — name, description, JSON schema, and every defaulted field.
         assert discovered.tool_def == eager.tool_def
-        # The only difference is the validation locus: eager validates locally; the discovered
-        # binding has no validator (the tool node validates on receipt; bad args -> fault rail).
+        # The only difference is the validation LOCUS, not whether validation happens: the eager
+        # binding carries a signature validator; the discovered binding has none, so the agent
+        # falls back to a validator built from the advertised schema. Same dispatch rail either way.
         assert eager.validator is not None
         assert discovered.validator is None

--- a/tests/test_tools_selector.py
+++ b/tests/test_tools_selector.py
@@ -109,7 +109,7 @@ class TestToolsResolveTools:
         assert isinstance(result, SelectorResult)
         assert [b.name for b in result.bindings] == ["add"]
         assert result.bindings[0].dispatch_topic == "tool.add.input"
-        assert result.bindings[0].validator is None  # discovered = schema-only (node validates on receipt)
+        assert result.bindings[0].validator is None  # discovered = no local validator (agent validates against the advertised schema at dispatch)
         assert not result.unresolved
 
     def test_resolves_multiple_names(self) -> None:
@@ -146,7 +146,7 @@ class TestToolsThroughAgent:
         view = {"add": make_tool_record("add"), "sub": make_tool_record("sub")}
         agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: view}, registry)
         assert sorted(registry) == ["add", "sub"]
-        assert all(registry[n].validator is None for n in registry)  # discovered = schema-only
+        assert all(registry[n].validator is None for n in registry)  # discovered = no local validator (schema-checked at dispatch)
 
     def test_eager_static_tool_wins_on_collision(self, caplog: pytest.LogCaptureFixture) -> None:
         # The per-turn registry merge: when a discovered binding's name is already in the
@@ -205,7 +205,7 @@ class TestToolsDiscoverMode:
         )
         result = Tools(discover=True).resolve_tools(view)
         assert sorted(b.name for b in result.bindings) == ["add", "sub"]  # toolbox record excluded
-        assert all(b.validator is None for b in result.bindings)  # discovered = schema-only
+        assert all(b.validator is None for b in result.bindings)  # discovered = no local validator (schema-checked at dispatch)
         assert not result.unresolved
 
 


### PR DESCRIPTION
## What & why

Validator-less tool bindings — capability-plane `Tools(...)` discovery, `MCPToolbox` tools, wire-deserialized per-run overrides, hand-rolled bindings — previously dispatched the model's raw arguments across Kafka **unvalidated**. A bad-arg model mistake that a *local* tool absorbs as a cheap in-conversation retry instead crossed the wire and killed the run at the callee. The failure economics of the same model error differed by an order of severity based on tool provenance, which callers can't see and didn't choose.

This validates **every** tool call at the agent's single dispatch chokepoint. Local bindings keep their signature validator; a validator-less binding falls back to one compiled from its advertised `parameters_json_schema` (new leaf module `calfkit/models/args_schema.py`, python-jsonschema). Schema-violating args are rejected pre-dispatch as a `RetryPromptPart` + `DeniedCall`, exactly the local-tool economics — no more faulting at the callee for a model mistake.

## Design highlights

- **One-site flip** in `agent.py`: `validator = binding.validator or schema_args_validator(binding.tool_def.parameters_json_schema)`. The `or` short-circuit means a local signature validator wins; only a validator-less binding hits the factory. The factory call sits *outside* the dispatch `try`.
- **Total factory**: an unenforceable advertised schema (malformed `$schema`, non-dict, cyclic/unresolvable `$ref`, or pathologically deep) degrades **open** (dispatch unvalidated + one warning) rather than crashing a run. It only ever raises the `pydantic.ValidationError` the `ArgsValidator` contract declares — synthesized from jsonschema violations via `pydantic_core.ValidationError.from_exception_data` — so the dispatch loop's existing `except ValidationError` arm needs no new species (exception translation at the boundary).
- **Non-coercing subset check**: the advertised contract is enforced *as written*; the callee stays authoritative on receipt.

## Behavioral deltas (two, both deliberate)

1. Validator-less bad args now retry in-conversation instead of faulting at the callee.
2. The advertised schema is enforced non-coercively: args a lax callee would have tolerated (a coercible `"3"` for an `integer`, extra keys under `additionalProperties: false`, an MCP server looser than its published schema) are rejected at the caller and the model retries.

## Tests

- **Factory unit suite** (`tests/test_args_schema.py`, 100% coverage): translation shape + determinism, content-keyed cache identity, all totality arms (compile-time bad/`$schema`/None/non-dict, validate-time external/internal-dangling/cyclic `$ref` + deep-args recursion + the deep-`json.dumps` key path, within-call all-or-none, uncached per-call warn), dialect, permissive floors, no-format, bool-for-integer.
- **Generator roundtrip** (`tests/test_schema_roundtrip_validation.py`): real `Tool(func)` schemas through the factory — nested models (`$defs`/`$ref`), `Optional` (`anyOf`), `**kwargs`, no-arg, loose MCP `inputSchema`.
- **Dispatch inversions + freeze pins** in `test_tool_errors.py` / `test_schema_only_dispatch.py`, including the anti-double-validation pin (a local tool still lax-coerces `"3"`).
- **Real-broker e2e** (`kafka` lane): reject-before-dispatch (tool body never runs), the full reject→correct→dispatch→`5` loop, and an MCP bad-args e2e proving the server never saw the bad call.

Offline suite 4360 passed; `make check` clean; full kafka lane 97 passed.

## Dependency

Adds `jsonschema>=4.18` as a direct dependency — already in the locked closure via `mcp`, so install-free.

## Notes

- Fixes the caller-side-arg-validation defect surfaced during the ADR-0035 handoff review; design captured in ADR-0040 (local).
- Reviewed to convergence: 4-lens review + adversarial totality verification (one critical — a `RecursionError` totality hole — found and fixed) + a simplify pass.