### PR TITLE
feat!: adopt mcp 2.0

### DIFF
--- a/calfkit/mcp/mcp_toolbox.py
+++ b/calfkit/mcp/mcp_toolbox.py
@@ -110,7 +110,7 @@ class MCPToolboxNode(BaseNodeDef):
         aborts boot.
         """
         listing = await session.list_tools()
-        tools = [CapabilityToolDef(name=tool.name, description=tool.description, parameters_json_schema=tool.inputSchema) for tool in listing.tools]
+        tools = [CapabilityToolDef(name=tool.name, description=tool.description, parameters_json_schema=tool.input_schema) for tool in listing.tools]
         if tools != self._last_tools:
             self._last_tools = tools
             self._tools_changed_at = datetime.now(tz=timezone.utc)

--- a/calfkit/mcp/mcp_transport.py
+++ b/calfkit/mcp/mcp_transport.py
@@ -1,3 +1,17 @@
+"""Transport constructors for the MCP client sessions calfkit drives.
+
+Two imports below reach into private ``mcp`` modules, which is deliberate rather
+than overlooked. mcp 2.0 publishes no other path to either: the HTTP-client
+factory and its recommended timeout defaults live only in
+``mcp.shared._httpx_utils``, and ``TransportStreams`` only in
+``mcp.client._transport`` (upstream carries a TODO to relocate it). The
+alternatives are worse — re-declaring the stream tuple would name element types
+that are *also* private, and owning copies of the timeout defaults would silently
+drift from MCP's recommendations. Importing the real definitions keeps the
+coupling visible and lets a version bump fail loudly at import rather than
+subtly at runtime.
+"""
+
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any

--- a/calfkit/mcp/mcp_transport.py
+++ b/calfkit/mcp/mcp_transport.py
@@ -2,12 +2,11 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
 
-import httpx
-from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+import httpx2
+from mcp.client._transport import TransportStreams
 from mcp.client.stdio import StdioServerParameters, stdio_client
 from mcp.client.streamable_http import streamable_http_client
 from mcp.shared._httpx_utils import MCP_DEFAULT_SSE_READ_TIMEOUT, MCP_DEFAULT_TIMEOUT, create_mcp_http_client
-from mcp.shared.message import SessionMessage
 from pydantic import BaseModel, ConfigDict
 
 __all__ = (
@@ -21,7 +20,7 @@ __all__ = (
 class StreamableHttpParameters(BaseModel):
     """Parameters for initializing a ``streamable_http_client``."""
 
-    # httpx.Auth is not a pydantic-native type; allow it as an arbitrary field.
+    # httpx2.Auth is not a pydantic-native type; allow it as an arbitrary field.
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     # The endpoint URL.
@@ -39,18 +38,21 @@ class StreamableHttpParameters(BaseModel):
     # Close the client session when the transport closes.
     terminate_on_close: bool = True
 
-    auth: httpx.Auth | None = None
+    auth: httpx2.Auth | None = None
 
 
-# The yielded stream pair both transports produce for a ``ClientSession``.
-_Streams = tuple[
-    MemoryObjectReceiveStream[SessionMessage | Exception],
-    MemoryObjectSendStream[SessionMessage],
-]
+# ``TransportStreams`` is mcp's own name for the (read, write) pair both
+# transports produce for a ``ClientSession``. mcp 2.0 offers no public path to
+# it: ``mcp.client._transport`` is the definition site and does name it in
+# ``__all__``, while every re-export — ``mcp.client.session``,
+# ``mcp.client.streamable_http`` — is implicit and so rejected under mypy
+# strict. Upstream carries a TODO to relocate it. Importing the canonical site
+# beats re-declaring the tuple, whose element types are themselves private, or
+# silencing the type checker.
 
 
 @asynccontextmanager
-async def http_client(server: StreamableHttpParameters) -> AsyncIterator[_Streams]:
+async def http_client(server: StreamableHttpParameters) -> AsyncIterator[TransportStreams]:
     """Connect to a Streamable HTTP MCP server described by ``server``.
 
     The HTTP analogue of ``mcp.stdio_client``: pass a config object and get back
