### PR TITLE
perf: defer agent imports from client-only usage

### DIFF
--- a/calfkit/__init__.py
+++ b/calfkit/__init__.py
@@ -1,4 +1,5 @@
 from importlib.metadata import version
+from typing import TYPE_CHECKING, Any
 
 from calfkit.client import (
     DEFAULT_MAX_MESSAGE_BYTES,
@@ -27,27 +28,30 @@ from calfkit.controlplane import ControlPlaneConfig, ControlPlaneRecord, Control
 from calfkit.exceptions import ClientClosedError, ClientTimeoutError, DeserializationError, LifecycleConfigError, MeshUnavailableError, NodeFaultError
 from calfkit.models import ErrorReport, ExceptionInfo, FaultTypes, ToolContext
 from calfkit.models.payload import retry_text_part
-from calfkit.nodes import (
-    Agent,
-    AgentSeamContext,
-    BaseNodeDef,
-    ConsumerFn,
-    ConsumerNode,
-    NodeDef,
-    ToolCall,
-    ToolErrorHandler,
-    ToolNodeDef,
-    Tools,
-    agent_tool,
-    consumer,
-    render_fault_for_model,
-    surface_to_model,
-)
 from calfkit.peers import Handoff, Messaging
-from calfkit.providers import AnthropicModelClient, OpenAIModelClient, OpenAIResponsesModelClient
 from calfkit.provisioning import ProvisioningConfig
 from calfkit.tuning import FanoutConfig, KTableReaderTuning
-from calfkit.worker import LifecycleContext, ResourceSetupContext, ServingContext, Worker
+from calfkit.worker import LifecycleContext, ResourceSetupContext, ServingContext
+
+if TYPE_CHECKING:
+    from calfkit.nodes import (
+        Agent,
+        AgentSeamContext,
+        BaseNodeDef,
+        ConsumerFn,
+        ConsumerNode,
+        NodeDef,
+        ToolCall,
+        ToolErrorHandler,
+        ToolNodeDef,
+        Tools,
+        agent_tool,
+        consumer,
+        render_fault_for_model,
+        surface_to_model,
+    )
+    from calfkit.providers import AnthropicModelClient, OpenAIModelClient, OpenAIResponsesModelClient
+    from calfkit.worker import Worker
 
 __version__ = version("calfkit")
 __all__ = [
@@ -131,3 +135,39 @@ __all__ = [
     "MeshUnavailableError",
     "NodeFaultError",
 ]
+
+_LAZY_EXPORTS = {
+    **{
+        name: "calfkit.nodes"
+        for name in (
+            "Agent",
+            "AgentSeamContext",
+            "BaseNodeDef",
+            "ConsumerFn",
+            "ConsumerNode",
+            "NodeDef",
+            "ToolCall",
+            "ToolErrorHandler",
+            "ToolNodeDef",
+            "Tools",
+            "agent_tool",
+            "consumer",
+            "render_fault_for_model",
+            "surface_to_model",
+        )
+    },
+    **{name: "calfkit.providers" for name in ("AnthropicModelClient", "OpenAIModelClient", "OpenAIResponsesModelClient")},
+    "Worker": "calfkit.worker",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    from importlib import import_module
+
+    value = getattr(import_module(module_name), name)
+    globals()[name] = value
+    return value

--- a/calfkit/__init__.py
+++ b/calfkit/__init__.py
@@ -160,14 +160,25 @@ _LAZY_EXPORTS = {
     "Worker": "calfkit.worker",
 }
 
+_LAZY_SUBMODULES = {"nodes", "providers"}
+
 
 def __getattr__(name: str) -> Any:
+    from importlib import import_module
+
+    if name in _LAZY_SUBMODULES:
+        # The import system sets the submodule on the package, so __getattr__ won't fire
+        # for it again — no need to cache in globals() here.
+        return import_module(f"calfkit.{name}")
+
     module_name = _LAZY_EXPORTS.get(name)
     if module_name is None:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-    from importlib import import_module
-
     value = getattr(import_module(module_name), name)
     globals()[name] = value
     return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__) | _LAZY_SUBMODULES)

--- a/tests/test_connection_profile.py
+++ b/tests/test_connection_profile.py
@@ -127,6 +127,24 @@ def test_ktables_connection_import_is_lazy() -> None:
     assert result.returncode == 0, result.stderr
 
 
+def test_client_import_does_not_load_agent_worker_or_provider_stacks() -> None:
+    # Importing any submodule executes calfkit's package initializer first. A caller that only
+    # needs Client must not pay for the agent, worker, and model-provider stacks as a side effect.
+    import subprocess
+    import sys
+
+    code = (
+        "import sys\n"
+        "from calfkit.client import Client\n"
+        "assert Client is not None\n"
+        "blocked = ('calfkit.nodes.agent', 'calfkit.providers.pydantic_ai', 'calfkit.worker.worker')\n"
+        "loaded = [name for name in blocked if name in sys.modules]\n"
+        "assert not loaded, loaded\n"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
 def test_repr_redacts_security_values() -> None:
     profile = _profile(security_opts={"sasl_plain_password": "hunter2", "sasl_plain_username": "svc"})
     rendered = repr(profile)

--- a/tests/test_connection_profile.py
+++ b/tests/test_connection_profile.py
@@ -145,6 +145,17 @@ def test_client_import_does_not_load_agent_worker_or_provider_stacks() -> None:
     assert result.returncode == 0, result.stderr
 
 
+def test_every_root_export_resolves() -> None:
+    # Each lazy name lives in three places (TYPE_CHECKING block, __all__, _LAZY_EXPORTS); a typo in
+    # _LAZY_EXPORTS would stay silent until someone imports that name. Resolve every export eagerly.
+    import calfkit
+
+    for name in calfkit.__all__:
+        getattr(calfkit, name)
+    with pytest.raises(AttributeError):
+        calfkit.not_a_real_export
+
+
 def test_repr_redacts_security_values() -> None:
     profile = _profile(security_opts={"sasl_plain_password": "hunter2", "sasl_plain_username": "svc"})
     rendered = repr(profile)


### PR DESCRIPTION
Closes #351

`calfkit` now defers its agent, worker, and model-provider root exports until they are accessed, so importing `calfkit.client` no longer loads those stacks. The existing top-level API remains available through lazy attribute resolution.

Added a clean-subprocess regression test; 4,517 tests passed, with two unrelated PTY tests failing identically on baseline because the network-denied sandbox cannot open `/dev/pty*`.
