### PR TITLE
feat!: dual-mode Toolboxes selector replaces the MCPToolbox handle

### DIFF
--- a/calfkit/__init__.py
+++ b/calfkit/__init__.py
@@ -34,6 +34,8 @@ from calfkit.nodes import (
     ConsumerFn,
     ConsumerNode,
     NodeDef,
+    Toolbox,
+    Toolboxes,
     ToolCall,
     ToolErrorHandler,
     ToolNodeDef,
@@ -43,6 +45,7 @@ from calfkit.nodes import (
     render_fault_for_model,
     surface_to_model,
 )
+from calfkit.nodes import Toolbox as MCPToolbox
 from calfkit.peers import Handoff, Messaging
 from calfkit.providers import AnthropicModelClient, OpenAIModelClient, OpenAIResponsesModelClient
 from calfkit.provisioning import ProvisioningConfig
@@ -87,6 +90,9 @@ __all__ = [
     "ConsumerFn",
     "ConsumerNode",
     "NodeDef",
+    "MCPToolbox",
+    "Toolbox",
+    "Toolboxes",
     "ToolNodeDef",
     "Tools",
     "agent_tool",

--- a/calfkit/_handle_names.py
+++ b/calfkit/_handle_names.py
@@ -1,15 +1,52 @@
-"""Shared name-normalization for the capability handles (:class:`~calfkit.nodes.tool.Tools`,
-:class:`~calfkit.peers.messaging.Messaging`, :class:`~calfkit.peers.handoff.Handoff`).
+"""Shared construction rails for the capability handles (:class:`~calfkit.nodes.tool.Tools`,
+:class:`~calfkit.peers.messaging.Messaging`, :class:`~calfkit.peers.handoff.Handoff`,
+:class:`~calfkit.nodes.toolbox.Toolboxes`).
 
-All three are frozen, identity-only handles with the *same* curated-XOR-discover varargs constructor; this
+All four are frozen, identity-only handles with the *same* curated-XOR-discover varargs constructor; this
 is the single home for that fail-loud rail (an accidental empty splat must never silently become an implicit
-"everything"). The three classes stay distinct — they discriminate by **type** (``isinstance``) for dispatch
-and for ``tools=``/``peers=`` routing — but the construction logic lives here so the rail is defined once.
+"everything"). The classes stay distinct — they discriminate by **type** (``isinstance``) for dispatch
+and for ``tools=``/``peers=`` routing — but the construction grammar lives here so the rail is defined once.
+
+The grammar (:func:`_selection_grammar`) is shared; the **collection policy** is per-family:
+name handles dedupe by value (a repeated name is repetition), toolbox entries raise on a repeated
+name (an entry carries policy — ``include=`` — so a duplicate is a conflict, never collapsed).
 """
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from typing import Protocol, TypeVar
+
+
+def _selection_grammar(
+    label: str,
+    noun: str,
+    *,
+    positional: tuple[object, ...],
+    alt: Sequence[object] | None,
+    discover: bool,
+    item_singular: str,
+    item_plural: str,
+    kwarg_label: str,
+) -> tuple[object, ...] | None:
+    """The discover-XOR-items grammar shared by every family handle.
+
+    Returns ``None`` for discover mode, else the raw ordered item tuple (pre-collection).
+    Owns the three fail-loud branches: discover-takes-no-items, varargs-XOR-kwarg, and
+    empty-raises. ``kwarg_label`` is threaded so each family's error names its *own* kwarg
+    (``names=`` for the name handles, ``entries=`` for ``Toolboxes``).
+    """
+    # ``discover`` IS the absence of items, so pairing it with items is contradictory.
+    if discover and (positional or alt is not None):
+        raise ValueError(f"{label}(discover=True) takes no {noun} {item_plural}")
+    if discover:
+        return None
+    if positional and alt is not None:
+        raise ValueError(f"{label}: pass {noun} {item_plural} positionally or via {kwarg_label}=, not both")
+    collected = positional if positional else tuple(alt or ())
+    if not collected:
+        raise ValueError(f"{label} requires at least one {noun} {item_singular}, or discover=True")
+    return collected
 
 
 def normalize_handle_names(label: str, noun: str, *, positional: tuple[str, ...], names: Sequence[str] | None, discover: bool) -> tuple[str, ...]:
@@ -23,16 +60,64 @@ def normalize_handle_names(label: str, noun: str, *, positional: tuple[str, ...]
     Both, or neither, of {non-empty names, ``discover=True``} raise — never an implicit "everything" (the
     fail-loud rail: an accidental empty splat ``Handle(*[])`` must not silently open the full scope).
     """
-    # ``discover`` IS the absence of names, so pairing it with names is contradictory.
-    if discover and (positional or names is not None):
-        raise ValueError(f"{label}(discover=True) takes no {noun} names")
-    if discover:
+    raw = _selection_grammar(
+        label,
+        noun,
+        positional=positional,
+        alt=names,
+        discover=discover,
+        item_singular="name",
+        item_plural="names",
+        kwarg_label="names",
+    )
+    if raw is None:
         return ()
-    if positional and names is not None:
-        raise ValueError(f"{label}: pass {noun} names positionally or via names=, not both")
-    collected = tuple(dict.fromkeys(positional if positional else tuple(names or ())))  # order-preserving dedupe
-    if not collected:
-        raise ValueError(f"{label} requires at least one {noun} name, or discover=True")
+    collected = tuple(dict.fromkeys(raw))  # order-preserving dedupe: a repeated name is repetition, not conflict
     if any(not n for n in collected):
         raise ValueError(f"{label} names must be non-empty")
-    return collected
+    return collected  # type: ignore[return-value]  # grammar preserves the str elements it was given
+
+
+class _NamedEntry(Protocol):
+    @property
+    def name(self) -> str: ...
+
+
+_EntryT = TypeVar("_EntryT", bound=_NamedEntry)
+
+
+def normalize_toolbox_entries(
+    label: str,
+    *,
+    positional: tuple[object, ...],
+    entries: Sequence[object] | None,
+    discover: bool,
+    desugar: Callable[[object], _EntryT],
+) -> tuple[_EntryT, ...]:
+    """The entry tuple for a toolbox-family selector: grammar + desugar + by-name duplicate-raise.
+
+    Returns ``()`` for discover mode, else the desugared, order-preserving tuple of entries.
+    ``desugar`` is the family's element constructor (bare name → entry spec; specs pass through) —
+    injected so this leaf module never imports from ``calfkit.nodes``. Duplicates raise **by
+    name**, byte-identical entries included: an entry carries per-box policy, so a repeat is a
+    conflict — never the silent value-dedupe of the name rail.
+    """
+    raw = _selection_grammar(
+        label,
+        "toolbox",
+        positional=positional,
+        alt=entries,
+        discover=discover,
+        item_singular="entry",
+        item_plural="entries",
+        kwarg_label="entries",
+    )
+    if raw is None:
+        return ()
+    desugared = tuple(desugar(e) for e in raw)
+    seen: set[str] = set()
+    for entry in desugared:
+        if entry.name in seen:
+            raise ValueError(f"{label}: duplicate toolbox {entry.name!r} — one policy per toolbox per handle")
+        seen.add(entry.name)
+    return desugared

--- a/calfkit/_handle_names.py
+++ b/calfkit/_handle_names.py
@@ -36,6 +36,10 @@ def _selection_grammar(
     empty-raises. ``kwarg_label`` is threaded so each family's error names its *own* kwarg
     (``names=`` for the name handles, ``entries=`` for ``Toolboxes``).
     """
+    # A bare string satisfies Sequence[str] and would silently iterate character-wise —
+    # reject it for the whole family (decided 2026-07-19, post-review).
+    if isinstance(alt, str):
+        raise ValueError(f"{label}: {kwarg_label}= must be a sequence of {item_plural}, not a bare string")
     # ``discover`` IS the absence of items, so pairing it with items is contradictory.
     if discover and (positional or alt is not None):
         raise ValueError(f"{label}(discover=True) takes no {noun} {item_plural}")

--- a/calfkit/mcp/__init__.py
+++ b/calfkit/mcp/__init__.py
@@ -1,13 +1,14 @@
-"""MCP integration: the hosting toolbox node and its identity-only reference.
+"""MCP integration: the hosting toolbox node and the call-side entry alias.
 
-`MCPToolboxNode` hosts an MCP server's tools as a calfkit node (deploy side);
-`MCPToolbox` references one by name from anywhere (call side) — they are
-exported together deliberately, the same way a servant and its handle travel
-together in the peer-node pattern.
+`MCPToolboxNode` hosts an MCP server's tools as a calfkit node (deploy side); the call side
+selects toolboxes with `Toolboxes(...)` and scopes one with a `Toolbox` entry —
+`MCPToolbox` is a code-level alias of `Toolbox` for MCP-flavored call sites, re-exported
+here so deploy-side and call-side names travel together (ADR-0045).
 """
 
-from calfkit.mcp.mcp_toolbox import MCPToolbox, MCPToolboxNode
+from calfkit.mcp.mcp_toolbox import MCPToolboxNode
 from calfkit.mcp.mcp_transport import StdioServerParameters, StreamableHttpParameters
+from calfkit.nodes.toolbox import Toolbox as MCPToolbox
 
 __all__ = [
     "MCPToolboxNode",

--- a/calfkit/mcp/mcp_toolbox.py
+++ b/calfkit/mcp/mcp_toolbox.py
@@ -1,9 +1,8 @@
 import asyncio
 import contextlib
 import logging
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, ClassVar
 
@@ -88,23 +87,10 @@ class MCPToolboxNode(BaseNodeDef):
     def resolve_tools(self, view: CapabilityLookup) -> SelectorResult:
         """All advertised tools, resolved against the Capability View.
 
-        Implements ``ToolSelector`` by delegating to this node's handle —
-        passing the node in ``tools=[...]`` and passing ``MCPToolbox(name)``
-        resolve identically; the handle is the canonical resolution path.
+        Implements ``ToolSelector`` via the resolution kernel directly — passing the node in
+        ``tools=[...]`` and naming its Toolbox with ``Toolboxes(name)`` resolve identically.
         """
-        return MCPToolbox(self.node_id).resolve_tools(view)
-
-    def select(self, *, include: Sequence[str] | None = None) -> "MCPToolbox":
-        """A scoped selector for this toolbox's tools.
-
-        ``include`` pins the exact tool names the agent may see (the trust
-        boundary: a server suddenly advertising new tools cannot enlarge the
-        agent's surface). An unresolved selection degrades with a warning.
-        """
-        return MCPToolbox(
-            name=self.node_id,
-            include=tuple(include) if include is not None else None,
-        )
+        return resolve_capability(view, self.node_id, expected_kind="toolbox")
 
     # -- capability advertisement (control-plane substrate) -------------------
 
@@ -223,32 +209,3 @@ class MCPToolboxNode(BaseNodeDef):
         tool_result: MCPCallToolResult = await session.call_tool(name=server_tool_name, arguments=payload.args)
         pydantic_core.to_json(tool_result)
         return ReturnCall[State](state=ctx.state, value=tool_result)
-
-
-@dataclass(frozen=True)
-class MCPToolbox:
-    """The identity-only, deployment-free handle to an MCP toolbox (#212).
-
-    The call-side counterpart to the hosting :class:`MCPToolboxNode` (the
-    peer-node pattern's reference/servant split): constructible anywhere with
-    just the toolbox's name — no connection params, no secrets — and resolved
-    per agent turn against the Capability View. At the MCP protocol layer the
-    toolbox is the cluster's MCP client; agents never speak MCP at all — they
-    hold one of these.
-
-    ``include`` pins the exact tool names the agent may see (the trust boundary);
-    an unresolved selection degrades with a warning. Frozen with value semantics:
-    equal handles compare and hash equal.
-    """
-
-    name: str
-    include: tuple[str, ...] | None = None
-
-    def __post_init__(self) -> None:
-        if not self.name:
-            raise ValueError("name must be non-empty")
-        if self.include is not None and not isinstance(self.include, tuple):
-            object.__setattr__(self, "include", tuple(self.include))
-
-    def resolve_tools(self, view: CapabilityLookup) -> SelectorResult:
-        return resolve_capability(view, self.name, include=self.include, expected_kind="toolbox")

--- a/calfkit/models/args_schema.py
+++ b/calfkit/models/args_schema.py
@@ -1,7 +1,7 @@
 """Caller-side JSON-schema arg-validator factory (issue: discovered tools get no caller-side arg
 validation).
 
-A discovered tool (capability-plane ``Tools``/``MCPToolbox`` discovery, wire-deserialized per-run
+A discovered tool (capability-plane ``Tools``/``Toolboxes`` discovery, wire-deserialized per-run
 overrides, hand-rolled bindings) carries no process-local validator — only its advertised
 ``parameters_json_schema``. :func:`schema_args_validator` compiles that schema into an
 :data:`~calfkit.models.tool_dispatch.ArgsValidator` the agent consults at the dispatch chokepoint,

--- a/calfkit/models/capability.py
+++ b/calfkit/models/capability.py
@@ -144,7 +144,7 @@ def resolve_capability(
 ) -> SelectorResult:
     """Resolve ``target_id`` (optionally filtered) against the capability view.
 
-    Public API: this is the resolution kernel behind ``MCPToolbox`` and ``Tools``;
+    Public API: this is the resolution kernel behind ``Toolboxes`` and ``Tools``;
     custom ``ToolSelector`` implementations may call it directly. The view owns
     staleness + schema-version filtering, so this only maps a present record to bindings.
 
@@ -187,7 +187,7 @@ class EnumerableCapabilityView(CapabilityLookup, Protocol):
 
     The discover-mode read surface. Satisfied by a ``ControlPlaneView[CapabilityRecord]``
     (which already exposes ``snapshot()``) and by the tests' ``_FakeView``. The
-    single-target path (:func:`resolve_capability`, ``MCPToolbox``) keeps the narrower
+    single-target path (:func:`resolve_capability`, a named ``Toolboxes`` entry) keeps the narrower
     :class:`CapabilityLookup` — it never enumerates (Interface Segregation): point-lookup
     clients must not depend on a ``snapshot()`` they never call.
     """

--- a/calfkit/models/tool_dispatch.py
+++ b/calfkit/models/tool_dispatch.py
@@ -108,9 +108,9 @@ class SelectorResult:
 class ToolSelector(Protocol):
     """Deferred tool declaration, resolved per turn against the Capability View.
 
-    Implemented by :class:`~calfkit.mcp.mcp_toolbox.MCPToolbox` (the handle
-    agents hold, including ``select()`` results) and the hosting
-    :class:`~calfkit.mcp.mcp_toolbox.MCPToolboxNode` that delegates to it, and by
+    Implemented by :class:`~calfkit.nodes.toolbox.Toolboxes` (the family selector agents
+    hold for toolboxes), the hosting :class:`~calfkit.mcp.mcp_toolbox.MCPToolboxNode`
+    (which calls the same kernel), and by
     :class:`~calfkit.nodes.tool.Tools` for function tool nodes: passing any of them
     to an agent extracts only a lookup key — no session contact, no deployment. The
     ``view`` is an :class:`~calfkit.models.capability.EnumerableCapabilityView` (``get``

--- a/calfkit/nodes/__init__.py
+++ b/calfkit/nodes/__init__.py
@@ -4,6 +4,7 @@ from calfkit.nodes.base import BaseNodeDef
 from calfkit.nodes.consumer import ConsumerFn, ConsumerNode, consumer
 from calfkit.nodes.node import NodeDef
 from calfkit.nodes.tool import BaseToolNodeDef, ToolNodeDef, Tools, agent_tool
+from calfkit.nodes.toolbox import Toolbox, Toolboxes
 
 __all__ = [
     "Agent",
@@ -14,6 +15,8 @@ __all__ = [
     "ConsumerNode",
     "NodeDef",
     "ToolNodeDef",
+    "Toolbox",
+    "Toolboxes",
     "Tools",
     "agent_tool",
     "consumer",

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -41,6 +41,7 @@ from calfkit.nodes._steps import DeniedCall, HandedOff, Observed, Said, StepFact
 from calfkit.nodes._tool_error import AgentSeamContext, ToolErrorHandler, _adapt_tool_error, _as_list, resolve_tool_call
 from calfkit.nodes.base import BaseNodeDef, _SeamArg, _SlotFailed, _SlotResolved
 from calfkit.nodes.tool import BaseToolNodeDef, Tools
+from calfkit.nodes.toolbox import Toolbox, Toolboxes
 from calfkit.peers import Handoff, Messaging
 from calfkit.peers.directory import render_peer_directory, resolve_live_peers
 from calfkit.peers.handoff import (
@@ -603,6 +604,8 @@ class BaseAgentNodeDef(
                 # (a legitimate empty cluster, not a misconfiguration). A DEBUG count aids the
                 # "why does my agent have no tools?" case without crying wolf.
                 logger.debug("agent=%s discover mode resolved %d tool node(s)", self.name, len(result.bindings))
+            if isinstance(selector, Toolboxes) and selector.discover:
+                logger.debug("agent=%s discover mode resolved %d toolbox tool(s)", self.name, len(result.bindings))
             if result.unresolved:
                 logger.warning(
                     "agent=%s tool selection partially unresolved by %r (missing_targets=%s "
@@ -953,16 +956,32 @@ class BaseAgentNodeDef(
     def _add_tools(self, raw_tools: Sequence[ToolProvider | ToolBinding | ToolSelector] | None) -> None:
         """Validate the prospective tool surface against the contract, then commit.
 
-        Shared by ``__init__`` and :meth:`add_tools`. The tool-surface contract (spec §15.3) is
-        checked over the RAW entries — types intact before ``split_tool_declarations`` flattens a
-        tool node into a bare :class:`ToolBinding`:
+        Shared by ``__init__`` and :meth:`add_tools`. The tool-surface contract (spec §15.3 +
+        toolbox-discovery spec D3/D5/D6) is checked over the RAW entries — types intact before
+        ``split_tool_declarations`` flattens a tool node into a bare :class:`ToolBinding`:
 
           1. **No duplicate tool names** across eager bindings + named ``Tools``.
           2. **``Tools(discover=True)`` owns the tool-node surface** — no eager tool node and no
-             named ``Tools(...)`` may accompany it (an ``MCPToolbox``, a different node kind, may).
+             named ``Tools(...)`` may accompany it (a ``Toolboxes``/eager toolbox node — a
+             different node kind — may).
+          3. **``Toolboxes(discover=True)`` is the exclusive author of the toolbox surface** —
+             no other ``Toolboxes`` handle (a redundant second discover included) and no eager
+             toolbox node may accompany it (Messaging-strength, checked before rule 4).
+          4. **One policy per toolbox per agent** — the same toolbox name declared twice, across
+             ``Toolboxes`` handles and eager toolbox nodes alike, is a conflict.
+
+        A bare :class:`Toolbox` entry is caught FIRST — before the split would raise its generic
+        ``TypeError`` — so the mistake teaches its own fix (wrap it in ``Toolboxes(...)``; a
+        deliberate divergence from the ``Messaging``/``Handoff`` fall-through, which stays
+        generic because those handles are not tool-flavored).
 
         Validate-before-commit: a raised ``ValueError`` leaves the existing surface unchanged.
         """
+        for t in raw_tools or ():
+            if isinstance(t, Toolbox):
+                raise ValueError(
+                    f"Toolbox({t.name!r}) is an entry spec, not a selector — wrap it in Toolboxes(...): tools=[Toolboxes(Toolbox({t.name!r}, ...))]"
+                )
         bindings, selectors = split_tool_declarations(raw_tools)
         # The eager tool nodes, kept TYPED — read off the raw ``BaseToolNodeDef`` entries (which the
         # split flattens into bindings). The discover-exclusivity check needs to know which
@@ -977,7 +996,7 @@ class BaseAgentNodeDef(
         if discover and (eager_nodes or named):
             raise ValueError(
                 "Tools(discover=True) owns the agent's tool-node surface: no eager tool node "
-                "or named Tools(...) may accompany it (an MCPToolbox may)."
+                "or named Tools(...) may accompany it (a Toolboxes(...) or eager toolbox node may)."
             )
         # (1) no duplicate tool names across the statically-named sources
         static_names = [b.name for b in self.tools + bindings] + [n for s in named for n in s.names]
@@ -985,7 +1004,23 @@ class BaseAgentNodeDef(
         if dupes:
             raise ValueError(f"duplicate tool name(s) in tools=: {dupes}; each tool may be referenced once")
 
-        self.tools += bindings  # commit only after both checks pass
+        # (3)+(4) the toolbox surface — ``Toolboxes`` handles plus eager toolbox nodes. An eager
+        # toolbox node is a ``ToolSelector`` (not a ``BaseToolNodeDef``), so the split keeps it
+        # TYPED in ``selectors``; it is sniffed by its ``_node_kind`` ClassVar rather than
+        # ``isinstance`` so this module never imports from ``calfkit.mcp``.
+        tb_handles = [s for s in selectors_all if isinstance(s, Toolboxes)]
+        tb_nodes = [s for s in selectors_all if getattr(s, "_node_kind", None) == "toolbox"]
+        if any(h.discover for h in tb_handles) and (len(tb_handles) + len(tb_nodes)) > 1:
+            raise ValueError(
+                "Toolboxes(discover=True) is the exclusive author of the toolbox surface — "
+                "no other Toolboxes handle or eager toolbox node may accompany it"
+            )
+        box_names = [e.name for h in tb_handles for e in h.entries] + [str(getattr(s, "node_id")) for s in tb_nodes]
+        box_dupes = sorted({n for n in box_names if box_names.count(n) > 1})
+        if box_dupes:
+            raise ValueError(f"duplicate toolbox declaration(s) in tools=: {box_dupes}; one policy per toolbox per agent")
+
+        self.tools += bindings  # commit only after every check passes
         self._tool_selectors += selectors
         self._eager_tool_nodes = eager_nodes
 

--- a/calfkit/nodes/agent.py
+++ b/calfkit/nodes/agent.py
@@ -1007,7 +1007,9 @@ class BaseAgentNodeDef(
         # (3)+(4) the toolbox surface — ``Toolboxes`` handles plus eager toolbox nodes. An eager
         # toolbox node is a ``ToolSelector`` (not a ``BaseToolNodeDef``), so the split keeps it
         # TYPED in ``selectors``; it is sniffed by its ``_node_kind`` ClassVar rather than
-        # ``isinstance`` so this module never imports from ``calfkit.mcp``.
+        # ``isinstance`` so this module never imports from ``calfkit.mcp``. Only
+        # ``MCPToolboxNode`` satisfies the sniff today; a future toolbox-kind selector MUST set
+        # ``_node_kind = "toolbox"`` or it silently escapes rules 3 and 4.
         tb_handles = [s for s in selectors_all if isinstance(s, Toolboxes)]
         tb_nodes = [s for s in selectors_all if getattr(s, "_node_kind", None) == "toolbox"]
         if any(h.discover for h in tb_handles) and (len(tb_handles) + len(tb_nodes)) > 1:

--- a/calfkit/nodes/tool.py
+++ b/calfkit/nodes/tool.py
@@ -207,7 +207,7 @@ def agent_tool(func: Callable[..., Any] | None = None, *, name: str | None = Non
 class Tools:
     """Identity-only handle to function tool nodes, resolved per agent turn.
 
-    The call-side counterpart to deployed tool nodes (mirrors :class:`~calfkit.mcp.MCPToolbox`):
+    The call-side counterpart to deployed tool nodes (mirrors :class:`~calfkit.nodes.toolbox.Toolboxes`):
     constructible anywhere with just the tool names — no schema, no import of the tool's code.
     Two modes, mutually exclusive on one handle:
 

--- a/calfkit/nodes/toolbox.py
+++ b/calfkit/nodes/toolbox.py
@@ -1,0 +1,116 @@
+"""Call-side toolbox selection: the ``Toolboxes`` family selector and its ``Toolbox`` entry spec.
+
+The toolbox counterpart of :class:`~calfkit.nodes.tool.Tools` (spec:
+``docs/designs/toolbox-discovery-spec.md``, ADR-0045): ``Toolboxes`` declares an agent's toolbox
+surface — named entries XOR discover — and ``Toolbox`` is the frozen per-box entry carrying the
+``include=`` trust boundary. Agents never speak MCP; they hold these identity-only values and the
+deployed :class:`~calfkit.mcp.mcp_toolbox.MCPToolboxNode` services the calls.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from calfkit._handle_names import normalize_toolbox_entries
+from calfkit.models.capability import (
+    EnumerableCapabilityView,
+    SelectorResult,
+    resolve_all_capabilities,
+    resolve_capability,
+)
+from calfkit.models.tool_dispatch import ToolBinding
+
+
+@dataclass(frozen=True)
+class Toolbox:
+    """Identity-only entry spec naming one toolbox inside a :class:`Toolboxes` selector.
+
+    A name plus optional ``include=`` scoping — the static per-toolbox trust boundary (bare
+    server-side tool names; a server growing its tool list cannot enlarge the agent's surface).
+    ``include=()`` is legal and means *explicit exclusion*: the box is bound with zero tools.
+
+    Deliberately **not** a selector: it exists only as an entry, and passing one directly in
+    ``tools=[...]`` raises a teaching error (wrap it in ``Toolboxes(...)``). ``MCPToolbox`` is a
+    code-level alias of this class for MCP-flavored call sites, not a distinct concept.
+    """
+
+    name: str
+    include: tuple[str, ...] | None = None
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("Toolbox name must be non-empty")
+        if self.include is not None and not isinstance(self.include, tuple):
+            object.__setattr__(self, "include", tuple(self.include))
+
+
+def _desugar(entry: object) -> Toolbox:
+    if isinstance(entry, str):
+        return Toolbox(entry)
+    if isinstance(entry, Toolbox):
+        return entry
+    raise TypeError(f"Toolboxes entries must be toolbox names or Toolbox specs, got {type(entry).__name__}")
+
+
+@dataclass(frozen=True)
+class Toolboxes:
+    """The call-side family selector declaring an agent's toolbox surface, passed in ``tools=[...]``.
+
+    Two modes, exactly one (the family's discover-XOR-items rail, shared with
+    ``Tools``/``Messaging``/``Handoff``):
+
+    - **named** — ``Toolboxes("github", "slack")`` or mixed entries
+      ``Toolboxes(Toolbox("github", include=("create_issue",)), "jira")``: bare names desugar to
+      :class:`Toolbox` at construction, so the canonical form is always a tuple of entries.
+      Duplicate toolbox names raise — an entry carries policy (``include=``), so a duplicate is a
+      conflict, never the name rail's silent dedupe.
+    - **discover** — ``Toolboxes(discover=True)``: every live toolbox, resolved fresh each turn.
+      The exclusive author of the agent's toolbox surface (no other ``Toolboxes`` handle and no
+      eager toolbox node may accompany it).
+
+    Frozen value semantics: equal declarations compare and hash equal.
+    """
+
+    entries: tuple[Toolbox, ...]
+    discover: bool = False
+
+    # ``*positional`` varargs (the common case) plus a keyword-only ``entries=`` list — the
+    # element-descriptive mirror of the siblings' ``names=``/``.names`` shape.
+    def __init__(self, *positional: str | Toolbox, entries: Sequence[str | Toolbox] | None = None, discover: bool = False) -> None:
+        object.__setattr__(
+            self,
+            "entries",
+            normalize_toolbox_entries("Toolboxes", positional=positional, entries=entries, discover=discover, desugar=_desugar),
+        )
+        object.__setattr__(self, "discover", discover)
+
+    def resolve_tools(self, view: EnumerableCapabilityView) -> SelectorResult:
+        """Resolve against the capability view.
+
+        Discover mode binds every live toolbox (``resolve_all_capabilities``); named mode
+        resolves each entry (``resolve_capability`` with the entry's ``include``), concatenating
+        all five ``SelectorResult`` fields — ``missing_tools`` is the channel ``Tools`` named
+        mode has no ``include=`` to populate.
+        """
+        if self.discover:
+            return resolve_all_capabilities(view, node_kind="toolbox")
+        bindings: list[ToolBinding] = []
+        missing: list[str] = []
+        missing_tools: list[str] = []
+        invalid: list[str] = []
+        wrong_kind: list[str] = []
+        for entry in self.entries:
+            result = resolve_capability(view, entry.name, include=entry.include, expected_kind="toolbox")
+            bindings.extend(result.bindings)
+            missing.extend(result.missing_targets)
+            missing_tools.extend(result.missing_tools)
+            invalid.extend(result.invalid_targets)
+            wrong_kind.extend(result.wrong_kind_targets)
+        return SelectorResult(
+            bindings=tuple(bindings),
+            missing_targets=tuple(missing),
+            missing_tools=tuple(missing_tools),
+            invalid_targets=tuple(invalid),
+            wrong_kind_targets=tuple(wrong_kind),
+        )

--- a/calfkit/nodes/toolbox.py
+++ b/calfkit/nodes/toolbox.py
@@ -43,6 +43,8 @@ class Toolbox:
     # field annotation and wrongly reject ``include=["a"]`` under type checking (family pattern:
     # ``Tools``/``Toolboxes`` also hand-write their ``__init__``).
     def __init__(self, name: str, include: Sequence[str] | None = None) -> None:
+        if isinstance(include, str):
+            raise ValueError("Toolbox include= must be a sequence of tool names, not a bare string")
         object.__setattr__(self, "name", name)
         object.__setattr__(self, "include", tuple(include) if include is not None else None)
         if not self.name:

--- a/calfkit/nodes/toolbox.py
+++ b/calfkit/nodes/toolbox.py
@@ -38,11 +38,15 @@ class Toolbox:
     name: str
     include: tuple[str, ...] | None = None
 
-    def __post_init__(self) -> None:
+    # Hand-written so the advertised parameter type is ``Sequence`` (spec D3) while the stored
+    # field stays a tuple — the dataclass-generated ``__init__`` would bind the parameter to the
+    # field annotation and wrongly reject ``include=["a"]`` under type checking (family pattern:
+    # ``Tools``/``Toolboxes`` also hand-write their ``__init__``).
+    def __init__(self, name: str, include: Sequence[str] | None = None) -> None:
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "include", tuple(include) if include is not None else None)
         if not self.name:
             raise ValueError("Toolbox name must be non-empty")
-        if self.include is not None and not isinstance(self.include, tuple):
-            object.__setattr__(self, "include", tuple(self.include))
 
 
 def _desugar(entry: object) -> Toolbox:
@@ -90,8 +94,8 @@ class Toolboxes:
 
         Discover mode binds every live toolbox (``resolve_all_capabilities``); named mode
         resolves each entry (``resolve_capability`` with the entry's ``include``), concatenating
-        all five ``SelectorResult`` fields — ``missing_tools`` is the channel ``Tools`` named
-        mode has no ``include=`` to populate.
+        all five ``SelectorResult`` fields — including ``missing_tools``, which named ``Tools``
+        can never populate (it has no ``include=``) but a ``Toolbox`` entry's ``include=`` can.
         """
         if self.discover:
             return resolve_all_capabilities(view, node_kind="toolbox")

--- a/calfkit/worker/worker.py
+++ b/calfkit/worker/worker.py
@@ -19,7 +19,7 @@ from calfkit.models.agents import AGENTS_TOPIC, AGENTS_VIEW_RESOURCE_KEY, AgentC
 from calfkit.models.capability import CAPABILITY_TOPIC, CAPABILITY_VIEW_RESOURCE_KEY, CapabilityRecord
 from calfkit.models.envelope import Envelope
 from calfkit.models.tool_dispatch import ToolSelector
-from calfkit.nodes import BaseNodeDef
+from calfkit.nodes import BaseNodeDef, Toolbox
 from calfkit.provisioning import framework_topics_for_nodes, topics_for_nodes
 from calfkit.tuning import FanoutConfig
 from calfkit.worker.lifecycle import (
@@ -174,7 +174,9 @@ class Worker(LifecycleHookMixin):
     def _add_node(self, node: BaseNodeDef) -> None:
         """Internal: register a node for hosting."""
         if not isinstance(node, BaseNodeDef):
-            if isinstance(node, ToolSelector):
+            # ``Toolbox`` is deliberately NOT a ToolSelector (it is an entry spec), but a
+            # misplaced one deserves the same reference-not-host teaching as a selector.
+            if isinstance(node, (ToolSelector, Toolbox)):
                 raise TypeError(
                     f"{type(node).__name__} is a name-only reference and can't host — construct the "
                     "hosting node instead (e.g. MCPToolboxNode(name, connection_params=...)) to deploy. "

--- a/docs/api.md
+++ b/docs/api.md
@@ -256,7 +256,7 @@ agent = Agent("researcher", subscribe_topics="researcher.input", model_client=mo
               tools=[Tools(discover=True)])         # discover: every live tool node
 ```
 
-A frozen, identity-only handle to deployed function tool nodes, resolved per turn from the capability control plane (the agent discovers schemas at runtime instead of importing the tool's code). Two mutually exclusive modes: **named** — `Tools("add", "subtract")` / `Tools(names=[...])` references specific tool nodes; **discover** — `Tools(discover=True)` selects every live tool node (`node_kind == "tool"`; never an MCP toolbox's tools), carrying no names. Exactly one of {non-empty names, `discover=True`} holds — both, or the empty handle, raise. An unresolved selection warns and degrades. The agent's tool surface admits no duplicate tool names, and `Tools(discover=True)` owns the tool-node surface (no eager tool node or named `Tools` alongside it — an `MCPToolbox` may); a violation raises at construction. See [discoverable tool nodes](tool-discovery.md).
+A frozen, identity-only handle to deployed function tool nodes, resolved per turn from the capability control plane (the agent discovers schemas at runtime instead of importing the tool's code). Two mutually exclusive modes: **named** — `Tools("add", "subtract")` / `Tools(names=[...])` references specific tool nodes; **discover** — `Tools(discover=True)` selects every live tool node (`node_kind == "tool"`; never an MCP toolbox's tools), carrying no names. Exactly one of {non-empty names, `discover=True`} holds — both, or the empty handle, raise. An unresolved selection warns and degrades. The agent's tool surface admits no duplicate tool names, and `Tools(discover=True)` owns the tool-node surface (no eager tool node or named `Tools` alongside it — a `Toolboxes(...)` or directly-passed toolbox node may); a violation raises at construction. See [discoverable tool nodes](tool-discovery.md).
 
 ### `@consumer`
 
@@ -450,12 +450,13 @@ See [Worker lifecycle & embedding](worker-lifecycle.md) for the full lifecycle h
 
 ## MCP toolboxes
 
-Host an MCP server's tools as a deployable node and reference them from agents. The toolbox types are imported from `calfkit.mcp`.
+Host an MCP server's tools as a deployable node and select them from agents by name. The deploy-side types are imported from `calfkit.mcp`; the call-side selector types (`Toolboxes`, `Toolbox`) are imported from `calfkit` (the `MCPToolbox` alias is also available from `calfkit.mcp`).
 
 | Symbol | Purpose |
 | --- | --- |
 | `MCPToolboxNode` | The deployable host — one per MCP server, placed in `Worker(nodes=[...])`. |
-| `MCPToolbox` | A frozen, identity-only handle to a toolbox by name, placed in an agent's `tools=[...]`. |
+| `Toolboxes` | The dual-mode selector declaring an agent's toolbox surface, placed in `tools=[...]`. |
+| `Toolbox` (alias `MCPToolbox`) | A frozen entry spec naming one toolbox inside `Toolboxes(...)`, with optional `include=` scoping. |
 | `StdioServerParameters` | Connection params for a local stdio (subprocess) MCP server. |
 | `StreamableHttpParameters` | Connection params for a Streamable HTTP MCP server. |
 
@@ -468,15 +469,23 @@ MCPToolboxNode(
 )
 ```
 
-Hosts the tools of one MCP server; `name` is the toolbox identity agents reference. `node.select(*, include: Sequence[str] | None = None) -> MCPToolbox` returns a handle to this toolbox, optionally scoped to `include` tool names.
+Hosts the tools of one MCP server; `name` is the toolbox identity agents select. Passing the node directly in an agent's `tools=[...]` resolves identically to `Toolboxes(name)`.
 
-### `MCPToolbox`
+### `Toolboxes`
 
 ```python
-MCPToolbox(name: str, include: tuple[str, ...] | None = None)
+Toolboxes(*positional: str | Toolbox, entries: Sequence[str | Toolbox] | None = None, discover: bool = False)
 ```
 
-A frozen, identity-only handle to a toolbox. `name` must match the hosting `MCPToolboxNode`. `include` pins the tool names the agent may use **by their bare server-side name** (`search`, not `docs_server__search`); `None` exposes all of the toolbox's tools. The LLM-facing name of each tool is namespaced `<name>__<tool>` (e.g. `docs_server__search`) and stripped back to the bare name before dispatch to the MCP server (ADR-0018); the combined name must fit the provider's tool-name charset (`[a-zA-Z0-9_-]`) and length limit. The handle carries no connection params — passing connection details, or deploying a handle as a node, raises.
+The frozen, dual-mode family selector for toolboxes (the toolbox counterpart of `Tools`). Two mutually exclusive modes: **named** — `Toolboxes("docs_server", "github")` or mixed entries `Toolboxes(Toolbox("docs_server", include=("search",)), "github")` (bare names desugar to `Toolbox` entries); **discover** — `Toolboxes(discover=True)` selects every live toolbox, carrying no entries. Exactly one of {non-empty entries, `discover=True`} holds — both, or the empty selector, raise. Duplicate toolbox names across an agent's declarations (directly-passed nodes included) raise at construction, and `Toolboxes(discover=True)` is the exclusive author of the toolbox surface — no other `Toolboxes` selector or directly-passed `MCPToolboxNode` alongside it. An unresolved selection warns and degrades.
+
+### `Toolbox`
+
+```python
+Toolbox(name: str, include: Sequence[str] | None = None)   # MCPToolbox is an alias of this class
+```
+
+A frozen, identity-only entry spec naming one toolbox inside a `Toolboxes` selector — not itself a selector (placing one directly in `tools=[...]` raises with a pointer to the wrapped form). `name` must match the hosting `MCPToolboxNode`. `include` pins the tool names the agent may use **by their bare server-side name** (`search`, not `docs_server__search`); `None` exposes all of the toolbox's tools, and `include=()` deliberately exposes none (explicit exclusion). The LLM-facing name of each tool is namespaced `<name>__<tool>` (e.g. `docs_server__search`) and stripped back to the bare name before dispatch to the MCP server (ADR-0018); the combined name must fit the provider's tool-name charset (`[a-zA-Z0-9_-]`) and length limit. The entry carries no connection params — deploying one as a node raises.
 
 ### Connection params
 

--- a/docs/mcp-tool-discovery.md
+++ b/docs/mcp-tool-discovery.md
@@ -35,32 +35,45 @@ connection rather than running dark.
 
 ## Give the tools to an agent
 
-Reference the toolbox **by name** with an `MCPToolbox` handle in `tools=[...]`.
+Select toolboxes **by name** with a `Toolboxes` selector in `tools=[...]`.
 This is the default pattern: it works whether the agent shares a process with the
 toolbox or runs as a separate deployment, and the agent host never needs the
 toolbox's connection config — secrets stay on the toolbox host.
 
 ```python
-from calfkit.mcp import MCPToolbox
+from calfkit import Toolboxes
 
 agent = Agent(
     "researcher",
     subscribe_topics="researcher.input",
     model_client=model,
-    tools=[MCPToolbox("docs_server")],   # all of the toolbox's tools; scope with include= (below)
+    tools=[Toolboxes("docs_server")],   # all of the toolbox's tools; scope with include= (below)
 )
 worker = Worker(client, nodes=[agent])
 ```
 
-An `MCPToolbox` is an identity-only handle: it carries no connection config, and
-deploying one fails immediately with a pointer to the hosting form. A toolbox
-that comes up later — or changes its tools — is picked up automatically on the
-agent's next turn. No restarts, no bring-up order.
+`Toolboxes` is an identity-only selector: it carries no connection config, and
+deploying its entries fails immediately with a pointer to the hosting form. A
+toolbox that comes up later — or changes its tools — is picked up automatically
+on the agent's next turn. No restarts, no bring-up order. Several boxes go in
+one selector: `Toolboxes("docs_server", "github")`.
+
+### Select every live toolbox
+
+```python
+tools=[Toolboxes(discover=True)]   # every toolbox currently in the mesh
+```
+
+Discover mode binds every live toolbox, resolved fresh each turn — a toolbox
+deployed tomorrow is offered to the agent automatically. It is the exclusive
+author of the agent's toolbox surface: no other `Toolboxes` selector and no
+directly-passed `MCPToolboxNode` may accompany it (that raises at construction).
+It composes freely with `Tools(...)` handles — a different node kind.
 
 ### Pass the toolbox object directly (when the agent shares the definition)
 
 If the agent's process already imports the toolbox definition — the same codebase
-— you can pass the `MCPToolboxNode` object itself instead of a name handle:
+— you can pass the `MCPToolboxNode` object itself instead of naming it:
 
 ```python
 from my_service.toolboxes import docs   # shared module; deployed elsewhere
@@ -73,20 +86,27 @@ agent = Agent(
 )
 ```
 
-Both forms behave the same; prefer the name handle unless you specifically want
-to share the definition.
+Both forms resolve identically; prefer selection by name unless you specifically
+want to share the definition. Each toolbox may be declared once per agent —
+naming a box that is also passed as an object raises at construction.
 
 ## Scope the selection
 
 ```python
-tools=[MCPToolbox("docs_server", include=("search", "fetch"))]   # only these tools, by BARE name
+from calfkit import Toolbox, Toolboxes
+
+tools=[Toolboxes(Toolbox("docs_server", include=("search", "fetch")), "github")]
+#          scoped entry: only these tools, by BARE name ^        ^ bare name: full surface
 ```
 
-Use `include` to pin the exact tool names the agent may see — a server that
-starts offering new tools cannot enlarge the agent's surface. (For the object
-form, `docs.select(include=("search", "fetch"))` returns the same handle.) If a
-requested tool isn't available — the toolbox is offline, or doesn't offer it —
-the turn proceeds with whatever tools are available and logs a warning.
+A `Toolbox` entry scopes one box: `include` pins the exact tool names the agent
+may see — a server that starts offering new tools cannot enlarge the agent's
+surface. Bare strings and scoped entries mix freely in one selector; an empty
+`include=()` deliberately binds the box with zero tools (explicit exclusion).
+`MCPToolbox` is an alias of `Toolbox` (importable from `calfkit.mcp`) for
+MCP-flavored call sites. If a requested tool isn't available — the toolbox is
+offline, or doesn't offer it — the turn proceeds with whatever tools are
+available and logs a warning.
 
 `include` names are the **bare** server-side tool names (`search`, not
 `docs_server__search`) — see below.

--- a/docs/mcp-tool-discovery.md
+++ b/docs/mcp-tool-discovery.md
@@ -53,7 +53,8 @@ worker = Worker(client, nodes=[agent])
 ```
 
 `Toolboxes` is an identity-only selector: it carries no connection config, and
-deploying its entries fails immediately with a pointer to the hosting form. A
+deploying a `Toolboxes` selector — or a bare `Toolbox` entry — fails immediately
+with a pointer to the hosting form. A
 toolbox that comes up later — or changes its tools — is picked up automatically
 on the agent's next turn. No restarts, no bring-up order. Several boxes go in
 one selector: `Toolboxes("docs_server", "github")`.

--- a/docs/tool-discovery.md
+++ b/docs/tool-discovery.md
@@ -79,9 +79,9 @@ agent = Agent(
 
 Discover mode takes no names and **owns the agent's tool-node surface**: you cannot
 pair `Tools(discover=True)` with an eager tool node or a named `Tools(...)` — that
-raises at construction, so pick one or the other. It still composes with an
-`MCPToolbox` (a different kind of provider), and it binds only function tool nodes,
-never an MCP toolbox's tools.
+raises at construction, so pick one or the other. It still composes with a
+`Toolboxes` selector (a different kind of provider), and it binds only function
+tool nodes, never a toolbox's tools.
 
 ## Names are cluster-wide identities
 

--- a/examples/quickstart_mcp/README.md
+++ b/examples/quickstart_mcp/README.md
@@ -2,7 +2,7 @@
 
 Give an agent tools served by an [MCP](https://modelcontextprotocol.io) server —
 deployed as its own node and used by a **separately-deployed agent that
-references it by name**. This is the end-to-end version of the
+selects it by name**. This is the end-to-end version of the
 [How to give agents MCP tools](../../docs/mcp-tool-discovery.md) guide.
 
 The toolbox here fronts the official **`fetch`** reference server, giving the
@@ -30,7 +30,7 @@ agent one tool — `fetch` (URL → markdown) — so it can read the live web.
 # 1) the toolbox node (spawns the MCP fetch server)
 $ ck run fetch_toolbox:fetcher
 
-# 2) the agent — references the toolbox by name
+# 2) the agent — selects the toolbox by name
 $ ck run research_agent:agent
 
 # 3) ask it something that needs the web

--- a/examples/quickstart_mcp/README.md
+++ b/examples/quickstart_mcp/README.md
@@ -13,7 +13,7 @@ agent one tool — `fetch` (URL → markdown) — so it can read the live web.
 | File | Role |
 | --- | --- |
 | `fetch_toolbox.py` | The toolbox node — spawns `uvx mcp-server-fetch` and advertises its tools on the control plane. |
-| `research_agent.py` | An agent that references the toolbox **by name** (`MCPToolbox("fetcher")`) — no shared import, no connection config. |
+| `research_agent.py` | An agent that selects the toolbox **by name** (`Toolboxes("fetcher")`) — no shared import, no connection config. |
 | `ask.py` | Sends the agent a question that needs a web fetch. |
 
 ## Prerequisites

--- a/examples/quickstart_mcp/research_agent.py
+++ b/examples/quickstart_mcp/research_agent.py
@@ -1,17 +1,16 @@
 """Deploy an agent that uses the fetch toolbox — by name, in a separate process.
 
 This agent never imports the toolbox definition or its connection config; it
-references the toolbox with an identity-only ``MCPToolbox`` handle. The agent's
-worker discovers the toolbox's tools over the capability control plane and
-re-resolves them every turn, so bring-up order does not matter.
+selects the toolbox by name with an identity-only ``Toolboxes`` selector. The
+agent's worker discovers the toolbox's tools over the capability control plane
+and re-resolves them every turn, so bring-up order does not matter.
 
 Prerequisites: a running broker, and ``export OPENAI_API_KEY=sk-...``.
 
 Run it with:  ck run research_agent:agent
 """
 
-from calfkit.mcp import MCPToolbox
-from calfkit.nodes import Agent
+from calfkit.nodes import Agent, Toolbox, Toolboxes
 from calfkit.providers import OpenAIResponsesModelClient
 
 agent = Agent(
@@ -19,6 +18,6 @@ agent = Agent(
     system_prompt=("You answer questions by fetching and reading web pages with your fetch tool. Always cite the URL you read."),
     subscribe_topics="researcher.input",
     model_client=OpenAIResponsesModelClient(model_name="gpt-5.4-nano"),
-    # Reference the toolbox by name; `include` pins the exact tool we expect.
-    tools=[MCPToolbox("fetcher", include=("fetch",))],
+    # Select the toolbox by name; the entry's `include` pins the exact tool we expect.
+    tools=[Toolboxes(Toolbox("fetcher", include=("fetch",)))],
 )

--- a/tests/integration/test_mcp_roundtrip_kafka.py
+++ b/tests/integration/test_mcp_roundtrip_kafka.py
@@ -49,7 +49,7 @@ from calfkit.client import Client
 from calfkit.controlplane import ControlPlaneConfig, ControlPlaneView
 from calfkit.mcp import MCPToolboxNode, StdioServerParameters
 from calfkit.models.capability import CAPABILITY_TOPIC, CapabilityRecord
-from calfkit.nodes import Agent
+from calfkit.nodes import Agent, Toolbox, Toolboxes
 from calfkit.worker import Worker
 from tests.integration._kafka_helpers import fast_control_plane, profile_for
 from tests.integration._roundtrip_helpers import (
@@ -201,7 +201,7 @@ async def test_single_tool_call_roundtrips_over_the_wire(kafka_bootstrap: str, t
         system_prompt="call the add tool",
         subscribe_topics=agent_in,
         model_client=scripted_model([ToolCallPart(_ns(server_name, "add"), {"a": 2, "b": 3}, tool_call_id="call-add")]),
-        tools=[toolbox.select(include=_TOOLS)],  # include uses BARE names (C5)
+        tools=[Toolboxes(Toolbox(toolbox.node_id, include=_TOOLS))],  # include uses BARE names (C5)
     )
 
     driver = Client.connect(kafka_bootstrap)
@@ -239,7 +239,7 @@ async def test_mcp_iserror_result_passes_through_transparently(kafka_bootstrap: 
         system_prompt="call domain_error",
         subscribe_topics=agent_in,
         model_client=scripted_model([ToolCallPart(_ns(server_name, "domain_error"), {}, tool_call_id="call-err")]),
-        tools=[toolbox.select(include=["domain_error"])],  # include = BARE (C5)
+        tools=[Toolboxes(Toolbox(toolbox.node_id, include=["domain_error"]))],  # include = BARE (C5)
     )
 
     driver = Client.connect(kafka_bootstrap)
@@ -284,7 +284,7 @@ async def test_concurrent_tool_calls_roundtrip_via_fanout(kafka_bootstrap: str, 
                 ToolCallPart(_ns(server_name, "echo"), {"text": "hi"}, tool_call_id="call-echo"),
             ]
         ),
-        tools=[toolbox.select(include=_TOOLS)],
+        tools=[Toolboxes(Toolbox(toolbox.node_id, include=_TOOLS))],
     )
     assert agent._is_fanout_capable
 
@@ -333,7 +333,7 @@ async def test_duplicate_tool_concurrent_slots_route_by_call_id(kafka_bootstrap:
                 ToolCallPart(_ns(server_name, "add"), {"a": 10, "b": 20}, tool_call_id="call-b"),
             ]
         ),
-        tools=[toolbox.select(include=_TOOLS)],
+        tools=[Toolboxes(Toolbox(toolbox.node_id, include=_TOOLS))],
     )
 
     driver = Client.connect(kafka_bootstrap)
@@ -377,7 +377,7 @@ async def test_two_mcp_servers_route_each_call_to_its_server(kafka_bootstrap: st
                 ToolCallPart(_ns(server_b_name, "mul"), {"a": 4, "b": 5}, tool_call_id="call-mul"),
             ]
         ),
-        tools=[box_a.select(include=["add"]), box_b.select(include=["mul"])],  # each include is BARE
+        tools=[Toolboxes(Toolbox(box_a.node_id, include=["add"])), Toolboxes(Toolbox(box_b.node_id, include=["mul"]))],  # each include is BARE
     )
 
     driver = Client.connect(kafka_bootstrap)
@@ -420,14 +420,14 @@ async def test_two_agents_share_one_toolbox_replies_route_per_caller(kafka_boots
         system_prompt="add",
         subscribe_topics=a1_in,
         model_client=scripted_model([ToolCallPart(_ns(server_name, "add"), {"a": 2, "b": 3}, tool_call_id="c1")]),
-        tools=[toolbox.select(include=["add"])],
+        tools=[Toolboxes(Toolbox(toolbox.node_id, include=["add"]))],
     )
     agent2 = Agent(
         a2_id,
         system_prompt="add",
         subscribe_topics=a2_in,
         model_client=scripted_model([ToolCallPart(_ns(server_name, "add"), {"a": 10, "b": 20}, tool_call_id="c2")]),
-        tools=[toolbox.select(include=["add"])],
+        tools=[Toolboxes(Toolbox(toolbox.node_id, include=["add"]))],
     )
 
     driver = Client.connect(kafka_bootstrap)
@@ -471,7 +471,7 @@ async def test_include_pinning_blocks_unselected_tool(kafka_bootstrap: str, topi
         system_prompt="try to call danger",
         subscribe_topics=agent_in,
         model_client=scripted_model([ToolCallPart(_ns(server_name, "danger"), {}, tool_call_id="call-danger")]),
-        tools=[toolbox.select(include=["add"])],  # danger is advertised but NOT included (include is BARE)
+        tools=[Toolboxes(Toolbox(toolbox.node_id, include=["add"]))],  # danger is advertised but NOT included (include is BARE)
     )
 
     driver = Client.connect(kafka_bootstrap)
@@ -513,14 +513,14 @@ async def test_tools_list_changed_grows_the_toolset(kafka_bootstrap: str, topic_
         system_prompt="enable the bonus tool",
         subscribe_topics=enable_in,
         model_client=scripted_model([ToolCallPart(_ns(server_name, "enable_bonus"), {}, tool_call_id="call-enable")]),
-        tools=[toolbox.select(include=["enable_bonus"])],
+        tools=[Toolboxes(Toolbox(toolbox.node_id, include=["enable_bonus"]))],
     )
     bonus_agent = Agent(
         bonus_id,
         system_prompt="use the bonus tool",
         subscribe_topics=bonus_in,
         model_client=scripted_model([ToolCallPart(_ns(server_name, "bonus"), {}, tool_call_id="call-bonus")]),
-        tools=[toolbox.select(include=["bonus"])],
+        tools=[Toolboxes(Toolbox(toolbox.node_id, include=["bonus"]))],
     )
 
     driver = Client.connect(kafka_bootstrap)
@@ -695,7 +695,7 @@ async def test_mcp_bad_args_rejected_before_dispatch_then_corrected(
             [ToolCallPart(tool, {"a": "not-an-int", "b": 3}, tool_call_id="bad")],
             [ToolCallPart(tool, {"a": 2, "b": 3}, tool_call_id="good")],
         ),
-        tools=[toolbox.select(include=["add"])],  # include = BARE (C5)
+        tools=[Toolboxes(Toolbox(toolbox.node_id, include=["add"]))],  # include = BARE (C5)
     )
 
     driver = Client.connect(kafka_bootstrap)

--- a/tests/integration/test_mcp_toolbox_capability.py
+++ b/tests/integration/test_mcp_toolbox_capability.py
@@ -29,6 +29,7 @@ from calfkit.mcp.mcp_toolbox import MCPToolboxNode
 from calfkit.mcp.mcp_transport import StreamableHttpParameters
 from calfkit.models.capability import CAPABILITY_TOPIC, CAPABILITY_VIEW_RESOURCE_KEY, CapabilityRecord
 from calfkit.nodes.agent import Agent
+from calfkit.nodes.toolbox import Toolbox, Toolboxes
 from calfkit.providers.pydantic_ai.model_client import PydanticModelClient
 from calfkit.provisioning import ProvisioningConfig
 from calfkit.worker.worker import Worker
@@ -100,7 +101,9 @@ async def test_capability_parity_toolbox_to_agent(kafka_bootstrap: str) -> None:
     name = f"docs-{uuid.uuid4().hex[:8]}"
     toolbox = MCPToolboxNode(name, connection_params=StreamableHttpParameters(url="http://unused.local/mcp"))
     await toolbox._refresh_tools(FakeSession(("search",)))  # prime cache (no real MCP server)
-    agent = Agent("researcher", subscribe_topics="researcher.in", model_client=FakeModel(), tools=[toolbox.select(include=["search"])])
+    agent = Agent(
+        "researcher", subscribe_topics="researcher.in", model_client=FakeModel(), tools=[Toolboxes(Toolbox(toolbox.node_id, include=["search"]))]
+    )
 
     pub, ctx, writer_gen = await _host_toolbox(kafka_bootstrap, toolbox)
     view = await _open_view(kafka_bootstrap)

--- a/tests/test_mcp_toolbox.py
+++ b/tests/test_mcp_toolbox.py
@@ -1,10 +1,10 @@
-"""#212: MCPToolbox — the public, identity-only handle to an MCP toolbox.
+"""`calfkit.mcp`'s call-side surface after ADR-0045: the `MCPToolbox` alias and the node rewire.
 
-Distributed agent hosts reference a toolbox by name with zero deployment
-knowledge (no connection params, no secrets). The handle is the call-side
-counterpart to the hosting MCPToolboxNode (peer-node pattern); `select()` mints
-one from a node instance; the node's own selector behavior delegates to its
-handle so both resolve identically.
+Distributed agent hosts reference a toolbox by name with zero deployment knowledge
+(no connection params, no secrets) — spelled `Toolboxes(...)`, with `MCPToolbox` a
+code-level alias of the `Toolbox` entry spec for MCP-flavored call sites. The node's
+own selector behavior calls the resolution kernel directly, so passing the node
+eagerly and naming its Toolbox resolve identically.
 """
 
 from __future__ import annotations
@@ -15,7 +15,7 @@ from typing import Any
 import pytest
 
 from calfkit.models.capability import CapabilityRecord, CapabilityToolDef
-from calfkit.models.tool_dispatch import ToolSelector, split_tool_declarations
+from calfkit.models.tool_dispatch import ToolSelector
 
 
 def make_record(toolbox_id: str = "github", tool_names: tuple[str, ...] = ("search", "create_issue")) -> CapabilityRecord:
@@ -43,17 +43,18 @@ class TestDirectConstruction:
 
     def test_resolves_by_name_only(self) -> None:
         from calfkit.mcp import MCPToolbox
+        from calfkit.nodes.toolbox import Toolboxes
 
-        ref = MCPToolbox("github")
-        result = ref.resolve_tools({"github": make_record()})
+        result = Toolboxes(MCPToolbox("github")).resolve_tools({"github": make_record()})
         # C1: toolbox tools are namespaced <node_id>__<tool> for the LLM.
         assert [b.name for b in result.bindings] == ["github__search", "github__create_issue"]
 
     def test_include_kwarg_filters(self) -> None:
         from calfkit.mcp import MCPToolbox
+        from calfkit.nodes.toolbox import Toolboxes
 
-        ref = MCPToolbox("github", include=("search",))  # include uses BARE names (C5)
-        result = ref.resolve_tools({"github": make_record()})
+        entry = MCPToolbox("github", include=("search",))  # include uses BARE names (C5)
+        result = Toolboxes(entry).resolve_tools({"github": make_record()})
         assert [b.name for b in result.bindings] == ["github__search"]
 
     def test_include_accepts_any_sequence_normalized_to_tuple(self) -> None:
@@ -70,31 +71,30 @@ class TestDirectConstruction:
             ref.include = ("other",)  # type: ignore[misc]
         assert len({ref, MCPToolbox("github", include=("search",))}) == 1  # value semantics
 
-    def test_satisfies_tool_selector_and_splits_as_selector(self) -> None:
+    def test_is_not_a_tool_selector(self) -> None:
+        # INVERTED post-ADR-0045: the alias is an entry spec, not a selector — the old
+        # `tools=[MCPToolbox("gh")]` idiom fails loud with the wrap-it teaching error.
         from calfkit.mcp import MCPToolbox
 
-        ref = MCPToolbox("github")
-        assert isinstance(ref, ToolSelector)
-        bindings, selectors = split_tool_declarations([ref])
-        assert bindings == [] and selectors == [ref]
+        assert not isinstance(MCPToolbox("github"), ToolSelector)
 
 
-class TestMintingAndParity:
-    def test_select_returns_the_public_ref_type(self) -> None:
+class TestNodeParity:
+    def test_select_is_gone_scoping_is_direct_construction(self) -> None:
         from calfkit.mcp import MCPToolbox
 
-        ref = make_toolbox().select(include=["search"])
-        assert isinstance(ref, MCPToolbox)
-        assert ref.name == "github" and ref.include == ("search",)
+        assert not hasattr(make_toolbox(), "select")
+        entry = MCPToolbox("github", include=("search",))
+        assert entry.name == "github" and entry.include == ("search",)
 
-    def test_toolbox_resolution_delegates_to_its_ref(self) -> None:
-        from calfkit.mcp import MCPToolbox
+    def test_toolbox_resolution_matches_naming_its_toolbox(self) -> None:
+        from calfkit.nodes.toolbox import Toolboxes
 
         view: dict[str, Any] = {"github": make_record()}
         via_toolbox = make_toolbox().resolve_tools(view)
-        via_ref = MCPToolbox("github").resolve_tools(view)
-        assert [b.name for b in via_toolbox.bindings] == [b.name for b in via_ref.bindings]
-        assert via_toolbox == via_ref  # identical SelectorResult (frozen value): toolbox and ref resolve the same
+        via_selector = Toolboxes("github").resolve_tools(view)
+        assert [b.name for b in via_toolbox.bindings] == [b.name for b in via_selector.bindings]
+        assert via_toolbox == via_selector  # identical SelectorResult (frozen value): node and selector resolve the same
 
     def test_scoped_selector_is_gone(self) -> None:
         import calfkit.mcp.mcp_toolbox as mod

--- a/tests/test_tool_selector.py
+++ b/tests/test_tool_selector.py
@@ -25,6 +25,7 @@ from calfkit.models.capability import (
     SelectorResult,
 )
 from calfkit.models.tool_dispatch import ToolBinding, ToolProvider, ToolSelector, split_tool_declarations
+from calfkit.nodes.toolbox import Toolbox, Toolboxes
 from tests.test_controlplane_view import _FakeTable  # the substrate's dict-backed GroupedTableReader fake
 
 
@@ -82,8 +83,7 @@ class TestResolveTools:
         assert result.unresolved
 
     def test_include_filter_and_missing_tools(self) -> None:
-        toolbox = make_toolbox()
-        selector = toolbox.select(include=["search", "nonexistent"])  # include = BARE names (C5)
+        selector = Toolboxes(Toolbox("docs_server", include=("search", "nonexistent")))  # include = BARE names (C5)
         result = selector.resolve_tools({"docs_server": make_record()})
         assert [b.name for b in result.bindings] == ["docs_server__search"]
         assert result.missing_tools == ("nonexistent",)  # missing_tools reported bare too
@@ -93,26 +93,26 @@ class TestResolveTools:
         # expand to docs_server__a__b AND stay pinnable by its bare name `a__b` — the include
         # strip must recover `a__b`, not mangle it (removeprefix, not split("__")).
         record = make_record(tools=[CapabilityToolDef(name="a__b", parameters_json_schema={"type": "object", "properties": {}})])
-        result = make_toolbox().select(include=["a__b"]).resolve_tools({"docs_server": record})
+        result = Toolboxes(Toolbox("docs_server", include=("a__b",))).resolve_tools({"docs_server": record})
         assert [b.name for b in result.bindings] == ["docs_server__a__b"]
         assert result.missing_tools == ()
 
     def test_empty_include_pins_nothing(self) -> None:
         # include=() pins ZERO tools — distinct from include=None (all tools).
-        result = make_toolbox().select(include=[]).resolve_tools({"docs_server": make_record()})
+        result = Toolboxes(Toolbox("docs_server", include=())).resolve_tools({"docs_server": make_record()})
         assert result.bindings == ()
         assert result.missing_tools == ()
 
     def test_empty_toolbox_record_resolves_to_no_bindings(self) -> None:
         # A toolbox advertising zero tools expands to zero bindings; an include miss is bare.
-        result = make_toolbox().select(include=["search"]).resolve_tools({"docs_server": make_record(tools=[])})
+        result = Toolboxes(Toolbox("docs_server", include=("search",))).resolve_tools({"docs_server": make_record(tools=[])})
         assert result.bindings == ()
         assert result.missing_tools == ("search",)
 
-    def test_scoped_selector_is_frozen(self) -> None:
-        selector = make_toolbox().select(include=["search"])
+    def test_scoped_spec_is_frozen(self) -> None:
+        spec = Toolbox("docs_server", include=("search",))
         with pytest.raises(Exception):
-            selector.include = ("other",)  # type: ignore[misc]
+            spec.include = ("other",)  # type: ignore[misc]
 
     def test_malformed_record_is_skipped_with_diagnostic(self) -> None:
         # Tolerant reader admits an empty dispatch_topic; binding expansion
@@ -164,7 +164,7 @@ class TestSplitToolDeclarations:
 
         tool_node = agent_tool(get_weather)
         toolbox = make_toolbox()
-        scoped = toolbox.select(include=["search"])
+        scoped = Toolboxes(Toolbox("docs_server", include=("search",)))
         raw = tool_node.tool_bindings()[0]
 
         bindings, selectors = split_tool_declarations([tool_node, toolbox, scoped, raw])
@@ -279,12 +279,13 @@ class TestAgentResolution:
 class TestNoStrictSurface:
     """D5: the strict knob and its exception are gone from the public surface."""
 
-    def test_select_has_no_strict_parameter(self) -> None:
+    def test_selection_surface_has_no_strict_parameter(self) -> None:
         import inspect
 
-        params = inspect.signature(MCPToolboxNode.select).parameters
-        assert "strict" not in params
-        assert "include" in params
+        toolboxes_params = inspect.signature(Toolboxes.__init__).parameters
+        toolbox_params = inspect.signature(Toolbox.__init__).parameters
+        assert "strict" not in toolboxes_params and "strict" not in toolbox_params
+        assert "include" in toolbox_params
 
     def test_selector_result_has_no_strict_or_filtering_diagnostics(self) -> None:
         fields = set(SelectorResult.__dataclass_fields__)

--- a/tests/test_toolboxes_selector.py
+++ b/tests/test_toolboxes_selector.py
@@ -1,0 +1,352 @@
+"""``Toolboxes``/``Toolbox`` — the dual-mode family selector for toolboxes (spec D1-D6).
+
+The toolbox counterpart of ``Tools``: ``Toolboxes`` declares the agent's toolbox surface
+(named entries XOR discover), and ``Toolbox`` is the frozen per-box entry spec carrying the
+``include=`` trust boundary. ``Toolbox`` is deliberately *not* a selector — it exists only
+inside ``Toolboxes(...)``.
+
+Phase 1 covers the construction surface; resolution (Phase 2) extends this file.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from calfkit.models.capability import CAPABILITY_VIEW_RESOURCE_KEY, CapabilityRecord, CapabilityToolDef, SelectorResult
+from calfkit.models.tool_dispatch import ToolSelector
+from calfkit.nodes.tool import Tools
+from calfkit.nodes.toolbox import Toolbox, Toolboxes
+from tests._capability_fakes import _FakeView
+from tests.test_mcp_toolbox import make_toolbox  # deployed MCPToolboxNode builder
+from tests.test_tools_selector import make_agent, make_tool_record
+
+
+class TestToolboxSpec:
+    def test_name_and_default_include(self) -> None:
+        box = Toolbox("github")
+        assert box.name == "github"
+        assert box.include is None
+
+    def test_include_coerced_to_tuple(self) -> None:
+        assert Toolbox("github", include=["a", "b"]).include == ("a", "b")
+
+    def test_empty_include_is_legal_explicit_exclusion(self) -> None:
+        assert Toolbox("github", include=()).include == ()
+
+    def test_rejects_empty_name(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            Toolbox("")
+
+    def test_frozen_value_semantics(self) -> None:
+        box = Toolbox("github", include=["a"])
+        with pytest.raises(Exception):
+            box.name = "x"  # type: ignore[misc]
+        assert Toolbox("github", include=["a"]) == Toolbox("github", include=("a",))
+        assert len({Toolbox("github"), Toolbox("github")}) == 1
+
+    def test_is_not_a_tool_selector(self) -> None:
+        assert not isinstance(Toolbox("github"), ToolSelector)
+
+
+class TestToolboxesConstruction:
+    def test_bare_names_desugar_to_entries(self) -> None:
+        assert Toolboxes("github", "slack").entries == (Toolbox("github"), Toolbox("slack"))
+
+    def test_mixed_entries_canonical_form(self) -> None:
+        got = Toolboxes(Toolbox("github", include=("create_issue",)), "jira")
+        assert got.entries == (Toolbox("github", include=("create_issue",)), Toolbox("jira"))
+
+    def test_entries_kwarg(self) -> None:
+        got = Toolboxes(entries=["github", Toolbox("slack")])
+        assert got.entries == (Toolbox("github"), Toolbox("slack"))
+
+    def test_discover_mode_carries_no_entries(self) -> None:
+        handle = Toolboxes(discover=True)
+        assert handle.discover is True
+        assert handle.entries == ()
+
+    def test_rejects_positional_entries_with_discover(self) -> None:
+        with pytest.raises(ValueError, match="takes no"):
+            Toolboxes("github", discover=True)
+
+    def test_rejects_kwarg_entries_with_discover(self) -> None:
+        # The check must cover BOTH entry channels — never silently prefer discover.
+        with pytest.raises(ValueError, match="takes no"):
+            Toolboxes(entries=["github"], discover=True)
+
+    def test_rejects_mixed_positional_and_kwarg(self) -> None:
+        # The message must direct to entries= (not the siblings' names=).
+        with pytest.raises(ValueError, match="entries="):
+            Toolboxes("github", entries=["slack"])
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(ValueError, match="at least one"):
+            Toolboxes()
+        with pytest.raises(ValueError, match="at least one"):
+            Toolboxes(entries=[])
+
+    def test_rejects_blank_name(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            Toolboxes("github", "")
+
+    def test_rejects_byte_identical_duplicates(self) -> None:
+        # A duplicate is a conflict, never silently collapsed (deliberate divergence
+        # from the names rail's dedupe — entries carry policy, not just identity).
+        with pytest.raises(ValueError, match="[Dd]uplicate"):
+            Toolboxes("github", "github")
+
+    def test_rejects_same_name_different_policy(self) -> None:
+        with pytest.raises(ValueError, match="[Dd]uplicate"):
+            Toolboxes("github", Toolbox("github", include=("a",)))
+
+    def test_rejects_kwarg_form_duplicates(self) -> None:
+        with pytest.raises(ValueError, match="[Dd]uplicate"):
+            Toolboxes(entries=[Toolbox("github"), Toolbox("github")])
+
+    def test_frozen_hashable_value_semantics(self) -> None:
+        handle = Toolboxes("github", Toolbox("slack", include=["post"]))
+        with pytest.raises(Exception):
+            handle.discover = True  # type: ignore[misc]
+        assert handle == Toolboxes("github", Toolbox("slack", include=("post",)))
+        assert len({Toolboxes(discover=True), Toolboxes(discover=True)}) == 1
+        # Hashability hinges on the canonical tuple-of-Toolbox form AND include
+        # tuple-coercion both holding — a list anywhere breaks it.
+        assert hash(Toolboxes("github", Toolbox("slack", include=["post"])))
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — resolution (spec D7)
+# ---------------------------------------------------------------------------
+
+
+def make_toolbox_record(name: str = "github", tool_names: tuple[str, ...] = ("search", "create_issue"), **overrides: Any) -> CapabilityRecord:
+    now = datetime.now(tz=timezone.utc)
+    defaults: dict[str, Any] = dict(
+        started_at=now,
+        last_heartbeat_at=now,
+        heartbeat_interval=30.0,
+        node_kind="toolbox",
+        dispatch_topic=f"mcp_server.{name}",
+        tools=[CapabilityToolDef(name=n, parameters_json_schema={"type": "object", "properties": {}}) for n in tool_names],
+        content_updated_at=now,
+    )
+    defaults.update(overrides)
+    return CapabilityRecord(**defaults)
+
+
+class TestToolboxesResolveTools:
+    def test_named_entry_resolves_namespaced_bindings(self) -> None:
+        result = Toolboxes("github").resolve_tools({"github": make_toolbox_record()})
+        assert isinstance(result, SelectorResult)
+        assert [b.name for b in result.bindings] == ["github__search", "github__create_issue"]
+
+    def test_include_scopes_bare_names(self) -> None:
+        result = Toolboxes(Toolbox("github", include=("search",))).resolve_tools({"github": make_toolbox_record()})
+        assert [b.name for b in result.bindings] == ["github__search"]
+
+    def test_multiple_entries_concatenate_in_order(self) -> None:
+        view = {"github": make_toolbox_record("github", ("search",)), "slack": make_toolbox_record("slack", ("post",))}
+        result = Toolboxes("github", "slack").resolve_tools(view)
+        assert [b.name for b in result.bindings] == ["github__search", "slack__post"]
+
+    def test_missing_box_is_missing_target_and_others_still_resolve(self) -> None:
+        result = Toolboxes("github", "ghost").resolve_tools({"github": make_toolbox_record("github", ("search",))})
+        assert [b.name for b in result.bindings] == ["github__search"]
+        assert result.missing_targets == ("ghost",)
+        assert result.unresolved
+
+    def test_missing_include_names_aggregate_into_missing_tools(self) -> None:
+        # The FIFTH channel — the one Tools named mode has no include= to populate.
+        result = Toolboxes(Toolbox("github", include=("search", "nope"))).resolve_tools({"github": make_toolbox_record()})
+        assert [b.name for b in result.bindings] == ["github__search"]
+        assert result.missing_tools == ("nope",)
+        assert result.unresolved
+
+    def test_empty_include_resolves_zero_bindings_silently(self) -> None:
+        # include=() is explicit exclusion: binds the box, zero tools, NO degrade signal.
+        result = Toolboxes(Toolbox("github", include=())).resolve_tools({"github": make_toolbox_record()})
+        assert result.bindings == ()
+        assert not result.unresolved
+
+    def test_tool_record_is_rejected_as_wrong_kind(self) -> None:
+        result = Toolboxes("add").resolve_tools({"add": make_tool_record("add")})
+        assert result.bindings == ()
+        assert result.wrong_kind_targets == ("add",)
+
+    def test_poisoned_record_degrades_to_invalid_target(self) -> None:
+        result = Toolboxes("github").resolve_tools({"github": make_toolbox_record(dispatch_topic="")})
+        assert result.bindings == ()
+        assert result.invalid_targets == ("github",)
+
+    def test_discover_binds_every_toolbox_and_skips_other_kinds(self) -> None:
+        view = _FakeView(
+            github=make_toolbox_record("github", ("search",)),
+            slack=make_toolbox_record("slack", ("post",)),
+            add=make_tool_record("add"),
+        )
+        result = Toolboxes(discover=True).resolve_tools(view)
+        assert sorted(b.name for b in result.bindings) == ["github__search", "slack__post"]
+        assert not result.unresolved
+
+    def test_discover_on_empty_view_resolves_empty_and_silent(self) -> None:
+        result = Toolboxes(discover=True).resolve_tools(_FakeView())
+        assert result.bindings == ()
+        assert not result.unresolved
+
+
+class TestToolboxesDiscoverDebugLog:
+    def test_discover_resolution_logs_debug_count(self, caplog: Any) -> None:
+        import logging
+
+        agent = make_agent(Toolboxes(discover=True))
+        registry: dict[str, Any] = {}
+        view = _FakeView(github=make_toolbox_record("github", ("search", "create_issue")))
+        with caplog.at_level(logging.DEBUG, logger="calfkit.nodes.agent"):
+            agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: view}, registry)
+        assert any("discover mode resolved" in r.message for r in caplog.records)
+        assert set(registry) == {"github__search", "github__create_issue"}
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — agent assembly rules (spec D3, D5, D6, §3)
+# ---------------------------------------------------------------------------
+
+
+class TestBareToolboxTeachingError:
+    def test_bare_toolbox_in_tools_raises_teaching_valueerror(self) -> None:
+        # Must be the teaching ValueError, not split_tool_declarations' generic TypeError.
+        with pytest.raises(ValueError, match=r"Toolboxes\("):
+            make_agent(Toolbox("github"))
+
+    def test_alias_shaped_mistake_gets_the_same_teaching(self) -> None:
+        with pytest.raises(ValueError, match=r"Toolboxes\("):
+            make_agent(Toolbox("github", include=("search",)))
+
+
+class TestDuplicateBoxAcrossDeclarations:
+    def test_duplicate_box_across_handles_raises(self) -> None:
+        with pytest.raises(ValueError, match="[Dd]uplicate"):
+            make_agent(Toolboxes("github"), Toolboxes(Toolbox("github", include=("a",))))
+
+    def test_eager_node_counts_as_a_declaration(self) -> None:
+        with pytest.raises(ValueError, match="[Dd]uplicate"):
+            make_agent(make_toolbox("github"), Toolboxes("github"))
+
+    def test_eager_node_counts_order_independent(self) -> None:
+        with pytest.raises(ValueError, match="[Dd]uplicate"):
+            make_agent(Toolboxes("github"), make_toolbox("github"))
+
+    def test_add_tools_after_construction_validates_before_commit(self) -> None:
+        agent = make_agent(Toolboxes("github"))
+        with pytest.raises(ValueError, match="[Dd]uplicate"):
+            agent.add_tools(Toolboxes("github"))
+        assert agent._tool_selectors == [Toolboxes("github")]  # surface unchanged
+
+    def test_distinct_boxes_across_handles_are_legal(self) -> None:
+        agent = make_agent(Toolboxes("github"), Toolboxes("slack"))
+        assert agent._tool_selectors == [Toolboxes("github"), Toolboxes("slack")]
+
+
+class TestDiscoverExclusivity:
+    def test_named_handle_beside_discover_raises(self) -> None:
+        with pytest.raises(ValueError, match="exclusive author"):
+            make_agent(Toolboxes(discover=True), Toolboxes("github"))
+
+    def test_duplicate_discover_raises(self) -> None:
+        # Messaging-style strength: a redundant second discover handle is an error.
+        with pytest.raises(ValueError, match="exclusive author"):
+            make_agent(Toolboxes(discover=True), Toolboxes(discover=True))
+
+    def test_eager_toolbox_node_beside_discover_raises(self) -> None:
+        with pytest.raises(ValueError, match="exclusive author"):
+            make_agent(Toolboxes(discover=True), make_toolbox("github"))
+
+    def test_exclusivity_checked_before_duplicates(self) -> None:
+        # Multi-violation list: the exclusivity message wins (spec §3 precedence).
+        with pytest.raises(ValueError, match="exclusive author"):
+            make_agent(Toolboxes(discover=True), Toolboxes("a"), Toolboxes(Toolbox("a", include=())))
+
+    def test_discover_alone_is_legal(self) -> None:
+        agent = make_agent(Toolboxes(discover=True))
+        assert agent._tool_selectors == [Toolboxes(discover=True)]
+
+
+class TestCrossKindCoexistence:
+    def test_toolbox_discover_beside_tools_discover_is_legal(self) -> None:
+        agent = make_agent(Toolboxes(discover=True), Tools(discover=True))
+        assert Toolboxes(discover=True) in agent._tool_selectors
+        assert Tools(discover=True) in agent._tool_selectors
+
+    def test_named_toolboxes_beside_named_tools_is_legal(self) -> None:
+        agent = make_agent(Toolboxes("github"), Tools("add"))
+        assert agent._tool_selectors == [Toolboxes("github"), Tools("add")]
+
+    def test_tools_exclusivity_message_names_the_new_surface(self) -> None:
+        # The old "(an MCPToolbox may)" parenthetical becomes false post-change.
+        with pytest.raises(ValueError, match=r"a Toolboxes\(...\) or eager toolbox node may"):
+            make_agent(Tools(discover=True), Tools("add"))
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — alias, exports, node rewire, worker gate (spec D3, D8, D9)
+# ---------------------------------------------------------------------------
+
+
+class TestAliasAndExports:
+    def test_mcptoolbox_is_an_alias_of_toolbox(self) -> None:
+        import calfkit
+        import calfkit.mcp
+
+        assert calfkit.MCPToolbox is Toolbox
+        assert calfkit.mcp.MCPToolbox is Toolbox
+
+    def test_top_level_exports(self) -> None:
+        import calfkit
+
+        assert calfkit.Toolboxes is Toolboxes
+        assert calfkit.Toolbox is Toolbox
+        assert {"Toolboxes", "Toolbox", "MCPToolbox"} <= set(calfkit.__all__)
+
+    def test_nodes_package_exports_beside_tools(self) -> None:
+        from calfkit import nodes
+
+        assert nodes.Toolboxes is Toolboxes
+        assert nodes.Toolbox is Toolbox
+        assert {"Toolboxes", "Toolbox"} <= set(nodes.__all__)
+
+    def test_old_selector_idiom_raises_the_teaching_error(self) -> None:
+        # The alias caveat (ADR-0045): old code imports and constructs, then fails
+        # loud at agent construction with the wrap-it hint — never silently.
+        from calfkit.mcp import MCPToolbox
+
+        with pytest.raises(ValueError, match=r"Toolboxes\("):
+            make_agent(MCPToolbox("github"))
+
+
+class TestNodeRewire:
+    def test_select_is_gone(self) -> None:
+        assert not hasattr(make_toolbox("github"), "select")
+
+    def test_node_resolves_identically_to_naming_its_toolbox(self) -> None:
+        view = {"github": make_toolbox_record()}
+        assert make_toolbox("github").resolve_tools(view) == Toolboxes("github").resolve_tools(view)
+
+
+class TestWorkerTeachingGate:
+    def test_add_nodes_rejects_toolbox_entry_with_teaching_message(self) -> None:
+        # The reference-detection gate widens to Toolbox so the alias-shaped mistake
+        # keeps its "belongs in Agent(tools=[...])" pointer (spec D3 worker parity).
+        from calfkit.client import Client
+        from calfkit.worker.worker import Worker
+
+        worker = Worker(Client.connect("kafka:9092"))
+        with pytest.raises(TypeError, match=r"MCPToolboxNode\(") as excinfo:
+            worker.add_nodes(Toolbox("github"))  # type: ignore[arg-type]
+        assert "reference" in str(excinfo.value).lower()
+
+    def test_rejects_garbage_entry_types(self) -> None:
+        with pytest.raises(TypeError, match="toolbox names or Toolbox specs"):
+            Toolboxes(123)  # type: ignore[arg-type]

--- a/tests/test_toolboxes_selector.py
+++ b/tests/test_toolboxes_selector.py
@@ -407,3 +407,16 @@ class TestFiveChannelAggregation:
         with caplog.at_level(logging.WARNING, logger="calfkit.nodes.agent"):
             agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: _FakeView()}, registry)
         assert any("partially unresolved" in r.getMessage() for r in caplog.records)
+
+
+class TestBareStringGuard:
+    """Family-wide decision (post-review, 2026-07-19): a bare string where a sequence is
+    expected raises instead of silently iterating character-wise."""
+
+    def test_entries_kwarg_rejects_bare_string(self) -> None:
+        with pytest.raises(ValueError, match="not a bare string"):
+            Toolboxes(entries="jira")
+
+    def test_include_rejects_bare_string(self) -> None:
+        with pytest.raises(ValueError, match="not a bare string"):
+            Toolbox("github", include="search")

--- a/tests/test_toolboxes_selector.py
+++ b/tests/test_toolboxes_selector.py
@@ -206,7 +206,7 @@ class TestToolboxesDiscoverDebugLog:
         view = _FakeView(github=make_toolbox_record("github", ("search", "create_issue")))
         with caplog.at_level(logging.DEBUG, logger="calfkit.nodes.agent"):
             agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: view}, registry)
-        assert any("discover mode resolved" in r.message for r in caplog.records)
+        assert any("discover mode resolved 2 toolbox tool(s)" in r.getMessage() for r in caplog.records)
         assert set(registry) == {"github__search", "github__create_issue"}
 
 
@@ -350,3 +350,60 @@ class TestWorkerTeachingGate:
     def test_rejects_garbage_entry_types(self) -> None:
         with pytest.raises(TypeError, match="toolbox names or Toolbox specs"):
             Toolboxes(123)  # type: ignore[arg-type]
+
+
+class TestAddToolsIncremental:
+    """The rules re-validate accumulated state on every add_tools call, each raise
+    leaving the committed surface unchanged (validate-before-commit, all raise types)."""
+
+    def test_add_discover_onto_named_raises_surface_unchanged(self) -> None:
+        agent = make_agent(Toolboxes("github"))
+        with pytest.raises(ValueError, match="exclusive author"):
+            agent.add_tools(Toolboxes(discover=True))
+        assert agent._tool_selectors == [Toolboxes("github")]
+        assert agent.tools == [] and agent._eager_tool_nodes == []
+
+    def test_add_named_onto_discover_raises_surface_unchanged(self) -> None:
+        agent = make_agent(Toolboxes(discover=True))
+        with pytest.raises(ValueError, match="exclusive author"):
+            agent.add_tools(Toolboxes("github"))
+        assert agent._tool_selectors == [Toolboxes(discover=True)]
+
+    def test_add_eager_node_onto_discover_raises_surface_unchanged(self) -> None:
+        agent = make_agent(Toolboxes(discover=True))
+        with pytest.raises(ValueError, match="exclusive author"):
+            agent.add_tools(make_toolbox("github"))
+        assert agent._tool_selectors == [Toolboxes(discover=True)]
+
+    def test_add_bare_toolbox_raises_teaching_surface_unchanged(self) -> None:
+        agent = make_agent(Toolboxes("github"))
+        with pytest.raises(ValueError, match=r"Toolboxes\("):
+            agent.add_tools(Toolbox("slack"))
+        assert agent._tool_selectors == [Toolboxes("github")]
+
+
+class TestFiveChannelAggregation:
+    def test_all_five_channels_aggregate_across_entries_in_one_handle(self) -> None:
+        # One handle tripping every channel at once — proves per-channel extend
+        # (not overwrite) across entries, independent of the shared loop body.
+        view = _FakeView(
+            gh=make_toolbox_record("gh", ("ok", "other")),
+            add=make_tool_record("add"),
+            poisoned=make_toolbox_record("poisoned", ("x",), dispatch_topic=""),
+        )
+        result = Toolboxes(Toolbox("gh", include=("ok", "miss")), "ghost", "add", "poisoned").resolve_tools(view)
+        assert [b.name for b in result.bindings] == ["gh__ok"]
+        assert result.missing_tools == ("miss",)
+        assert result.missing_targets == ("ghost",)
+        assert result.wrong_kind_targets == ("add",)
+        assert result.invalid_targets == ("poisoned",)
+        assert result.unresolved
+
+    def test_unresolved_named_selection_warns_at_agent_level(self, caplog: Any) -> None:
+        import logging
+
+        agent = make_agent(Toolboxes("ghost"))
+        registry: dict[str, Any] = {}
+        with caplog.at_level(logging.WARNING, logger="calfkit.nodes.agent"):
+            agent._resolve_selector_tools({CAPABILITY_VIEW_RESOURCE_KEY: _FakeView()}, registry)
+        assert any("partially unresolved" in r.getMessage() for r in caplog.records)

--- a/tests/test_tools_selector.py
+++ b/tests/test_tools_selector.py
@@ -383,3 +383,9 @@ class TestToolsExport:
 
         assert TopLevel is FromModule is FromNodes
         assert "Tools" in calfkit.__all__
+
+
+class TestBareStringGuard:
+    def test_names_kwarg_rejects_bare_string(self) -> None:
+        with pytest.raises(ValueError, match="not a bare string"):
+            Tools(names="abc")

--- a/tests/test_tools_selector.py
+++ b/tests/test_tools_selector.py
@@ -1,6 +1,6 @@
 """``Tools`` — the identity-only handle to one or more function tool nodes.
 
-The call-side counterpart to a deployed tool node (mirrors ``MCPToolbox``): an agent
+The call-side counterpart to a deployed tool node (mirrors ``Toolboxes``): an agent
 holds ``Tools("add", "subtract")`` and the schemas are discovered per turn from the
 shared capability view. Resolution reuses ``resolve_capability`` with
 ``expected_kind="tool"`` (the over-pull guard), so ``Tools`` can never bind a toolbox
@@ -214,7 +214,7 @@ class TestToolSurfaceContract:
     ``Agent(tools=...)`` and ``add_tools``:
       (1) no duplicate tool names across eager bindings + named ``Tools``;
       (2) ``Tools(discover=True)`` owns the tool-node surface (no eager tool node or named
-          ``Tools`` alongside it; an ``MCPToolbox`` — a different kind — may).
+          ``Tools`` alongside it; a ``Toolboxes``/eager toolbox node — a different kind — may).
     """
 
     # --- (1) no duplicate tool names ------------------------------------------------
@@ -244,12 +244,12 @@ class TestToolSurfaceContract:
         agent = make_agent(Tools(discover=True))
         assert agent._tool_selectors == [Tools(discover=True)]
 
-    def test_discover_composes_with_mcp_toolbox(self) -> None:
-        from calfkit.mcp import MCPToolbox
+    def test_discover_composes_with_toolboxes(self) -> None:
+        from calfkit.nodes.toolbox import Toolboxes
 
-        agent = make_agent(Tools(discover=True), MCPToolbox("fs"))
+        agent = make_agent(Tools(discover=True), Toolboxes("fs"))
         assert Tools(discover=True) in agent._tool_selectors
-        assert MCPToolbox("fs") in agent._tool_selectors
+        assert Toolboxes("fs") in agent._tool_selectors
 
     def test_distinct_named_handles_are_legal(self) -> None:
         agent = make_agent(Tools("add"), Tools("sub"))

--- a/tests/test_worker_capability_view.py
+++ b/tests/test_worker_capability_view.py
@@ -65,7 +65,9 @@ class TestCapabilityViewRegistration:
         assert worker_resource_names(worker).count(CAPABILITY_VIEW_RESOURCE_KEY) == 1
 
     def test_scoped_selectors_also_trigger_registration(self) -> None:
-        worker = Worker(Client.connect("kafka:9092"), nodes=[make_agent(make_toolbox().select(include=["search"]))])
+        from calfkit.nodes.toolbox import Toolbox, Toolboxes
+
+        worker = Worker(Client.connect("kafka:9092"), nodes=[make_agent(Toolboxes(Toolbox("github", include=("search",))))])
         worker._maybe_register_capability_view()
         assert CAPABILITY_VIEW_RESOURCE_KEY in worker_resource_names(worker)
 


### PR DESCRIPTION
## Summary

Toolbox selection becomes a full, symmetric member of the capability-handle family (ADR-0045, design-locked and review-converged over two adversarial rounds):

- **`Toolboxes(*positional, entries=None, discover=False)`** — dual-mode family selector (entries XOR discover), sharing the construction grammar with `Tools`/`Messaging`/`Handoff` via an extracted grammar core with per-family collection policy.
- **`Toolbox(name, include=...)`** — frozen entry spec carrying the per-box static allowlist (trust boundary). Not a selector: bare in `tools=[...]` raises a teaching error. `include=()` is explicit exclusion (binds the box, zero tools).
- **`Toolboxes(discover=True)`** — binds every live toolbox, resolved fresh each turn; exclusive author of the toolbox surface (Messaging-strength: no other `Toolboxes` handle or eager toolbox node beside it, duplicates included).
- **Duplicate toolbox declarations raise at construction** — across handles, eager `MCPToolboxNode`s included (one policy per toolbox per agent). Deliberate divergence from the name rail's silent dedupe: entries carry policy, so duplicates are conflicts.
- **Removal + alias:** the `MCPToolbox` selector class and `MCPToolboxNode.select()` are deleted; `MCPToolbox = Toolbox` alias remains importable from both `calfkit` and `calfkit.mcp`; the node's `resolve_tools` calls the resolution kernel directly. The worker's `add_nodes` teaching gate widens to `Toolbox`.

Resolution kernels, wire model, and namespacing are unchanged.

## Migration (breaking)

| Old | New |
| --- | --- |
| `MCPToolbox("x")` in `tools=` | `Toolboxes("x")` |
| `MCPToolbox("x", include=...)` | `Toolboxes(Toolbox("x", include=...))` |
| `node.select(include=...)` | `Toolboxes(Toolbox(node.node_id, include=...))` |

Because of the alias, old selector usage **imports and constructs** — it fails at agent construction with a teaching `ValueError`, not at import.

## Verification

- TDD throughout (every behavior red-first). New-surface suite: 54 tests incl. the full construction-error inventory.
- Default suite: 4,571 passed · `make fix`/`make check` clean (lint, format, mypy) · **100% coverage** on `calfkit/nodes/toolbox.py` + `calfkit/_handle_names.py`.
- Real-broker lane: `make test-kafka` — 106 passed (covers the 13 migrated `.select()` integration sites invisible to default gates).
- Grep gates: zero `MCPToolbox(`-as-selector or `.select(` remnants in source/tests.

Docs: `mcp-tool-discovery.md` (rewritten, new discover section), `api.md` reference blocks, `tool-discovery.md` cross-ref, runnable quickstart rewritten and executed.