@@ -65,7 +67,7 @@ async def http_client(server: StreamableHttpParameters) -> AsyncIterator[_Stream
     # headers/timeout, so construct one with the MCP-recommended defaults.
     async with create_mcp_http_client(
         headers=server.headers,
-        timeout=httpx.Timeout(
+        timeout=httpx2.Timeout(
             server.timeout,
             read=server.sse_read_timeout,
         ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,16 @@ dependencies = [
     "anthropic>=0.80.0",
     "typing-extensions>=4.15.0",
     "dishka>=1.9.1",
-    # Capped below 2.0: mcp 2.0 renamed the camelCase model fields (`Tool.inputSchema` ->
-    # `Tool.input_schema`) and swapped httpx for httpx2, breaking `mcp/mcp_toolbox.py` and
-    # `mcp/mcp_transport.py`. Lift the cap in the 2.0 migration.
-    "mcp>=1.27.2,<2",
+    # Floor at 2.0: the 2.0 model fields are snake_case (`Tool.input_schema`) and the
+    # HTTP stack is httpx2, neither of which 1.x provides — `mcp/mcp_toolbox.py` and
+    # `mcp/mcp_transport.py` require both. Capped below 3 so the next major arrives as
+    # its own reviewable Dependabot PR rather than inside an unrelated one.
+    "mcp>=2.0.0,<3",
+    # httpx2 is the HTTP stack mcp 2.0 exposes: `create_mcp_http_client` returns an
+    # `httpx2.AsyncClient` and `StreamableHttpParameters.auth` is an `httpx2.Auth`.
+    # Already in the locked closure via genai-prices, so declaring it is install-free —
+    # it is a direct, load-bearing import here, not an incidental transitive.
+    "httpx2>=2.5.0",
     "ktables>=2.0.0",
     # CLI (`ck`): typer powers the console script, watchfiles powers `ck run --reload`.
     "typer>=0.12",

--- a/tests/integration/_mcp_roundtrip_server.py
+++ b/tests/integration/_mcp_roundtrip_server.py
@@ -1,6 +1,6 @@
 """A minimal, self-contained MCP server for the real-broker roundtrip test.
 
-Built on the *real* ``mcp`` package (``mcp.server.fastmcp.FastMCP``) and
+Built on the *real* ``mcp`` package (``mcp.server.MCPServer``) and
 deliberately free of any ``calfkit`` or vendored-pydantic-ai imports, so the
 test exercises a genuine external MCP server rather than a stub. The
 :class:`~calfkit.mcp.MCPToolboxNode` spawns this module as a subprocess over stdio
@@ -13,9 +13,10 @@ argument arities a real toolbox must handle: multi-arg (:func:`add`), single-arg
 (:func:`echo`), and no-arg (:func:`ping`).
 """
 
-from mcp.server.fastmcp import Context, FastMCP
+from mcp.server import MCPServer
+from mcp.server.mcpserver import Context
 
-mcp = FastMCP("roundtrip-test-server")
+mcp = MCPServer("roundtrip-test-server")
 
 
 @mcp.tool()
@@ -45,7 +46,7 @@ def danger() -> str:
 
 @mcp.tool()
 def domain_error() -> str:
-    """Raise a domain error → FastMCP returns a ``CallToolResult`` with ``isError=True``
+    """Raise a domain error → the server returns a ``CallToolResult`` with ``isError=True``
     (a model-visible failure by MCP convention). calfkit passes this through transparently
     as an ordinary return — NOT the fault rail (the temporary PR-6 behavior)."""
     raise ValueError("domain failure")

--- a/tests/integration/_mcp_roundtrip_server_b.py
+++ b/tests/integration/_mcp_roundtrip_server_b.py
@@ -7,9 +7,9 @@ selectors), so two servers exposing the same name would collide. Distinct names
 let a test prove each call routed to the correct server.
 """
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
-mcp = FastMCP("roundtrip-test-server-b")
+mcp = MCPServer("roundtrip-test-server-b")
 
 
 @mcp.tool()

--- a/tests/integration/test_mcp_roundtrip_kafka.py
+++ b/tests/integration/test_mcp_roundtrip_kafka.py
@@ -709,7 +709,7 @@ async def test_mcp_bad_args_rejected_before_dispatch_then_corrected(
 
     by_id = returns_by_call_id(result.message_history)
     # The bad call was rejected caller-side (calfkit's json_schema_violation — NOT a server-side
-    # FastMCP validation error, which would prove the server was contacted).
+    # server-side validation error, which would prove the server was contacted).
     surfaced_bad = f"{by_id.get('bad', '')} {' '.join(retry_prompt_texts(result.message_history))}"
     assert "json_schema_violation" in surfaced_bad, f"expected a caller-side schema violation, got: {surfaced_bad!r}"
     # The corrected call round-tripped through the real server.

--- a/tests/integration/test_mcp_toolbox_capability.py
+++ b/tests/integration/test_mcp_toolbox_capability.py
@@ -44,7 +44,7 @@ class FakeSession:
         self._tool_names = tool_names
 
     async def list_tools(self) -> ListToolsResult:
-        return ListToolsResult(tools=[Tool(name=n, description=n, inputSchema={"type": "object", "properties": {}}) for n in self._tool_names])
+        return ListToolsResult(tools=[Tool(name=n, description=n, input_schema={"type": "object", "properties": {}}) for n in self._tool_names])
 
 
 class FakeModel(PydanticModelClient):

--- a/tests/integration/test_mesh_view_kafka.py
+++ b/tests/integration/test_mesh_view_kafka.py
@@ -72,7 +72,7 @@ class FakeSession:
         self._tool_names = tool_names
 
     async def list_tools(self) -> ListToolsResult:
-        return ListToolsResult(tools=[Tool(name=n, description=n, inputSchema={"type": "object", "properties": {}}) for n in self._tool_names])
+        return ListToolsResult(tools=[Tool(name=n, description=n, input_schema={"type": "object", "properties": {}}) for n in self._tool_names])
 
 
 def _add(a: int, b: int) -> int:

--- a/tests/test_mcp_server_harnesses.py
+++ b/tests/test_mcp_server_harnesses.py
@@ -1,0 +1,79 @@
+"""The integration roundtrip harnesses start and speak MCP — checked offline.
+
+``tests/integration/_mcp_roundtrip_server{,_b}.py`` are real MCP servers built on
+the real ``mcp`` package, spawned as stdio subprocesses. Until now they were only
+ever exercised by the ``kafka`` lane, which needs Docker — so an mcp upgrade that
+broke them was invisible until CI, and even there it surfaced only as
+``MCPError: Connection closed``, with the real cause (an ImportError at module
+scope) buried in the subprocess's stderr. That is exactly how the mcp 2.0 removal
+of ``mcp.server.fastmcp`` reached CI.
+
+Nothing about these servers actually needs a broker: they are subprocesses over
+stdio. Handshaking with them directly costs a fraction of a second and needs no
+Docker, network, or credentials. The failure still surfaces as ``Connection
+closed`` — that is what a dead subprocess looks like from the client — but the
+subprocess's traceback lands in the captured output alongside it, so the real
+cause is right there. These tests therefore live in the default lane,
+deliberately unmarked.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from mcp import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+_HARNESS_DIR = Path(__file__).parent / "integration"
+
+
+async def _list_and_call(harness: str, tool: str, args: dict[str, object]) -> tuple[set[str], str]:
+    """Spawn ``harness`` over stdio, complete a handshake, and call one tool.
+
+    Returns the advertised tool names and the called tool's text result.
+    """
+    params = StdioServerParameters(command=sys.executable, args=[str(_HARNESS_DIR / harness)])
+    async with stdio_client(params) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            names = {tool_def.name for tool_def in (await session.list_tools()).tools}
+            result = await session.call_tool(tool, args)
+            return names, result.content[0].text  # type: ignore[union-attr]
+
+
+@pytest.mark.parametrize(
+    ("harness", "expected_tools", "tool", "args", "expected"),
+    [
+        pytest.param(
+            "_mcp_roundtrip_server.py",
+            {"add", "echo", "ping", "danger", "domain_error", "enable_bonus"},
+            "add",
+            {"a": 2, "b": 3},
+            "5",
+            id="server-a",
+        ),
+        pytest.param(
+            "_mcp_roundtrip_server_b.py",
+            {"mul", "upper"},
+            "mul",
+            {"a": 4, "b": 5},
+            "20",
+            id="server-b",
+        ),
+    ],
+)
+async def test_harness_starts_and_advertises_its_tools(
+    harness: str, expected_tools: set[str], tool: str, args: dict[str, object], expected: str
+) -> None:
+    """The harness imports, completes an MCP handshake, and dispatches a call.
+
+    Asserting the full advertised set — not just a subset — means a tool silently
+    dropped by an upstream decorator change fails here too, not only a server that
+    refuses to start.
+    """
+    names, result = await _list_and_call(harness, tool, args)
+
+    assert names == expected_tools
+    assert result == expected

--- a/tests/test_mcp_toolbox_publisher.py
+++ b/tests/test_mcp_toolbox_publisher.py
@@ -41,8 +41,8 @@ class FakeSession:
 
 def make_tools() -> list[Tool]:
     return [
-        Tool(name="search", description="Search the docs", inputSchema={"type": "object", "properties": {"q": {"type": "string"}}}),
-        Tool(name="fetch", inputSchema={"type": "object", "properties": {}}),
+        Tool(name="search", description="Search the docs", input_schema={"type": "object", "properties": {"q": {"type": "string"}}}),
+        Tool(name="fetch", input_schema={"type": "object", "properties": {}}),
     ]
 
 
@@ -128,7 +128,7 @@ class TestCapabilityFactory:
 
         # A genuine tool-set change advances it.
         await asyncio.sleep(0.005)
-        session._tools = [Tool(name="new_tool", inputSchema={"type": "object", "properties": {}})]
+        session._tools = [Tool(name="new_tool", input_schema={"type": "object", "properties": {}})]
         await toolbox._refresh_tools(session)
         after = toolbox._capability_record(make_stamp())
         assert after.content_updated_at > before
@@ -159,7 +159,7 @@ class TestListChanged:
         toolbox.resources[toolbox._session_resource_key] = session
         await toolbox._refresh_tools(session)  # prime as session setup would
 
-        session._tools = [Tool(name="new_tool", inputSchema={"type": "object", "properties": {}})]
+        session._tools = [Tool(name="new_tool", input_schema={"type": "object", "properties": {}})]
         await toolbox._mcp_message_handler(ToolListChangedNotification(method="notifications/tools/list_changed"))
         for _ in range(100):
             if toolbox._last_tools and toolbox._last_tools[0].name == "new_tool":

--- a/tests/test_mcp_transport.py
+++ b/tests/test_mcp_transport.py
@@ -1,0 +1,94 @@
+"""`calfkit.mcp.mcp_transport`'s Streamable HTTP client construction.
+
+`http_client` translates a `StreamableHttpParameters` config into the pre-built
+HTTP client that `streamable_http_client` requires. The translation is easy to
+get silently wrong: the underlying HTTP library's `Timeout` accepts an unknown
+object as a scalar default rather than rejecting it, so a mismatched `Timeout`
+produces a client whose per-phase timeouts are `Timeout` objects instead of
+floats. That configuration is nonsense but constructs cleanly and even reprs
+plausibly, so nothing surfaces it until a request actually hangs.
+
+These tests pin the translation by asserting on the constructed client itself.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+
+from calfkit.mcp import mcp_transport
+from calfkit.mcp.mcp_transport import StreamableHttpParameters
+
+
+@asynccontextmanager
+async def _capturing_streamable_http_client(
+    url: str, *, http_client: Any = None, terminate_on_close: bool = True
+) -> AsyncIterator[tuple[Any, Any, Any]]:
+    """Stand-in for `streamable_http_client` that records what it was handed.
+
+    Records onto the context manager's own attribute store so the test can read
+    the client back after the `async with` block has exited.
+    """
+    _capturing_streamable_http_client.captured = {  # type: ignore[attr-defined]
+        "url": url,
+        "http_client": http_client,
+        "terminate_on_close": terminate_on_close,
+    }
+    yield ("read", "write", "session_id_callback")
+
+
+@pytest.fixture
+def captured_client(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Run `http_client` against a stubbed transport and return the built HTTP client."""
+
+    async def _run(server: StreamableHttpParameters) -> Any:
+        monkeypatch.setattr(mcp_transport, "streamable_http_client", _capturing_streamable_http_client)
+        async with mcp_transport.http_client(server):
+            pass
+        return _capturing_streamable_http_client.captured  # type: ignore[attr-defined]
+
+    return _run
+
+
+@pytest.mark.asyncio
+async def test_timeouts_reach_the_client_as_numbers(captured_client: Any) -> None:
+    """`timeout` and `sse_read_timeout` land as real numbers on the built client.
+
+    The regression this guards: passing a `Timeout` from the wrong HTTP library
+    is accepted and wrapped as a scalar default, leaving every phase set to a
+    nested `Timeout` object. Asserting the numeric values catches that, where
+    asserting the client merely constructs would not.
+    """
+    result = await captured_client(StreamableHttpParameters(url="https://example.test/mcp", timeout=7.5, sse_read_timeout=42.0))
+    timeout = result["http_client"].timeout
+
+    assert isinstance(timeout.connect, (int, float)), f"connect timeout is {type(timeout.connect).__name__}, not a number"
+    assert isinstance(timeout.read, (int, float)), f"read timeout is {type(timeout.read).__name__}, not a number"
+
+    assert timeout.connect == 7.5
+    assert timeout.read == 42.0
+
+
+@pytest.mark.asyncio
+async def test_defaults_are_the_mcp_recommended_values(captured_client: Any) -> None:
+    """An otherwise-bare config still yields MCP's recommended timeout defaults."""
+    result = await captured_client(StreamableHttpParameters(url="https://example.test/mcp"))
+    timeout = result["http_client"].timeout
+
+    assert timeout.connect == mcp_transport.MCP_DEFAULT_TIMEOUT
+    assert timeout.read == mcp_transport.MCP_DEFAULT_SSE_READ_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_headers_and_terminate_on_close_pass_through(captured_client: Any) -> None:
+    """Headers ride on the built client; `terminate_on_close` reaches the transport."""
+    result = await captured_client(
+        StreamableHttpParameters(url="https://example.test/mcp", headers={"authorization": "Bearer token"}, terminate_on_close=False)
+    )
+
+    assert result["http_client"].headers.get("authorization") == "Bearer token"
+    assert result["terminate_on_close"] is False
+    assert result["url"] == "https://example.test/mcp"

--- a/uv.lock
+++ b/uv.lock
@@ -186,6 +186,7 @@ dependencies = [
     { name = "genai-prices" },
     { name = "griffe" },
     { name = "httpx" },
+    { name = "httpx2" },
     { name = "jsonschema" },
     { name = "ktables" },
     { name = "mcp" },
@@ -241,9 +242,10 @@ requires-dist = [
     { name = "genai-prices", specifier = ">=0.0.48" },
     { name = "griffe", specifier = ">=2.0,<3" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "httpx2", specifier = ">=2.5.0" },
     { name = "jsonschema", specifier = ">=4.18" },
     { name = "ktables", specifier = ">=2.0.0" },
-    { name = "mcp", specifier = ">=1.27.2,<2" },
+    { name = "mcp", specifier = ">=2.0.0,<3" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "opentelemetry-api", specifier = ">=1.28.0" },
     { name = "psutil", marker = "extra == 'mesh'", specifier = ">=5.9" },
@@ -730,7 +732,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -907,15 +909,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
-]
-
-[[package]]
-name = "httpx-sse"
-version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
 ]
 
 [[package]]
@@ -1201,15 +1194,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.29.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -1219,9 +1212,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -1589,20 +1595,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1704,7 +1696,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six", marker = "python_full_version < '3.14'" },
+    { name = "six", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft — stacked on #363.** Base is `ci/lockfile-reproducible`, not `main`, because this PR relocks `uv.lock`. Retarget to `main` once #363 merges. One open decision (**D1a**) is called out in the comment below.

Lifts the `mcp<2` cap from #362 and migrates to mcp 2.0.

## Scope: mcp only

Deliberately **does not** touch the `ruff<0.16` cap. Adopting ruff 0.16 is a docs/tooling policy question (it reformats Python code blocks inside Markdown) that shares nothing with this migration but a line in `pyproject.toml`. Bundling them would review a breaking API change alongside ~100 lines of doc reflow. That's a separate PR.

## Changes

**`Tool.inputSchema` → `Tool.input_schema`.** mcp 2.0 renamed the model fields to snake_case. The alias still accepts `inputSchema` at *construction*, but attribute access does not — which is what raised `AttributeError` in `mcp_toolbox.py:113`.

The wire field is still `inputSchema`:
```
>>> Tool(name='z', input_schema={...}).model_dump(by_alias=True).keys()
['name', 'title', 'description', 'inputSchema', ...]
```
So prose describing the MCP protocol is left alone; only Python attribute access and kwargs changed.

**httpx → httpx2** in `mcp_transport.py`, declared as a direct dependency. Already in the locked closure via `genai-prices`, so it's install-free — and it's now a load-bearing import, not an incidental transitive.

**`_Streams` → mcp's `TransportStreams`.** The old alias named `MemoryObjectReceiveStream`/`MemoryObjectSendStream`, which are no longer the yielded types.

**`mcp>=2.0.0,<3`** — capped so the next major arrives as its own Dependabot PR rather than inside an unrelated one, which is the #362 lesson.

## The bug this fixes has no existing coverage

`httpx2.Timeout` accepts a *foreign* `Timeout` object as a scalar default instead of rejecting it. The pre-migration code built an httpx-v1 `Timeout` and handed it to mcp 2.0, producing a client whose every phase timeout was a nested `Timeout` rather than a float:

```
connect= Timeout(connect=7.5, read=42.0, write=7.5, pool=7.5)   # expected: 7.5
```

It constructs cleanly and reprs plausibly, so nothing surfaces it until a request misbehaves. `mypy` flagged the type mismatch; no test did.

`tests/test_mcp_transport.py` closes that. Written first and confirmed red against the pre-fix code:

```
E  AssertionError: connect timeout is Timeout, not a number
```

## Verification

- `make check` clean — lint, format, mypy strict.
- **2888 passed**, 7 skipped (3 new tests).
- Real-broker `kafka` lane not run locally (no Docker); CI covers it.

## Breaking change

`StreamableHttpParameters.auth` is now `httpx2.Auth` instead of `httpx.Auth`. No in-repo caller passes `auth` — the only `auth=` was the internal call site — but it is public API, so downstream users constructing an authenticated MCP HTTP client must switch to httpx2.